### PR TITLE
Greatly simplify Mac/Linux install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ For some examples, see [Go](https://docs.earthly.dev/examples/go), [Java](https:
 ##### Linux
 
 ```bash
-sudo /bin/sh -c 'curl -s https://api.github.com/repos/earthly/earthly/releases/latest | grep browser_download_url | grep linux-amd64 | cut -d : -f 2- | tr -d \" | wget -P /usr/local/bin/ -i - && mv /usr/local/bin/earth-linux-amd64 /usr/local/bin/earth && chmod +x /usr/local/bin/earth'
+sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/latest/download/earth-linux-amd64 -O /usr/local/bin/earth && chmod +x /usr/local/bin/earth'
 ```
 
 ##### Mac
@@ -54,7 +54,7 @@ brew install earthly
 ###### Script
 
 ```bash
-curl -s https://api.github.com/repos/earthly/earthly/releases/latest | grep browser_download_url | grep darwin-amd64 | cut -d : -f 2- | tr -d \" | wget -P /usr/local/bin/ -i - && mv /usr/local/bin/earth-darwin-amd64 /usr/local/bin/earth && chmod +x /usr/local/bin/earth
+wget https://github.com/earthly/earthly/releases/latest/download/earth-darwin-amd64 -O /usr/local/bin/earth && chmod +x /usr/local/bin/earth
 ```
 
 ##### Alternative Linux & Mac


### PR DESCRIPTION
Github now has the ability to download the latest release directly. See [here](https://stackoverflow.com/questions/24987542/is-there-a-link-to-github-for-downloading-a-file-in-the-latest-release-of-a-repo/54836319#54836319) and [here](https://help.github.com/en/github/administering-a-repository/linking-to-releases).