### PR TITLE
Add support for HEALTHCHECK

### DIFF
--- a/contrib/earthfile-syntax-highlighting/README.md
+++ b/contrib/earthfile-syntax-highlighting/README.md
@@ -13,3 +13,7 @@ Initial release of earthfile-syntax-highlighting.
 ### 0.0.2
 
 Add screenshot in the README.
+
+### 0.0.3
+
+Add highlighting for `HEALTHCHECK`.

--- a/contrib/earthfile-syntax-highlighting/build.earth
+++ b/contrib/earthfile-syntax-highlighting/build.earth
@@ -8,7 +8,7 @@ package:
     ARG RELEASE_TAG
     RUN test -n "$RELEASE_TAG"
     RUN VERSION=${RELEASE_TAG#v} ; \
-        sed -i 's^:VERSION:^'"$VERSION"'^g' ./package.json
+        sed -i 's^0.0.0^'"$VERSION"'^g' ./package.json
     RUN vsce package
     RUN VERSION=${RELEASE_TAG#v} ; \
         mv ./earthfile-syntax-highlighting-$VERSION.vsix ./earthfile-syntax-highlighting-$RELEASE_TAG.vsix

--- a/contrib/earthfile-syntax-highlighting/package.json
+++ b/contrib/earthfile-syntax-highlighting/package.json
@@ -2,7 +2,7 @@
     "name": "earthfile-syntax-highlighting",
     "displayName": "Earthfile Syntax Highlighting",
     "description": "Syntax highlighting for Earthly build earthfiles (build.earth).",
-    "version": ":VERSION:",
+    "version": "0.0.0",
     "publisher": "earthly",
     "icon": "logo.png",
     "repository": {

--- a/contrib/earthfile-syntax-highlighting/syntaxes/earthfile.tmLanguage.json
+++ b/contrib/earthfile-syntax-highlighting/syntaxes/earthfile.tmLanguage.json
@@ -132,7 +132,11 @@
 				},
 				{
 					"name": "keyword.other.special-method.earthfile",
-					"match": "^\\s*(?i:(ONBUILD)\\s+)?(?i:(FROM|COPY|SAVE ARTIFACT|SAVE IMAGE|RUN|LABEL|EXPOSE|VOLUME|USER|ENV|ARG|BUILD|WORKDIR|ENTRYPOINT|GIT CLONE|DOCKER LOAD|DOCKER PULL))\\s"
+					"match": "^\\s*(?i:(HEALTHCHECK)\\s+)?(?i:(NONE|CMD))\\s"
+				},
+				{
+					"name": "keyword.other.special-method.earthfile",
+					"match": "^\\s*(?i:(ONBUILD|HEALTHCHECK)\\s+)?(?i:(FROM|COPY|SAVE ARTIFACT|SAVE IMAGE|RUN|LABEL|EXPOSE|VOLUME|USER|ENV|ARG|BUILD|WORKDIR|ENTRYPOINT|GIT CLONE|DOCKER LOAD|DOCKER PULL|HEALTHCHECK))\\s"
 				}
 			]
 		},

--- a/docs/earthfile/earthfile.md
+++ b/docs/earthfile/earthfile.md
@@ -512,6 +512,35 @@ The `USER` command sets the user name (or UID) and optionally the user group (or
 
 The `WORKDIR` command strs the working directory for other commands that follow in the recipe. The working directory is also persisted as the default directory for the image. If the directory does not exist, it is automatically created. This command works the same way as the [Dockerfile `WORKDIR` command](https://docs.docker.com/engine/reference/builder/#workdir).
 
+## HEALTHCHECK (same as Dockerfile HEALTHCHECK)
+
+#### Synopsis
+
+* `HEALTHCHECK NONE` (disable healthchecking)
+* `HEALTHCHECK [--interval=DURATION] [--timeout=DURATION] [--start-period=DURATION] [--retries=N] CMD command arg1 arg2` (check container health by running command inside the container)
+
+#### Description
+
+The `HEALTHCHECK` command tells Docker how to test a container to check that it is still working. It works the same way as the [Dockerfile `HEALTHCHECK` command](https://docs.docker.com/engine/reference/builder/#healthcheck), with the only exception that the exec form of this command is not yet supported.
+
+#### Options
+
+##### `--interval=DURATION`
+
+Sets the time interval between health checks. Defaults to `30s`.
+
+##### `--timeout=DURATION`
+
+Sets the timeout for a single run before it is considered as failed. Defaults to `30s`.
+
+##### `--start-period=DURATION`
+
+Sets an initialization time period in which failures are not counted towards the maximum number of retries. Defaults to `0s`.
+
+##### `--retries=N`
+
+Sets the number of retries before a container is considered `unhealthy`. Defaults to `3`.
+
 ## SHELL (not supported)
 
 The classical [`SHELL` Dockerfile command](https://docs.docker.com/engine/reference/builder/#add) is not yet supported. Use the *exec form* of `RUN`, `ENTRYPOINT` and `CMD` instead and prepend a different shell.
@@ -527,7 +556,3 @@ The classical [`ONBUILD` Dockerfile command](https://docs.docker.com/engine/refe
 ## STOPSIGNAL (not supported)
 
 The classical [`STOPSIGNAL` Dockerfile command](https://docs.docker.com/engine/reference/builder/#stopsignal) is not yet supported.
-
-## HEALTHCHECK (not supported)
-
-The classical [`HEALTHCHECK` Dockerfile command](https://docs.docker.com/engine/reference/builder/#healthcheck) is not yet supported.

--- a/examples/cpp/.gitignore
+++ b/examples/cpp/.gitignore
@@ -1,0 +1,1 @@
+fibonacci

--- a/examples/tests/config.earth
+++ b/examples/tests/config.earth
@@ -14,5 +14,8 @@ test:
 	CMD /bin/bash abc def
 	VOLUME ["/tmp/earthly", "/another/volume"]
 	VOLUME /tmp/earthly2 /another/volume2
+	HEALTHCHECK NONE
+	HEALTHCHECK CMD true
+	HEALTHCHECK --interval 15s --retries 2 --timeout 45s --start-period 10s  CMD echo one two three
 	USER jack
 	SAVE IMAGE

--- a/go.sum
+++ b/go.sum
@@ -76,11 +76,13 @@ github.com/docker/docker v1.4.2-0.20200227233006-38f52c9fec82 h1:kZwwJwYnVWtU/by
 github.com/docker/docker v1.4.2-0.20200227233006-38f52c9fec82/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.6.0 h1:5bhDRLn1roGiNjz8IezRngHxMfoeaXGyr0BeMHq4rD8=
 github.com/docker/docker-credential-helpers v0.6.0/go.mod h1:WRaJzqw3CTB9bk10avuGsjVBZsD05qeibJ1/TYlvc0Y=
+github.com/docker/go-connections v0.3.0 h1:3lOnM9cSzgGwx8VfK/NGOW5fLQ0GjIlCkaktF+n1M6o=
 github.com/docker/go-connections v0.3.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c h1:+pKlWGMw7gf6bQ+oDZB4KHQFypsfjYlq/C4rfL7D3g8=
 github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c/go.mod h1:Uw6UezgYA44ePAFQYUehOuCzmy5zmg/+nl2ZfMWGkpA=
 github.com/docker/go-metrics v0.0.0-20180209012529-399ea8c73916/go.mod h1:/u0gXw0Gay3ceNrsHubL3BtdOL2fHf93USgMTe0W5dI=
 github.com/docker/go-units v0.3.1/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/libnetwork v0.8.0-dev.2.0.20200226230617-d8334ccdb9be/go.mod h1:93m0aTqz6z+g32wla4l4WxTrdtvBRmVzYRkYvasA5Z8=
 github.com/docker/libtrust v0.0.0-20150114040149-fa567046d9b1/go.mod h1:cyGadeNEkKy96OOhEzfZl+yxihPEzKnqJwvfuSUqbZE=

--- a/llbutil/constants.go
+++ b/llbutil/constants.go
@@ -6,4 +6,7 @@ var (
 	// TargetPlatform is the platform used for the build and for the resulting output images.
 	// This will be configurable in the future.
 	TargetPlatform = platforms.MustParse("linux/amd64")
+
+	// DefaultPathEnv is the default PATH to use.
+	DefaultPathEnv = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 )


### PR DESCRIPTION
* Smoke tested via augmenting existing config test
* Manually tested via docker inspect on produced image
* Manually tested via [this example](https://medium.com/better-programming/docker-healthchecks-eb744bfe3f3b)

![Screenshot from 2020-07-08 18-07-05](https://user-images.githubusercontent.com/446771/86985633-903cda00-c146-11ea-8995-372ce28588a7.png)

This will require a release of the syntax highlighting package for vscode.

~I still need to add docs for this hence draft.~ Done

Fixes #80 