### PR TITLE
Create global config file for storing credentials

### DIFF
--- a/build.earth
+++ b/build.earth
@@ -30,10 +30,9 @@ deps:
 
 code:
 	FROM +deps
-	COPY --dir buildcontext builder cleanup cmd conslogging dockertar domain \
+	COPY --dir buildcontext builder cleanup cmd config conslogging dockertar domain \
 		llbutil logging ./
 	COPY --dir buildkitd/buildkitd.go buildkitd/settings.go buildkitd/
-	COPY --dir config/*.go config/
 	COPY --dir earthfile2llb/antlrhandler earthfile2llb/dedup earthfile2llb/image \
 		earthfile2llb/imr earthfile2llb/variables earthfile2llb/*.go earthfile2llb/
 	COPY ./earthfile2llb/parser+parser/*.go ./earthfile2llb/parser/

--- a/build.earth
+++ b/build.earth
@@ -33,6 +33,7 @@ code:
 	COPY --dir buildcontext builder cleanup cmd conslogging dockertar domain \
 		llbutil logging ./
 	COPY --dir buildkitd/buildkitd.go buildkitd/settings.go buildkitd/
+	COPY --dir config/*.go config/
 	COPY --dir earthfile2llb/antlrhandler earthfile2llb/dedup earthfile2llb/image \
 		earthfile2llb/imr earthfile2llb/variables earthfile2llb/*.go earthfile2llb/
 	COPY ./earthfile2llb/parser+parser/*.go ./earthfile2llb/parser/

--- a/buildcontext/git.go
+++ b/buildcontext/git.go
@@ -89,7 +89,7 @@ func (gr *gitResolver) resolveGitProject(ctx context.Context, target domain.Targ
 		return nil, "", "", fmt.Errorf("Invalid github project path %s", target.ProjectPath)
 	}
 	githubUsername := projectPathParts[0]
-	githubProject := projectPathParts[1]
+	githubProject := strings.TrimSuffix(projectPathParts[1], ".git")
 	subDir = strings.Join(projectPathParts[2:], "/")
 	gitURL = fmt.Sprintf("git@%s:%s/%s.git", target.Registry, githubUsername, githubProject)
 	ref := target.Tag

--- a/buildcontext/git.go
+++ b/buildcontext/git.go
@@ -89,7 +89,7 @@ func (gr *gitResolver) resolveGitProject(ctx context.Context, target domain.Targ
 		return nil, "", "", fmt.Errorf("Invalid github project path %s", target.ProjectPath)
 	}
 	githubUsername := projectPathParts[0]
-	githubProject := strings.TrimSuffix(projectPathParts[1], ".git")
+	githubProject := projectPathParts[1]
 	subDir = strings.Join(projectPathParts[2:], "/")
 	gitURL = fmt.Sprintf("git@%s:%s/%s.git", target.Registry, githubUsername, githubProject)
 	ref := target.Tag

--- a/buildkitd/build.earth
+++ b/buildkitd/build.earth
@@ -10,10 +10,6 @@ buildkitd:
     RUN echo "github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==" >> ~/.ssh/known_hosts
     RUN echo "gitlab.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCsj2bNKTBSpIYDEGk9KxsGh3mySTRgMtXL583qmBpzeQ+jqCMRgBqB98u3z++J1sKlXHWfM9dyhSevkMwSbhoR8XIq/U0tCNyokEi/ueaBMCvbcTHhO7FcwzY92WK4Yt0aGROY5qX2UKSeOvuP4D6TPqKF1onrSzH9bx9XUf2lEdWT/ia1NEKjunUqu1xOB/StKDHMoX4/OKyIzuS0q/T1zOATthvasJFoPrAjkohTyaDUz2LN5JoH839hViyEG82yB+MjcFV5MU3N1l1QL3cVUCh93xSaua1N85qivl+siMkPGbO5xR/En4iEY6K2XPASUEMaieWVNTRCtJ4S8H+9" >> ~/.ssh/known_hosts
 
-    # Install git cred helper which uses env vars for https username and password.
-    COPY ./envcredhelper.sh /usr/bin/envcredhelper.sh
-    RUN git config --global credential.helper "/bin/sh /usr/bin/envcredhelper.sh"
-
     # Copy fuse-overlayfs binary.
     #COPY +fuse/fuse-overlayfs /usr/bin/fuse-overlayfs
 

--- a/buildkitd/buildkitd.go
+++ b/buildkitd/buildkitd.go
@@ -2,6 +2,7 @@ package buildkitd
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"os"
 	"os/exec"
@@ -198,24 +199,23 @@ func Start(ctx context.Context, image string, settings Settings, reset bool) err
 			"-e", "SSH_AUTH_SOCK=/ssh-agent.sock",
 		)
 	}
-	if len(settings.GitSettings) > 0 {
-		// TODO: Only the first GitSettings entry is used, and it is not bound
-		//       to the specified domain.
+
+	args = append(args,
+		"-e", "GIT_CONFIG",
+	)
+	env = append(env,
+		fmt.Sprintf("GIT_CONFIG=%s", base64.StdEncoding.EncodeToString([]byte(settings.GitConfig))),
+	)
+
+	for i, data := range settings.GitCredentials {
 		args = append(args,
-			"-e", "GIT_USERNAME",
-			"-e", "GIT_PASSWORD",
+			"-e", fmt.Sprintf("GIT_CREDENTIALS_%d", i),
 		)
-		// Pass secrets via env vars, not via command-line.
 		env = append(env,
-			fmt.Sprintf("GIT_USERNAME=%s", settings.GitSettings[0].Username),
-			fmt.Sprintf("GIT_PASSWORD=%s", settings.GitSettings[0].Password),
+			fmt.Sprintf("GIT_CREDENTIALS_%d=%s", i, base64.StdEncoding.EncodeToString([]byte(data))),
 		)
 	}
-	if settings.GitURLInsteadOf != "" {
-		args = append(args,
-			"-e", fmt.Sprintf("GIT_URL_INSTEAD_OF=%s", settings.GitURLInsteadOf),
-		)
-	}
+
 	// Apply reset.
 	if reset {
 		args = append(args, "-e", "EARTHLY_RESET_TMP_DIR=true")

--- a/buildkitd/buildkitd.go
+++ b/buildkitd/buildkitd.go
@@ -212,7 +212,7 @@ func Start(ctx context.Context, image string, settings Settings, reset bool) err
 			"-e", fmt.Sprintf("GIT_CREDENTIALS_%d", i),
 		)
 		env = append(env,
-			fmt.Sprintf("GIT_CREDENTIALS_%d=%s", i, base64.StdEncoding.EncodeToString([]byte(data))),
+			fmt.Sprintf("GIT_CREDENTIALS_%d=%s", i, base64.StdEncoding.EncodeToString([]byte("password="+data))),
 		)
 	}
 

--- a/buildkitd/entrypoint.sh
+++ b/buildkitd/entrypoint.sh
@@ -42,7 +42,7 @@ do
     eval data=\$$varname
     if [ -n "$data" ]
     then
-        echo echo \$$varname \| base64 -d > /usr/bin/git_credentials_"$i"
+        echo 'echo $'$varname' | base64 -d' > /usr/bin/git_credentials_"$i"
         chmod +x /usr/bin/git_credentials_"$i"
     else
         break

--- a/buildkitd/entrypoint.sh
+++ b/buildkitd/entrypoint.sh
@@ -34,6 +34,23 @@ if [ -n "$GIT_URL_INSTEAD_OF" ]; then
 
 fi
 
+# setup git credentials and config
+i=0
+while true
+do
+    varname=GIT_CREDENTIALS_"$i"
+    eval data=\$$varname
+    if [ -n "$data" ]
+    then
+        echo $data | base64 -d > /usr/bin/git_credentials_"$i"
+        chmod +x /usr/bin/git_credentials_"$i"
+    else
+        break
+    fi
+    i=$((i+1))
+done
+echo $GIT_CONFIG | base64 -d > /root/.gitconfig
+
 # Create an ext4 fs in a pre-allocated file. Ext4 will allow
 # us to use overlayfs snapshotter even when running on mac.
 if [ "$ENABLE_LOOP_DEVICE" == "true" ]; then

--- a/buildkitd/entrypoint.sh
+++ b/buildkitd/entrypoint.sh
@@ -42,7 +42,7 @@ do
     eval data=\$$varname
     if [ -n "$data" ]
     then
-        echo $data | base64 -d > /usr/bin/git_credentials_"$i"
+        echo echo \$$varname \| base64 -d > /usr/bin/git_credentials_"$i"
         chmod +x /usr/bin/git_credentials_"$i"
     else
         break

--- a/buildkitd/entrypoint.sh
+++ b/buildkitd/entrypoint.sh
@@ -49,7 +49,7 @@ do
     fi
     i=$((i+1))
 done
-echo $GIT_CONFIG | base64 -d > /root/.gitconfig
+echo "$GIT_CONFIG" | base64 -d > /root/.gitconfig
 
 # Create an ext4 fs in a pre-allocated file. Ext4 will allow
 # us to use overlayfs snapshotter even when running on mac.

--- a/buildkitd/envcredhelper.sh
+++ b/buildkitd/envcredhelper.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-echo username="$GIT_USERNAME"
-echo password="$GIT_PASSWORD"

--- a/buildkitd/settings.go
+++ b/buildkitd/settings.go
@@ -11,18 +11,12 @@ import (
 
 // Settings represents the buildkitd settings used to start up the daemon with.
 type Settings struct {
-	SSHAuthSock       string       `json:"sshAuthSock"`
-	GitURLInsteadOf   string       `json:"gitUrlInsteadOf"`
-	GitSettings       []GitSetting `json:"gitSettings"`
-	CacheSizeMb       int          `json:"cacheSizeMb"`
-	DisableLoopDevice bool         `json:"disableLoopDevice"`
-}
-
-// GitSetting represents git settings for a specific domain.
-type GitSetting struct {
-	Domain   string `json:"domain"`
-	Username string `json:"username"`
-	Password string `json:"password"`
+	SSHAuthSock       string   `json:"sshAuthSock"`
+	GitURLInsteadOf   string   `json:"gitUrlInsteadOf"`
+	CacheSizeMb       int      `json:"cacheSizeMb"`
+	DisableLoopDevice bool     `json:"disableLoopDevice"`
+	GitConfig         string   `json:"gitConfig"`
+	GitCredentials    []string `json:"gitCredentials"`
 }
 
 // Hash returns a secure hash of the settings.

--- a/cmd/earth/main.go
+++ b/cmd/earth/main.go
@@ -57,8 +57,8 @@ type cliFlags struct {
 	buildkitdImage      string
 	remoteCache         string
 	configPath          string
-	GitUsernameOverride string
-	GitPasswordOverride string
+	gitUsernameOverride string
+	gitPasswordOverride string
 }
 
 var (
@@ -168,7 +168,7 @@ func newEarthApp(ctx context.Context, console conslogging.ConsoleLogger) *earthA
 		},
 		&cli.StringFlag{
 			Name:        "config",
-			Value:       "~/earthly/config.yaml",
+			Value:       filepath.Join(os.Getenv("HOME"), ".earthly", "config.yaml"),
 			EnvVars:     []string{"EARTHLY_CONFIG"},
 			Usage:       "Path to config file for",
 			Destination: &app.configPath,
@@ -184,13 +184,13 @@ func newEarthApp(ctx context.Context, console conslogging.ConsoleLogger) *earthA
 			Name:        "git-username",
 			EnvVars:     []string{"GIT_USERNAME"},
 			Usage:       "The git username to use for git HTTPS authentication",
-			Destination: &app.GitUsernameOverride,
+			Destination: &app.gitUsernameOverride,
 		},
 		&cli.StringFlag{
 			Name:        "git-password",
 			EnvVars:     []string{"GIT_PASSWORD"},
 			Usage:       "The git password to use for git HTTPS authentication",
-			Destination: &app.GitPasswordOverride,
+			Destination: &app.gitPasswordOverride,
 		},
 		&cli.StringFlag{
 			Name:        "git-url-instead-of",
@@ -299,7 +299,7 @@ func (app *earthApp) parseConfigFile(context *cli.Context) error {
 	}
 
 	// command line overrides the config file
-	if app.GitUsernameOverride != "" || app.GitPasswordOverride != "" {
+	if app.gitUsernameOverride != "" || app.gitPasswordOverride != "" {
 		if _, ok := cfg.Git["github.com"]; !ok {
 			cfg.Git["github.com"] = config.GitConfig{}
 		}
@@ -309,11 +309,11 @@ func (app *earthApp) parseConfigFile(context *cli.Context) error {
 
 		for k, v := range cfg.Git {
 			v.Auth = "https"
-			if app.GitUsernameOverride != "" {
-				v.User = app.GitUsernameOverride
+			if app.gitUsernameOverride != "" {
+				v.User = app.gitUsernameOverride
 			}
-			if app.GitPasswordOverride != "" {
-				v.Password = app.GitPasswordOverride
+			if app.gitPasswordOverride != "" {
+				v.Password = app.gitPasswordOverride
 			}
 			cfg.Git[k] = v
 		}

--- a/cmd/earth/main.go
+++ b/cmd/earth/main.go
@@ -300,8 +300,11 @@ func (app *earthApp) parseConfigFile(context *cli.Context) error {
 
 	// command line overrides the config file
 	if app.GitUsernameOverride != "" || app.GitPasswordOverride != "" {
-		if _, ok := cfg.Git["default"]; !ok {
-			cfg.Git["default"] = config.GitConfig{}
+		if _, ok := cfg.Git["github.com"]; !ok {
+			cfg.Git["github.com"] = config.GitConfig{}
+		}
+		if _, ok := cfg.Git["gitlab.com"]; !ok {
+			cfg.Git["gitlab.com"] = config.GitConfig{}
 		}
 
 		for k, v := range cfg.Git {

--- a/cmd/earth/main.go
+++ b/cmd/earth/main.go
@@ -343,7 +343,7 @@ func (app *earthApp) run(ctx context.Context, args []string) int {
 		if strings.Contains(err.Error(), "failed to fetch remote") {
 			app.console.Printf(
 				"Check your git auth settings.\n" +
-					"Did you ssh-add today? Need to specify GIT_USERNAME and GIT_PASSWORD?\n" +
+					"Did you ssh-add today? Need to configure ~/earthly/config.yaml?\n" +
 					"For more information see https://docs.earthly.dev/guides/auth\n")
 		}
 		return 1

--- a/cmd/earth/main.go
+++ b/cmd/earth/main.go
@@ -286,12 +286,12 @@ func (app *earthApp) parseConfigFile(context *cli.Context) error {
 	if os.IsNotExist(err) && !context.IsSet("config") {
 		yamlData = []byte{}
 	} else if err != nil {
-		return err
+		return errors.Wrapf(err, "failed to read from %s", app.configPath)
 	}
 
 	cfg, err := config.ParseConfigFile(yamlData)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "failed to parse %s", app.configPath)
 	}
 
 	if cfg.Git == nil {
@@ -321,7 +321,7 @@ func (app *earthApp) parseConfigFile(context *cli.Context) error {
 
 	gitConfig, gitCredentials, err := config.CreateGitConfig(cfg)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "failed to create git config from %s", app.configPath)
 	}
 
 	app.buildkitdSettings.GitConfig = gitConfig

--- a/cmd/earth/main.go
+++ b/cmd/earth/main.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -14,11 +15,13 @@ import (
 	"github.com/earthly/earthly/builder"
 	"github.com/earthly/earthly/buildkitd"
 	"github.com/earthly/earthly/cleanup"
+	"github.com/earthly/earthly/config"
 	"github.com/earthly/earthly/conslogging"
 	"github.com/earthly/earthly/domain"
 	"github.com/earthly/earthly/earthfile2llb"
 	"github.com/earthly/earthly/earthfile2llb/variables"
 	"github.com/earthly/earthly/logging"
+
 	"github.com/moby/buildkit/client"
 	_ "github.com/moby/buildkit/client/connhelper/dockercontainer" // Load "docker-container://" helper.
 	"github.com/moby/buildkit/session"
@@ -39,20 +42,23 @@ type earthApp struct {
 }
 
 type cliFlags struct {
-	buildArgs         cli.StringSlice
-	secrets           cli.StringSlice
-	artifactMode      bool
-	imageMode         bool
-	push              bool
-	noOutput          bool
-	noCache           bool
-	pruneAll          bool
-	pruneReset        bool
-	buildkitdSettings buildkitd.Settings
-	allowPrivileged   bool
-	buildkitHost      string
-	buildkitdImage    string
-	remoteCache       string
+	buildArgs           cli.StringSlice
+	secrets             cli.StringSlice
+	artifactMode        bool
+	imageMode           bool
+	push                bool
+	noOutput            bool
+	noCache             bool
+	pruneAll            bool
+	pruneReset          bool
+	buildkitdSettings   buildkitd.Settings
+	allowPrivileged     bool
+	buildkitHost        string
+	buildkitdImage      string
+	remoteCache         string
+	configPath          string
+	GitUsernameOverride string
+	GitPasswordOverride string
 }
 
 var (
@@ -98,10 +104,7 @@ func newEarthApp(ctx context.Context, console conslogging.ConsoleLogger) *earthA
 		console:   console,
 		sessionID: base64.StdEncoding.EncodeToString(sessionIDBytes),
 		cliFlags: cliFlags{
-			buildkitdSettings: buildkitd.Settings{
-				// Add one empty entry for git settings.
-				GitSettings: []buildkitd.GitSetting{buildkitd.GitSetting{}},
-			},
+			buildkitdSettings: buildkitd.Settings{},
 		},
 	}
 
@@ -164,6 +167,13 @@ func newEarthApp(ctx context.Context, console conslogging.ConsoleLogger) *earthA
 			Destination: &app.noCache,
 		},
 		&cli.StringFlag{
+			Name:        "config",
+			Value:       "~/earthly/config.yaml",
+			EnvVars:     []string{"EARTHLY_CONFIG"},
+			Usage:       "Path to config file for",
+			Destination: &app.configPath,
+		},
+		&cli.StringFlag{
 			Name:        "ssh-auth-sock",
 			Value:       defaultSSHAuthSock(),
 			EnvVars:     []string{"EARTHLY_SSH_AUTH_SOCK"},
@@ -174,13 +184,13 @@ func newEarthApp(ctx context.Context, console conslogging.ConsoleLogger) *earthA
 			Name:        "git-username",
 			EnvVars:     []string{"GIT_USERNAME"},
 			Usage:       "The git username to use for git HTTPS authentication",
-			Destination: &app.buildkitdSettings.GitSettings[0].Username,
+			Destination: &app.GitUsernameOverride,
 		},
 		&cli.StringFlag{
 			Name:        "git-password",
 			EnvVars:     []string{"GIT_PASSWORD"},
 			Usage:       "The git password to use for git HTTPS authentication",
-			Destination: &app.buildkitdSettings.GitSettings[0].Password,
+			Destination: &app.GitPasswordOverride,
 		},
 		&cli.StringFlag{
 			Name:        "git-url-instead-of",
@@ -262,7 +272,59 @@ func newEarthApp(ctx context.Context, console conslogging.ConsoleLogger) *earthA
 			},
 		},
 	}
+
+	app.cliApp.Before = app.parseConfigFile
 	return app
+}
+
+func (app *earthApp) parseConfigFile(context *cli.Context) error {
+	if context.IsSet("config") {
+		app.console.Printf("loading config values from %q\n", app.configPath)
+	}
+
+	yamlData, err := ioutil.ReadFile(app.configPath)
+	if os.IsNotExist(err) && !context.IsSet("config") {
+		yamlData = []byte{}
+	} else if err != nil {
+		return err
+	}
+
+	cfg, err := config.ParseConfigFile(yamlData)
+	if err != nil {
+		return err
+	}
+
+	if cfg.Git == nil {
+		cfg.Git = map[string]config.GitConfig{}
+	}
+
+	// command line overrides the config file
+	if app.GitUsernameOverride != "" || app.GitPasswordOverride != "" {
+		if _, ok := cfg.Git["default"]; !ok {
+			cfg.Git["default"] = config.GitConfig{}
+		}
+
+		for k, v := range cfg.Git {
+			v.Auth = "https"
+			if app.GitUsernameOverride != "" {
+				v.User = app.GitUsernameOverride
+			}
+			if app.GitPasswordOverride != "" {
+				v.Password = app.GitPasswordOverride
+			}
+			cfg.Git[k] = v
+		}
+	}
+
+	gitConfig, gitCredentials, err := config.CreateGitConfig(cfg)
+	if err != nil {
+		return err
+	}
+
+	app.buildkitdSettings.GitConfig = gitConfig
+	app.buildkitdSettings.GitCredentials = gitCredentials
+	return nil
+
 }
 
 func (app *earthApp) run(ctx context.Context, args []string) int {

--- a/config/config.go
+++ b/config/config.go
@@ -87,7 +87,7 @@ func CreateGitConfig(config *Config) (string, []string, error) {
 			lines = append(lines, fmt.Sprintf("[credential %q]", url))
 			lines = append(lines, fmt.Sprintf("  username=%q", v.User))
 			lines = append(lines, fmt.Sprintf("  helper=/usr/bin/git_credentials_%d", cred_i))
-			credentials = append(credentials, fmt.Sprintf("echo password=%q", v.Password))
+			credentials = append(credentials, v.Password)
 			cred_i++
 
 			// use https instead of ssh://git@....

--- a/config/config.go
+++ b/config/config.go
@@ -61,20 +61,21 @@ func CreateGitConfig(config *Config) (string, []string, error) {
 	}
 	sort.Strings(keys)
 
+	// TODO figure out how to get the URL rewritting working for the generic case for all URLs
 	// default
-	if v, ok := config.Git["default"]; ok {
-		if v.Auth == "https" {
-			lines = append(lines, fmt.Sprintf("[credential]"))
-			lines = append(lines, fmt.Sprintf("  username=%q", v.User))
-			lines = append(lines, fmt.Sprintf("  helper=/usr/bin/git_credentials_%d", cred_i))
-			credentials = append(credentials, fmt.Sprintf("echo password=%q", v.Password))
-			cred_i++
+	//if v, ok := config.Git["default"]; ok {
+	//	if v.Auth == "https" {
+	//		lines = append(lines, fmt.Sprintf("[credential]"))
+	//		lines = append(lines, fmt.Sprintf("  username=%q", v.User))
+	//		lines = append(lines, fmt.Sprintf("  helper=/usr/bin/git_credentials_%d", cred_i))
+	//		credentials = append(credentials, fmt.Sprintf("echo password=%q", v.Password))
+	//		cred_i++
 
-			// use https instead of ssh://git@....
-			lines = append(lines, fmt.Sprintf("[url \"https://\"]"))
-			lines = append(lines, fmt.Sprintf("  insteadOf = ssh://git@"))
-		}
-	}
+	//		// use https instead of ssh://git@....
+	//		lines = append(lines, fmt.Sprintf("[url \"https://\"]"))
+	//		lines = append(lines, fmt.Sprintf("  insteadOf = ssh://git@"))
+	//	}
+	//}
 
 	for _, k := range keys {
 		v := config.Git[k]
@@ -90,8 +91,8 @@ func CreateGitConfig(config *Config) (string, []string, error) {
 			cred_i++
 
 			// use https instead of ssh://git@....
-			lines = append(lines, fmt.Sprintf("[url %q]", url))
-			lines = append(lines, fmt.Sprintf("  insteadOf = ssh://git@%s", url[8:]))
+			lines = append(lines, fmt.Sprintf("[url %q]", url+"/"))
+			lines = append(lines, fmt.Sprintf("  insteadOf = git@%s:", url[8:]))
 		}
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,102 @@
+package config
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+)
+
+var ErrInvalidTransport = fmt.Errorf("invalid transport")
+
+type GlobalConfig struct {
+	//TODO add support for global config as needed
+}
+
+type GitConfig struct {
+	Auth     string `yaml:"auth"`
+	User     string `yaml:"user"`
+	Password string `yaml:"password"`
+}
+
+type Config struct {
+	Global GlobalConfig         `yaml:"global"`
+	Git    map[string]GitConfig `yaml:"git"`
+}
+
+func ensureTransport(s, transport string) (string, error) {
+	parts := strings.SplitN(s, "://", 2)
+	if len(parts) == 2 {
+		if parts[0] != transport {
+			return "", ErrInvalidTransport
+		}
+	}
+	return transport + "://" + s, nil
+}
+
+func ParseConfigFile(yamlData []byte) (*Config, error) {
+	var config Config
+
+	err := yaml.Unmarshal(yamlData, &config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &config, nil
+}
+
+func CreateGitConfig(config *Config) (string, []string, error) {
+	credentials := []string{}
+	lines := []string{}
+	cred_i := 0
+
+	// iterate over map in a consistent order otherwise it will cause the buildkitd image to restart
+	// due to the settings hash being different
+	keys := []string{}
+	for k := range config.Git {
+		if k != "default" {
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+
+	// default
+	if v, ok := config.Git["default"]; ok {
+		if v.Auth == "https" {
+			lines = append(lines, fmt.Sprintf("[credential]"))
+			lines = append(lines, fmt.Sprintf("  username=%q", v.User))
+			lines = append(lines, fmt.Sprintf("  helper=/usr/bin/git_credentials_%d", cred_i))
+			credentials = append(credentials, fmt.Sprintf("echo password=%q", v.Password))
+			cred_i++
+
+			// use https instead of ssh://git@....
+			lines = append(lines, fmt.Sprintf("[url \"https://\"]"))
+			lines = append(lines, fmt.Sprintf("  insteadOf = ssh://git@"))
+		}
+	}
+
+	for _, k := range keys {
+		v := config.Git[k]
+		if v.Auth == "https" {
+			url, err := ensureTransport(k, "https")
+			if err != nil {
+				return "", nil, err
+			}
+			lines = append(lines, fmt.Sprintf("[credential %q]", url))
+			lines = append(lines, fmt.Sprintf("  username=%q", v.User))
+			lines = append(lines, fmt.Sprintf("  helper=/usr/bin/git_credentials_%d", cred_i))
+			credentials = append(credentials, fmt.Sprintf("echo password=%q", v.Password))
+			cred_i++
+
+			// use https instead of ssh://git@....
+			lines = append(lines, fmt.Sprintf("[url %q]", url))
+			lines = append(lines, fmt.Sprintf("  insteadOf = ssh://git@%s", url[8:]))
+		}
+	}
+
+	lines = append(lines, "")
+	gitConfig := strings.Join(lines, "\n")
+
+	return gitConfig, credentials, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -68,6 +68,7 @@ require (
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	google.golang.org/api v0.0.0-20160322025152-9bf6e6e569ff // indirect
 	google.golang.org/cloud v0.0.0-20151119220103-975617b05ea8 // indirect
+	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/kubernetes v1.13.0 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -422,6 +422,7 @@ gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gotest.tools v2.1.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=

--- a/go.sum
+++ b/go.sum
@@ -420,6 +420,7 @@ gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2/go.mod h1:Xk6kEKp8OKb+X14hQBKW
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gotest.tools v2.1.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=


### PR DESCRIPTION
The global config file (default location ~/earthly/config.yaml) can be
used to store https credentials for various sites. For example:

```yaml
git:
  default:
    auth: https
    username: foo
    password: bar
  github.com:
    username: f00
    password: bart
```

If the --git-username or --git-password command line values are given,
then those values will override all values stored in the config file.