### PR TITLE
Fix prefixing for control character progress bars

### DIFF
--- a/conslogging/conslogging.go
+++ b/conslogging/conslogging.go
@@ -94,7 +94,7 @@ func (cl ConsoleLogger) PrintBytes(data []byte) {
 	cl.mu.Lock()
 	defer cl.mu.Unlock()
 
-	output := []byte{}
+	output := make([]byte, 0, len(data))
 	for len(data) > 0 {
 		r, size := utf8.DecodeRune(data)
 		ch := data[:size]
@@ -110,7 +110,7 @@ func (cl ConsoleLogger) PrintBytes(data []byte) {
 			if !cl.trailingLine {
 				if len(output) > 0 {
 					cl.w.Write(output)
-					output = []byte{}
+					output = output[:0]
 				}
 				cl.printPrefix()
 				cl.trailingLine = true
@@ -120,7 +120,7 @@ func (cl ConsoleLogger) PrintBytes(data []byte) {
 	}
 	if len(output) > 0 {
 		cl.w.Write(output)
-		output = []byte{}
+		output = output[:0]
 	}
 }
 

--- a/conslogging/conslogging.go
+++ b/conslogging/conslogging.go
@@ -1,12 +1,12 @@
 package conslogging
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"os"
 	"strings"
 	"sync"
+	"unicode/utf8"
 
 	"github.com/fatih/color"
 )
@@ -24,6 +24,7 @@ type ConsoleLogger struct {
 	prefixColors   map[string]*color.Color
 	nextColorIndex *int
 	w              io.Writer
+	trailingLine   bool
 }
 
 // Current returns the current console.
@@ -90,19 +91,36 @@ func (cl ConsoleLogger) Printf(format string, args ...interface{}) {
 
 // PrintBytes prints bytes directly to the console.
 func (cl ConsoleLogger) PrintBytes(data []byte) {
-	// TODO: This does not deal well with control characters, because of the prefix.
 	cl.mu.Lock()
 	defer cl.mu.Unlock()
-	if !bytes.Contains(data, []byte("\n")) {
-		// No prefix when it's not a complete line.
-		cl.w.Write(data)
-	} else {
-		adjustedData := bytes.TrimSuffix(data, []byte("\n"))
-		for _, line := range bytes.Split(adjustedData, []byte("\n")) {
-			cl.printPrefix()
-			cl.w.Write(line)
-			cl.w.Write([]byte("\n"))
+
+	output := []byte{}
+	for len(data) > 0 {
+		r, size := utf8.DecodeRune(data)
+		ch := data[:size]
+		data = data[size:]
+		switch r {
+		case '\r':
+			output = append(output, ch...)
+			cl.trailingLine = false
+		case '\n':
+			output = append(output, ch...)
+			cl.trailingLine = false
+		default:
+			if !cl.trailingLine {
+				if len(output) > 0 {
+					cl.w.Write(output)
+					output = []byte{}
+				}
+				cl.printPrefix()
+				cl.trailingLine = true
+			}
+			output = append(output, ch...)
 		}
+	}
+	if len(output) > 0 {
+		cl.w.Write(output)
+		output = []byte{}
 	}
 }
 


### PR DESCRIPTION
This fixes the handling of control characters which are used to display
progress bars which use the \r control character.