### PR TITLE
Update docs for earthly config

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -11,6 +11,7 @@
 * [Earthfile reference](earthfile/earthfile.md)
     * [Builtin args](earthfile/builtin-args.md)
 * [earth command reference](earth-command/earth-command.md)
+* [Configuration reference](earth-config/earth-config.md)
 * [Examples](examples/examples.md)
     * [Go](examples/go.md)
     * [Java](examples/java.md)

--- a/docs/earth-config/earth-config.md
+++ b/docs/earth-config/earth-config.md
@@ -36,7 +36,7 @@ git:
 
 ### site
 
-The git repo hostname; e.g. `github.com`, or `gitlab.com`
+The git repository hostname. For example `github.com`, or `gitlab.com`
 
 ### auth
 

--- a/docs/earth-config/earth-config.md
+++ b/docs/earth-config/earth-config.md
@@ -6,7 +6,7 @@ By default, earth reads the configuration file `~/.earthly/config.yaml`; however
 overridden with the `--config` command flag option.
 
 Currently only https authentication configuration is configured in the config file; ssh authentication
-is additionally supported (and the default when the no overrides have been configured)
+is additionally [supported](../guides/auth.md) (and the default when the no overrides have been configured).
 
 ## Format
 

--- a/docs/earth-config/earth-config.md
+++ b/docs/earth-config/earth-config.md
@@ -51,4 +51,4 @@ The https username to use when auth is set to `https`. This setting is ignored w
 
 ### password
 
-The https password to use when auth is set to https; this is ignored when auth is ssh.
+The https password to use when auth is set to `https`. This setting is ignored when auth is `ssh`.

--- a/docs/earth-config/earth-config.md
+++ b/docs/earth-config/earth-config.md
@@ -47,7 +47,7 @@ See the [Authentication guide](../guides/auth.md) for a guide on setting up auth
 
 ### user
 
-The https username to use when auth is set to https; this is ignored when auth is ssh.
+The https username to use when auth is set to `https`. This setting is ignored when auth is `ssh`.
 
 ### password
 

--- a/docs/earth-config/earth-config.md
+++ b/docs/earth-config/earth-config.md
@@ -1,0 +1,55 @@
+# Earthly configuration file
+
+Global configuration values for earth can be stored on disk in the configuration file.
+
+By default, earth reads the configuration file `~/.earthly/config.yaml`; however, it can also be
+overridden with the `--config` command flag option.
+
+Currently only https authentication configuration is configured in the config file; ssh authentication
+is additionally supported (and the default when the no overrides have been configured)
+
+## Format
+
+The earthly config file is a [yaml](https://yaml.org/) formatted file that looks like:
+
+```yaml
+git:
+    <site>:
+        auth: https|ssh
+        user: <username>
+        password: <password>
+    <site2>:
+        ...
+```
+
+Example:
+
+```yaml
+git:
+    github.com:
+        auth: https
+        user: alice
+        password: itsasecret
+```
+
+## Git configuration reference
+
+### site
+
+The git repo hostname; e.g. `github.com`, or `gitlab.com`
+
+### auth
+
+Either `https` or `ssh` (default). If https is specified, user and password fields are used
+to authenticate over https when pulling from git for the corresponding site.
+
+See the [Authentication guide](guides/auth.md) for a guide on setting up authentication.
+
+### user
+
+The https username to use when auth is set to https; this is ignored when auth is ssh.
+
+### password
+
+The https password to use when auth is set to https; this is ignored when auth is ssh.
+

--- a/docs/earth-config/earth-config.md
+++ b/docs/earth-config/earth-config.md
@@ -43,7 +43,7 @@ The git repo hostname; e.g. `github.com`, or `gitlab.com`
 Either `https` or `ssh` (default). If https is specified, user and password fields are used
 to authenticate over https when pulling from git for the corresponding site.
 
-See the [Authentication guide](guides/auth.md) for a guide on setting up authentication.
+See the [Authentication guide](../guides/auth.md) for a guide on setting up authentication.
 
 ### user
 
@@ -52,4 +52,3 @@ The https username to use when auth is set to https; this is ignored when auth i
 ### password
 
 The https password to use when auth is set to https; this is ignored when auth is ssh.
-

--- a/docs/guides/auth.md
+++ b/docs/guides/auth.md
@@ -38,16 +38,27 @@ Another key setting available, is `GIT_URL_INSTEAD_OF`. It allows for `https://g
 
 #### Username-password authentication
 
-Username-password based authentication works by specifying the following environment variables
+Username-password based authentication can be configured in the [earthly config file](../earth-config/earth-config.md) under the git section: 
+
+```yaml
+git:
+    github.com:
+        auth: https
+        user: <username>
+        password: <password>
+    gitlab.com:
+        auth: https
+        user: <username>
+        password: <password>
+
+```
+
+Alternatively, environment variables can be set which will be override all host entries from the config file:
 
 * `GIT_USERNAME`
 * `GIT_PASSWORD`
 
-And additionally overriding the setting `GIT_URL_INSTEAD_OF` to force `git@github.com` URLs to be interpreted as `https://github.com` URLs:
-
-```bash
-export GIT_URL_INSTEAD_OF='https://github.com/=git@github.com:'
-```
+However, environment variable authentication are now deprecated in favor of using the configuration file instead.
 
 ## Docker authentication
 


### PR DESCRIPTION
Additionally removed the reference to GIT_URL_INSTEAD_OF which is no
longer used.