### PR TITLE
bugfix: GIT_URL_INSTEAD_OF needs to be passed to buildkitd

### DIFF
--- a/buildkitd/buildkitd.go
+++ b/buildkitd/buildkitd.go
@@ -202,6 +202,7 @@ func Start(ctx context.Context, image string, settings Settings, reset bool) err
 
 	args = append(args,
 		"-e", "GIT_CONFIG",
+		"-e", fmt.Sprintf("GIT_URL_INSTEAD_OF=%s", settings.GitURLInsteadOf),
 	)
 	env = append(env,
 		fmt.Sprintf("GIT_CONFIG=%s", base64.StdEncoding.EncodeToString([]byte(settings.GitConfig))),


### PR DESCRIPTION
This fixes a bug which was introduced by #101