### PR TITLE
GIT_CONFIG env conflicts with using git

### DIFF
--- a/buildkitd/buildkitd.go
+++ b/buildkitd/buildkitd.go
@@ -201,11 +201,11 @@ func Start(ctx context.Context, image string, settings Settings, reset bool) err
 	}
 
 	args = append(args,
-		"-e", "GIT_CONFIG",
+		"-e", "EARTH_GIT_CONFIG",
 		"-e", fmt.Sprintf("GIT_URL_INSTEAD_OF=%s", settings.GitURLInsteadOf),
 	)
 	env = append(env,
-		fmt.Sprintf("GIT_CONFIG=%s", base64.StdEncoding.EncodeToString([]byte(settings.GitConfig))),
+		fmt.Sprintf("EARTH_GIT_CONFIG=%s", base64.StdEncoding.EncodeToString([]byte(settings.GitConfig))),
 	)
 
 	for i, data := range settings.GitCredentials {

--- a/buildkitd/buildkitd.go
+++ b/buildkitd/buildkitd.go
@@ -201,11 +201,11 @@ func Start(ctx context.Context, image string, settings Settings, reset bool) err
 	}
 
 	args = append(args,
-		"-e", "EARTH_GIT_CONFIG",
+		"-e", "EARTHLY_GIT_CONFIG",
 		"-e", fmt.Sprintf("GIT_URL_INSTEAD_OF=%s", settings.GitURLInsteadOf),
 	)
 	env = append(env,
-		fmt.Sprintf("EARTH_GIT_CONFIG=%s", base64.StdEncoding.EncodeToString([]byte(settings.GitConfig))),
+		fmt.Sprintf("EARTHLY_GIT_CONFIG=%s", base64.StdEncoding.EncodeToString([]byte(settings.GitConfig))),
 	)
 
 	for i, data := range settings.GitCredentials {

--- a/buildkitd/entrypoint.sh
+++ b/buildkitd/entrypoint.sh
@@ -38,7 +38,7 @@ do
     fi
     i=$((i+1))
 done
-echo "$EARTH_GIT_CONFIG" | base64 -d > /root/.gitconfig
+echo "$EARTHLY_GIT_CONFIG" | base64 -d > /root/.gitconfig
 
 if [ -n "$GIT_URL_INSTEAD_OF" ]; then
     # GIT_URL_INSTEAD_OF can support multiple comma-separated values

--- a/buildkitd/entrypoint.sh
+++ b/buildkitd/entrypoint.sh
@@ -23,17 +23,6 @@ buildkit_cache_size_mb=$(( CACHE_SIZE_MB - 1000 ))
 sed 's^:BUILDKIT_ROOT_DIR:^'"$BUILDKIT_ROOT_DIR"'^g; s/:CACHE_SIZE_MB:/'"$buildkit_cache_size_mb"'/g' \
     /etc/buildkitd.toml.template > /etc/buildkitd.toml
 
-if [ -n "$GIT_URL_INSTEAD_OF" ]; then
-    # GIT_URL_INSTEAD_OF can support multiple comma-separated values
-    for instead_of in $(echo "${GIT_URL_INSTEAD_OF}" | sed "s/,/ /g")
-    do
-        base="${instead_of%%=*}"
-        insteadOf="${instead_of#*=}"
-        git config --global url."$base".insteadOf "$insteadOf"
-    done
-
-fi
-
 # setup git credentials and config
 i=0
 while true
@@ -50,6 +39,17 @@ do
     i=$((i+1))
 done
 echo "$EARTH_GIT_CONFIG" | base64 -d > /root/.gitconfig
+
+if [ -n "$GIT_URL_INSTEAD_OF" ]; then
+    # GIT_URL_INSTEAD_OF can support multiple comma-separated values
+    for instead_of in $(echo "${GIT_URL_INSTEAD_OF}" | sed "s/,/ /g")
+    do
+        base="${instead_of%%=*}"
+        insteadOf="${instead_of#*=}"
+        git config --global url."$base".insteadOf "$insteadOf"
+    done
+
+fi
 
 # Create an ext4 fs in a pre-allocated file. Ext4 will allow
 # us to use overlayfs snapshotter even when running on mac.

--- a/buildkitd/entrypoint.sh
+++ b/buildkitd/entrypoint.sh
@@ -49,7 +49,7 @@ do
     fi
     i=$((i+1))
 done
-echo "$GIT_CONFIG" | base64 -d > /root/.gitconfig
+echo "$EARTH_GIT_CONFIG" | base64 -d > /root/.gitconfig
 
 # Create an ext4 fs in a pre-allocated file. Ext4 will allow
 # us to use overlayfs snapshotter even when running on mac.


### PR DESCRIPTION
earth sets a variable named GIT_CONFIG which conflicts with what "git config" is looking for, renaming it to EARTH_GIT_CONFIG avoids the conflict.