### PR TITLE
Rename build.earth to Earthfile

### DIFF
--- a/buildcontext/detectearthfile.go
+++ b/buildcontext/detectearthfile.go
@@ -1,0 +1,29 @@
+package buildcontext
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+)
+
+// detectEarthfile detects whether to use Earthfile or build.earth.
+func detectEarthfile(targetName string, localDir string) (string, error) {
+	earthfilePath := filepath.Join(localDir, "Earthfile")
+	buildEarthPath := filepath.Join(localDir, "build.earth")
+	_, err := os.Stat(earthfilePath)
+	if os.IsNotExist(err) {
+		_, err := os.Stat(buildEarthPath)
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf(
+				"No Earthfile nor build.earth file found for target %s", targetName)
+		} else if err != nil {
+			return "", errors.Wrapf(err, "stat file %s", buildEarthPath)
+		}
+		return buildEarthPath, nil
+	} else if err != nil {
+		return "", errors.Wrapf(err, "stat file %s", earthfilePath)
+	}
+	return earthfilePath, nil
+}

--- a/buildcontext/excludes.go
+++ b/buildcontext/excludes.go
@@ -15,6 +15,7 @@ const EarthIgnoreFile = ".earthignore"
 var ImplicitExcludes = []string{
 	".tmp-earth-out/",
 	"build.earth",
+	"Earthfile",
 	EarthIgnoreFile,
 }
 

--- a/buildcontext/git.go
+++ b/buildcontext/git.go
@@ -116,7 +116,7 @@ func (gr *gitResolver) resolveGitProject(ctx context.Context, target domain.Targ
 		llb.Args([]string{
 			"find",
 			"-type", "f",
-			"-name", "build.earth", "-o", "-name", "Earthfile",
+			"(", "-name", "build.earth", "-o", "-name", "Earthfile", ")",
 			"-exec", "cp", "--parents", "{}", "/dest", ";",
 		}),
 		llb.Dir("/git-src"),
@@ -263,7 +263,10 @@ func (gr *gitResolver) resolveGitProject(ctx context.Context, target domain.Targ
 func (gr *gitResolver) close() error {
 	var lastErr error
 	for _, rgp := range gr.projectCache {
-		lastErr = os.RemoveAll(rgp.localGitDir)
+		err := os.RemoveAll(rgp.localGitDir)
+		if err != nil {
+			lastErr = err
+		}
 	}
 	if lastErr != nil {
 		return errors.Wrap(lastErr, "remove temp git dir")

--- a/buildcontext/git.go
+++ b/buildcontext/git.go
@@ -30,7 +30,7 @@ type gitResolver struct {
 }
 
 type resolvedGitProject struct {
-	// localGitDir is where the git dir exists locally (only build.earth files).
+	// localGitDir is where the git dir exists locally (only Earthfile and build.earth files).
 	localGitDir string
 	// gitProject is the git project identifier. For GitHub, this is <username>/<project>.
 	gitProject string
@@ -66,10 +66,14 @@ func (gr *gitResolver) resolveEarthProject(ctx context.Context, target domain.Ta
 	}
 
 	// TODO: Apply excludes / .earthignore.
+	localEarthfileDir := filepath.Join(rgp.localGitDir, filepath.FromSlash(subDir))
+	earthfilePath, err := detectEarthfile(target.String(), localEarthfileDir)
+	if err != nil {
+		return nil, err
+	}
 	return &Data{
-		EarthfilePath: filepath.Join(
-			rgp.localGitDir, filepath.FromSlash(subDir), "build.earth"),
-		BuildContext: buildContext,
+		EarthfilePath: earthfilePath,
+		BuildContext:  buildContext,
 		GitMetadata: &GitMetadata{
 			BaseDir:    "",
 			RelDir:     subDir,
@@ -102,7 +106,7 @@ func (gr *gitResolver) resolveGitProject(ctx context.Context, target domain.Targ
 	}
 	// Not cached.
 
-	// Copy all build.earth files.
+	// Copy all Earthfile and build.earth files.
 	gitOpts := []llb.GitOption{
 		llb.WithCustomNamef("[context] GIT CLONE %s", gitURL),
 		llb.KeepGitDir(),
@@ -112,13 +116,13 @@ func (gr *gitResolver) resolveGitProject(ctx context.Context, target domain.Targ
 		llb.Args([]string{
 			"find",
 			"-type", "f",
-			"-name", "build.earth",
+			"-name", "build.earth", "-o", "-name", "Earthfile",
 			"-exec", "cp", "--parents", "{}", "/dest", ";",
 		}),
 		llb.Dir("/git-src"),
 		llb.ReadonlyRootFS(),
 		llb.AddMount("/git-src", gitState, llb.Readonly),
-		llb.WithCustomNamef("COPY GIT CLONE %s build.earth", target.ProjectCanonical()),
+		llb.WithCustomNamef("COPY GIT CLONE %s Earthfile", target.ProjectCanonical()),
 	}
 	opImg := llb.Image(
 		defaultGitImage, llb.MarkImageInternal,
@@ -145,11 +149,11 @@ func (gr *gitResolver) resolveGitProject(ctx context.Context, target domain.Targ
 	// Build.
 	dt, err := gitMetaAndEarthfileState.Marshal(ctx, llb.LinuxAmd64)
 	if err != nil {
-		return nil, "", "", errors.Wrapf(err, "get build.earth from %s", target.ProjectCanonical())
+		return nil, "", "", errors.Wrapf(err, "get Earthfile from %s", target.ProjectCanonical())
 	}
 	earthfileTmpDir, err := ioutil.TempDir("/tmp", "earthly-git")
 	if err != nil {
-		return nil, "", "", errors.Wrap(err, "create temp dir for build.earth")
+		return nil, "", "", errors.Wrap(err, "create temp dir for Earthfile")
 	}
 	defer func() {
 		if finalErr != nil {

--- a/buildcontext/local.go
+++ b/buildcontext/local.go
@@ -49,8 +49,12 @@ func (lr *localResolver) resolveLocal(ctx context.Context, target domain.Target)
 		lr.gitMetaCache[target.LocalPath] = metadata
 	}
 
+	earthfilePath, err := detectEarthfile(target.String(), filepath.FromSlash(target.LocalPath))
+	if err != nil {
+		return nil, err
+	}
 	return &Data{
-		EarthfilePath: filepath.Join(filepath.FromSlash(target.LocalPath), "build.earth"),
+		EarthfilePath: earthfilePath,
 		BuildContext: llb.Local(
 			target.LocalPath,
 			llb.SharedKeyHint(target.LocalPath),

--- a/buildcontext/resolver.go
+++ b/buildcontext/resolver.go
@@ -11,7 +11,7 @@ import (
 
 // Data represents a resolved target's build context data.
 type Data struct {
-	// EarthfilePath is the local path where the build.earth file can be found.
+	// EarthfilePath is the local path where the Earthfile can be found.
 	EarthfilePath string
 	// BuildContext is the state to use for the build.
 	BuildContext llb.State

--- a/cmd/earth/main.go
+++ b/cmd/earth/main.go
@@ -244,8 +244,8 @@ func newEarthApp(ctx context.Context, console conslogging.ConsoleLogger) *earthA
 	app.cliApp.Commands = []*cli.Command{
 		{
 			Name:        "debug",
-			Usage:       "Print debug information about a build.earth file",
-			Description: "Print debug information about a build.earth file",
+			Usage:       "Print debug information about an Earthfile",
+			Description: "Print debug information about an Earthfile",
 			ArgsUsage:   "[<path>]",
 			Hidden:      true,
 			Action:      app.actionDebug,
@@ -359,7 +359,7 @@ func (app *earthApp) actionDebug(c *cli.Context) error {
 	if c.NArg() == 1 {
 		path = c.Args().First()
 	}
-	path = filepath.Join(path, "build.earth")
+	path = filepath.Join(path, "Earthfile")
 
 	err := earthfile2llb.ParseDebug(path)
 	if err != nil {

--- a/contrib/earthfile-syntax-highlighting/README.md
+++ b/contrib/earthfile-syntax-highlighting/README.md
@@ -1,6 +1,6 @@
 # earthfile-syntax-highlighting README
 
-Syntax highlighting for Earthly build earthfile's (`build.earth`).
+Syntax highlighting for Earthly build Earthfiles.
 
 ![Earthfile Syntax Highlighting](https://github.com/earthly/earthly/raw/master/images/vscode-plugin.png)
 
@@ -16,4 +16,5 @@ Add screenshot in the README.
 
 ### 0.0.3
 
-Add highlighting for `HEALTHCHECK`.
+* Add highlighting for `HEALTHCHECK`.
+* Switch from `build.earth` to `Earthfile`.

--- a/contrib/earthfile-syntax-highlighting/package.json
+++ b/contrib/earthfile-syntax-highlighting/package.json
@@ -1,7 +1,7 @@
 {
     "name": "earthfile-syntax-highlighting",
     "displayName": "Earthfile Syntax Highlighting",
-    "description": "Syntax highlighting for Earthly build earthfiles (build.earth).",
+    "description": "Syntax highlighting for Earthly build Earthfiles.",
     "version": "0.0.0",
     "publisher": "earthly",
     "icon": "logo.png",
@@ -19,7 +19,7 @@
         "languages": [{
             "id": "earthfile",
             "aliases": ["Earthfile", "earthfile"],
-            "extensions": [".earth"],
+            "extensions": [".earth", ".Earthfile", "Earthfile"],
             "configuration": "./language-configuration.json"
         }],
         "grammars": [{

--- a/examples/tests/build.earth
+++ b/examples/tests/build.earth
@@ -13,6 +13,7 @@ all:
 	BUILD +lc-test
 	BUILD +from-expose-test
 	BUILD +scratch-test
+	BUILD +build-earth-test
 	BUILD +star-test
 
 experimental:
@@ -22,41 +23,41 @@ experimental:
 	BUILD +docker-pull-test
 
 privileged-test:
-	COPY privileged.earth ./build.earth
+	COPY privileged.earth ./Earthfile
 	RUN --privileged \
 		--entrypoint \
 		-- --allow-privileged +test
 
 cache-test:
-	COPY cache1.earth ./build.earth
+	COPY cache1.earth ./Earthfile
 	RUN --privileged \
 		--entrypoint \
 		-- +test
-	COPY cache2.earth ./build.earth
+	COPY cache2.earth ./Earthfile
 	RUN --privileged \
 		--entrypoint \
 		-- +test
 
 git-clone-test:
-	COPY git-clone.earth ./build.earth
+	COPY git-clone.earth ./Earthfile
 	RUN --privileged \
 		--entrypoint \
 		-- +test
 
 builtin-args-test:
-	COPY builtin-args.earth ./build.earth
+	COPY builtin-args.earth ./Earthfile
 	RUN --privileged \
 		--entrypoint \
 		-- +builtin-args-test
 
 config-test:
-	COPY config.earth ./build.earth
+	COPY config.earth ./Earthfile
 	RUN --privileged \
 		--entrypoint \
 		-- +test
 
 excludes-test:
-	COPY excludes.earth ./build.earth
+	COPY excludes.earth ./Earthfile
 	RUN touch exclude-me.txt
 	RUN touch do-not-exclude-me.txt
 	RUN echo 'exclude-me.txt' > .earthignore
@@ -65,7 +66,7 @@ excludes-test:
 		-- +test
 
 secrets-test:
-	COPY secrets.earth ./build.earth
+	COPY secrets.earth ./Earthfile
 	ENV SECRET1=foo
 	ENV SECRET2=wrong
 	RUN --privileged \
@@ -73,28 +74,35 @@ secrets-test:
 		-- --secret SECRET1 --secret SECRET2=bar +test
 
 build-arg-test:
-	COPY build-arg.earth ./build.earth
+	COPY build-arg.earth ./Earthfile
 	RUN --privileged \
 		--entrypoint \
 		-- +test
 
 lc-test:
-	COPY lc.earth ./build.earth
+	COPY lc.earth ./Earthfile
 	RUN --privileged \
 		--entrypoint \
 		-- +test
 
 from-expose-test:
-	COPY from-expose.earth ./build.earth
+	COPY from-expose.earth ./Earthfile
 	RUN --privileged \
 		--entrypoint \
 		-- --no-output +test
 
 scratch-test:
-	COPY scratch-test.earth ./build.earth
+	COPY scratch-test.earth ./Earthfile
 	RUN --privileged \
 		--entrypoint \
 		-- --no-output +test
+
+build-earth-test:
+	# Test that build.earth is supported.
+	COPY config.earth ./build.earth
+	RUN --privileged \
+		--entrypoint \
+		-- +test
 
 # TODO: This does not pass, due to space on device limitation (dind caused).
 remote-test:
@@ -105,7 +113,7 @@ remote-test:
 
 # TODO: This does not pass.
 transitive-args-test-todo:
-	COPY transitive-args.earth ./build.earth
+	COPY transitive-args.earth ./Earthfile
 	RUN --privileged \
 		--entrypoint \
 		-- --build-arg SOMEARG=def +test
@@ -113,7 +121,7 @@ transitive-args-test-todo:
 	RUN test -f ./abc && test -f ./def && test ! -f ./default
 
 star-test:
-	COPY star.earth ./build.earth
+	COPY star.earth ./Earthfile
 	RUN touch a.txt b.txt c.nottxt
 	RUN --privileged \
 		--entrypoint \
@@ -121,7 +129,7 @@ star-test:
 
 # TODO: This does not pass.
 star-test-todo:
-	COPY star.earth ./build.earth
+	COPY star.earth ./Earthfile
 	RUN touch a.txt b.txt c.nottxt
 	RUN --privileged \
 		--entrypoint \
@@ -136,19 +144,19 @@ star-test-todo:
 		test "$cached_lines" == "6"
 
 docker-load-test:
-	COPY docker-load.earth ./build.earth
+	COPY docker-load.earth ./Earthfile
 	RUN --privileged \
 		--entrypoint \
 		-- --allow-privileged +test
 
 dind-test:
-	COPY dind.earth ./build.earth
+	COPY dind.earth ./Earthfile
 	RUN --privileged \
 		--entrypoint \
 		-- --allow-privileged +test
 
 docker-pull-test:
-	COPY docker-pull.earth ./build.earth
+	COPY docker-pull.earth ./Earthfile
 	RUN --privileged \
 		--entrypoint \
 		-- --allow-privileged +test


### PR DESCRIPTION
* For backwards compatibility, `build.earth` is used if an `Earthfile` is not present
* Docs update coming in separate PR