### PR TITLE
Use a sparse file for the loop device

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,9 @@ jobs:
       run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/latest/download/earth-linux-amd64 -O /usr/local/bin/earth && chmod +x /usr/local/bin/earth'"
     - name: Earth version
       run: earth --version
-    - name: Build
+    - name: Build latest earth
       run: earth +all
-    - name: Build, test, push
+    - name: Reset cache
+      run: ./build/linux/amd64/earth prune --reset
+    - name: Build, test, push using latest earth
       run: ./build/linux/amd64/earth --push -P +test

--- a/build.earth
+++ b/build.earth
@@ -90,6 +90,7 @@ earth-docker:
 	FROM ./buildkitd+buildkitd
 	RUN apk add --update --no-cache docker-cli
 	ENV ENABLE_LOOP_DEVICE=false
+	ENV FORCE_LOOP_DEVICE=false
 	COPY earth-buildkitd-wrapper.sh /usr/bin/earth-buildkitd-wrapper.sh
 	ENTRYPOINT ["/usr/bin/earth-buildkitd-wrapper.sh"]
 	ARG EARTHLY_TARGET_TAG

--- a/buildkitd/build.earth
+++ b/buildkitd/build.earth
@@ -20,6 +20,7 @@ buildkitd:
     ENV EARTHLY_RESET_TMP_DIR=false
     ENV EARTHLY_TMP_DIR=/tmp/earthly
     ENV ENABLE_LOOP_DEVICE=true
+    ENV FORCE_LOOP_DEVICE=true
     # 10GB
     ENV CACHE_SIZE_MB=10000
     ENTRYPOINT ["/usr/bin/entrypoint.sh", "buildkitd", "--config=/etc/buildkitd.toml"]

--- a/buildkitd/buildkitd.go
+++ b/buildkitd/buildkitd.go
@@ -182,6 +182,7 @@ func Start(ctx context.Context, image string, settings Settings, reset bool) err
 		"-d", "--rm",
 		"-v", cacheMount,
 		"-e", fmt.Sprintf("ENABLE_LOOP_DEVICE=%t", !settings.DisableLoopDevice),
+		"-e", fmt.Sprintf("FORCE_LOOP_DEVICE=%t", !settings.DisableLoopDevice),
 		"--label", fmt.Sprintf("dev.earthly.settingshash=%s", settingsHash),
 		"--name", ContainerName,
 		"--privileged",

--- a/buildkitd/entrypoint.sh
+++ b/buildkitd/entrypoint.sh
@@ -17,12 +17,6 @@ if [ "$EARTHLY_RESET_TMP_DIR" == "true" ]; then
     rm -rf "$EARTHLY_TMP_DIR"/* || true
 fi
 
-BUILDKIT_ROOT_DIR="$EARTHLY_TMP_DIR"/buildkit
-# Leave 1GB as additional buffer.
-buildkit_cache_size_mb=$(( CACHE_SIZE_MB - 1000 ))
-sed 's^:BUILDKIT_ROOT_DIR:^'"$BUILDKIT_ROOT_DIR"'^g; s/:CACHE_SIZE_MB:/'"$buildkit_cache_size_mb"'/g' \
-    /etc/buildkitd.toml.template > /etc/buildkitd.toml
-
 # setup git credentials and config
 i=0
 while true
@@ -51,11 +45,33 @@ if [ -n "$GIT_URL_INSTEAD_OF" ]; then
 
 fi
 
-# Create an ext4 fs in a pre-allocated file. Ext4 will allow
-# us to use overlayfs snapshotter even when running on mac.
-if [ "$ENABLE_LOOP_DEVICE" == "true" ]; then
-    echo "ENABLE_LOOP_DEVICE=true"
-    echo "CACHE_SIZE_MB=$CACHE_SIZE_MB"
+# Set up buildkit cache.
+BUILDKIT_ROOT_DIR="$EARTHLY_TMP_DIR"/buildkit
+mkdir -p "$BUILDKIT_ROOT_DIR"
+echo "BUILDKIT_ROOT_DIR=$BUILDKIT_ROOT_DIR"
+echo "CACHE_SIZE_MB=$CACHE_SIZE_MB"
+sed 's^:BUILDKIT_ROOT_DIR:^'"$BUILDKIT_ROOT_DIR"'^g; s/:CACHE_SIZE_MB:/'"$CACHE_SIZE_MB"'/g' \
+    /etc/buildkitd.toml.template > /etc/buildkitd.toml
+
+echo "ENABLE_LOOP_DEVICE=$ENABLE_LOOP_DEVICE"
+echo "FORCE_LOOP_DEVICE=$FORCE_LOOP_DEVICE"
+use_loop_device=false
+if [ "$FORCE_LOOP_DEVICE" == "true" ]; then
+    use_loop_device=true
+else
+    if [ "$ENABLE_LOOP_DEVICE" == "true" ]; then
+        tmp_dir_fs="$(df -T $BUILDKIT_ROOT_DIR | awk '{print $2}' | tail -1)"
+        echo "Buildkit dir $BUILDKIT_ROOT_DIR fs type is $tmp_dir_fs"
+        if [ "$tmp_dir_fs" != "ext4" ]; then
+            echo "Using a loop device, because fs is not ext4"
+            use_loop_device=true
+        fi
+    fi
+fi
+echo "use_loop_device=$use_loop_device"
+if [ "$use_loop_device" == "true" ]; then
+    # Create an ext4 fs in a pre-allocated file. Ext4 will allow
+    # us to use overlayfs snapshotter even when running on mac.
     image_file="$EARTHLY_TMP_DIR"/buildkit.img
     mount_point="$BUILDKIT_ROOT_DIR"
 
@@ -69,8 +85,12 @@ if [ "$ENABLE_LOOP_DEVICE" == "true" ]; then
     function init_mount {
         echo "Creating loop device"
         mkdir -p "$mount_point"
-        fallocate -l "$CACHE_SIZE_MB"M "$image_file" || \
-            dd if=/dev/zero of="$image_file" bs=1M count=0 seek="$CACHE_SIZE_MB"
+        # We use quadruple the cache size for the loop device. This uses
+        # a sparse file for the allocation, meaning that the space is not
+        # actually occupied until the cache grows.
+        sparse_loop_device_size_mb=$(( CACHE_SIZE_MB * 4 ))
+        echo "sparse_loop_device_size_mb=$sparse_loop_device_size_mb"
+        dd if=/dev/zero of="$image_file" bs=1M count=0 seek="$sparse_loop_device_size_mb"
         mkfs.ext4 "$image_file"
     }
 


### PR DESCRIPTION
Use a sparse file for the loop device.

Incidentally - we already had the `dd` command needed to create a sparse file, as a fallback. So this PR makes that `dd` command the only one to be used.

There is also an option to auto-detect whether the underlying fs is already ext4 to skip wrapping with a loop device. However, this option is not used by default (`FORCE_LOOP_DEVICE` is true).

Fixes #36 