### PR TITLE
docs: target reference

### DIFF
--- a/docs/earth-command/earth-command.md
+++ b/docs/earth-command/earth-command.md
@@ -74,7 +74,7 @@ specified by `<local-path>`, which must start with `./`, `../`, or `/`.
 
 ##### Artifact Reference
 
-`<target-ref>/<artifact-path>` will reference a build target's artifact.
+The `<artifact-ref>` can reference artifacts built by targets. `<target-ref>/<artifact-path>` will reference a build target's artifact.
 
 ##### Examples
 

--- a/docs/earth-command/earth-command.md
+++ b/docs/earth-command/earth-command.md
@@ -57,6 +57,31 @@ If the build phase does not succeed, not output is produced and no push instruct
 
 The output of the two phases are separated by a `=== SUCCESS ===` marker.
 
+#### Target and Artifact Reference
+
+The `<target-ref>` can reference both local and remote targets.
+
+##### Local Reference
+
+`+<target-name>` will reference a target in the local earthfile in the current directory.
+
+`<local-path>+<target-name>` will reference a local earthfile in a different directory as
+specified by `<local-path>`, which must start with `./`, `../`, or `/`.
+
+##### Remote Reference
+
+`<gitvendor>/<namespace>/<project>/path/in/project[:some-tag]+<target-name>` will access a remote git repository.
+
+##### Artifact Reference
+
+`<target-ref>/<artifact-path>` will reference a build target's artifact.
+
+##### Examples
+
+See the [Target, artifact, and image referencing guide](../guides/target-ref) for more details and examples.
+
+
+
 #### Options
 
 ##### `--build-arg <key>[=<value>]`


### PR DESCRIPTION
when a user runs `earth --help` it shows a links to https://docs.earthly.dev/earth-command however on that page it doesn't define how the target-reference can be formatted.