### PR TITLE
Allow user to change earthly cache path

### DIFF
--- a/buildkitd/buildkitd.go
+++ b/buildkitd/buildkitd.go
@@ -17,8 +17,6 @@ import (
 const (
 	// ContainerName is the name of the buildkitd container.
 	ContainerName = "earthly-buildkitd"
-	// TempDir is the directory used for buildkitd cache.
-	TempDir = "/tmp/earthly"
 )
 
 // Address is the address at which the daemon is available.
@@ -176,7 +174,7 @@ func Start(ctx context.Context, image string, settings Settings, reset bool) err
 		return errors.Wrap(err, "settings hash")
 	}
 	env := os.Environ()
-	cacheMount := fmt.Sprintf("%s:%s:delegated", TempDir, TempDir)
+	cacheMount := fmt.Sprintf("%s:/tmp/earthly:delegated", settings.TempDir)
 	args := []string{
 		"run",
 		"-d", "--rm",

--- a/buildkitd/settings.go
+++ b/buildkitd/settings.go
@@ -17,6 +17,7 @@ type Settings struct {
 	DisableLoopDevice bool     `json:"disableLoopDevice"`
 	GitConfig         string   `json:"gitConfig"`
 	GitCredentials    []string `json:"gitCredentials"`
+	TempDir           string   `json:"tmpDir"`
 }
 
 // Hash returns a secure hash of the settings.

--- a/cmd/earth/main.go
+++ b/cmd/earth/main.go
@@ -324,6 +324,7 @@ func (app *earthApp) parseConfigFile(context *cli.Context) error {
 		return errors.Wrapf(err, "failed to create git config from %s", app.configPath)
 	}
 
+	app.buildkitdSettings.TempDir = cfg.Global.CachePath
 	app.buildkitdSettings.GitConfig = gitConfig
 	app.buildkitdSettings.GitCredentials = gitCredentials
 	return nil

--- a/config/config.go
+++ b/config/config.go
@@ -11,7 +11,7 @@ import (
 var ErrInvalidTransport = fmt.Errorf("invalid transport")
 
 type GlobalConfig struct {
-	//TODO add support for global config as needed
+	CachePath string `yaml:"cache_path"`
 }
 
 type GitConfig struct {
@@ -36,7 +36,11 @@ func ensureTransport(s, transport string) (string, error) {
 }
 
 func ParseConfigFile(yamlData []byte) (*Config, error) {
-	var config Config
+	config := Config{
+		Global: GlobalConfig{
+			CachePath: "/var/cache/earthly",
+		},
+	}
 
 	err := yaml.Unmarshal(yamlData, &config)
 	if err != nil {


### PR DESCRIPTION
Rather than assume users want to cache data under tmp,
allow the user to override it.

The default value will be changed to /var/cache/earthly
so the cache persists between reboots.