### PR TITLE
Add warnf func to print warning messages in red

### DIFF
--- a/conslogging/color.go
+++ b/conslogging/color.go
@@ -5,18 +5,17 @@ import "github.com/fatih/color"
 var noColor = makeNoColor()
 var cachedColor = makeColor(color.FgHiGreen)
 var successColor = makeColor(color.FgHiGreen)
+var warnColor = makeColor(color.FgHiRed)
 
 var availablePrefixColors = []*color.Color{
 	makeColor(color.FgBlue),
 	makeColor(color.FgMagenta),
 	makeColor(color.FgCyan),
-	makeColor(color.FgRed),
 	makeColor(color.FgYellow),
 	makeColor(color.FgGreen),
 	makeColor(color.FgHiBlue),
 	makeColor(color.FgHiMagenta),
 	makeColor(color.FgHiCyan),
-	makeColor(color.FgHiRed),
 	makeColor(color.FgHiYellow),
 	makeColor(color.FgHiWhite),
 }

--- a/conslogging/conslogging.go
+++ b/conslogging/conslogging.go
@@ -76,6 +76,19 @@ func (cl ConsoleLogger) PrintSuccess() {
 	successColor.Fprintf(cl.w, "=========================== SUCCESS ===========================\n")
 }
 
+// Warnf prints a warning message in red
+func (cl ConsoleLogger) Warnf(format string, args ...interface{}) {
+	cl.mu.Lock()
+	defer cl.mu.Unlock()
+
+	c := noColor
+	if !cl.disableColors {
+		c = warnColor
+	}
+
+	c.Fprintf(cl.w, format, args...)
+}
+
 // Printf prints formatted text to the console.
 func (cl ConsoleLogger) Printf(format string, args ...interface{}) {
 	cl.mu.Lock()


### PR DESCRIPTION
Also removes red colors from prefixes to prevent confusion regular
output with errors/warnings.