### PR TITLE
Remove socket file rm hack

### DIFF
--- a/examples/dotnet/Earthfile
+++ b/examples/dotnet/Earthfile
@@ -13,11 +13,6 @@ build:
 
     # make sure you have /bin and /obj in .earthignore, as their content from context might cause problems
     RUN dotnet publish --no-restore src/HelloEarthly -o publish
-    
-    # 'dotnet publish' flag creates socket files in /tmp , which causes buildkit to fail
-    # this command removes these files
-    # for more see https://github.com/earthly/earthly/issues/115
-    RUN find /tmp -type s | xargs rm
 
     SAVE ARTIFACT publish AS LOCAL publish
 


### PR DESCRIPTION
An issue in buildkit caused a "tar/archive: sockets not supported" error
while building the dot net example; this issue has been fixed upstream
in buildkit ( see https://github.com/moby/buildkit/pull/1581 ), and we
can now remove this work-around.