### PR TITLE
Improve vertex names... and colors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,5 +10,5 @@ jobs:
       - run: docker login --username vladaionescu --password "$DOCKERHUB_TOKEN"
       - run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/latest/download/earth-linux-amd64 -O /usr/local/bin/earth && chmod +x /usr/local/bin/earth'"
       - run: earth --version
-      - run: earth +all
+      - run: earth +for-linux
       - run: ./build/linux/amd64/earth -P +test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Earth version
       run: earth --version
     - name: Build latest earth
-      run: earth +all
+      run: earth +for-linux
     - name: Reset cache
       run: ./build/linux/amd64/earth prune --reset
     - name: Build, test, push using latest earth

--- a/buildcontext/git.go
+++ b/buildcontext/git.go
@@ -108,7 +108,7 @@ func (gr *gitResolver) resolveGitProject(ctx context.Context, target domain.Targ
 
 	// Copy all Earthfile and build.earth files.
 	gitOpts := []llb.GitOption{
-		llb.WithCustomNamef("[context] GIT CLONE %s", gitURL),
+		llb.WithCustomNamef("[context %s] GIT CLONE %s", gitURL, gitURL),
 		llb.KeepGitDir(),
 	}
 	gitState := llbgit.Git(gitURL, ref, gitOpts...)
@@ -179,7 +179,8 @@ func (gr *gitResolver) resolveGitProject(ctx context.Context, target domain.Targ
 				}
 				for _, vertex := range ss.Vertexes {
 					if vertex.Error != "" {
-						gr.console.Printf("ERROR: %s\n", vertex.Error)
+						// TODO: Should also print full logs in case of error.
+						gr.console.Warnf("ERROR: %s\n", vertex.Error)
 					}
 				}
 			case <-ctx.Done():
@@ -243,7 +244,7 @@ func (gr *gitResolver) resolveGitProject(ctx context.Context, target domain.Targ
 		state: llbgit.Git(
 			gitURL,
 			gitHash,
-			llb.WithCustomNamef("[context] git context %s", target.StringCanonical()),
+			llb.WithCustomNamef("[context %s] git context %s", gitURL, target.StringCanonical()),
 		),
 	}
 	gr.projectCache[cacheKey] = resolved

--- a/buildcontext/local.go
+++ b/buildcontext/local.go
@@ -61,7 +61,7 @@ func (lr *localResolver) resolveLocal(ctx context.Context, target domain.Target)
 			llb.ExcludePatterns(excludes),
 			llb.SessionID(lr.sessionID),
 			llb.Platform(llbutil.TargetPlatform),
-			llb.WithCustomNamef("[context] local context %s", target.LocalPath),
+			llb.WithCustomNamef("[context %s] local context %s", target.LocalPath, target.LocalPath),
 		),
 		GitMetadata: metadata,
 	}, nil

--- a/earthfile2llb/states.go
+++ b/earthfile2llb/states.go
@@ -45,6 +45,7 @@ type SingleTargetStates struct {
 	RunPush                RunPush
 	LocalDirs              map[string]string
 	Ongoing                bool
+	Salt                   string
 }
 
 // LastSaveImage returns the last save image available (if any).


### PR DESCRIPTION
#### Improvements

* Use different colors if the build args are different
* Use different colors for different build contexts
* Improved, slightly cleaner printout of Earthfile commands
* An unrelated change: Add some handy build targets (eg `earth +for-linux`) for faster development

#### Example output

![Screenshot from 2020-07-27 18-38-35](https://user-images.githubusercontent.com/446771/88609316-a6003980-d038-11ea-8467-958652b4631b.png)

* `+earth` for mac and linux have different colors
* The different contexts have different colors so as to be able to tell them apart
* Other improvements (eg eliminating the `[ ]` around the `RUN` command arguments)