### PR TITLE
Add verbose command line flag

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -136,7 +136,7 @@ for-darwin:
 
 all:
 	BUILD +buildkitd
-	BUILD +debugger
+	BUILD +debugger-docker
 	BUILD +earth-all
 	BUILD +earth-docker
 

--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -21,6 +21,7 @@ buildkitd:
     ENV EARTHLY_TMP_DIR=/tmp/earthly
     ENV ENABLE_LOOP_DEVICE=true
     ENV FORCE_LOOP_DEVICE=true
+    ENV BUILDKIT_DEBUG=false
     # 10GB
     ENV CACHE_SIZE_MB=10000
     ENTRYPOINT ["/usr/bin/entrypoint.sh", "buildkitd", "--config=/etc/buildkitd.toml"]

--- a/buildkitd/buildkitd.go
+++ b/buildkitd/buildkitd.go
@@ -181,6 +181,7 @@ func Start(ctx context.Context, image string, settings Settings, reset bool) err
 		"-v", cacheMount,
 		"-e", fmt.Sprintf("ENABLE_LOOP_DEVICE=%t", !settings.DisableLoopDevice),
 		"-e", fmt.Sprintf("FORCE_LOOP_DEVICE=%t", !settings.DisableLoopDevice),
+		"-e", fmt.Sprintf("BUILDKIT_DEBUG=%t", settings.Debug),
 		"--label", fmt.Sprintf("dev.earthly.settingshash=%s", settingsHash),
 		"--name", ContainerName,
 		"--privileged",

--- a/buildkitd/buildkitd.toml.template
+++ b/buildkitd/buildkitd.toml.template
@@ -1,3 +1,4 @@
+debug = :BUILDKIT_DEBUG:
 root = ":BUILDKIT_ROOT_DIR:"
 insecure-entitlements = [ "security.insecure" ]
 

--- a/buildkitd/entrypoint.sh
+++ b/buildkitd/entrypoint.sh
@@ -7,6 +7,11 @@ if [ -z "$CACHE_SIZE_MB" ]; then
     exit 1
 fi
 
+if [ -z "$BUILDKIT_DEBUG" ]; then
+    echo "BUILDKIT_DEBUG not set"
+    exit 1
+fi
+
 if [ -z "$EARTHLY_TMP_DIR" ]; then
     echo "EARTHLY_TMP_DIR not set"
     exit 1
@@ -50,7 +55,7 @@ BUILDKIT_ROOT_DIR="$EARTHLY_TMP_DIR"/buildkit
 mkdir -p "$BUILDKIT_ROOT_DIR"
 echo "BUILDKIT_ROOT_DIR=$BUILDKIT_ROOT_DIR"
 echo "CACHE_SIZE_MB=$CACHE_SIZE_MB"
-sed 's^:BUILDKIT_ROOT_DIR:^'"$BUILDKIT_ROOT_DIR"'^g; s/:CACHE_SIZE_MB:/'"$CACHE_SIZE_MB"'/g' \
+sed 's^:BUILDKIT_ROOT_DIR:^'"$BUILDKIT_ROOT_DIR"'^g; s/:CACHE_SIZE_MB:/'"$CACHE_SIZE_MB"'/g; s/:BUILDKIT_DEBUG:/'"$BUILDKIT_DEBUG"'/g' \
     /etc/buildkitd.toml.template > /etc/buildkitd.toml
 
 echo "ENABLE_LOOP_DEVICE=$ENABLE_LOOP_DEVICE"

--- a/buildkitd/settings.go
+++ b/buildkitd/settings.go
@@ -18,6 +18,7 @@ type Settings struct {
 	GitConfig         string   `json:"gitConfig"`
 	GitCredentials    []string `json:"gitCredentials"`
 	TempDir           string   `json:"tmpDir"`
+	Debug             bool     `json:"debug"`
 }
 
 // Hash returns a secure hash of the settings.

--- a/cmd/earth/main.go
+++ b/cmd/earth/main.go
@@ -273,6 +273,7 @@ func newEarthApp(ctx context.Context, console conslogging.ConsoleLogger) *earthA
 			Usage:       "Enable interactive debugging",
 			Destination: &app.interactiveDebugging,
 			Hidden:      true, // Experimental.
+		},
 		&cli.BoolFlag{
 			Name:        "verbose",
 			Aliases:     []string{"V"},

--- a/cmd/earth/main.go
+++ b/cmd/earth/main.go
@@ -273,6 +273,12 @@ func newEarthApp(ctx context.Context, console conslogging.ConsoleLogger) *earthA
 			Usage:       "Enable interactive debugging",
 			Destination: &app.interactiveDebugging,
 			Hidden:      true, // Experimental.
+		&cli.BoolFlag{
+			Name:        "verbose",
+			Aliases:     []string{"V"},
+			EnvVars:     []string{"EARTHLY_VERBOSE"},
+			Usage:       "enable verbose logging of the earthly-buildkitd container",
+			Destination: &app.buildkitdSettings.Debug,
 		},
 	}
 


### PR DESCRIPTION
verbose flag enables debugging mode of the buildkitd container (which
enables logs to be viewed via docker logs earthly-buildkitd)