### PR TITLE
Add experimental interactive debugging mode

### DIFF
--- a/buildkitd/buildkitd.go
+++ b/buildkitd/buildkitd.go
@@ -177,7 +177,7 @@ func Start(ctx context.Context, image string, settings Settings, reset bool) err
 	cacheMount := fmt.Sprintf("%s:/tmp/earthly:delegated", settings.TempDir)
 	args := []string{
 		"run",
-		"-d",
+		"-d", "--rm",
 		"-v", cacheMount,
 		"-e", fmt.Sprintf("ENABLE_LOOP_DEVICE=%t", !settings.DisableLoopDevice),
 		"-e", fmt.Sprintf("FORCE_LOOP_DEVICE=%t", !settings.DisableLoopDevice),
@@ -185,12 +185,6 @@ func Start(ctx context.Context, image string, settings Settings, reset bool) err
 		"--name", ContainerName,
 		"--privileged",
 		"--network=host",
-	}
-	// remove the container on exit (unless KEEP_BUILDKIT_CONTAINER=1 which is useful for debugging issues)
-	if os.Getenv("EARTHLY_KEEP_BUILDKIT_CONTAINER") == "1" {
-		fmt.Printf("RUNNING EARTHLY_KEEP_BUILDKIT_CONTAINER without --rm\n")
-	} else {
-		args = append(args, "--rm")
 	}
 	// Apply some buildkitd-related settings.
 	if settings.CacheSizeMb > 0 {

--- a/cmd/debugger/main.go
+++ b/cmd/debugger/main.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+)
+
+var (
+	// Version is the version of the debugger
+	Version string
+)
+
+func interactiveMode(remoteConsoleAddr string) {
+	c, err := net.Dial("tcp", remoteConsoleAddr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to connect to earth remote console: %v\n", err)
+		return
+	}
+
+	cmd := exec.Command("sh", "-i")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to attach to shell stdin: %v\n", err)
+		return
+	}
+
+	err = cmd.Start()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to exec debugger shell: %v\n", err)
+		return
+	}
+
+	b := make([]byte, 256)
+	for {
+		n, err := c.Read(b)
+		if err != nil {
+			if err != io.EOF {
+				fmt.Printf("err: %v\n", err)
+			}
+			break
+		}
+		stdin.Write(b[:n])
+	}
+	err = cmd.Wait()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to wait for debugger shell: %v\n", err)
+		return
+	}
+}
+
+func main() {
+	remoteConsoleAddr := os.Getenv("EARTHLY_REMOTE_CONSOLE_ADDR")
+	if remoteConsoleAddr == "" {
+		remoteConsoleAddr = "127.0.0.1:8543"
+	}
+
+	args := os.Args[1:]
+
+	cmd := exec.Command(args[0], args[1:]...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "command failed: %v; entering debug mode (debugger version %v)\n", err, Version)
+		interactiveMode(remoteConsoleAddr)
+		os.Exit(1)
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -26,6 +26,7 @@ type GlobalConfig struct {
 	DisableLoopDevice   bool   `yaml:"no_loop_device"`
 	BuildkitCacheSizeMb int    `yaml:"cache_size_mb"`
 	BuildkitImage       string `yaml:"buildkit_image"`
+	DebuggerImage       string `yaml:"debugger_image"`
 }
 
 // GitConfig contains git-specific config values

--- a/debugger/server/debugger_server.go
+++ b/debugger/server/debugger_server.go
@@ -1,0 +1,62 @@
+package server
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"os"
+
+	"github.com/earthly/earthly/conslogging"
+)
+
+// DebugServer is provides a console which reverse shells connect to
+type DebugServer struct {
+	addr    string
+	console conslogging.ConsoleLogger
+}
+
+// NewDebugServer creates a new debug server
+func NewDebugServer(console conslogging.ConsoleLogger) *DebugServer {
+	return &DebugServer{
+		addr:    "127.0.0.1:8543", // TODO make this configurable (and support port 0 which auto assigns a free port)
+		console: console,
+	}
+}
+
+func (ds *DebugServer) handleRequest(conn net.Conn) {
+	defer conn.Close()
+	b := make([]byte, 256)
+	for {
+		n, err := os.Stdin.Read(b)
+		if err != nil {
+			if err != io.EOF {
+				fmt.Printf("err: %v\n", err)
+			}
+			break
+		}
+		conn.Write(b[:n])
+	}
+}
+
+// Start starts the debug server listener
+func (ds *DebugServer) Start() (string, error) {
+	l, err := net.Listen("tcp", ds.addr)
+	if err != nil {
+		return "", err
+	}
+	go func() {
+		ds.console.Printf("interactive debugger listening\n")
+		defer l.Close()
+		for {
+			// Listen for an incoming connection.
+			conn, err := l.Accept()
+			if err != nil {
+				ds.console.Warnf("Error accepting: %v", err.Error())
+				os.Exit(1)
+			}
+			// Handle connections in a new goroutine.
+			ds.handleRequest(conn)
+		}
+	}()
+	return l.Addr().String(), nil
+}

--- a/earthfile2llb/earthfile2llb.go
+++ b/earthfile2llb/earthfile2llb.go
@@ -17,7 +17,7 @@ import (
 )
 
 // Earthfile2LLB parses a earthfile and executes the statements for a given target.
-func Earthfile2LLB(ctx context.Context, target domain.Target, resolver *buildcontext.Resolver, dockerBuilderFun DockerBuilderFun, cleanCollection *cleanup.Collection, visitedStates map[string][]*SingleTargetStates, varCollection *variables.Collection) (mts *MultiTargetStates, err error) {
+func Earthfile2LLB(ctx context.Context, target domain.Target, resolver *buildcontext.Resolver, dockerBuilderFun DockerBuilderFun, cleanCollection *cleanup.Collection, visitedStates map[string][]*SingleTargetStates, varCollection *variables.Collection, interactiveDebugging bool, debuggerImage, remoteConsoleAddr string) (mts *MultiTargetStates, err error) {
 	if visitedStates == nil {
 		visitedStates = make(map[string][]*SingleTargetStates)
 	}
@@ -70,7 +70,7 @@ func Earthfile2LLB(ctx context.Context, target domain.Target, resolver *buildcon
 	}
 	converter, err := NewConverter(
 		targetCtx, bc.Target, resolver, dockerBuilderFun, cleanCollection, bc,
-		visitedStates, varCollection)
+		visitedStates, varCollection, interactiveDebugging, debuggerImage, remoteConsoleAddr)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
In the event that a RUN command fails, when earth is run with the
interactive flag (-I); rather than clean up the failed build process, it
will present the user with an interactive shell.

This allows a user to manually inspect the system at the point of
failure, and additionally lets arbitrary commands be run interactively
without the need to modify the Earthfile.

This is currently limited by:
 - no up/down arrow support for history
 - output text race condition where two lines sometimes appear on the same line
 - hardcoded ip/port for the reverse debugger shell