### PR TITLE
let the OS provide an open port for the debugger

### DIFF
--- a/cmd/debugger/main.go
+++ b/cmd/debugger/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -54,21 +55,36 @@ func interactiveMode(remoteConsoleAddr string) {
 	}
 }
 
-func main() {
-	remoteConsoleAddr := os.Getenv("EARTHLY_REMOTE_CONSOLE_ADDR")
-	if remoteConsoleAddr == "" {
-		remoteConsoleAddr = "127.0.0.1:8543"
+func getRemoteDebuggerAddr() string {
+	remoteConsoleAddr, err := ioutil.ReadFile("/run/secrets/earthly_remote_console_addr")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to read earthly_remote_console_addr: %v", err)
 	}
+	return string(remoteConsoleAddr)
+}
 
+func main() {
 	args := os.Args[1:]
+
+	remoteConsoleAddr := getRemoteDebuggerAddr()
 
 	cmd := exec.Command(args[0], args[1:]...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	err := cmd.Run()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "command failed: %v; entering debug mode (debugger version %v)\n", err, Version)
-		interactiveMode(remoteConsoleAddr)
-		os.Exit(1)
+		exitCode := 1
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			exitCode = exitErr.ExitCode()
+			fmt.Fprintf(os.Stderr, "Command %v failed with exit code %d", args, exitCode)
+		} else {
+			fmt.Fprintf(os.Stderr, "Command %v failed with unexpected execution error %v", args, err)
+		}
+
+		if remoteConsoleAddr != "" {
+			interactiveMode(remoteConsoleAddr)
+		}
+
+		os.Exit(exitCode)
 	}
 }

--- a/cmd/earth/main.go
+++ b/cmd/earth/main.go
@@ -600,9 +600,11 @@ func (app *earthApp) actionBuild(c *cli.Context) error {
 	defer bkClient.Close()
 	resolver := buildcontext.NewResolver(bkClient, app.console, app.sessionID)
 	defer resolver.Close()
-	secrets := processSecrets(app.secrets.Value())
+	secrets := app.secrets.Value()
+	//interactive debugger settings are passed as secrets to avoid having it affect the cache hash
+	secrets = append(secrets, fmt.Sprintf("earthly_remote_console_addr=%s", remoteConsoleAddr))
 	attachables := []session.Attachable{
-		secrets,
+		processSecrets(secrets),
 		authprovider.NewDockerAuthProvider(os.Stderr),
 	}
 	var enttlmnts []entitlements.Entitlement

--- a/debugger/server/debugger_server.go
+++ b/debugger/server/debugger_server.go
@@ -18,7 +18,7 @@ type DebugServer struct {
 // NewDebugServer creates a new debug server
 func NewDebugServer(console conslogging.ConsoleLogger) *DebugServer {
 	return &DebugServer{
-		addr:    "127.0.0.1:8543", // TODO make this configurable (and support port 0 which auto assigns a free port)
+		addr:    "127.0.0.1:0",
 		console: console,
 	}
 }

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -672,10 +672,11 @@ func (c *Converter) internalRun(ctx context.Context, args []string, secretKeyVal
 		}
 	}
 
-	if c.interactiveDebugging {
-		finalOpts = append(finalOpts, llb.AddMount("/usr/bin/earth_debugger", llb.Image(c.debuggerImage), llb.SourcePath("/earth_debugger"), llb.Readonly))
-		extraEnvVars = append(extraEnvVars, fmt.Sprintf("EARTHLY_REMOTE_CONSOLE_ADDR=%s", c.remoteConsoleAddr))
+	finalOpts = append(finalOpts, llb.AddMount("/usr/bin/earth_debugger", llb.Image(c.debuggerImage), llb.SourcePath("/earth_debugger"), llb.Readonly))
+	secretOpts := []llb.SecretOption{
+		llb.SecretID("earthly_remote_console_addr"),
 	}
+	finalOpts = append(finalOpts, llb.AddSecret("/run/secrets/earthly_remote_console_addr", secretOpts...))
 
 	var finalArgs []string
 	if withDocker {


### PR DESCRIPTION
Rather than use a hardcoded port, let the OS provide a free port. The
address to connect to is now passed as a secret to prevent the port from
affecting the cache.