### PR TITLE
Remove earthly-buildkitd container if exited

### DIFF
--- a/buildkitd/buildkitd.go
+++ b/buildkitd/buildkitd.go
@@ -167,17 +167,41 @@ func MaybeRestart(ctx context.Context, console conslogging.ConsoleLogger, image 
 	return nil
 }
 
+// RemoveExited removes any stopped or exited buildkitd containers
+func RemoveExited(ctx context.Context) error {
+	started, err := IsStarted(ctx)
+	if err != nil {
+		return err
+	}
+	if started {
+		return nil
+	}
+	cmd := exec.CommandContext(ctx, "docker", "ps", "-a", "-q", "-f", fmt.Sprintf("name=%s", ContainerName))
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return errors.Wrap(err, "get combined output")
+	}
+	if len(output) == 0 {
+		return nil
+	}
+	return exec.CommandContext(ctx, "docker", "rm", ContainerName).Run()
+}
+
 // Start starts the buildkitd daemon.
 func Start(ctx context.Context, image string, settings Settings, reset bool) error {
 	settingsHash, err := settings.Hash()
 	if err != nil {
 		return errors.Wrap(err, "settings hash")
 	}
+	err = RemoveExited(ctx)
+	if err != nil {
+		return err
+	}
 	env := os.Environ()
 	cacheMount := fmt.Sprintf("%s:/tmp/earthly:delegated", settings.TempDir)
 	args := []string{
 		"run",
-		"-d", "--rm",
+		"-d",
 		"-v", cacheMount,
 		"-e", fmt.Sprintf("ENABLE_LOOP_DEVICE=%t", !settings.DisableLoopDevice),
 		"-e", fmt.Sprintf("FORCE_LOOP_DEVICE=%t", !settings.DisableLoopDevice),

--- a/buildkitd/buildkitd.go
+++ b/buildkitd/buildkitd.go
@@ -169,13 +169,6 @@ func MaybeRestart(ctx context.Context, console conslogging.ConsoleLogger, image 
 
 // RemoveExited removes any stopped or exited buildkitd containers
 func RemoveExited(ctx context.Context) error {
-	started, err := IsStarted(ctx)
-	if err != nil {
-		return err
-	}
-	if started {
-		return nil
-	}
 	cmd := exec.CommandContext(ctx, "docker", "ps", "-a", "-q", "-f", fmt.Sprintf("name=%s", ContainerName))
 	output, err := cmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
If the earthly-buildkitd container is in a stopped or exited state,
remove it before attempting to start a new instance of it.

This fix is to allow for the removal of the --rm flag from the
docker run command, so that logs persist in the cause of a failure.

This fixes https://github.com/earthly/earthly/issues/152