### PR TITLE
Pin debugger image to a specific version

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -94,7 +94,7 @@ earth:
 	ARG EARTHLY_TARGET_TAG
 	ARG VERSION=$EARTHLY_TARGET_TAG
 	ARG DEFAULT_BUILDKITD_IMAGE=earthly/buildkitd:$VERSION
-	ARG DEFAULT_DEBUGGER_IMAGE=earthly/debugger:$VERSION
+	ARG DEFAULT_DEBUGGER_IMAGE=earthly/debugger-docker-image:asdf@sha256:b3d0c0db9b08c3e63b105f6efb9bd028632955d337128188406c0256d95f39b2
 	ARG GOCACHE=/go-cache
 	RUN --mount=type=cache,target=$GOCACHE \
 		go build \

--- a/Earthfile
+++ b/Earthfile
@@ -94,7 +94,7 @@ earth:
 	ARG EARTHLY_TARGET_TAG
 	ARG VERSION=$EARTHLY_TARGET_TAG
 	ARG DEFAULT_BUILDKITD_IMAGE=earthly/buildkitd:$VERSION
-	ARG DEFAULT_DEBUGGER_IMAGE=earthly/debugger-docker-image:asdf@sha256:b3d0c0db9b08c3e63b105f6efb9bd028632955d337128188406c0256d95f39b2
+	ARG DEFAULT_DEBUGGER_IMAGE=earthly/debugger:docker-image@sha256:b3d0c0db9b08c3e63b105f6efb9bd028632955d337128188406c0256d95f39b2
 	ARG GOCACHE=/go-cache
 	RUN --mount=type=cache,target=$GOCACHE \
 		go build \


### PR DESCRIPTION
Our build has a circular dependency where the debugger image is required
before our CI can pass; however CI is responsible for creating the image
after the tests pass. We will pin the version to get around this problem
and come up with a better solution down the road.