### PR TITLE
Docker login not necessary in circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,6 @@ jobs:
       - GIT_URL_INSTEAD_OF: "https://github.com/=git@github.com:"
     steps:
       - checkout
-      - run: docker login --username vladaionescu --password "$DOCKERHUB_TOKEN"
       - run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/latest/download/earth-linux-amd64 -O /usr/local/bin/earth && chmod +x /usr/local/bin/earth'"
       - run: earth --version
       - run: earth +for-linux

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,4 +10,4 @@ jobs:
       - run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/latest/download/earth-linux-amd64 -O /usr/local/bin/earth && chmod +x /usr/local/bin/earth'"
       - run: earth --version
       - run: earth +for-linux
-      - run: ./build/linux/amd64/earth -P +test
+      - run: ./build/linux/amd64/earth -P --no-output +test


### PR DESCRIPTION
This will allow circle to run safely for external contributors.