### PR TITLE
Bind interactive debugger to socket

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -72,7 +72,7 @@ debugger:
     ARG EARTHLY_GIT_HASH
     RUN --mount=type=cache,target=$GOCACHE \
         go build \
-            -ldflags "-d -X main.Version=$VERSION $GO_EXTRA_LDFLAGS" -X main.GitSha=$EARTHLY_GIT_HASH $GO_EXTRA_LDFLAGS" \
+            -ldflags "-d -X main.Version=$VERSION $GO_EXTRA_LDFLAGS -X main.GitSha=$EARTHLY_GIT_HASH $GO_EXTRA_LDFLAGS" \
             -tags netgo -installsuffix netgo \
             -o build/earth_debugger \
             cmd/debugger/*.go
@@ -97,7 +97,7 @@ earth:
     ARG VERSION=$EARTHLY_TARGET_TAG_DOCKER
     ARG EARTHLY_GIT_HASH
     ARG DEFAULT_BUILDKITD_IMAGE=earthly/buildkitd:$VERSION
-    ARG DEFAULT_DEBUGGER_IMAGE=earthly/debugger:socket-debugger@sha256:866f2dc0fa3f8f07f4bdf5d31ac39b77f88d3104f77ebf52acaa3a77a63ec879
+    ARG DEFAULT_DEBUGGER_IMAGE=earthly/debugger:socket-debugger@sha256:5aede226d821ec854ea62e2136876a75dff124479337ce99d8421be8bb90bb6c
     ARG GOCACHE=/go-cache
     RUN --mount=type=cache,target=$GOCACHE \
         go build \

--- a/Earthfile
+++ b/Earthfile
@@ -69,9 +69,10 @@ debugger:
     ARG GOCACHE=/go-cache
     ARG EARTHLY_TARGET_TAG
     ARG VERSION=$EARTHLY_TARGET_TAG
+    ARG EARTHLY_GIT_HASH
     RUN --mount=type=cache,target=$GOCACHE \
         go build \
-            -ldflags "-d -X main.Version=$VERSION $GO_EXTRA_LDFLAGS" \
+            -ldflags "-d -X main.Version=$VERSION $GO_EXTRA_LDFLAGS" -X main.GitSha=$EARTHLY_GIT_HASH $GO_EXTRA_LDFLAGS" \
             -tags netgo -installsuffix netgo \
             -o build/earth_debugger \
             cmd/debugger/*.go
@@ -96,7 +97,7 @@ earth:
     ARG VERSION=$EARTHLY_TARGET_TAG_DOCKER
     ARG EARTHLY_GIT_HASH
     ARG DEFAULT_BUILDKITD_IMAGE=earthly/buildkitd:$VERSION
-    ARG DEFAULT_DEBUGGER_IMAGE=earthly/debugger:interactive-debugger-pty@sha256:a0314de585cc3ba5b44a032f54bd31c61a8fdc13b05267666168069e8932eb25
+    ARG DEFAULT_DEBUGGER_IMAGE=earthly/debugger:socket-debugger@sha256:866f2dc0fa3f8f07f4bdf5d31ac39b77f88d3104f77ebf52acaa3a77a63ec879
     ARG GOCACHE=/go-cache
     RUN --mount=type=cache,target=$GOCACHE \
         go build \

--- a/buildkitd/buildkitd.go
+++ b/buildkitd/buildkitd.go
@@ -192,7 +192,7 @@ func Start(ctx context.Context, image string, settings Settings, reset bool) err
 	}
 	env := os.Environ()
 	cacheMount := fmt.Sprintf("%s:/tmp/earthly:delegated", settings.TempDir)
-	runMount := fmt.Sprintf("%s:/run/earthly:delegated", settings.RunDir)
+	runMount := fmt.Sprintf("%s:/run/earthly:consistent", settings.RunDir)
 	args := []string{
 		"run",
 		"-d",

--- a/buildkitd/buildkitd.go
+++ b/buildkitd/buildkitd.go
@@ -192,10 +192,12 @@ func Start(ctx context.Context, image string, settings Settings, reset bool) err
 	}
 	env := os.Environ()
 	cacheMount := fmt.Sprintf("%s:/tmp/earthly:delegated", settings.TempDir)
+	runMount := fmt.Sprintf("%s:/run/earthly:delegated", settings.RunDir)
 	args := []string{
 		"run",
 		"-d",
 		"-v", cacheMount,
+		"-v", runMount,
 		"-e", fmt.Sprintf("ENABLE_LOOP_DEVICE=%t", !settings.DisableLoopDevice),
 		"-e", fmt.Sprintf("FORCE_LOOP_DEVICE=%t", !settings.DisableLoopDevice),
 		"-e", fmt.Sprintf("BUILDKIT_DEBUG=%t", settings.Debug),

--- a/buildkitd/settings.go
+++ b/buildkitd/settings.go
@@ -18,6 +18,7 @@ type Settings struct {
 	GitConfig         string   `json:"gitConfig"`
 	GitCredentials    []string `json:"gitCredentials"`
 	TempDir           string   `json:"tmpDir"`
+	RunDir            string   `json:"runDir"`
 	Debug             bool     `json:"debug"`
 }
 

--- a/cmd/debugger/main.go
+++ b/cmd/debugger/main.go
@@ -160,7 +160,7 @@ func main() {
 
 	ctx := context.Background()
 
-	debuggerSettings, err := getSettings("/run/secrets/earthly_debugger_settings")
+	debuggerSettings, err := getSettings(fmt.Sprintf("/run/secrets/%s", common.DebuggerSettingsSecretsKey))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to read settings: %v\n", debuggerSettings)
 		os.Exit(1)
@@ -184,16 +184,18 @@ func main() {
 			fmt.Fprintf(os.Stderr, "Command %v failed with unexpected execution error %v\n", args, err)
 		}
 
-		// Sometimes the interactive shell doesn't correctly get a newline
-		// Take a brief pause and issue a new line as a work around.
-		time.Sleep(time.Millisecond * 5)
-		fmt.Printf("\n")
-		interactiveMode(ctx, remoteConsoleAddr)
+		if debuggerSettings.Enabled {
+			// Sometimes the interactive shell doesn't correctly get a newline
+			// Take a brief pause and issue a new line as a work around.
+			time.Sleep(time.Millisecond * 5)
+			fmt.Printf("\n")
+			interactiveMode(ctx, remoteConsoleAddr)
 
-		// ensure that this always exits with an error status; otherwise it will be cached by earthly
-		if exitCode == 0 {
-			exitCode = 1
+			// ensure that this always exits with an error status; otherwise it will be cached by earthly
+			if exitCode == 0 {
+				exitCode = 1
+			}
+			os.Exit(exitCode)
 		}
-		os.Exit(exitCode)
 	}
 }

--- a/cmd/earth/main.go
+++ b/cmd/earth/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -20,6 +21,7 @@ import (
 	"github.com/earthly/earthly/cleanup"
 	"github.com/earthly/earthly/config"
 	"github.com/earthly/earthly/conslogging"
+	debuggercommon "github.com/earthly/earthly/debugger/common"
 	"github.com/earthly/earthly/debugger/server"
 	"github.com/earthly/earthly/domain"
 	"github.com/earthly/earthly/earthfile2llb"
@@ -382,7 +384,15 @@ func (app *earthApp) parseConfigFile(context *cli.Context) error {
 		}
 	}
 
+	if _, err := os.Stat(cfg.Global.RunPath); os.IsNotExist(err) {
+		err := os.Mkdir(cfg.Global.RunPath, 0755)
+		if err != nil {
+			return errors.Wrapf(err, "failed to create run directory %s", cfg.Global.RunPath)
+		}
+	}
+
 	app.buildkitdSettings.TempDir = cfg.Global.CachePath
+	app.buildkitdSettings.RunDir = cfg.Global.RunPath
 	app.buildkitdSettings.GitConfig = gitConfig
 	app.buildkitdSettings.GitCredentials = gitCredentials
 	return nil
@@ -539,11 +549,10 @@ func (app *earthApp) actionPrune(c *cli.Context) error {
 }
 
 func (app *earthApp) actionBuild(c *cli.Context) error {
-	var remoteConsoleAddr string
-	var err error
 	if app.interactiveDebugging {
-		debugServer := server.NewDebugServer(c.Context, app.console)
-		remoteConsoleAddr, err = debugServer.Start()
+		sockPath := fmt.Sprintf("%s/debugger.sock", app.buildkitdSettings.RunDir)
+		debugServer := server.NewDebugServer(c.Context, app.console, sockPath)
+		err := debugServer.Start()
 		if err != nil {
 			app.console.Warnf("failed to open remote console listener: %v; interactive debugging disabled\n", err)
 			app.interactiveDebugging = false
@@ -622,9 +631,22 @@ func (app *earthApp) actionBuild(c *cli.Context) error {
 	defer resolver.Close()
 	secrets := app.secrets.Value()
 	//interactive debugger settings are passed as secrets to avoid having it affect the cache hash
-	secrets = append(secrets, fmt.Sprintf("earthly_remote_console_addr=%s", remoteConsoleAddr))
+
+	secretsMap := processSecrets(secrets)
+
+	debuggerSettings := debuggercommon.DebuggerSettings{
+		DebugLevelLogging: app.buildkitdSettings.Debug,
+		Enabled:           app.interactiveDebugging,
+	}
+
+	debuggerSettingsData, err := json.Marshal(&debuggerSettings)
+	if err != nil {
+		return errors.Wrap(err, "debugger settings json marshal")
+	}
+	secretsMap["earthly_debugger_settings"] = debuggerSettingsData
+
 	attachables := []session.Attachable{
-		processSecrets(secrets),
+		secretsprovider.FromMap(secretsMap),
 		authprovider.NewDockerAuthProvider(os.Stderr),
 	}
 	var enttlmnts []entitlements.Entitlement
@@ -645,7 +667,7 @@ func (app *earthApp) actionBuild(c *cli.Context) error {
 	defer cleanCollection.Close()
 	mts, err := earthfile2llb.Earthfile2LLB(
 		c.Context, target, resolver, b.BuildOnlyLastImageAsTar, cleanCollection,
-		nil, varCollection, app.interactiveDebugging, app.debuggerImage, remoteConsoleAddr)
+		nil, varCollection, app.interactiveDebugging, app.debuggerImage, "TODO")
 	if err != nil {
 		return err
 	}
@@ -687,7 +709,7 @@ func (app *earthApp) newBuildkitdClient(ctx context.Context, opts ...client.Clie
 	return bkClient, nil
 }
 
-func processSecrets(secrets []string) session.Attachable {
+func processSecrets(secrets []string) map[string][]byte {
 	finalSecrets := make(map[string][]byte)
 	for _, secret := range secrets {
 		parts := strings.SplitN(secret, "=", 2)
@@ -700,7 +722,7 @@ func processSecrets(secrets []string) session.Attachable {
 			finalSecrets[secret] = []byte(value)
 		}
 	}
-	return secretsprovider.FromMap(finalSecrets)
+	return finalSecrets
 }
 
 func defaultSSHAuthSock() string {

--- a/config/config.go
+++ b/config/config.go
@@ -23,6 +23,7 @@ var (
 // GlobalConfig contains global config values
 type GlobalConfig struct {
 	CachePath           string `yaml:"cache_path"`
+	RunPath             string `yaml:"run_path"`
 	DisableLoopDevice   bool   `yaml:"no_loop_device"`
 	BuildkitCacheSizeMb int    `yaml:"cache_size_mb"`
 	BuildkitImage       string `yaml:"buildkit_image"`
@@ -61,6 +62,7 @@ func ParseConfigFile(yamlData []byte) (*Config, error) {
 	config := Config{
 		Global: GlobalConfig{
 			CachePath:           defaultCachePath(),
+			RunPath:             defaultRunPath(),
 			DisableLoopDevice:   false,
 			BuildkitCacheSizeMb: 10000,
 		},
@@ -156,4 +158,8 @@ func defaultCachePath() string {
 		return filepath.Join(os.Getenv("HOME"), "Library/Caches/earthly")
 	}
 	return "/var/cache/earthly"
+}
+
+func defaultRunPath() string {
+	return filepath.Join(os.Getenv("HOME"), ".earthly/run")
 }

--- a/debugger/common/settings.go
+++ b/debugger/common/settings.go
@@ -1,0 +1,11 @@
+package common
+
+// DebuggerSettingsSecretsKey stores the secrets key name
+const DebuggerSettingsSecretsKey = "earthly_debugger_settings"
+
+// DebuggerSettings is used to pass settings to the debugger
+type DebuggerSettings struct {
+	DebugLevelLogging bool   `json:"debugLevel"`
+	Enabled           bool   `json:"enabled"`
+	SockPath          string `json:"sockPath"`
+}

--- a/debugger/server/debugger_server.go
+++ b/debugger/server/debugger_server.go
@@ -114,7 +114,6 @@ func (ds *DebugServer) Start() error {
 
 // Stop stops the server
 func (ds *DebugServer) Stop() {
-	fmt.Printf("stopping debug server")
 	ds.cancel()
 }
 

--- a/debugger/server/debugger_server.go
+++ b/debugger/server/debugger_server.go
@@ -91,6 +91,8 @@ func (ds *DebugServer) Start() error {
 	go func() {
 		ds.console.Printf("interactive debugger listening on %v\n", ds.addr)
 		defer l.Close()
+		defer fmt.Printf("deleting %v", ds.addr)
+		defer os.Remove(ds.addr)
 		for {
 			// Listen for an incoming connection.
 			conn, err := l.Accept()
@@ -112,6 +114,7 @@ func (ds *DebugServer) Start() error {
 
 // Stop stops the server
 func (ds *DebugServer) Stop() {
+	fmt.Printf("stopping debug server")
 	ds.cancel()
 }
 

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -672,6 +672,14 @@ func (c *Converter) internalRun(ctx context.Context, args []string, secretKeyVal
 		}
 	}
 
+	finalOpts = append(finalOpts,
+		llb.AddMount("/usr/bin/earth_debugger",
+			llb.Image(c.debuggerImage, llb.MarkImageInternal, llb.ResolveModePreferLocal, llb.Platform(llbutil.TargetPlatform)),
+			llb.SourcePath("/earth_debugger"),
+			llb.Readonly,
+		),
+	)
+
 	finalOpts = append(finalOpts, llb.AddMount("/usr/bin/earth_debugger", llb.Image(c.debuggerImage), llb.SourcePath("/earth_debugger"), llb.Readonly))
 	secretOpts := []llb.SecretOption{
 		llb.SecretID("earthly_remote_console_addr"),

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -16,6 +16,7 @@ import (
 	"github.com/docker/distribution/reference"
 	"github.com/earthly/earthly/buildcontext"
 	"github.com/earthly/earthly/cleanup"
+	"github.com/earthly/earthly/debugger/common"
 	"github.com/earthly/earthly/dockertar"
 	"github.com/earthly/earthly/domain"
 	"github.com/earthly/earthly/earthfile2llb/dedup"
@@ -682,9 +683,9 @@ func (c *Converter) internalRun(ctx context.Context, args []string, secretKeyVal
 
 	finalOpts = append(finalOpts, llb.AddMount("/usr/bin/earth_debugger", llb.Image(c.debuggerImage), llb.SourcePath("/earth_debugger"), llb.Readonly))
 	secretOpts := []llb.SecretOption{
-		llb.SecretID("earthly_remote_console_addr"),
+		llb.SecretID(common.DebuggerSettingsSecretsKey),
 	}
-	finalOpts = append(finalOpts, llb.AddSecret("/run/secrets/earthly_remote_console_addr", secretOpts...))
+	finalOpts = append(finalOpts, llb.AddSecret(fmt.Sprintf("/run/secrets/%s", common.DebuggerSettingsSecretsKey), secretOpts...))
 
 	finalOpts = append(finalOpts, llb.AddMount("/run/earthly", llb.Scratch(), llb.HostBind(), llb.SourcePath("/run/earthly")))
 

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -678,6 +678,8 @@ func (c *Converter) internalRun(ctx context.Context, args []string, secretKeyVal
 	}
 	finalOpts = append(finalOpts, llb.AddSecret("/run/secrets/earthly_remote_console_addr", secretOpts...))
 
+	finalOpts = append(finalOpts, llb.AddMount("/run/earthly", llb.Scratch(), llb.HostBind(), llb.SourcePath("/run/earthly")))
+
 	var finalArgs []string
 	if withDocker {
 		finalArgs = withDockerdWrap(args, extraEnvVars, isWithShell)

--- a/examples/cpp/Earthfile
+++ b/examples/cpp/Earthfile
@@ -6,9 +6,6 @@ ENV DEBCONF_NONINTERACTIVE_SEEN true
 
 RUN apt-get update && apt-get install -y build-essential cmake
 
-RUN --mount=type=bind-experimental,target=/tmpper,source=/tmp \
-    ls /tmpp | grep alex
-
 WORKDIR /code
 
 code:

--- a/examples/cpp/Earthfile
+++ b/examples/cpp/Earthfile
@@ -6,6 +6,9 @@ ENV DEBCONF_NONINTERACTIVE_SEEN true
 
 RUN apt-get update && apt-get install -y build-essential cmake
 
+RUN --mount=type=bind-experimental,target=/tmpper,source=/tmp \
+    ls /tmpp | grep alex
+
 WORKDIR /code
 
 code:


### PR DESCRIPTION
Rather than using tcp to run the interactive debugger, use a
socket-based connection. This is more secure as it doesn't expose any
ports on the network (and also prevents firewalls from disallowing
connections).