### PR TITLE
Support for dockerfile builds in remote targets too

### DIFF
--- a/buildcontext/detectbuildfile.go
+++ b/buildcontext/detectbuildfile.go
@@ -5,19 +5,23 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/earthly/earthly/domain"
 	"github.com/pkg/errors"
 )
 
-// detectEarthfile detects whether to use Earthfile or build.earth.
-func detectEarthfile(targetName string, localDir string) (string, error) {
+// detectBuildFile detects whether to use Earthfile, build.earth or Dockerfile.
+func detectBuildFile(target domain.Target, localDir string) (string, error) {
+	if target.Target == DockerfileMetaTarget {
+		return filepath.Join(localDir, "Dockerfile"), nil
+	}
 	earthfilePath := filepath.Join(localDir, "Earthfile")
-	buildEarthPath := filepath.Join(localDir, "build.earth")
 	_, err := os.Stat(earthfilePath)
 	if os.IsNotExist(err) {
+		buildEarthPath := filepath.Join(localDir, "build.earth")
 		_, err := os.Stat(buildEarthPath)
 		if os.IsNotExist(err) {
 			return "", fmt.Errorf(
-				"No Earthfile nor build.earth file found for target %s", targetName)
+				"No Earthfile nor build.earth file found for target %s", target.String())
 		} else if err != nil {
 			return "", errors.Wrapf(err, "stat file %s", buildEarthPath)
 		}

--- a/buildcontext/git.go
+++ b/buildcontext/git.go
@@ -67,12 +67,12 @@ func (gr *gitResolver) resolveEarthProject(ctx context.Context, target domain.Ta
 
 	// TODO: Apply excludes / .earthignore.
 	localEarthfileDir := filepath.Join(rgp.localGitDir, filepath.FromSlash(subDir))
-	earthfilePath, err := detectEarthfile(target.String(), localEarthfileDir)
+	buildFilePath, err := detectBuildFile(target, localEarthfileDir)
 	if err != nil {
 		return nil, err
 	}
 	return &Data{
-		EarthfilePath: earthfilePath,
+		BuildFilePath: buildFilePath,
 		BuildContext:  buildContext,
 		GitMetadata: &GitMetadata{
 			BaseDir:    "",
@@ -106,7 +106,7 @@ func (gr *gitResolver) resolveGitProject(ctx context.Context, target domain.Targ
 	}
 	// Not cached.
 
-	// Copy all Earthfile and build.earth files.
+	// Copy all Earthfile, build.earth and Dockerfile files.
 	gitOpts := []llb.GitOption{
 		llb.WithCustomNamef("[context %s] GIT CLONE %s", gitURL, gitURL),
 		llb.KeepGitDir(),
@@ -116,7 +116,7 @@ func (gr *gitResolver) resolveGitProject(ctx context.Context, target domain.Targ
 		llb.Args([]string{
 			"find",
 			"-type", "f",
-			"(", "-name", "build.earth", "-o", "-name", "Earthfile", ")",
+			"(", "-name", "build.earth", "-o", "-name", "Earthfile", "-o", "-name", "Dockerfile", ")",
 			"-exec", "cp", "--parents", "{}", "/dest", ";",
 		}),
 		llb.Dir("/git-src"),

--- a/buildcontext/local.go
+++ b/buildcontext/local.go
@@ -49,12 +49,12 @@ func (lr *localResolver) resolveLocal(ctx context.Context, target domain.Target)
 		lr.gitMetaCache[target.LocalPath] = metadata
 	}
 
-	earthfilePath, err := detectEarthfile(target.String(), filepath.FromSlash(target.LocalPath))
+	buildFilePath, err := detectBuildFile(target, filepath.FromSlash(target.LocalPath))
 	if err != nil {
 		return nil, err
 	}
 	return &Data{
-		EarthfilePath: earthfilePath,
+		BuildFilePath: buildFilePath,
 		BuildContext: llb.Local(
 			target.LocalPath,
 			llb.SharedKeyHint(target.LocalPath),

--- a/buildcontext/resolver.go
+++ b/buildcontext/resolver.go
@@ -9,10 +9,14 @@ import (
 	"github.com/moby/buildkit/client/llb"
 )
 
+// DockerfileMetaTarget is a target name which signals the resolver that the build file is a
+// dockerfile. The DockerfileMetaTarget is really not a valid Earthly target otherwise.
+const DockerfileMetaTarget = "@dockerfile"
+
 // Data represents a resolved target's build context data.
 type Data struct {
-	// EarthfilePath is the local path where the Earthfile can be found.
-	EarthfilePath string
+	// BuildFilePath is the local path where the Earthfile or Dockerfile can be found.
+	BuildFilePath string
 	// BuildContext is the state to use for the build.
 	BuildContext llb.State
 	// GitMetadata contains git metadata information.

--- a/earthfile2llb/earthfile2llb.go
+++ b/earthfile2llb/earthfile2llb.go
@@ -64,7 +64,7 @@ func Earthfile2LLB(ctx context.Context, target domain.Target, resolver *buildcon
 	targetCtx := logging.With(ctx, "target", target)
 	errorListener := antlrhandler.NewReturnErrorListener()
 	errorStrategy := antlrhandler.NewReturnErrorStrategy()
-	tree, err := newEarthfileTree(bc.EarthfilePath, errorListener, errorStrategy)
+	tree, err := newEarthfileTree(bc.BuildFilePath, errorListener, errorStrategy)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
One limitation: The dockerfile **has** to be named `Dockerfile`. The option `-f` is not yet supported.

This pretty much reuses the build context resolver that we use for Earthfiles - it was just extended to also work on Dockerfiles.