### PR TITLE
Use a docker volume rather than a bind-mount for cache

### DIFF
--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -21,6 +21,7 @@ buildkitd:
     ENV BUILDKIT_DEBUG=false
     # 10GB
     ENV CACHE_SIZE_MB=10000
+    VOLUME /tmp/earthly
     ENTRYPOINT ["/usr/bin/entrypoint.sh", "buildkitd", "--config=/etc/buildkitd.toml"]
     ARG EARTHLY_TARGET_TAG
     ARG EARTHLY_TARGET_TAG_DOCKER=$EARTHLY_TARGET_TAG

--- a/buildkitd/buildkitd.go
+++ b/buildkitd/buildkitd.go
@@ -17,6 +17,8 @@ import (
 const (
 	// ContainerName is the name of the buildkitd container.
 	ContainerName = "earthly-buildkitd"
+	// VolumeName is the name of the docker volume used for storing the cache.
+	VolumeName = "earthly-cache"
 )
 
 // Address is the address at which the daemon is available.
@@ -191,12 +193,11 @@ func Start(ctx context.Context, image string, settings Settings, reset bool) err
 		return err
 	}
 	env := os.Environ()
-	cacheMount := fmt.Sprintf("%s:/tmp/earthly:delegated", settings.TempDir)
 	runMount := fmt.Sprintf("%s:/run/earthly:consistent", settings.RunDir)
 	args := []string{
 		"run",
 		"-d",
-		"-v", cacheMount,
+		"-v", fmt.Sprintf("%s:/tmp/earthly:rw", VolumeName),
 		"-v", runMount,
 		"-e", fmt.Sprintf("ENABLE_LOOP_DEVICE=%t", !settings.DisableLoopDevice),
 		"-e", fmt.Sprintf("FORCE_LOOP_DEVICE=%t", !settings.DisableLoopDevice),

--- a/buildkitd/settings.go
+++ b/buildkitd/settings.go
@@ -17,7 +17,6 @@ type Settings struct {
 	DisableLoopDevice bool     `json:"disableLoopDevice"`
 	GitConfig         string   `json:"gitConfig"`
 	GitCredentials    []string `json:"gitCredentials"`
-	TempDir           string   `json:"tmpDir"`
 	RunDir            string   `json:"runDir"`
 	Debug             bool     `json:"debug"`
 }

--- a/cmd/earth/main.go
+++ b/cmd/earth/main.go
@@ -392,7 +392,6 @@ func (app *earthApp) parseConfigFile(context *cli.Context) error {
 		}
 	}
 
-	app.buildkitdSettings.TempDir = cfg.Global.CachePath
 	app.buildkitdSettings.RunDir = cfg.Global.RunPath
 	app.buildkitdSettings.GitConfig = gitConfig
 	app.buildkitdSettings.GitCredentials = gitCredentials
@@ -401,6 +400,9 @@ func (app *earthApp) parseConfigFile(context *cli.Context) error {
 }
 
 func (app *earthApp) processDeprecatedCommandOptions(context *cli.Context, cfg *config.Config) error {
+	if cfg.Global.CachePath != "" {
+		app.console.Warnf("Warning: the setting cache_path is now obsolete and will be ignored")
+	}
 
 	// command line overrides the config file
 	if app.gitUsernameOverride != "" || app.gitPasswordOverride != "" {

--- a/config/config.go
+++ b/config/config.go
@@ -27,7 +27,7 @@ type GlobalConfig struct {
 	BuildkitImage       string `yaml:"buildkit_image"`
 	DebuggerImage       string `yaml:"debugger_image"`
 
-	// Deprecated.
+	// Obsolete.
 	CachePath string `yaml:"cache_path"`
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"sort"
 	"strings"
 
@@ -22,12 +21,14 @@ var (
 
 // GlobalConfig contains global config values
 type GlobalConfig struct {
-	CachePath           string `yaml:"cache_path"`
 	RunPath             string `yaml:"run_path"`
 	DisableLoopDevice   bool   `yaml:"no_loop_device"`
 	BuildkitCacheSizeMb int    `yaml:"cache_size_mb"`
 	BuildkitImage       string `yaml:"buildkit_image"`
 	DebuggerImage       string `yaml:"debugger_image"`
+
+	// Deprecated.
+	CachePath string `yaml:"cache_path"`
 }
 
 // GitConfig contains git-specific config values
@@ -61,7 +62,6 @@ func ensureTransport(s, transport string) (string, error) {
 func ParseConfigFile(yamlData []byte) (*Config, error) {
 	config := Config{
 		Global: GlobalConfig{
-			CachePath:           defaultCachePath(),
 			RunPath:             defaultRunPath(),
 			DisableLoopDevice:   false,
 			BuildkitCacheSizeMb: 10000,
@@ -151,13 +151,6 @@ func CreateGitConfig(config *Config) (string, []string, error) {
 	gitConfig := strings.Join(lines, "\n")
 
 	return gitConfig, credentials, nil
-}
-
-func defaultCachePath() string {
-	if runtime.GOOS == "darwin" {
-		return filepath.Join(os.Getenv("HOME"), "Library/Caches/earthly")
-	}
-	return "/var/cache/earthly"
 }
 
 func defaultRunPath() string {

--- a/examples/tests/Earthfile
+++ b/examples/tests/Earthfile
@@ -35,12 +35,10 @@ cache-test:
 	COPY cache1.earth ./Earthfile
 	RUN --privileged \
 		--entrypoint \
-		--mount=type=tmpfs,target=/tmp/earthly \
 		-- +test
 	COPY cache2.earth ./Earthfile
 	RUN --privileged \
 		--entrypoint \
-		--mount=type=tmpfs,target=/tmp/earthly \
 		-- +test
 
 git-clone-test:

--- a/examples/tests/Earthfile
+++ b/examples/tests/Earthfile
@@ -2,201 +2,201 @@ FROM ../..+earth-docker
 WORKDIR /test
 
 all:
-	BUILD +privileged-test
-	BUILD +cache-test
-	BUILD +git-clone-test
-	BUILD +builtin-args-test
-	BUILD +config-test
-	BUILD +excludes-test
-	BUILD +secrets-test
-	BUILD +build-arg-test
-	BUILD +lc-test
-	BUILD +from-expose-test
-	BUILD +scratch-test
-	BUILD +build-earth-test
-	BUILD +host-bind-test
-	BUILD +star-test
-	BUILD +dockerfile-test
+    BUILD +privileged-test
+    BUILD +cache-test
+    BUILD +git-clone-test
+    BUILD +builtin-args-test
+    BUILD +config-test
+    BUILD +excludes-test
+    BUILD +secrets-test
+    BUILD +build-arg-test
+    BUILD +lc-test
+    BUILD +from-expose-test
+    BUILD +scratch-test
+    BUILD +build-earth-test
+    BUILD +host-bind-test
+    BUILD +star-test
+    BUILD +dockerfile-test
 
 experimental:
-	# TODO: These are troublesome due to vfs driver used in dind. They quickly exhaust disk space.
-	BUILD +docker-load-test
-	BUILD +dind-test
-	BUILD +docker-pull-test
+    # TODO: These are troublesome due to vfs driver used in dind. They quickly exhaust disk space.
+    BUILD +docker-load-test
+    BUILD +dind-test
+    BUILD +docker-pull-test
 
 privileged-test:
-	COPY privileged.earth ./Earthfile
-	RUN --privileged \
-		--entrypoint \
-		--mount=type=tmpfs,target=/tmp/earthly \
-		-- --allow-privileged +test
+    COPY privileged.earth ./Earthfile
+    RUN --privileged \
+        --entrypoint \
+        --mount=type=tmpfs,target=/tmp/earthly \
+        -- --allow-privileged +test
 
 cache-test:
-	COPY cache1.earth ./Earthfile
-	RUN --privileged \
-		--entrypoint \
-		-- +test
-	COPY cache2.earth ./Earthfile
-	RUN --privileged \
-		--entrypoint \
-		-- +test
+    COPY cache1.earth ./Earthfile
+    RUN --privileged \
+        --entrypoint \
+        -- +test
+    COPY cache2.earth ./Earthfile
+    RUN --privileged \
+        --entrypoint \
+        -- +test
 
 git-clone-test:
-	COPY git-clone.earth ./Earthfile
-	RUN --privileged \
-		--entrypoint \
-		--mount=type=tmpfs,target=/tmp/earthly \
-		-- +test
+    COPY git-clone.earth ./Earthfile
+    RUN --privileged \
+        --entrypoint \
+        --mount=type=tmpfs,target=/tmp/earthly \
+        -- +test
 
 builtin-args-test:
-	COPY builtin-args.earth ./Earthfile
-	RUN --privileged \
-		--entrypoint \
-		--mount=type=tmpfs,target=/tmp/earthly \
-		-- +builtin-args-test
+    COPY builtin-args.earth ./Earthfile
+    RUN --privileged \
+        --entrypoint \
+        --mount=type=tmpfs,target=/tmp/earthly \
+        -- +builtin-args-test
 
 config-test:
-	COPY config.earth ./Earthfile
-	RUN --privileged \
-		--entrypoint \
-		--mount=type=tmpfs,target=/tmp/earthly \
-		-- +test
+    COPY config.earth ./Earthfile
+    RUN --privileged \
+        --entrypoint \
+        --mount=type=tmpfs,target=/tmp/earthly \
+        -- +test
 
 excludes-test:
-	COPY excludes.earth ./Earthfile
-	RUN touch exclude-me.txt
-	RUN touch do-not-exclude-me.txt
-	RUN echo 'exclude-me.txt' > .earthignore
-	RUN --privileged \
-		--entrypoint \
-		--mount=type=tmpfs,target=/tmp/earthly \
-		-- +test
+    COPY excludes.earth ./Earthfile
+    RUN touch exclude-me.txt
+    RUN touch do-not-exclude-me.txt
+    RUN echo 'exclude-me.txt' > .earthignore
+    RUN --privileged \
+        --entrypoint \
+        --mount=type=tmpfs,target=/tmp/earthly \
+        -- +test
 
 secrets-test:
-	COPY secrets.earth ./Earthfile
-	ENV SECRET1=foo
-	ENV SECRET2=wrong
-	RUN --privileged \
-		--entrypoint \
-		--mount=type=tmpfs,target=/tmp/earthly \
-		-- --secret SECRET1 --secret SECRET2=bar +test
+    COPY secrets.earth ./Earthfile
+    ENV SECRET1=foo
+    ENV SECRET2=wrong
+    RUN --privileged \
+        --entrypoint \
+        --mount=type=tmpfs,target=/tmp/earthly \
+        -- --secret SECRET1 --secret SECRET2=bar +test
 
 build-arg-test:
-	COPY build-arg.earth ./Earthfile
-	RUN --privileged \
-		--entrypoint \
-		--mount=type=tmpfs,target=/tmp/earthly \
-		-- +test
+    COPY build-arg.earth ./Earthfile
+    RUN --privileged \
+        --entrypoint \
+        --mount=type=tmpfs,target=/tmp/earthly \
+        -- +test
 
 lc-test:
-	COPY lc.earth ./Earthfile
-	RUN --privileged \
-		--entrypoint \
-		--mount=type=tmpfs,target=/tmp/earthly \
-		-- +test
+    COPY lc.earth ./Earthfile
+    RUN --privileged \
+        --entrypoint \
+        --mount=type=tmpfs,target=/tmp/earthly \
+        -- +test
 
 from-expose-test:
-	COPY from-expose.earth ./Earthfile
-	RUN --privileged \
-		--entrypoint \
-		--mount=type=tmpfs,target=/tmp/earthly \
-		-- --no-output +test
+    COPY from-expose.earth ./Earthfile
+    RUN --privileged \
+        --entrypoint \
+        --mount=type=tmpfs,target=/tmp/earthly \
+        -- --no-output +test
 
 scratch-test:
-	COPY scratch-test.earth ./Earthfile
-	RUN --privileged \
-		--entrypoint \
-		--mount=type=tmpfs,target=/tmp/earthly \
-		-- --no-output +test
+    COPY scratch-test.earth ./Earthfile
+    RUN --privileged \
+        --entrypoint \
+        --mount=type=tmpfs,target=/tmp/earthly \
+        -- --no-output +test
 
 build-earth-test:
-	# Test that build.earth is supported.
-	COPY config.earth ./build.earth
-	RUN --privileged \
-		--entrypoint \
-		--mount=type=tmpfs,target=/tmp/earthly \
-		-- +test
+    # Test that build.earth is supported.
+    COPY config.earth ./build.earth
+    RUN --privileged \
+        --entrypoint \
+        --mount=type=tmpfs,target=/tmp/earthly \
+        -- +test
 
 host-bind-test:
-	RUN mkdir /bind-test
-	RUN echo "a" > /bind-test/a.txt
-	COPY host-bind.earth ./Earthfile
-	RUN --privileged \
-		--entrypoint \
-		--mount=type=tmpfs,target=/tmp/earthly \
-		-- +test
-	RUN test -f /bind-test/b.txt
-	RUN cat /bind-test/b.txt
+    RUN mkdir /bind-test
+    RUN echo "a" > /bind-test/a.txt
+    COPY host-bind.earth ./Earthfile
+    RUN --privileged \
+        --entrypoint \
+        --mount=type=tmpfs,target=/tmp/earthly \
+        -- +test
+    RUN test -f /bind-test/b.txt
+    RUN cat /bind-test/b.txt
 
 # TODO: This does not pass, due to space on device limitation (dind caused).
 remote-test:
-	ENV GIT_URL_INSTEAD_OF="https://github.com/=git@github.com:"
-	RUN --privileged \
-		--entrypoint \
-		--mount=type=tmpfs,target=/tmp/earthly \
-		-- --no-output github.com/earthly/earthly+earth-docker
+    ENV GIT_URL_INSTEAD_OF="https://github.com/=git@github.com:"
+    RUN --privileged \
+        --entrypoint \
+        --mount=type=tmpfs,target=/tmp/earthly \
+        -- --no-output github.com/earthly/earthly+earth-docker
 
 # TODO: This does not pass.
 transitive-args-test-todo:
-	COPY transitive-args.earth ./Earthfile
-	RUN --privileged \
-		--entrypoint \
-		--mount=type=tmpfs,target=/tmp/earthly \
-		-- --build-arg SOMEARG=def +test
-	RUN ls
-	RUN test -f ./abc && test -f ./def && test ! -f ./default
+    COPY transitive-args.earth ./Earthfile
+    RUN --privileged \
+        --entrypoint \
+        --mount=type=tmpfs,target=/tmp/earthly \
+        -- --build-arg SOMEARG=def +test
+    RUN ls
+    RUN test -f ./abc && test -f ./def && test ! -f ./default
 
 star-test:
-	COPY star.earth ./Earthfile
-	RUN touch a.txt b.txt c.nottxt
-	RUN --privileged \
-		--entrypoint \
-		--mount=type=tmpfs,target=/tmp/earthly \
-		-- +test
+    COPY star.earth ./Earthfile
+    RUN touch a.txt b.txt c.nottxt
+    RUN --privileged \
+        --entrypoint \
+        --mount=type=tmpfs,target=/tmp/earthly \
+        -- +test
 
 # TODO: This does not pass.
 star-test-todo:
-	COPY star.earth ./Earthfile
-	RUN touch a.txt b.txt c.nottxt
-	RUN --privileged \
-		--entrypoint \
-		--mount=type=tmpfs,target=/tmp/earthly \
-		-- +test
-	RUN echo "a change" > c.nottxt
-	RUN --privileged \
-		--entrypoint \
-		--mount=type=tmpfs,target=/tmp/earthly \
-		-- +test >output.txt
-	RUN cat output.txt
-	RUN cached_lines=$(cat output.txt | grep cached | wc -l); \
-		echo "cached_lines=$cached_lines"; \
-		test "$cached_lines" == "6"
+    COPY star.earth ./Earthfile
+    RUN touch a.txt b.txt c.nottxt
+    RUN --privileged \
+        --entrypoint \
+        --mount=type=tmpfs,target=/tmp/earthly \
+        -- +test
+    RUN echo "a change" > c.nottxt
+    RUN --privileged \
+        --entrypoint \
+        --mount=type=tmpfs,target=/tmp/earthly \
+        -- +test >output.txt
+    RUN cat output.txt
+    RUN cached_lines=$(cat output.txt | grep cached | wc -l); \
+        echo "cached_lines=$cached_lines"; \
+        test "$cached_lines" == "6"
 
 docker-load-test:
-	COPY docker-load.earth ./Earthfile
-	RUN --privileged \
-		--entrypoint \
-		--mount=type=tmpfs,target=/tmp/earthly \
-		-- --allow-privileged +test
+    COPY docker-load.earth ./Earthfile
+    RUN --privileged \
+        --entrypoint \
+        --mount=type=tmpfs,target=/tmp/earthly \
+        -- --allow-privileged +test
 
 dind-test:
-	COPY dind.earth ./Earthfile
-	RUN --privileged \
-		--entrypoint \
-		--mount=type=tmpfs,target=/tmp/earthly \
-		-- --allow-privileged +test
+    COPY dind.earth ./Earthfile
+    RUN --privileged \
+        --entrypoint \
+        --mount=type=tmpfs,target=/tmp/earthly \
+        -- --allow-privileged +test
 
 docker-pull-test:
-	COPY docker-pull.earth ./Earthfile
-	RUN --privileged \
-		--entrypoint \
-		--mount=type=tmpfs,target=/tmp/earthly \
-		-- --allow-privileged +test
+    COPY docker-pull.earth ./Earthfile
+    RUN --privileged \
+        --entrypoint \
+        --mount=type=tmpfs,target=/tmp/earthly \
+        -- --allow-privileged +test
 
 dockerfile-test:
-	COPY --dir dockerfile ./
-	WORKDIR /test/dockerfile
-	RUN --privileged \
-		--entrypoint \
-		--mount=type=tmpfs,target=/tmp/earthly \
-		-- --no-output +test
+    COPY --dir dockerfile ./
+    WORKDIR /test/dockerfile
+    RUN --privileged \
+        --entrypoint \
+        --mount=type=tmpfs,target=/tmp/earthly \
+        -- --no-output +test

--- a/examples/tests/Earthfile
+++ b/examples/tests/Earthfile
@@ -28,34 +28,40 @@ privileged-test:
 	COPY privileged.earth ./Earthfile
 	RUN --privileged \
 		--entrypoint \
+		--mount=type=tmpfs,target=/tmp/earthly \
 		-- --allow-privileged +test
 
 cache-test:
 	COPY cache1.earth ./Earthfile
 	RUN --privileged \
 		--entrypoint \
+		--mount=type=tmpfs,target=/tmp/earthly \
 		-- +test
 	COPY cache2.earth ./Earthfile
 	RUN --privileged \
 		--entrypoint \
+		--mount=type=tmpfs,target=/tmp/earthly \
 		-- +test
 
 git-clone-test:
 	COPY git-clone.earth ./Earthfile
 	RUN --privileged \
 		--entrypoint \
+		--mount=type=tmpfs,target=/tmp/earthly \
 		-- +test
 
 builtin-args-test:
 	COPY builtin-args.earth ./Earthfile
 	RUN --privileged \
 		--entrypoint \
+		--mount=type=tmpfs,target=/tmp/earthly \
 		-- +builtin-args-test
 
 config-test:
 	COPY config.earth ./Earthfile
 	RUN --privileged \
 		--entrypoint \
+		--mount=type=tmpfs,target=/tmp/earthly \
 		-- +test
 
 excludes-test:
@@ -65,6 +71,7 @@ excludes-test:
 	RUN echo 'exclude-me.txt' > .earthignore
 	RUN --privileged \
 		--entrypoint \
+		--mount=type=tmpfs,target=/tmp/earthly \
 		-- +test
 
 secrets-test:
@@ -73,30 +80,35 @@ secrets-test:
 	ENV SECRET2=wrong
 	RUN --privileged \
 		--entrypoint \
+		--mount=type=tmpfs,target=/tmp/earthly \
 		-- --secret SECRET1 --secret SECRET2=bar +test
 
 build-arg-test:
 	COPY build-arg.earth ./Earthfile
 	RUN --privileged \
 		--entrypoint \
+		--mount=type=tmpfs,target=/tmp/earthly \
 		-- +test
 
 lc-test:
 	COPY lc.earth ./Earthfile
 	RUN --privileged \
 		--entrypoint \
+		--mount=type=tmpfs,target=/tmp/earthly \
 		-- +test
 
 from-expose-test:
 	COPY from-expose.earth ./Earthfile
 	RUN --privileged \
 		--entrypoint \
+		--mount=type=tmpfs,target=/tmp/earthly \
 		-- --no-output +test
 
 scratch-test:
 	COPY scratch-test.earth ./Earthfile
 	RUN --privileged \
 		--entrypoint \
+		--mount=type=tmpfs,target=/tmp/earthly \
 		-- --no-output +test
 
 build-earth-test:
@@ -104,6 +116,7 @@ build-earth-test:
 	COPY config.earth ./build.earth
 	RUN --privileged \
 		--entrypoint \
+		--mount=type=tmpfs,target=/tmp/earthly \
 		-- +test
 
 host-bind-test:
@@ -112,6 +125,7 @@ host-bind-test:
 	COPY host-bind.earth ./Earthfile
 	RUN --privileged \
 		--entrypoint \
+		--mount=type=tmpfs,target=/tmp/earthly \
 		-- +test
 	RUN test -f /bind-test/b.txt
 	RUN cat /bind-test/b.txt
@@ -121,6 +135,7 @@ remote-test:
 	ENV GIT_URL_INSTEAD_OF="https://github.com/=git@github.com:"
 	RUN --privileged \
 		--entrypoint \
+		--mount=type=tmpfs,target=/tmp/earthly \
 		-- --no-output github.com/earthly/earthly+earth-docker
 
 # TODO: This does not pass.
@@ -128,6 +143,7 @@ transitive-args-test-todo:
 	COPY transitive-args.earth ./Earthfile
 	RUN --privileged \
 		--entrypoint \
+		--mount=type=tmpfs,target=/tmp/earthly \
 		-- --build-arg SOMEARG=def +test
 	RUN ls
 	RUN test -f ./abc && test -f ./def && test ! -f ./default
@@ -137,6 +153,7 @@ star-test:
 	RUN touch a.txt b.txt c.nottxt
 	RUN --privileged \
 		--entrypoint \
+		--mount=type=tmpfs,target=/tmp/earthly \
 		-- +test
 
 # TODO: This does not pass.
@@ -145,10 +162,12 @@ star-test-todo:
 	RUN touch a.txt b.txt c.nottxt
 	RUN --privileged \
 		--entrypoint \
+		--mount=type=tmpfs,target=/tmp/earthly \
 		-- +test
 	RUN echo "a change" > c.nottxt
 	RUN --privileged \
 		--entrypoint \
+		--mount=type=tmpfs,target=/tmp/earthly \
 		-- +test >output.txt
 	RUN cat output.txt
 	RUN cached_lines=$(cat output.txt | grep cached | wc -l); \
@@ -159,18 +178,21 @@ docker-load-test:
 	COPY docker-load.earth ./Earthfile
 	RUN --privileged \
 		--entrypoint \
+		--mount=type=tmpfs,target=/tmp/earthly \
 		-- --allow-privileged +test
 
 dind-test:
 	COPY dind.earth ./Earthfile
 	RUN --privileged \
 		--entrypoint \
+		--mount=type=tmpfs,target=/tmp/earthly \
 		-- --allow-privileged +test
 
 docker-pull-test:
 	COPY docker-pull.earth ./Earthfile
 	RUN --privileged \
 		--entrypoint \
+		--mount=type=tmpfs,target=/tmp/earthly \
 		-- --allow-privileged +test
 
 dockerfile-test:
@@ -178,4 +200,5 @@ dockerfile-test:
 	WORKDIR /test/dockerfile
 	RUN --privileged \
 		--entrypoint \
+		--mount=type=tmpfs,target=/tmp/earthly \
 		-- --no-output +test


### PR DESCRIPTION
* Also, use tmpfs for cache in integration tests to avoid bloating Earthly cache.

This change makes Earthly 2.76X (!!!) faster on Mac, bringing its performance up-to-par with Linux.