### PR TITLE
Use buildkit Earthfile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,5 +9,5 @@ jobs:
       - checkout
       - run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/latest/download/earth-linux-amd64 -O /usr/local/bin/earth && chmod +x /usr/local/bin/earth'"
       - run: earth --version
-      - run: earth --build-arg TAG=ci --build-arg VERSION=ci +for-linux
+      - run: earth --build-arg BUILDKIT_BASE_IMAGE=earthly/buildkit:earthly-master@sha256:505101caf912109c11e9dc281a2efd5fd4cb9d4999324b1f67f030208a2b9343 --build-arg TAG=ci --build-arg VERSION=ci +for-linux
       - run: ./build/linux/amd64/earth -P --no-output +test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Earth version
       run: earth --version
     - name: Build latest earth
-      run: earth --build-arg TAG=ci --build-arg VERSION=ci +for-linux
+      run: earth --build-arg BUILDKIT_BASE_IMAGE=earthly/buildkit:earthly-master@sha256:505101caf912109c11e9dc281a2efd5fd4cb9d4999324b1f67f030208a2b9343 --build-arg TAG=ci --build-arg VERSION=ci +for-linux
     - name: Reset cache
       run: ./build/linux/amd64/earth prune --reset
     - name: Build, test, push using latest earth

--- a/Earthfile
+++ b/Earthfile
@@ -98,9 +98,11 @@ earth:
     ARG EARTHLY_GIT_HASH
     ARG DEFAULT_BUILDKITD_IMAGE=earthly/buildkitd:$VERSION
     ARG DEFAULT_DEBUGGER_IMAGE=earthly/debugger:socket-debugger@sha256:5aede226d821ec854ea62e2136876a75dff124479337ce99d8421be8bb90bb6c
+    ARG BUILD_TAGS=dfrunmount dfrunsecurity dfsecrets dfssh dfrunnetwork
     ARG GOCACHE=/go-cache
     RUN --mount=type=cache,target=$GOCACHE \
         go build \
+            -tags "$BUILD_TAGS" \
             -ldflags "-X main.DefaultBuildkitdImage=$DEFAULT_BUILDKITD_IMAGE -X main.DefaultDebuggerImage=$DEFAULT_DEBUGGER_IMAGE -X main.Version=$VERSION -X main.GitSha=$EARTHLY_GIT_HASH $GO_EXTRA_LDFLAGS" \
             -o build/earth \
             cmd/earth/*.go

--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -1,6 +1,7 @@
 
 buildkitd:
-    FROM earthly/buildkit:earthly-master@sha256:505101caf912109c11e9dc281a2efd5fd4cb9d4999324b1f67f030208a2b9343
+    ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:vlad-earthfile+build
+    FROM $BUILDKIT_BASE_IMAGE
 
     # Install some missing binaries.
     RUN apk add --update --no-cache openssh-client pigz xz fuse3 e2fsprogs util-linux

--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -1,6 +1,6 @@
 
 buildkitd:
-    ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:vlad-earthfile+build
+    ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:earthly-master+build
     FROM $BUILDKIT_BASE_IMAGE
 
     # Install some missing binaries.


### PR DESCRIPTION
Also, fix run mounts not working in Dockerfiles.

- [x] Should update this PR to use `earthly-master`, when https://github.com/earthly/buildkit/pull/6 gets merged