### PR TITLE
Get rid of vfs in docker-in-docker (experiment)

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -164,6 +164,3 @@ examples:
     BUILD ./examples/readme/go3+build
     BUILD ./examples/readme/proto+docker
     BUILD github.com/earthly/hello-world+hello
-
-test-experimental:
-    BUILD ./examples/tests+experimental

--- a/buildkitd/entrypoint.sh
+++ b/buildkitd/entrypoint.sh
@@ -22,6 +22,8 @@ if [ "$EARTHLY_RESET_TMP_DIR" == "true" ]; then
     rm -rf "$EARTHLY_TMP_DIR"/* || true
 fi
 
+mkdir -p "$EARTHLY_TMP_DIR/dind"
+
 # setup git credentials and config
 i=0
 while true

--- a/examples/tests/Earthfile
+++ b/examples/tests/Earthfile
@@ -15,11 +15,12 @@ all:
     BUILD +scratch-test
     BUILD +build-earth-test
     BUILD +host-bind-test
+    BUILD +remote-test
     BUILD +star-test
     BUILD +dockerfile-test
+    BUILD +experimental-dind
 
-experimental:
-    # TODO: These are troublesome due to vfs driver used in dind. They quickly exhaust disk space.
+experimental-dind:
     BUILD +docker-load-test
     BUILD +dind-test
     BUILD +docker-pull-test
@@ -128,7 +129,6 @@ host-bind-test:
     RUN test -f /bind-test/b.txt
     RUN cat /bind-test/b.txt
 
-# TODO: This does not pass, due to space on device limitation (dind caused).
 remote-test:
     ENV GIT_URL_INSTEAD_OF="https://github.com/=git@github.com:"
     RUN --privileged \
@@ -160,12 +160,10 @@ star-test-todo:
     RUN touch a.txt b.txt c.nottxt
     RUN --privileged \
         --entrypoint \
-        --mount=type=tmpfs,target=/tmp/earthly \
         -- +test
     RUN echo "a change" > c.nottxt
     RUN --privileged \
         --entrypoint \
-        --mount=type=tmpfs,target=/tmp/earthly \
         -- +test >output.txt
     RUN cat output.txt
     RUN cached_lines=$(cat output.txt | grep cached | wc -l); \


### PR DESCRIPTION
This gets us closer to being able to use docker-in-docker safely.

Changes:

* Use a separate dir for docker data for each target and bind that dir to the host.
* In our case, the host is the buildkitd container, so binding to the host, really means binding to a dir within the buildkitd container.
* The dir used is `/tmp/earthly/dind/<hash-of-target>` within buildkitd container, which will end up being part of the same docker volume as the rest of the cache.
* Between runs, the same data dir is used. Meaning that docker data will be reused between runs. This is a temporary unintended consequence.

Things that are no longer a limitation due to this:

* The docker daemon no longer uses vfs driver, but rather overlayfs2, which is far more performant (both in terms of speed and disk usage).

New limitations (for now):

* Between runs, the same docker dir is used, causing an unintended leaky abstraction.
* Because the docker dir is not part of the regular cache, there may be surprising effects if only part of the build executes (eg partly cached).
* The data generated by dind runs is not garbage-collected automatically (it's separate from the buildkit cache). However, because it's in the same volume as the cache it would be cleaned up by a `earth prune --reset`. This needs to be addressed separately.

This requires more thinking.