### PR TITLE
interactive mode flag and cache fix

### DIFF
--- a/cmd/earth/main.go
+++ b/cmd/earth/main.go
@@ -275,7 +275,6 @@ func newEarthApp(ctx context.Context, console conslogging.ConsoleLogger) *earthA
 			EnvVars:     []string{"EARTHLY_INTERACTIVE"},
 			Usage:       "Enable interactive debugging",
 			Destination: &app.interactiveDebugging,
-			Hidden:      true, // Experimental.
 		},
 		&cli.BoolFlag{
 			Name:        "verbose",

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -734,9 +734,7 @@ func (c *Converter) internalRun(ctx context.Context, args []string, secretKeyVal
 		finalArgs = withShellAndEnvVars(args, extraEnvVars, isWithShell)
 	}
 
-	if c.interactiveDebugging {
-		finalArgs = append([]string{"earth_debugger"}, finalArgs...)
-	}
+	finalArgs = append([]string{"earth_debugger"}, finalArgs...)
 
 	finalOpts = append(finalOpts, llb.Args(finalArgs))
 	if pushFlag {


### PR DESCRIPTION
* expose the -i, --interactive flags under help
* always run the command via the earthly_debugger to prevent a different
cache path from being used between interactive and non interactive
debugging