### PR TITLE
Remove extraneous checkout step in Actions example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,15 +16,6 @@ jobs:
     if: github.repository == 'earthly/earthly'
     steps:
     - uses: actions/checkout@v2
-    - name: Put back the git branch into git (Earthly uses it for tagging)
-      run: |
-        branch=""
-        if [ -n "$GITHUB_HEAD_REF" ]; then
-          branch="$GITHUB_HEAD_REF"
-        else
-          branch="${GITHUB_REF##*/}"
-        fi
-        git checkout -b "$branch" || true
     - name: Docker Login
       run: docker login --username vladaionescu --password "$DOCKERHUB_TOKEN"
     - name: Download latest earth

--- a/docs/examples/gh-actions-integration.md
+++ b/docs/examples/gh-actions-integration.md
@@ -24,15 +24,6 @@ jobs:
       FORCE_COLOR: 1
     steps:
     - uses: actions/checkout@v2
-    - name: Put back the git branch into git (Earthly uses it for tagging)
-      run: |
-        branch=""
-        if [ -n "$GITHUB_HEAD_REF" ]; then
-          branch="$GITHUB_HEAD_REF"
-        else
-          branch="${GITHUB_REF##*/}"
-        fi
-        git checkout -b "$branch" || true
     - name: Docker Login
       run: docker login --username "$DOCKERHUB_USERNAME" --password "$DOCKERHUB_TOKEN"
     - name: Download latest earth


### PR DESCRIPTION
GitHub Actions checkout@v2 no longer leaves the branch in a detached head state,
so there is no longer a need to run `git checkout` as a step.