### PR TITLE
Use the same go build flags in homebrew build

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -111,13 +111,12 @@ earth:
     ARG VERSION=$EARTHLY_TARGET_TAG_DOCKER
     ARG EARTHLY_GIT_HASH
     ARG DEFAULT_BUILDKITD_IMAGE=earthly/buildkitd:$VERSION
-    ARG DEFAULT_DEBUGGER_IMAGE=earthly/debugger:socket-debugger@sha256:5aede226d821ec854ea62e2136876a75dff124479337ce99d8421be8bb90bb6c
     ARG BUILD_TAGS=dfrunmount dfrunsecurity dfsecrets dfssh dfrunnetwork
     ARG GOCACHE=/go-cache
     RUN --mount=type=cache,target=$GOCACHE \
         go build \
             -tags "$BUILD_TAGS" \
-            -ldflags "-X main.DefaultBuildkitdImage=$DEFAULT_BUILDKITD_IMAGE -X main.DefaultDebuggerImage=$DEFAULT_DEBUGGER_IMAGE -X main.Version=$VERSION -X main.GitSha=$EARTHLY_GIT_HASH $GO_EXTRA_LDFLAGS" \
+            -ldflags "-X main.DefaultBuildkitdImage=$DEFAULT_BUILDKITD_IMAGE -X main.Version=$VERSION -X main.GitSha=$EARTHLY_GIT_HASH $GO_EXTRA_LDFLAGS" \
             -o build/earth \
             cmd/earth/*.go
     SAVE ARTIFACT build/earth AS LOCAL "build/$GOOS/$GOARCH/earth"

--- a/release/Earthfile
+++ b/release/Earthfile
@@ -97,7 +97,8 @@ release-homebrew:
     RUN mkdir -p /params
     RUN curl -L "$NEW_URL" | sha256sum | cut -f 1 -d ' ' > /params/downloadsha256
     COPY ./earthly.rb ./Formula/earthly.rb
-    COPY --build-arg GOOS=darwin \
+    COPY --build-arg VERSION=$RELEASE_TAG \
+        --build-arg GOOS=darwin \
         --build-arg GOARCH=amd64 \
         --build-arg GO_EXTRA_LDFLAGS= \
         ../+earth/tags ../+earth/ldflags /params/

--- a/release/Earthfile
+++ b/release/Earthfile
@@ -100,11 +100,7 @@ release-homebrew:
     COPY --build-arg GOOS=darwin \
         --build-arg GOARCH=amd64 \
         --build-arg GO_EXTRA_LDFLAGS= \
-        ../+earth/tags /params/
-    COPY --build-arg GOOS=darwin \
-        --build-arg GOARCH=amd64 \
-        --build-arg GO_EXTRA_LDFLAGS= \
-        ../+earth/ldflags /params/
+        ../+earth/tags ../+earth/ldflags /params/
     RUN sed -i \
         -e 's^:URL:^'"$NEW_URL"'^g' \
         -e 's^:SHA256:^'"$(cat /params/downloadsha256)"'^g' \

--- a/release/Earthfile
+++ b/release/Earthfile
@@ -94,10 +94,22 @@ release-homebrew:
 
     # Make the change in a new branch.
     RUN git checkout -b "release-$RELEASE_TAG"
-    RUN curl -L "$NEW_URL" | sha256sum | cut -f 1 -d ' ' > /downloadsha256.txt
+    RUN mkdir -p /params
+    RUN curl -L "$NEW_URL" | sha256sum | cut -f 1 -d ' ' > /params/downloadsha256
+    COPY ./earthly.rb ./Formula/earthly.rb
+    COPY --build-arg GOOS=darwin \
+        --build-arg GOARCH=amd64 \
+        --build-arg GO_EXTRA_LDFLAGS= \
+        ../+earth/tags /params/
+    COPY --build-arg GOOS=darwin \
+        --build-arg GOARCH=amd64 \
+        --build-arg GO_EXTRA_LDFLAGS= \
+        ../+earth/ldflags /params/
     RUN sed -i \
-        -e 's/sha256 ".*"$/sha256 "'$(cat /downloadsha256.txt)'"/' \
-        -e 's#url ".*"#url "'"$NEW_URL"'"#' \
+        -e 's^:URL:^'"$NEW_URL"'^g' \
+        -e 's^:SHA256:^'"$(cat /params/downloadsha256)"'^g' \
+        -e 's^:TAGS:^'"$(cat /params/tags)"'^g' \
+        -e 's^:LDFLAGS:^'"$(cat /params/ldflags)"'^g' \
         ./Formula/earthly.rb
     RUN echo "Resulting formula:" && cat ./Formula/earthly.rb && \
         echo "Diff:" && git diff
@@ -136,7 +148,9 @@ release-homebrew:
             -m '* `RELEASE_TAG='"$RELEASE_TAG"'`' \
             -m '* `GIT_USERNAME='"$GIT_USERNAME"'`' \
             -m '* `NEW_URL='"$NEW_URL"'`' \
-            -m '* `NEW_SHA256='"$(cat /downloadsha256.txt)"'`'
+            -m '* `NEW_SHA256='"$(cat /params/downloadsha256)"'`' \
+            -m '* `TAGS='"$(cat /params/tags)"'`' \
+            -m '* `LDFLAGS='"$(cat /params/ldflags)"'`'
 
 release-vscode-syntax-highlighting:
     ARG VSCODE_RELEASE_TAG

--- a/release/earthly.rb
+++ b/release/earthly.rb
@@ -1,0 +1,37 @@
+class Earthly < Formula
+  desc "Build automation tool for the post-container era"
+  homepage "https://earthly.dev/"
+  url ":URL:"
+  sha256 ":SHA256:"
+  license "MPL-2.0"
+  head "https://github.com/earthly/earthly.git"
+
+  bottle do
+    cellar :any_skip_relocation
+    sha256 "5929dc77833f8c3df5401ac67fb3cd6f519b9f24152d6c8e52d8675919826934" => :catalina
+    sha256 "b6d2e459b9d8d12033899bb16acb33b5db19119f8bb198983ecb051bb367ab2a" => :mojave
+    sha256 "5d6412cc573aebf07cf98b90d755964747d4868135f2ca721761d30e7133d53d" => :high_sierra
+  end
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build",
+        "-tags", ":TAGS:",
+        "-ldflags", ":LDFLAGS:",
+        *std_go_args,
+        "-o", bin/"earth",
+        "./cmd/earth/main.go"
+  end
+
+  test do
+    (testpath/"build.earth").write <<~EOS
+
+      default:
+      \tRUN echo Homebrew
+    EOS
+
+    output = shell_output("#{bin}/earth --buildkit-host 127.0.0.1 +default 2>&1", 1).strip
+    assert_match "Error while dialing invalid address 127.0.0.1", output
+  end
+end


### PR DESCRIPTION
Example generated earthly.rb:

```
./release+release-homebrew | class Earthly < Formula
./release+release-homebrew |   desc "Build automation tool for the post-container era"
./release+release-homebrew |   homepage "https://earthly.dev/"
./release+release-homebrew |   url "https://github.com/earthly/earthly/archive/v0.0.0.tar.gz"
./release+release-homebrew |   sha256 "d5558cd419c8d46bdc958064cb97f963d1ea793866414c025906ec15033512ed"
./release+release-homebrew |   license "MPL-2.0"
./release+release-homebrew |   head "https://github.com/earthly/earthly.git"

./release+release-homebrew |   bottle do
./release+release-homebrew |     cellar :any_skip_relocation
./release+release-homebrew |     sha256 "5929dc77833f8c3df5401ac67fb3cd6f519b9f24152d6c8e52d8675919826934" => :catalina
./release+release-homebrew |     sha256 "b6d2e459b9d8d12033899bb16acb33b5db19119f8bb198983ecb051bb367ab2a" => :mojave
./release+release-homebrew |     sha256 "5d6412cc573aebf07cf98b90d755964747d4868135f2ca721761d30e7133d53d" => :high_sierra
./release+release-homebrew |   end

./release+release-homebrew |   depends_on "go" => :build

./release+release-homebrew |   def install
./release+release-homebrew |     system "go", "build",
./release+release-homebrew |         "-tags", "dfrunmount dfrunsecurity dfsecrets dfssh dfrunnetwork",
./release+release-homebrew |         "-ldflags", "-X main.DefaultBuildkitdImage=earthly/buildkitd:v0.0.0 -X main.Version=v0.0.0 -X main.GitSha=6299507121592be6f64d6cc49f6b4778c2ab4cb2 ",
./release+release-homebrew |         *std_go_args,
./release+release-homebrew |         "-o", bin/"earth",
./release+release-homebrew |         "./cmd/earth/main.go"
./release+release-homebrew |   end

./release+release-homebrew |   test do
./release+release-homebrew |     (testpath/"build.earth").write <<~EOS

./release+release-homebrew |       default:
./release+release-homebrew |       \tRUN echo Homebrew
./release+release-homebrew |     EOS

./release+release-homebrew |     output = shell_output("#{bin}/earth --buildkit-host 127.0.0.1 +default 2>&1", 1).strip
./release+release-homebrew |     assert_match "Error while dialing invalid address 127.0.0.1", output
./release+release-homebrew |   end
./release+release-homebrew | end
```

Example diff
```
./release+release-homebrew | diff --git a/Formula/earthly.rb b/Formula/earthly.rb
./release+release-homebrew | index 9644a81e53..3fcd4ebafc 100644
./release+release-homebrew | --- a/Formula/earthly.rb
./release+release-homebrew | +++ b/Formula/earthly.rb
./release+release-homebrew | @@ -1,8 +1,8 @@
./release+release-homebrew |  class Earthly < Formula
./release+release-homebrew |    desc "Build automation tool for the post-container era"
./release+release-homebrew |    homepage "https://earthly.dev/"
./release+release-homebrew | -  url "https://github.com/earthly/earthly/archive/v0.3.0.tar.gz"
./release+release-homebrew | -  sha256 "7a2f28d56d5c74872638a131e69c2edb02de3d2d1808ea10012175fca5168b75"
./release+release-homebrew | +  url "https://github.com/earthly/earthly/archive/v0.0.0.tar.gz"
./release+release-homebrew | +  sha256 "d5558cd419c8d46bdc958064cb97f963d1ea793866414c025906ec15033512ed"
./release+release-homebrew |    license "MPL-2.0"
./release+release-homebrew |    head "https://github.com/earthly/earthly.git"
./release+release-homebrew |  
./release+release-homebrew | @@ -16,8 +16,9 @@ class Earthly < Formula
./release+release-homebrew |    depends_on "go" => :build
./release+release-homebrew |  
./release+release-homebrew |    def install
./release+release-homebrew | -    system "go", "build", "-ldflags",
./release+release-homebrew | -        "-X main.DefaultBuildkitdImage=earthly/buildkitd:v#{version} -X main.Version=v#{version}",
./release+release-homebrew | +    system "go", "build",
./release+release-homebrew | +        "-tags", "dfrunmount dfrunsecurity dfsecrets dfssh dfrunnetwork",
./release+release-homebrew | +        "-ldflags", "-X main.DefaultBuildkitdImage=earthly/buildkitd:v0.0.0 -X main.Version=v0.0.0 -X main.GitSha=6299507121592be6f64d6cc49f6b4778c2ab4cb2 ",
./release+release-homebrew |          *std_go_args,
./release+release-homebrew |          "-o", bin/"earth",
./release+release-homebrew |          "./cmd/earth/main.go"
./release+release-homebrew | --> RUN version=${RELEASE_TAG#v} ;echo version=$version ;git commit -a -m "earthly $version"
./release+release-homebrew | version=0.0.0
./release+release-homebrew | [release-v0.0.0 31e7b874a8] earthly 0.0.0
./release+release-homebrew |  1 file changed, 5 insertions(+), 4 deletions(-)
```