### PR TITLE
VS code syntax highlighting improvements.

### DIFF
--- a/contrib/earthfile-syntax-highlighting/README.md
+++ b/contrib/earthfile-syntax-highlighting/README.md
@@ -6,6 +6,12 @@ Syntax highlighting for Earthly build Earthfiles.
 
 ## Release Notes
 
+### 0.0.5
+
+* Fix `FROM DOCKERFILE`
+* Fix highlighting for target and artifact refs in edge cases (eg `g++`)
+* Make case-sensitive
+
 ### 0.0.4
 
 * Add highlighting for `FROM DOCKERFILE`

--- a/contrib/earthfile-syntax-highlighting/syntaxes/earthfile.tmLanguage.json
+++ b/contrib/earthfile-syntax-highlighting/syntaxes/earthfile.tmLanguage.json
@@ -113,7 +113,7 @@
 							"name": "keyword.other.special-method.earthfile"
 						}
 					},
-					"match": "^\\s*\\b(?i:(SAVE ARTIFACT))(\\b.*?\\b)(?i:(AS LOCAL))\\b"
+					"match": "^\\s*\\b(SAVE ARTIFACT)(\\b.*?\\b)(AS LOCAL)\\b"
 				},
 				{
 					"captures": {
@@ -128,15 +128,15 @@
 				},
 				{
 					"name": "keyword.other.special-method.earthfile",
-					"match": "^\\s*(?i:(ONBUILD)\\s+)?(?i:(CMD|ENTRYPOINT))\\s"
+					"match": "^\\s*HEALTHCHECK\\s+(NONE|CMD)\\s"
 				},
 				{
 					"name": "keyword.other.special-method.earthfile",
-					"match": "^\\s*(?i:(HEALTHCHECK)\\s+)?(?i:(NONE|CMD))\\s"
+					"match": "^\\s*FROM DOCKERFILE\\s"
 				},
 				{
 					"name": "keyword.other.special-method.earthfile",
-					"match": "^\\s*(?i:(ONBUILD|HEALTHCHECK)\\s+)?(?i:(FROM|FROM DOCKERFILE|COPY|SAVE ARTIFACT|SAVE IMAGE|RUN|LABEL|EXPOSE|VOLUME|USER|ENV|ARG|BUILD|WORKDIR|ENTRYPOINT|GIT CLONE|DOCKER LOAD|DOCKER PULL|HEALTHCHECK))\\s"
+					"match": "^\\s*(FROM|COPY|SAVE ARTIFACT|SAVE IMAGE|RUN|LABEL|EXPOSE|VOLUME|USER|ENV|ARG|BUILD|WORKDIR|ENTRYPOINT|CMD|GIT CLONE|DOCKER LOAD|DOCKER PULL|HEALTHCHECK)\\s"
 				}
 			]
 		},
@@ -213,11 +213,11 @@
 		"entity": {
 			"patterns": [
 				{
-					"match": "(\\S*\\+\\S*(/\\S*)+)",
+					"match": "(\\S*\\+[a-zA-Z0-9.\\-]+(/\\S*)+)",
 					"name": "entity.name.variable.target.earthfile"
 				},
 				{
-					"match": "(\\S*\\+\\S*)",
+					"match": "(\\S*\\+[a-zA-Z0-9.\\-]+)",
 					"name": "entity.name.type.target.earthfile"
 				}
 			]


### PR DESCRIPTION
* Fix FROM DOCKERFILE
* Fix highlighting for target and artifact refs in edge cases (eg `g++`)
* Make case-sensitive