### PR TITLE
Fix parallel dind's

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -182,7 +182,7 @@ func (b *Builder) buildCommon(ctx context.Context, mts *earthfile2llb.MultiTarge
 			existingValue, alreadyExists := localDirs[key]
 			if alreadyExists && existingValue != value {
 				return "", nil, fmt.Errorf(
-					"Inconsistent local dirs. For dir entry %s found both %s and %s",
+					"inconsistent local dirs. For dir entry %s found both %s and %s",
 					key, value, existingValue)
 			}
 			localDirs[key] = value

--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -17,6 +17,7 @@ buildkitd:
 
     COPY ../+shellrepeater/shellrepeater /usr/bin/shellrepeater
     COPY ../+debugger/earth_debugger /usr/bin/earth_debugger
+    COPY ./dockerd-wrapper.sh /var/earthly/dockerd-wrapper.sh
 
     ENV EARTHLY_RESET_TMP_DIR=false
     ENV EARTHLY_TMP_DIR=/tmp/earthly

--- a/buildkitd/dockerd-wrapper.sh
+++ b/buildkitd/dockerd-wrapper.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+
+set -e
+
+if [ -z "$EARTHLY_DOCKERD_DATA_ROOT" ]; then
+    echo "EARTHLY_DOCKERD_DATA_ROOT not set"
+    exit 1
+fi
+
+function start_dockerd() {
+    mkdir -p "$EARTHLY_DOCKERD_DATA_ROOT"
+    dockerd --data-root="$EARTHLY_DOCKERD_DATA_ROOT" &>/var/log/docker.log &
+    let i=1
+    timeout=30
+    while ! docker ps &>/dev/null; do
+        sleep 1
+        if [ "$i" -gt "$timeout" ]; then
+            # Print dockerd logs on start failure.
+            cat /var/log/docker.log
+            exit 1
+        fi
+        let i+=1
+    done
+}
+
+function stop_dockerd() {
+    dockerd_pid="$(cat /var/run/docker.pid)"
+    timeout=10
+    if [ -n "$dockerd_pid" ]; then
+        kill "$dockerd_pid" &>/dev/null
+        let i=1
+        while kill -0 "$dockerd_pid" &>/dev/null; do
+            sleep 1
+            if [ "$i" -gt "$timeout" ]; then
+                kill -9 "$dockerd_pid" &>/dev/null || true
+            fi
+            let i+=1
+        done
+    fi
+    # Wipe dockerd data when done.
+    rm -rf "$EARTHLY_DOCKERD_DATA_ROOT"
+}
+
+function load_images() {
+    if [ -n "$EARTHLY_DOCKER_LOAD_IMAGES" ]; then
+        echo "Loading images..."
+        for img in $EARTHLY_DOCKER_LOAD_IMAGES; do
+            docker load -i "$img" || (stop_dockerd; exit 1)
+        done
+        echo "...done"
+    fi
+}
+
+export EARTHLY_WITH_DOCKER=1
+
+# Lock the creation of the docker daemon - only one daemon can be started at a time
+# (dockerd race conditions in handling networking setup).
+(
+    flock -x 200
+    start_dockerd
+) 200>/var/earthly/dind/lock
+load_images
+set +e
+"$@"
+exit_code="$?"
+set -e
+stop_dockerd
+exit "$exit_code"

--- a/buildkitd/dockerd-wrapper.sh
+++ b/buildkitd/dockerd-wrapper.sh
@@ -58,6 +58,7 @@ export EARTHLY_WITH_DOCKER=1
 (
     flock -x 200
     start_dockerd
+    flock -u 200
 ) 200>/var/earthly/dind/lock
 load_images
 set +e

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -49,6 +49,7 @@ type Converter struct {
 	artifactBuilderFun ArtifactBuilderFun
 	cleanCollection    *cleanup.Collection
 	nextArgIndex       int
+	solveCache         map[string]llb.State
 }
 
 // NewConverter constructs a new converter for a given earth target.
@@ -81,6 +82,7 @@ func NewConverter(ctx context.Context, target domain.Target, bc *buildcontext.Da
 		dockerBuilderFun:   opt.DockerBuilderFun,
 		artifactBuilderFun: opt.ArtifactBuilderFun,
 		cleanCollection:    opt.CleanCollection,
+		solveCache:         opt.SolveCache,
 	}, nil
 }
 
@@ -483,7 +485,9 @@ func (c *Converter) Build(ctx context.Context, fullTargetName string, buildArgs 
 			DockerBuilderFun: c.dockerBuilderFun,
 			CleanCollection:  c.cleanCollection,
 			VisitedStates:    c.mts.VisitedStates,
-			VarCollection:    newVarCollection})
+			VarCollection:    newVarCollection,
+			SolveCache:       c.solveCache,
+		})
 	if err != nil {
 		return nil, errors.Wrapf(err, "earthfile2llb for %s", fullTargetName)
 	}

--- a/examples/tests/Earthfile
+++ b/examples/tests/Earthfile
@@ -39,8 +39,6 @@ dind-test-setup:
     FROM docker:19.03.12-dind
     RUN apk --update --no-cache add git
     COPY ../..+earth/earth /usr/local/bin/
-    COPY config.yaml /earthly/config.yaml
-    ENV EARTHLY_CONFIG=/earthly/config.yaml
     ENV EARTHLY_BUILDKIT_IMAGE=earthly/buildkitd:dind-test
     WORKDIR /test
     SAVE IMAGE
@@ -49,6 +47,7 @@ dind-test-setup:
 dind-config-test-todo:
     FROM +dind-test-setup
     COPY config.earth ./Earthfile
+    RUN echo aaa
     WITH DOCKER
         DOCKER LOAD ../../buildkitd+buildkitd earthly/buildkitd:dind-test
         RUN earth +test

--- a/examples/tests/Earthfile
+++ b/examples/tests/Earthfile
@@ -19,6 +19,7 @@ ga:
     BUILD +scratch-test
     BUILD +build-earth-test
     BUILD +host-bind-test
+    BUILD +remote-test
     BUILD +star-test
     BUILD +dockerfile-test
     BUILD +fail-test
@@ -31,27 +32,10 @@ experimental:
     BUILD +docker-load-test
     BUILD +dind-test
     BUILD +docker-pull-test
+    BUILD +load-parallel-test
     BUILD +docker-load-test-old
     BUILD +dind-test-old
     BUILD +docker-pull-test-old
-
-dind-test-setup:
-    FROM docker:19.03.12-dind
-    RUN apk --update --no-cache add git
-    COPY ../..+earth/earth /usr/local/bin/
-    ENV EARTHLY_BUILDKIT_IMAGE=earthly/buildkitd:dind-test
-    WORKDIR /test
-    SAVE IMAGE
-
-# TODO: This does not work due to docker run --privileged not being supported yet.
-dind-config-test-todo:
-    FROM +dind-test-setup
-    COPY config.earth ./Earthfile
-    RUN echo aaa
-    WITH DOCKER
-        DOCKER LOAD ../../buildkitd+buildkitd earthly/buildkitd:dind-test
-        RUN earth +test
-    END
 
 privileged-test:
     COPY privileged.earth ./Earthfile
@@ -157,13 +141,12 @@ host-bind-test:
     RUN test -f /bind-test/b.txt
     RUN cat /bind-test/b.txt
 
-# TODO: This does not pass, due to space on device limitation (dind caused).
 remote-test:
     ENV GIT_URL_INSTEAD_OF="https://github.com/=git@github.com:"
     RUN --privileged \
         --entrypoint \
         --mount=type=tmpfs,target=/tmp/earthly \
-        -- --no-output github.com/earthly/earthly+earth-docker
+        -- --no-output github.com/earthly/hello-world+hello
 
 # TODO: This does not pass.
 transitive-args-test-todo:
@@ -217,6 +200,13 @@ dind-test:
 
 docker-pull-test:
     COPY docker-pull.earth ./Earthfile
+    RUN --privileged \
+        --entrypoint \
+        --mount=type=tmpfs,target=/tmp/earthly \
+        -- --allow-privileged +test
+
+load-parallel-test:
+    COPY load-parallel.earth ./Earthfile
     RUN --privileged \
         --entrypoint \
         --mount=type=tmpfs,target=/tmp/earthly \
@@ -298,3 +288,27 @@ chown-test:
     --entrypoint \
     --mount=type=tmpfs,target=/tmp/earthly \
     -- --no-output +test
+
+eine-test-base:
+    FROM docker:19.03.12-dind
+    RUN apk --update --no-cache add git
+    COPY ../..+earth/earth /usr/local/bin/
+    ENV EARTHLY_BUILDKIT_IMAGE=earthly/buildkitd:dind-test
+    WORKDIR /test
+    SAVE IMAGE
+
+eine-config-test:
+    FROM +eine-test-base
+    COPY config.earth ./Earthfile
+    WITH DOCKER
+        DOCKER LOAD ../../buildkitd+buildkitd earthly/buildkitd:dind-test
+        RUN earth +test
+    END
+
+eine-privileged-test:
+    FROM +eine-test-base
+    COPY privileged.earth ./Earthfile
+    WITH DOCKER
+        DOCKER LOAD ../../buildkitd+buildkitd earthly/buildkitd:dind-test
+        RUN earth --allow-privileged +test
+    END

--- a/examples/tests/config.yaml
+++ b/examples/tests/config.yaml
@@ -1,2 +1,0 @@
-global:
-    debugger_port: 4999

--- a/examples/tests/load-parallel.earth
+++ b/examples/tests/load-parallel.earth
@@ -1,0 +1,29 @@
+FROM docker:19.03.7-dind
+
+some-image:
+    FROM alpine:3.11
+    RUN mkdir /abc
+    WORKDIR /abc
+    RUN echo "hello world" >def.txt
+    ENTRYPOINT cat /abc/def.txt && pwd
+    SAVE IMAGE
+
+load1:
+    WITH DOCKER
+        DOCKER LOAD +some-image test-img:xyz
+        DOCKER PULL hello-world
+        RUN docker run test-img:xyz && \
+            docker run hello-world
+    END
+
+load2:
+    WITH DOCKER
+        DOCKER LOAD +some-image test-img:xyz
+        DOCKER PULL hello-world
+        RUN docker run test-img:xyz && \
+            docker run hello-world
+    END
+
+test:
+    BUILD +load1
+    BUILD +load2


### PR DESCRIPTION
This fixes two issues:

* Two DOCKER LOAD of the same target would cause a local dir key collision
* An error where two docker daemons being started at the same time would cause a race condition.

The errors looked like this

```
failed to start daemon: Error initializing network controller: error obtaining controller instance: failed to create FILTER isolation chain: iptables failed: iptables --wait -t filter -N DOCKER-ISOLATION-STAGE-2: iptables: Chain already exists.
```

```
failed to start daemon: Error initializing network controller: error obtaining controller instance: unable to add return rule in DOCKER-ISOLATION-STAGE-2 chain:  (iptables failed: iptables --wait -A DOCKER-ISOLATION-STAGE-2 -j RETURN: iptables: No chain/target/match by that name.
```

This also contains a few unrelated changes regarding eine (earthly-in-earthly).