### PR TITLE
package up binaries in docker for pre-release testing

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -42,7 +42,7 @@ code:
 
 lintscripts:
     FROM +deps
-    COPY ./buildkitd/entrypoint.sh ./shell_scripts/.
+    COPY ./earth ./buildkitd/entrypoint.sh ./shell_scripts/.
     RUN shellcheck shell_scripts/*
 
 lint:

--- a/Earthfile
+++ b/Earthfile
@@ -153,6 +153,15 @@ earth-docker:
     COPY --build-arg VERSION=$TAG +earth/earth /usr/bin/earth
     SAVE IMAGE --push earthly/earth:$TAG
 
+# we abuse docker here to distribute our binaries
+prerelease-docker:
+    COPY +earth/earth /earth-linux-amd64
+    COPY --build-arg GOOS=darwin \
+        --build-arg GOARCH=amd64 \
+        --build-arg GO_EXTRA_LDFLAGS= \
+    +earth/earth /earth-darwin-amd64
+    SAVE IMAGE --push earthly/earthlybinaries:latest
+
 for-linux:
     BUILD +buildkitd
     BUILD +earth
@@ -165,6 +174,7 @@ all:
     BUILD +buildkitd
     BUILD +earth-all
     BUILD +earth-docker
+    BUILD +prerelease-docker
 
 test:
     BUILD +lint

--- a/earth
+++ b/earth
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+
+LAST_CHECK_STATE_PATH=/tmp/last-earth-prerelease-check
+
+function get_latest_binary {
+    docker pull alexcb132/earthlybinaries:latest
+    docker create --name earthly_binary alexcb132/earthlybinaries
+
+    earthbinpath=/earth-linux-amd64
+    if [ "$(uname)" == "Darwin" ]; then
+        earthbinpath=/earth-darwin-amd64
+    fi
+
+    docker cp earthly_binary:$earthbinpath ~/bin/earth-bin
+    docker rm earthly_binary
+}
+
+LAST=`cat $LAST_CHECK_STATE_PATH 2>/dev/null || echo 0`
+NOW=`date +%s`
+since=$(expr $NOW - $LAST)
+
+if [ $since -ge 3600 ]; then
+    echo checking for latest earth pre-release binaries
+    get_latest_binary
+    echo $NOW > $LAST_CHECK_STATE_PATH
+fi
+
+~/bin/earth-bin $@

--- a/earth
+++ b/earth
@@ -4,7 +4,7 @@ set -e
 last_check_state_path=/tmp/last-earth-prerelease-check
 
 function get_latest_binary {
-    docker pull alexcb132/earthlybinaries:latest
+    docker pull earthly/earthlybinaries:latest
     docker create --name earthly_binary earthly/earthlybinaries
 
     earth_bin_path=/earth-linux-amd64
@@ -16,14 +16,14 @@ function get_latest_binary {
     docker rm earthly_binary
 }
 
-last=`cat "$last_check_state_path" 2>/dev/null || echo 0`
-now=`date +%s`
-since=$(expr $now - $last)
+last=$(cat "$last_check_state_path" 2>/dev/null || echo 0)
+now=$(date +%s)
+since=$(( "$now" - "$last" ))
 
-if [ $since -ge 3600 ]; then
+if [ "$since" -ge 3600 ]; then
     echo checking for latest earth pre-release binaries
     get_latest_binary
-    echo $now > $last_check_state_path
+    echo "$now" > $last_check_state_path
 fi
 
 ~/bin/earth-bin "$@"

--- a/earth
+++ b/earth
@@ -1,29 +1,29 @@
 #!/bin/bash
 set -e
 
-LAST_CHECK_STATE_PATH=/tmp/last-earth-prerelease-check
+last_check_state_path=/tmp/last-earth-prerelease-check
 
 function get_latest_binary {
     docker pull alexcb132/earthlybinaries:latest
-    docker create --name earthly_binary alexcb132/earthlybinaries
+    docker create --name earthly_binary earthly/earthlybinaries
 
-    earthbinpath=/earth-linux-amd64
+    earth_bin_path=/earth-linux-amd64
     if [ "$(uname)" == "Darwin" ]; then
-        earthbinpath=/earth-darwin-amd64
+        earth_bin_path=/earth-darwin-amd64
     fi
 
-    docker cp earthly_binary:$earthbinpath ~/bin/earth-bin
+    docker cp earthly_binary:"$earth_bin_path" ~/bin/earth-bin
     docker rm earthly_binary
 }
 
-LAST=`cat $LAST_CHECK_STATE_PATH 2>/dev/null || echo 0`
-NOW=`date +%s`
-since=$(expr $NOW - $LAST)
+last=`cat "$last_check_state_path" 2>/dev/null || echo 0`
+now=`date +%s`
+since=$(expr $now - $last)
 
 if [ $since -ge 3600 ]; then
     echo checking for latest earth pre-release binaries
     get_latest_binary
-    echo $NOW > $LAST_CHECK_STATE_PATH
+    echo $now > $last_check_state_path
 fi
 
-~/bin/earth-bin $@
+~/bin/earth-bin "$@"


### PR DESCRIPTION
The Idea with this new target, is we could have it built on master, then we can use a script like this:

```
set -e

function get_latest_binary {
    docker pull alexcb132/earthlybinaries:latest
    docker create --name binaryhack alexcb132/earthlybinaries
    
    earthbinpath=/earth-linux-amd64
    if [ "$(uname)" == "Darwin" ]; then
    earthbinpath=/earth-darwin-amd64
    fi
    
    docker cp binaryhack:$earthbinpath ~/bin/earth-bin
    docker rm binaryhack
}

LAST=`cat /tmp/last-earth-check 2>/dev/null || echo 0`
NOW=`date +%s`
since=$(expr $NOW - $LAST)

if [ $since -ge 3600 ]; then
    echo pulling latest earth version
    get_latest_binary
    echo $NOW > /tmp/last-earth-check
fi

~/bin/earth-bin $@

```

to periodically check for latest pre-releases.