### PR TITLE
Consistent transitive override of build args

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -159,10 +159,9 @@ earth-docker:
 # we abuse docker here to distribute our binaries
 prerelease-docker:
     FROM alpine:3.11
-    ARG EARTHLY_TARGET_TAG_DOCKER
-    ARG TAG=$EARTHLY_TARGET_TAG_DOCKER
-    COPY --build-arg VERSION=$TAG +earth-all/* ./
-    SAVE IMAGE --push earthly/earthlybinaries:$TAG
+    BUILD --build-arg TAG=prerelease ./buildkitd+buildkitd
+    COPY --build-arg VERSION=prerelease +earth-all/* ./
+    SAVE IMAGE --push earthly/earthlybinaries:prerelease
 
 for-linux:
     BUILD +buildkitd

--- a/earth
+++ b/earth
@@ -4,8 +4,8 @@ set -e
 last_check_state_path=/tmp/last-earth-prerelease-check
 
 get_latest_binary() {
-    docker pull earthly/earthlybinaries:latest
-    docker create --name earthly_binary earthly/earthlybinaries
+    docker pull earthly/earthlybinaries:master
+    docker create --name earthly_binary earthly/earthlybinaries:master
 
     earth_bin_path=/earth-linux-amd64
     if [ "$(uname)" == "Darwin" ]; then

--- a/earth
+++ b/earth
@@ -4,8 +4,8 @@ set -e
 last_check_state_path=/tmp/last-earth-prerelease-check
 
 get_latest_binary() {
-    docker pull earthly/earthlybinaries:master
-    docker create --name earthly_binary earthly/earthlybinaries:master
+    docker pull earthly/earthlybinaries:prerelease
+    docker create --name earthly_binary earthly/earthlybinaries:prerelease
 
     earth_bin_path=/earth-linux-amd64
     if [ "$(uname)" == "Darwin" ]; then

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -442,7 +442,7 @@ func (c *Converter) Build(ctx context.Context, fullTargetName string, buildArgs 
 	newVarCollection := c.varCollection
 	if relTarget.IsExternal() {
 		// Don't allow transitive overriding variables to cross project boundaries.
-		newVarCollection = newVarCollection.WithResetOverrides()
+		newVarCollection = variables.NewCollection()
 	}
 	newVarCollection, err = newVarCollection.WithParseBuildArgs(
 		buildArgs, c.processNonConstantBuildArgFunc(ctx))

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -70,9 +70,7 @@ func NewConverter(ctx context.Context, target domain.Target, bc *buildcontext.Da
 		FinalStates:   sts,
 		VisitedStates: opt.VisitedStates,
 	}
-	fmt.Printf("@# Entering %s:\n", target.String())
 	for _, key := range opt.VarCollection.SortedOverridingVariables() {
-		fmt.Printf("\t@# overriding %s\n", key)
 		ovVar, _, _ := opt.VarCollection.Get(key)
 		sts.TargetInput = sts.TargetInput.WithBuildArgInput(ovVar.BuildArgInput(key, ""))
 	}

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -70,6 +70,12 @@ func NewConverter(ctx context.Context, target domain.Target, bc *buildcontext.Da
 		FinalStates:   sts,
 		VisitedStates: opt.VisitedStates,
 	}
+	fmt.Printf("@# Entering %s:\n", target.String())
+	for _, key := range opt.VarCollection.SortedOverridingVariables() {
+		fmt.Printf("\t@# overriding %s\n", key)
+		ovVar, _, _ := opt.VarCollection.Get(key)
+		sts.TargetInput = sts.TargetInput.WithBuildArgInput(ovVar.BuildArgInput(key, ""))
+	}
 	targetStr := target.String()
 	opt.VisitedStates[targetStr] = append(opt.VisitedStates[targetStr], sts)
 	return &Converter{
@@ -427,16 +433,20 @@ func (c *Converter) Build(ctx context.Context, fullTargetName string, buildArgs 
 		With("build-args", buildArgs).
 		Info("Applying BUILD")
 
-	target, err := domain.ParseTarget(fullTargetName)
+	relTarget, err := domain.ParseTarget(fullTargetName)
 	if err != nil {
 		return nil, errors.Wrapf(err, "earth target parse %s", fullTargetName)
 	}
-
-	target, err = domain.JoinTargets(c.mts.FinalStates.Target, target)
+	target, err := domain.JoinTargets(c.mts.FinalStates.Target, relTarget)
 	if err != nil {
 		return nil, errors.Wrap(err, "join targets")
 	}
-	newVarCollection, err := c.varCollection.WithParseBuildArgs(
+	newVarCollection := c.varCollection
+	if relTarget.IsExternal() {
+		// Don't allow transitive overriding variables to cross project boundaries.
+		newVarCollection = newVarCollection.WithResetOverrides()
+	}
+	newVarCollection, err = newVarCollection.WithParseBuildArgs(
 		buildArgs, c.processNonConstantBuildArgFunc(ctx))
 	if err != nil {
 		return nil, errors.Wrap(err, "parse build args")
@@ -532,8 +542,7 @@ func (c *Converter) Env(ctx context.Context, envKey string, envValue string) {
 func (c *Converter) Arg(ctx context.Context, argKey string, defaultArgValue string) {
 	logging.GetLogger(ctx).With("arg-key", argKey).With("arg-value", defaultArgValue).Info("Applying ARG")
 	effective := c.varCollection.AddActive(argKey, variables.NewConstant(defaultArgValue), false)
-	c.mts.FinalStates.TargetInput.BuildArgs = append(
-		c.mts.FinalStates.TargetInput.BuildArgs,
+	c.mts.FinalStates.TargetInput = c.mts.FinalStates.TargetInput.WithBuildArgInput(
 		effective.BuildArgInput(argKey, defaultArgValue))
 }
 
@@ -815,7 +824,7 @@ func (c *Converter) internalFromClassical(ctx context.Context, imageName string,
 	if imageName == "scratch" {
 		// FROM scratch
 		return llb.Scratch().Platform(llbutil.TargetPlatform), image.NewImage(),
-			variables.NewCollection(), nil
+			c.varCollection.WithResetEnvVars(), nil
 	}
 	ref, err := reference.ParseNormalizedNamed(imageName)
 	if err != nil {

--- a/earthfile2llb/variables/collection.go
+++ b/earthfile2llb/variables/collection.go
@@ -163,16 +163,6 @@ func (c *Collection) WithResetEnvVars() *Collection {
 	return ret
 }
 
-// WithResetOverrides returns a copy of the current collection with all override
-// variables removed.
-func (c *Collection) WithResetOverrides() *Collection {
-	ret := NewCollection()
-	for k, v := range c.variables {
-		ret.variables[k] = v
-	}
-	return ret
-}
-
 // WithBuiltinBuildArgs returns a new collection containing the current variables together with
 // builtin args. This operation does not modify the current collection.
 func (c *Collection) WithBuiltinBuildArgs(target domain.Target, gitMeta *buildcontext.GitMetadata) *Collection {

--- a/examples/tests/Earthfile
+++ b/examples/tests/Earthfile
@@ -21,6 +21,7 @@ ga:
     BUILD +host-bind-test
     BUILD +remote-test
     BUILD +transitive-args-test
+    BUILD +non-transitive-args-test
     BUILD +star-test
     BUILD +dockerfile-test
     BUILD +fail-test
@@ -158,6 +159,31 @@ transitive-args-test:
         -- --build-arg SOMEARG=def +test
     RUN ls
     RUN test -f ./abc && test -f ./def && test ! -f ./default
+
+non-transitive-args-test:
+    COPY non-transitive-args1.earth ./Earthfile
+    COPY non-transitive-args2.earth ./subdir/Earthfile
+    # Should not override if transitive and corssing project boundaries.
+    RUN --privileged \
+        --entrypoint \
+        --mount=type=tmpfs,target=/tmp/earthly \
+        -- --build-arg SOMEARG=def +test
+    RUN ls ./subdir
+    RUN test -f ./subdir/default && test ! -f ./subdir/def && test ! -f ./subdir/abc
+    RUN rm ./subdir/default
+    # Should override, if override is direct.
+    RUN --privileged \
+        --entrypoint \
+        --mount=type=tmpfs,target=/tmp/earthly \
+        -- --build-arg SOMEARG=xyz ./subdir+arg-target
+    RUN ls ./subdir
+    RUN test -f ./subdir/xyz && test ! -f ./subdir/default
+    RUN --privileged \
+        --entrypoint \
+        --mount=type=tmpfs,target=/tmp/earthly \
+        -- +direct
+    RUN ls ./subdir
+    RUN test -f ./subdir/direct && test ! -f ./subdir/default
 
 star-test:
     COPY star.earth ./Earthfile

--- a/examples/tests/Earthfile
+++ b/examples/tests/Earthfile
@@ -20,6 +20,7 @@ ga:
     BUILD +build-earth-test
     BUILD +host-bind-test
     BUILD +remote-test
+    BUILD +transitive-args-test
     BUILD +star-test
     BUILD +dockerfile-test
     BUILD +fail-test
@@ -149,8 +150,7 @@ remote-test:
         --mount=type=tmpfs,target=/tmp/earthly \
         -- --no-output github.com/earthly/hello-world+hello
 
-# TODO: This does not pass.
-transitive-args-test-todo:
+transitive-args-test:
     COPY transitive-args.earth ./Earthfile
     RUN --privileged \
         --entrypoint \

--- a/examples/tests/non-transitive-args1.earth
+++ b/examples/tests/non-transitive-args1.earth
@@ -1,0 +1,8 @@
+FROM alpine:3.11
+test:
+    BUILD +intermediate
+    BUILD --build-arg SOMEARG=abc +intermediate
+intermediate:
+    BUILD ./subdir+arg-target
+direct:
+    BUILD --build-arg SOMEARG=direct ./subdir+arg-target

--- a/examples/tests/non-transitive-args2.earth
+++ b/examples/tests/non-transitive-args2.earth
@@ -1,0 +1,5 @@
+FROM alpine:3.11
+arg-target:
+    ARG SOMEARG=default
+    RUN echo content >file.txt
+    SAVE ARTIFACT file.txt AS LOCAL "$SOMEARG"

--- a/examples/tests/transitive-args.earth
+++ b/examples/tests/transitive-args.earth
@@ -1,10 +1,10 @@
 FROM alpine:3.11
 test:
-    BUILD --build-arg SOMEARG=$SOMEARG +intermediate
+    BUILD +intermediate
     BUILD --build-arg SOMEARG=abc +intermediate
 intermediate:
     BUILD +arg-target
 arg-target:
     ARG SOMEARG=default
-    RUN echo abc > file.txt
-    SAVE ARTIFACT file.txt "/$SOMEARG" AS LOCAL "$SOMEARG"
+    RUN echo content >file.txt
+    SAVE ARTIFACT file.txt AS LOCAL "$SOMEARG"

--- a/release/Earthfile
+++ b/release/Earthfile
@@ -3,7 +3,7 @@ FROM alpine:3.11
 release:
     ARG RELEASE_TAG
     RUN test -n "$RELEASE_TAG"
-    BUILD ../+test
+    BUILD ../+test-all
     BUILD --build-arg RELEASE_TAG="$RELEASE_TAG" +release-dockerhub
     BUILD --build-arg RELEASE_TAG="$RELEASE_TAG" +release-github
 
@@ -23,7 +23,7 @@ release-github:
     ARG EARTHLY_GIT_HASH
     RUN test -n "$RELEASE_TAG" && test -n "$EARTHLY_GIT_HASH"
     COPY --build-arg VERSION=$RELEASE_TAG \
-        ../+earth-all/* ./
+        ../+earth-all/* ./release/
     ARG BODY="No details provided"
     RUN --secret GITHUB_TOKEN=+secrets/GITHUB_TOKEN test -n "$GITHUB_TOKEN"
     RUN --push \
@@ -35,7 +35,7 @@ release-github:
         --tag "$RELEASE_TAG" \
         --name "$RELEASE_TAG" \
         --body "$BODY" \
-        ./*
+        ./release/*
 
 release-homebrew:
     RUN apk add --update --no-cache \

--- a/release/Earthfile
+++ b/release/Earthfile
@@ -23,12 +23,7 @@ release-github:
     ARG EARTHLY_GIT_HASH
     RUN test -n "$RELEASE_TAG" && test -n "$EARTHLY_GIT_HASH"
     COPY --build-arg VERSION=$RELEASE_TAG \
-        ../+earth/earth ./earth-linux-amd64
-    COPY --build-arg VERSION=$RELEASE_TAG \
-        --build-arg GOOS=darwin \
-        --build-arg GOARCH=amd64 \
-        --build-arg GO_EXTRA_LDFLAGS= \
-        ../+earth/earth ./earth-darwin-amd64
+        ../+earth-all/* ./
     ARG BODY="No details provided"
     RUN --secret GITHUB_TOKEN=+secrets/GITHUB_TOKEN test -n "$GITHUB_TOKEN"
     RUN --push \
@@ -40,7 +35,7 @@ release-github:
         --tag "$RELEASE_TAG" \
         --name "$RELEASE_TAG" \
         --body "$BODY" \
-        earth-linux-amd64 earth-darwin-amd64
+        ./*
 
 release-homebrew:
     RUN apk add --update --no-cache \
@@ -97,10 +92,7 @@ release-homebrew:
     RUN mkdir -p /params
     RUN curl -L "$NEW_URL" | sha256sum | cut -f 1 -d ' ' > /params/downloadsha256
     COPY --build-arg VERSION=$RELEASE_TAG \
-        --build-arg GOOS=darwin \
-        --build-arg GOARCH=amd64 \
-        --build-arg GO_EXTRA_LDFLAGS= \
-        ../+earth/tags ../+earth/ldflags /params/
+        ../+earth-darwin/tags ../+earth-darwin/ldflags /params/
     # Split /params/ldflags over two lines (to satisfy ruby linter).
     RUN split --numeric-suffixes=1 --suffix-length=1 --bytes=80 /params/ldflags /params/ldflags && \
         touch /params/ldflags2 && \

--- a/release/README.md
+++ b/release/README.md
@@ -1,7 +1,7 @@
 # Releasing instructions
 
 ### earth
-* Test on Mac using `earth --build-arg GOOS=darwin --build-arg GOARCH=amd64 --build-arg GO_EXTRA_LDFLAGS= --artifact github.com/earthly/earthly+earth/earth ./earth && docker pull earthly/buildkitd:master && ./earth -P github.com/earthly/earthly+test-all`
+* Test on Mac using `earth --artifact github.com/earthly/earthly+for-darwin/earth ./earth && docker pull earthly/buildkitd:master && ./earth -P github.com/earthly/earthly+test-all`
 * Make sure you have a GITHUB_TOKEN set. If you don't have a GITHUB_TOKEN, generate one [here](https://github.com/settings/tokens) with scope `repo`.
   ```bash
   export GITHUB_TOKEN="..."


### PR DESCRIPTION
The logic is as follows:

A build arg override is passed transitively between targets within the same project (same Earthfile). If crossing projects, only immediate overrides are applied but not all transitive overrides.

In this case, the override will work, and the echo will print `override`.

```
one:
  BUILD --build-arg VAR=override +two
two:
  BUILD +three
three:
  ARG VAR=default
  RUN echo $VAR 
```

In this case, the override will not work, and the echo will print `default`:

`./Earthfile`:
```
one:
  BUILD --build-arg VAR=override +two
two:
  BUILD ./otherproj+three
```

`./otherproj/Earthfile`:
```
three:
  ARG VAR=default
  RUN echo $VAR 
```
-------

Additional, unrelated change:

* Use the tag `prerelease` for the prerelease earth+buildkitd, to avoid any local clash with a `:master` build of the buildkitd image.