### PR TITLE
Dont check for updates on autocompletion

### DIFF
--- a/earth
+++ b/earth
@@ -21,7 +21,7 @@ last=$(cat "$last_check_state_path" 2>/dev/null || echo 0)
 now=$(date +%s)
 since=$(( now - last ))
 
-if [ "$since" -ge 3600 ]; then
+if [ "$since" -ge 3600 ] && [ -z "$COMP_LINE" ]; then
     echo checking for latest earth pre-release binaries
     get_latest_binary
     echo "$now" >"$last_check_state_path"


### PR DESCRIPTION
When performing bash auto completion, we can't check for updates because
it slows down the interactive experience and we can't print out anything
to stdout.