### PR TITLE
Use $HOME rather than user.Current().HomeDir

### DIFF
--- a/cmd/earth/main.go
+++ b/cmd/earth/main.go
@@ -163,11 +163,11 @@ func (app *earthApp) deleteZcompdump() error {
 	var homeDir string
 	sudoUser, found := os.LookupEnv("SUDO_USER")
 	if !found {
-		currentUser, err := user.Current()
+		var err error
+		homeDir, err = os.UserHomeDir()
 		if err != nil {
-			return errors.Wrapf(err, "failed to lookup current user")
+			return errors.Wrapf(err, "failed to lookup current user home dir")
 		}
-		homeDir = currentUser.HomeDir
 	} else {
 		currentUser, err := user.Lookup(sudoUser)
 		if err != nil {
@@ -292,12 +292,12 @@ func main() {
 		FullTimestamp: true,
 	})
 	logrus.SetLevel(logrus.InfoLevel)
-	currentUser, err := user.Current()
+	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		fmt.Printf("Error looking up current user: %s\n", err.Error())
 		os.Exit(1)
 	}
-	logDir := filepath.Join(currentUser.HomeDir, ".earthly")
+	logDir := filepath.Join(homeDir, ".earthly")
 	logFile := filepath.Join(logDir, "earth.log")
 	err = os.MkdirAll(logDir, 0755)
 	if err != nil {
@@ -979,13 +979,13 @@ func defaultSSHAuthSock() string {
 }
 
 func defaultConfigPath() string {
-	currentUser, err := user.Current()
+	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		panic(err)
 	}
 
-	oldConfig := filepath.Join(currentUser.HomeDir, ".earthly", "config.yaml")
-	newConfig := filepath.Join(currentUser.HomeDir, ".earthly", "config.yml")
+	oldConfig := filepath.Join(homeDir, ".earthly", "config.yaml")
+	newConfig := filepath.Join(homeDir, ".earthly", "config.yml")
 	if fileExists(oldConfig) && !fileExists(newConfig) {
 		return oldConfig
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -2,7 +2,7 @@ package config
 
 import (
 	"fmt"
-	"os/user"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -155,9 +155,9 @@ func CreateGitConfig(config *Config) (string, []string, error) {
 }
 
 func defaultRunPath() string {
-	currentUser, err := user.Current()
+	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		panic(err)
 	}
-	return filepath.Join(currentUser.HomeDir, ".earthly/run")
+	return filepath.Join(homeDir, ".earthly/run")
 }


### PR DESCRIPTION
the brew install overrides $HOME to point to a sandbox; however when
using user.Current().HomeDir it doesn't pick this setting up ( see
https://github.com/golang/go/issues/26463 ).