### PR TITLE
Pass along user's TERM type.

### DIFF
--- a/cmd/debugger/main.go
+++ b/cmd/debugger/main.go
@@ -213,7 +213,12 @@ func main() {
 			// Take a brief pause and issue a new line as a work around.
 			time.Sleep(time.Millisecond * 5)
 
-			err := interactiveMode(ctx, remoteConsoleAddr)
+			err := os.Setenv("TERM", debuggerSettings.Term)
+			if err != nil {
+				conslogger.Warnf("Failed to set term: %v", err)
+			}
+
+			err = interactiveMode(ctx, remoteConsoleAddr)
 			if err != nil {
 				log.Error(err)
 			}

--- a/cmd/earth/main.go
+++ b/cmd/earth/main.go
@@ -858,6 +858,7 @@ func (app *earthApp) actionBuild(c *cli.Context) error {
 		DebugLevelLogging: app.buildkitdSettings.Debug,
 		Enabled:           app.interactiveDebugging,
 		SockPath:          fmt.Sprintf("/run/earthly/%s", sockName),
+		Term:              os.Getenv("TERM"),
 	}
 
 	debuggerSettingsData, err := json.Marshal(&debuggerSettings)

--- a/debugger/common/settings.go
+++ b/debugger/common/settings.go
@@ -8,4 +8,5 @@ type DebuggerSettings struct {
 	DebugLevelLogging bool   `json:"debugLevel"`
 	Enabled           bool   `json:"enabled"`
 	SockPath          string `json:"sockPath"`
+	Term              string `json:"term"`
 }


### PR DESCRIPTION
* fixes #286 by correctly setting the TERM environment variable before
  starting the interactive debugger shell.