### PR TITLE
fix earth failure when ssh agent sock doesnt exist

### DIFF
--- a/cmd/earth/main.go
+++ b/cmd/earth/main.go
@@ -1015,10 +1015,19 @@ func processSecrets(secrets []string, dotEnvMap map[string]string) (map[string][
 }
 
 func defaultSSHAuthSock() string {
+	var sshPath string
 	if runtime.GOOS == "darwin" {
-		return "/run/host-services/ssh-auth.sock"
+		sshPath = "/run/host-services/ssh-auth.sock"
+	} else {
+		sshPath = os.Getenv("SSH_AUTH_SOCK")
 	}
-	return os.Getenv("SSH_AUTH_SOCK")
+
+	if !fileExists(sshPath) {
+		// darwin path doesn't always exist, reset to "" to skip ssh auth sock passthrough
+		sshPath = ""
+	}
+
+	return sshPath
 }
 
 func defaultConfigPath() string {


### PR DESCRIPTION
* fixes issue where "ssh agent provider: stat /run/host-services/ssh-auth.sock: no such file or directory"
error occurs when trying to access the ssh-auth.sock during CI testing (or
cases where the user doesnt have an ssh agent running)