### PR TITLE
Implement WITH DOCKER --compose

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -189,7 +189,6 @@ test:
 test-all:
     BUILD +examples
     BUILD +test
-    BUILD ./examples/tests+experimental
 
 examples:
     BUILD ./examples/go+docker

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -457,13 +457,14 @@ func (c *Converter) Build(ctx context.Context, fullTargetName string, buildArgs 
 	// Recursion.
 	mts, err := Earthfile2LLB(
 		ctx, target, ConvertOpt{
-			Resolver:         c.resolver,
-			ImageResolveMode: c.imageResolveMode,
-			DockerBuilderFun: c.dockerBuilderFun,
-			CleanCollection:  c.cleanCollection,
-			VisitedStates:    c.mts.VisitedStates,
-			VarCollection:    newVarCollection,
-			SolveCache:       c.solveCache,
+			Resolver:           c.resolver,
+			ImageResolveMode:   c.imageResolveMode,
+			DockerBuilderFun:   c.dockerBuilderFun,
+			ArtifactBuilderFun: c.artifactBuilderFun,
+			CleanCollection:    c.cleanCollection,
+			VisitedStates:      c.mts.VisitedStates,
+			VarCollection:      newVarCollection,
+			SolveCache:         c.solveCache,
 		})
 	if err != nil {
 		return nil, errors.Wrapf(err, "earthfile2llb for %s", fullTargetName)

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -312,7 +312,7 @@ func (c *Converter) CopyClassical(ctx context.Context, srcs []string, dest strin
 // Run applies the earth RUN command.
 func (c *Converter) Run(ctx context.Context, args []string, mounts []string, secretKeyValues []string, privileged bool, withEntrypoint bool, withDocker bool, isWithShell bool, pushFlag bool, withSSH bool) error {
 	if withDocker {
-		fmt.Printf("Warning: RUN --with-docker is deprecated. Use WITH DOCKER ... RUN ... END instead\n")
+		fmt.Printf("Warning: RUN --with-docker is deprecated. Please use WITH DOCKER ... RUN ... END instead\n")
 	}
 	logging.GetLogger(ctx).
 		With("args", args).
@@ -584,7 +584,7 @@ func (c *Converter) WithDockerRun(ctx context.Context, args []string, opt WithDo
 
 // DockerLoadOld applies the DOCKER LOAD command (outside of WITH DOCKER).
 func (c *Converter) DockerLoadOld(ctx context.Context, targetName string, dockerTag string, buildArgs []string) error {
-	fmt.Printf("Warning: DOCKER LOAD outside of WITH DOCKER is deprecated\n")
+	fmt.Printf("Warning: DOCKER LOAD is deprecated. Please use WITH DOCKER --load\n")
 	logging.GetLogger(ctx).With("target-name", targetName).With("dockerTag", dockerTag).Info("Applying DOCKER LOAD")
 	depTarget, err := domain.ParseTarget(targetName)
 	if err != nil {
@@ -606,7 +606,7 @@ func (c *Converter) DockerLoadOld(ctx context.Context, targetName string, docker
 
 // DockerPullOld applies the DOCKER PULL command (outside of WITH DOCKER).
 func (c *Converter) DockerPullOld(ctx context.Context, dockerTag string) error {
-	fmt.Printf("Warning: DOCKER PULL outside of WITH DOCKER is deprecated\n")
+	fmt.Printf("Warning: DOCKER PULL is deprecated. Please use WITH DOCKER --pull\n")
 	logging.GetLogger(ctx).With("dockerTag", dockerTag).Info("Applying DOCKER PULL")
 	state, image, _, err := c.internalFromClassical(
 		ctx, dockerTag,

--- a/earthfile2llb/shell.go
+++ b/earthfile2llb/shell.go
@@ -37,9 +37,12 @@ func withShell(args []string, withShell bool) []string {
 	return args
 }
 
-func strWithEnvVars(args []string, envVars []string, withShell bool, withDebugger bool) string {
+func strWithEnvVarsAndDocker(args []string, envVars []string, withShell bool, withDebugger bool, withDocker bool) string {
 	var cmdParts []string
 	cmdParts = append(cmdParts, strings.Join(envVars, " "))
+	if withDocker {
+		cmdParts = append(cmdParts, dockerdWrapperPath, "execute")
+	}
 	if withDebugger {
 		cmdParts = append(cmdParts, debuggerPath)
 	}
@@ -61,7 +64,7 @@ type shellWrapFun func(args []string, envVars []string, withShell bool, withDebu
 func withShellAndEnvVars(args []string, envVars []string, withShell bool, withDebugger bool) []string {
 	return []string{
 		"/bin/sh", "-c",
-		strWithEnvVars(args, envVars, withShell, withDebugger),
+		strWithEnvVarsAndDocker(args, envVars, withShell, withDebugger, false),
 	}
 }
 
@@ -87,7 +90,7 @@ func withDockerdWrapOld(args []string, envVars []string, withShell bool, withDeb
 			"let i+=1\n" +
 			"done\n" +
 			// Run provided args.
-			strWithEnvVars(args, envVars, withShell, withDebugger) + "\n" +
+			strWithEnvVarsAndDocker(args, envVars, withShell, withDebugger, false) + "\n" +
 			"exit_code=\"\\$?\"\n" +
 			// Shut down dockerd.
 			"kill \"\\$dockerd_pid\" &>/dev/null\n" +

--- a/earthfile2llb/variables/collection.go
+++ b/earthfile2llb/variables/collection.go
@@ -251,7 +251,7 @@ func (c *Collection) parseBuildArg(arg string, pncvf ProcessNonConstantVariableF
 	var name string
 	splitArg := strings.SplitN(arg, "=", 2)
 	if len(splitArg) < 1 {
-		return "", Variable{}, false, fmt.Errorf("Invalid build arg %s", splitArg)
+		return "", Variable{}, false, fmt.Errorf("invalid build arg %s", splitArg)
 	}
 	name = splitArg[0]
 	value := ""

--- a/earthfile2llb/withdockerrun.go
+++ b/earthfile2llb/withdockerrun.go
@@ -21,7 +21,7 @@ import (
 
 const dockerdWrapperPath = "/var/earthly/dockerd-wrapper.sh"
 
-// DockerLoadOpt holds parameters for DOCKER LOAD commands.
+// DockerLoadOpt holds parameters for WITH DOCKER --load parameter.
 type DockerLoadOpt struct {
 	Target    string
 	ImageName string
@@ -30,12 +30,14 @@ type DockerLoadOpt struct {
 
 // WithDockerOpt holds parameters for WITH DOCKER run.
 type WithDockerOpt struct {
-	Mounts         []string
-	Secrets        []string
-	WithShell      bool
-	WithEntrypoint bool
-	Pulls          []string
-	Loads          []DockerLoadOpt
+	Mounts          []string
+	Secrets         []string
+	WithShell       bool
+	WithEntrypoint  bool
+	Pulls           []string
+	Loads           []DockerLoadOpt
+	ComposeFiles    []string
+	ComposeServices []string
 }
 
 type withDockerRun struct {

--- a/earthfile2llb/withdockerrun.go
+++ b/earthfile2llb/withdockerrun.go
@@ -211,13 +211,17 @@ func makeWithDockerdWrapFun(dindID string, tarPaths []string) shellWrapFun {
 	dockerRoot := path.Join("/var/earthly/dind", dindID)
 	params := []string{
 		fmt.Sprintf("EARTHLY_DOCKERD_DATA_ROOT=\"%s\"", dockerRoot),
-		fmt.Sprintf("EARTHLY_DOCKER_LOAD_IMAGES=\"%s\"", strings.Join(tarPaths, " ")),
+		fmt.Sprintf("EARTHLY_DOCKER_LOAD_FILES=\"%s\"", strings.Join(tarPaths, " ")),
+		// TODO
+		fmt.Sprintf("EARTHLY_START_COMPOSE=\"%t\"", false),
+		fmt.Sprintf("EARTHLY_COMPOSE_FILES=\"%s\"", strings.Join([]string{}, " ")),
+		fmt.Sprintf("EARTHLY_COMPOSE_SERVICES=\"%s\"", strings.Join([]string{}, " ")),
 	}
 	return func(args []string, envVars []string, isWithShell bool, withDebugger bool) []string {
 		return []string{
 			"/bin/sh", "-c",
 			fmt.Sprintf(
-				"%s %s %s",
+				"%s %s execute %s",
 				strings.Join(params, " "),
 				dockerdWrapperPath,
 				strWithEnvVars(args, envVars, isWithShell, withDebugger)),

--- a/examples/tests/Earthfile
+++ b/examples/tests/Earthfile
@@ -7,7 +7,6 @@ WORKDIR /test
 
 all:
     BUILD +ga
-    BUILD +experimental
     BUILD +experimental-old
 
 ga:
@@ -37,6 +36,7 @@ ga:
     BUILD +dotenv-test
     BUILD +env-test
     BUILD ./with-docker+all
+    BUILD ./with-docker-compose+all
 
 experimental-old:
     BUILD +docker-load-test-old

--- a/examples/tests/Earthfile
+++ b/examples/tests/Earthfile
@@ -36,8 +36,6 @@ ga:
     BUILD +chown-test
     BUILD +dotenv-test
     BUILD +env-test
-
-experimental:
     BUILD ./with-docker+all
 
 experimental-old:

--- a/examples/tests/with-docker-compose/Earthfile
+++ b/examples/tests/with-docker-compose/Earthfile
@@ -4,9 +4,6 @@ WORKDIR /test
 all:
     BUILD --build-arg INDEX=1 +test
     BUILD --build-arg INDEX=2 +test
-    BUILD --build-arg INDEX=3 +test
-    BUILD --build-arg INDEX=4 +test
-    BUILD --build-arg INDEX=5 +test
 
 print-countries:
     FROM jbergknoff/postgresql-client:latest

--- a/examples/tests/with-docker-compose/Earthfile
+++ b/examples/tests/with-docker-compose/Earthfile
@@ -23,6 +23,6 @@ test:
             --service postgres \
             --load print-countries:latest=+print-countries
         RUN for i in {1..30}; do nc -z localhost 5432 && break; sleep 1; done; \
-            sleep 20 ;\
+            sleep 30 ;\
             docker-compose up --exit-code-from print-countries print-countries | grep Brazil
     END

--- a/examples/tests/with-docker-compose/Earthfile
+++ b/examples/tests/with-docker-compose/Earthfile
@@ -23,6 +23,6 @@ test:
             --service postgres \
             --load print-countries:latest=+print-countries
         RUN for i in {1..30}; do nc -z localhost 5432 && break; sleep 1; done; \
-            sleep 30 ;\
+            sleep 60 ;\
             docker-compose up --exit-code-from print-countries print-countries | grep Brazil
     END

--- a/examples/tests/with-docker-compose/Earthfile
+++ b/examples/tests/with-docker-compose/Earthfile
@@ -1,0 +1,28 @@
+FROM docker:19.03.7-dind
+WORKDIR /test
+
+all:
+    BUILD --build-arg INDEX=1 +test
+    BUILD --build-arg INDEX=2 +test
+    BUILD --build-arg INDEX=3 +test
+    BUILD --build-arg INDEX=4 +test
+    BUILD --build-arg INDEX=5 +test
+
+print-countries:
+    FROM jbergknoff/postgresql-client:latest
+    CMD ["-c", "SELECT * FROM country WHERE country_id = '76'"]
+    SAVE IMAGE
+
+test:
+    COPY docker-compose.yml .
+    # Index is used to create parallel tests.
+    ARG INDEX=0
+    RUN echo "$INDEX"
+    WITH DOCKER \
+            --compose docker-compose.yml \
+            --service postgres \
+            --load print-countries:latest=+print-countries
+        RUN for i in {1..30}; do nc -z localhost 5432 && break; sleep 1; done; \
+            sleep 20 ;\
+            docker-compose up --exit-code-from print-countries print-countries | grep Brazil
+    END

--- a/examples/tests/with-docker-compose/docker-compose.yml
+++ b/examples/tests/with-docker-compose/docker-compose.yml
@@ -1,0 +1,20 @@
+version: "3"
+
+services:
+  print-countries:
+    image: print-countries:latest
+    depends_on:
+      - postgres
+    environment:
+      - PGHOST=postgres
+      - PGUSER=postgres
+      - PGPASSWORD=postgres
+      - PGDATABASE=iso3166
+
+  postgres:
+    image: aa8y/postgres-dataset:iso3166
+    ports:
+      - 5432
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres

--- a/examples/tests/with-docker/Earthfile
+++ b/examples/tests/with-docker/Earthfile
@@ -41,6 +41,3 @@ docker-pull-test:
 load-parallel-test:
     BUILD --build-arg INDEX=1 +docker-load-test
     BUILD --build-arg INDEX=2 +docker-load-test
-    BUILD --build-arg INDEX=3 +docker-load-test
-    BUILD --build-arg INDEX=4 +docker-load-test
-    BUILD --build-arg INDEX=5 +docker-load-test

--- a/examples/tests/with-docker/Earthfile
+++ b/examples/tests/with-docker/Earthfile
@@ -15,6 +15,9 @@ a-test-image:
     SAVE IMAGE
 
 docker-load-test:
+    # Index is used to create parallel tests.
+    ARG INDEX=0
+    RUN echo "$INDEX"
     WITH DOCKER
         DOCKER LOAD +a-test-image test-img:xyz
         DOCKER PULL hello-world
@@ -35,22 +38,9 @@ docker-pull-test:
         RUN docker run hello-world
     END
 
-load1:
-    WITH DOCKER \
-            --load test-img:xyz=+a-test-image \
-            --pull hello-world
-        RUN docker run test-img:xyz && \
-            docker run hello-world
-    END
-
-load2:
-    WITH DOCKER \
-            --load test-img:xyz=+a-test-image \
-            --pull hello-world
-        RUN docker run test-img:xyz && \
-            docker run hello-world
-    END
-
 load-parallel-test:
-    BUILD +load1
-    BUILD +load2
+    BUILD --build-arg INDEX=1 +docker-load-test
+    BUILD --build-arg INDEX=2 +docker-load-test
+    BUILD --build-arg INDEX=3 +docker-load-test
+    BUILD --build-arg INDEX=4 +docker-load-test
+    BUILD --build-arg INDEX=5 +docker-load-test

--- a/examples/tests/with-docker/Earthfile
+++ b/examples/tests/with-docker/Earthfile
@@ -29,25 +29,24 @@ dind-test:
 
 docker-pull-test:
     # Note that this is mainly a smoke test, because the RUN command
-    # works even in absence of the PULL (it pull automatically if image
+    # works even in absence of the --pull (it pull automatically if image
     # not present).
-    WITH DOCKER
-        DOCKER PULL hello-world
+    WITH DOCKER --pull hello-world
         RUN docker run hello-world
     END
 
 load1:
-    WITH DOCKER
-        DOCKER LOAD +a-test-image test-img:xyz
-        DOCKER PULL hello-world
+    WITH DOCKER \
+            --load test-img:xyz=+a-test-image \
+            --pull hello-world
         RUN docker run test-img:xyz && \
             docker run hello-world
     END
 
 load2:
-    WITH DOCKER
-        DOCKER LOAD +a-test-image test-img:xyz
-        DOCKER PULL hello-world
+    WITH DOCKER \
+            --load test-img:xyz=+a-test-image \
+            --pull hello-world
         RUN docker run test-img:xyz && \
             docker run hello-world
     END


### PR DESCRIPTION
Fixes https://github.com/earthly/earthly/issues/324

This also fixes two bugs, which were tangential:
* In certain circumstances `FROM DOCKERFILE` would cause a nil deref panic.
* `ARG` before `WITH DOCKER` caused a cryptic failure

There are still a few limitations:
* Ports exposed to the host can conflict with each other, causing issues with parallelism. We need to find a way to isolate these to the specific targets they run in.
* `WITH DOCKER --compose` installs docker-compose automatically as a separate layer from the RUN execution. However, if there are COPY's before the WITH DOCKER command, there will be noticeable re-installation of docker-compose every time those files change. A possible future solution for this is to require a specific Earthly-provided dind image, in which we put in all the necessary dependencies, including docker-compose.