### PR TITLE
Fixed typos and grammatical errors in documentation

### DIFF
--- a/docs/earthfile/builtin-args.md
+++ b/docs/earthfile/builtin-args.md
@@ -2,7 +2,7 @@
 
 Builtin args are variables with values automatically filled-in by Earthly.
 
-The value of a builtin arg can never be overriden. However, you can always have an additional `ARG`, which takes as the default value, the value of the builtin arg. The additional arg can be overriden. Example
+The value of a builtin arg can never be overridden. However, you can always have an additional `ARG`, which takes as the default value, the value of the builtin arg. The additional arg can be overridden. Example
 
 ```Dockerfile
 ARG EARTHLY_TARGET_TAG

--- a/docs/earthfile/earthfile.md
+++ b/docs/earthfile/earthfile.md
@@ -473,7 +473,7 @@ It is recommended that you avoid issuing `RUN docker pull ...` and use `DOCKER P
 {% endhint %}
 
 {% hint style='danger' %}
-The use of `DOCKER PULL` outside of a `WITH DOCKER` clause is deperected and will not be supported in future versions of Earthly.
+The use of `DOCKER PULL` outside of a `WITH DOCKER` clause is deprecated and will not be supported in future versions of Earthly.
 {% endhint %}
 
 
@@ -488,7 +488,7 @@ The use of `DOCKER PULL` outside of a `WITH DOCKER` clause is deperected and wil
 The command `DOCKER LOAD` builds the image referenced by `<target-ref>` and then loads it into the temporary docker daemon created by `WITH DOCKER`. The image can be referenced as `<image-name>` within `WITH DOCKER`. `DOCKER LOAD` can be used in conjunction with `RUN docker run ...` to execute docker images that are produced by other targets of the build.
 
 {% hint style='danger' %}
-The use of `DOCKER LOAD` outside of a `WITH DOCKER` clause is deperected and will not be supported in future versions of Earthly.
+The use of `DOCKER LOAD` outside of a `WITH DOCKER` clause is deprecated and will not be supported in future versions of Earthly.
 {% endhint %}
 
 #### Options

--- a/docs/examples/go.md
+++ b/docs/examples/go.md
@@ -2,7 +2,7 @@
 
 This page will walk you through an example of how to build a hello-world application using Earthly.
 
-First, let's assume that you have written a Hello Wolrd app in `./main.go`:
+First, let's assume that you have written a Hello World app in `./main.go`:
 
 ```go
 // main.go

--- a/docs/guides/basics.md
+++ b/docs/guides/basics.md
@@ -317,7 +317,7 @@ build:
     # artifacts bin and lib (they can be later referenced as +build/bin and
     # +build/lib respectively).
     # In addition, store the artifacts as local dirs (on the host) named
-    # build/bin and build/lib. This local dirs are only written if the entire
+    # build/bin and build/lib. These local dirs are only written if the entire
     # build succeeds.
     SAVE ARTIFACT build/install/java-example/bin /bin AS LOCAL build/bin
     SAVE ARTIFACT build/install/java-example/lib /lib AS LOCAL build/lib
@@ -351,7 +351,7 @@ WORKDIR /code
 
 #Declare a target, build
 build:
-     # Copy the source files from build context to the build enviroment 
+     # Copy the source files from build context to the build environment 
     COPY src src
     # Save the python source in an artifact dir called src (it can be later
     SAVE ARTIFACT src /src
@@ -726,7 +726,7 @@ For a primer into Dockerfile layer caching see [this article](https://pythonspee
 
 ## Reduce code duplication
 
-In some cases, the dependencies might be used in more than one build target. For this usecase, we might want to separate dependency downloading and reuse it. For this reason, let's consider breaking this out into a separate build target, called `deps`. We can then inherit from `deps` by using the command `FROM +deps`.
+In some cases, the dependencies might be used in more than one build target. For this use case, we might want to separate dependency downloading and reuse it. For this reason, let's consider breaking this out into a separate build target, called `deps`. We can then inherit from `deps` by using the command `FROM +deps`.
 
 Note that in our case, only the JavaScript version has an example where `FROM +deps` is used in more than one place: both in `build` and in `docker`. Nevertheless, all versions show how dependencies may be separated.
 

--- a/docs/guides/ci-integration.md
+++ b/docs/guides/ci-integration.md
@@ -2,7 +2,7 @@
 
 Integrating Earthly into your CI is simply a matter of automating the same steps you would use for your local installation. In this guide, we will walk through this process.
 
-## Step 1: Ensure pre-requisited are available
+## Step 1: Ensure pre-requisites are available
 
 ### Docker and Git
 

--- a/docs/guides/docker-in-earthly.md
+++ b/docs/guides/docker-in-earthly.md
@@ -108,7 +108,7 @@ This, of course, has limitations, such as not being able to mount volumes the sa
 
 ### Alternative to docker build
 
-Running `docker build` within Earthly is discouraged, as it has a number of key limitaitons:
+Running `docker build` within Earthly is discouraged, as it has a number of key limitations:
 
 * Layer caching does not work. This is because `WITH DOCKER` does not preserve Docker cache between runs (other than `DOCKER PULL`).
 * Once an image is created, it cannot be exported as a build output in a form other than a TAR archive (e.g. it cannot be automatically loaded onto the host Docker daemon).

--- a/docs/guides/integration.md
+++ b/docs/guides/integration.md
@@ -239,7 +239,7 @@ In a real-world example, we would likely use a tool like [Flyway](https://flyway
 
 {% hint style='info' %}
 #### Adminer
-Our example application has one direct dependency, Postgres, and a helper app `adminer` which is a web UI for postgres. It is strictly not nessary for running our integration tests but useful in local development and serves to show how this solution scales to multiple dependencies.
+Our example application has one direct dependency, Postgres, and a helper app `adminer` which is a web UI for postgres. It is strictly not necessary for running our integration tests but useful in local development and serves to show how this solution scales to multiple dependencies.
 {% endhint %}
 
 ## Integration Testing Step 2 - Run your tests


### PR DESCRIPTION
Resolves some typos and grammatical mistakes found in the Earthly documentation pages.