### PR TITLE
Auto-install dockerd if not found and using WITH DOCKER

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
         run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/latest/download/earth-linux-amd64 -O /usr/local/bin/earth && chmod +x /usr/local/bin/earth'"
       - name: Build latest earth using released earth
         run: earth +for-linux
+      - name: "Test dind auto-install"
+        run: ./build/linux/amd64/earth ./examples/tests/dind-auto-install+all
       - name: Execute test similar to homebrew test in https://github.com/Homebrew/homebrew-core/blob/master/Formula/earthly.rb
         run: ./build/linux/amd64/earth --buildkit-host 127.0.0.1 ./examples/tests/with-docker+all | grep 'Error while dialing invalid address 127.0.0.1'
       - name: Docker Login

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Build latest earth using released earth
         run: earth +for-linux
       - name: "Test dind auto-install"
-        run: ./build/linux/amd64/earth ./examples/tests/dind-auto-install+all
+        run: ./build/linux/amd64/earth -P ./examples/tests/dind-auto-install+all
       - name: Execute test similar to homebrew test in https://github.com/Homebrew/homebrew-core/blob/master/Formula/earthly.rb
         run: ./build/linux/amd64/earth --buildkit-host 127.0.0.1 ./examples/tests/with-docker+all | grep 'Error while dialing invalid address 127.0.0.1'
       - name: Docker Login

--- a/Earthfile
+++ b/Earthfile
@@ -165,6 +165,21 @@ prerelease-docker:
     COPY --build-arg VERSION=prerelease +earth-all/* ./
     SAVE IMAGE --push earthly/earthlybinaries:prerelease
 
+dind:
+    BUILD +dind-alpine
+    BUILD +dind-ubuntu
+
+dind-alpine:
+    FROM docker:dind
+    RUN apk add --update --no-cache docker-compose
+    SAVE IMAGE --push earthly/dind:alpine earthly/dind:latest
+
+dind-ubuntu:
+    FROM ubuntu:latest
+    COPY ./buildkitd/docker-auto-install.sh /usr/local/bin/docker-auto-install.sh
+    RUN docker-auto-install.sh
+    SAVE IMAGE --push earthly/dind:ubuntu
+
 for-linux:
     BUILD +buildkitd
     COPY +earth/earth ./
@@ -180,6 +195,7 @@ all:
     BUILD +earth-all
     BUILD +earth-docker
     BUILD +prerelease-docker
+    BUILD +dind
 
 test:
     BUILD +lint
@@ -190,6 +206,7 @@ test:
 test-all:
     BUILD +examples
     BUILD +test
+    BUILD ./examples/tests+experimental
 
 examples:
     BUILD ./examples/go+docker

--- a/buildkitd/docker-auto-install.sh
+++ b/buildkitd/docker-auto-install.sh
@@ -64,6 +64,7 @@ install_dockerd() {
 }
 
 install_dockerd_debian_like() {
+    apt-get remove -y docker docker-engine docker.io containerd runc || true
     apt-get update
     apt-get install -y \
         apt-transport-https \
@@ -94,7 +95,9 @@ else
     print_debug "dockerd already installed"
 fi
 
-if [ "$EARTHLY_START_COMPOSE" = "true" ]; then
+set +u
+if [ "$EARTHLY_START_COMPOSE" = "true" ] || [ "$EARTHLY_START_COMPOSE" = "" ]; then
+    set -u
     if ! detect_docker_compose; then
         echo "Docker Compose is missing. Attempting to install automatically."
         install_docker_compose

--- a/buildkitd/docker-auto-install.sh
+++ b/buildkitd/docker-auto-install.sh
@@ -2,4 +2,116 @@
 
 set -eu
 
-apk add --update --no-cache docker-compose
+detect_dockerd() {
+    set +e
+    command -v dockerd
+    has_d="$?"
+    set -e
+    return "$has_d"
+}
+
+detect_docker_compose() {
+    set +e
+    command -v docker-compose
+    has_dc="$?"
+    set -e
+    return "$has_dc"
+}
+
+print_debug() {
+    set +u
+    if [ "$EARTHLY_DEBUG" = "true" ] ; then
+        echo "$@"
+    fi
+    set -u
+}
+
+for_alpine() {
+    if ! detect_dockerd; then
+        echo "Docker Engine is missing. Attempting to install automatically."
+        apk add --update --no-cache docker
+        echo "Docker Engine was missing. It has been installed automatically by Earthly."
+        dockerd --version
+        echo "For better use of cache, try using the official earthly/dind image for WITH DOCKER."
+    else
+        print_debug "dockerd already installed"
+    fi
+    if [ "$EARTHLY_START_COMPOSE" = "true" ]; then
+        if ! detect_docker_compose; then
+            echo "Docker Compose is missing. Attempting to install automatically."
+            apk add --update --no-cache docker-compose
+            echo "Docker Compose was missing. It has been installed automatically by Earthly."
+            docker-compose --version
+            echo "For better use of cache, try using the official earthly/dind image for WITH DOCKER."
+        else
+            print_debug "docker-compose already installed"
+        fi
+    else
+        print_debug "docker-compose not needed"
+    fi
+}
+
+for_debian() {
+    if ! detect_dockerd; then
+        echo "Docker Engine is missing. Attempting to install automatically."
+        apt-get update
+        apt-get install -y \
+            apt-transport-https \
+            ca-certificates \
+            curl \
+            gnupg-agent \
+            software-properties-common
+        curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
+        add-apt-repository \
+            "deb [arch=amd64] https://download.docker.com/linux/debian \
+            $(lsb_release -cs) \
+            stable"
+        apt-get update
+        apt-get install -y docker-ce docker-ce-cli containerd.io
+        echo "Docker Engine was missing. It has been installed automatically by Earthly."
+        dockerd --version
+        echo "For better use of cache, try using the official earthly/dind image for WITH DOCKER."
+    else
+        print_debug "dockerd already installed"
+    fi
+
+    if [ "$EARTHLY_START_COMPOSE" = "true" ]; then
+        if ! detect_docker_compose; then
+            echo "Docker Compose is missing. Attempting to install automatically."
+            curl -L "https://github.com/docker/compose/releases/download/1.27.4/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+            chmod +x /usr/local/bin/docker-compose
+            echo "Docker Compose was missing. It has been installed automatically by Earthly."
+            docker-compose --version
+            echo "For better use of cache, try using the official earthly/dind image for WITH DOCKER."
+        else
+            print_debug "docker-compose already installed"
+        fi
+    else
+        print_debug "docker-compose not needed"
+    fi
+}
+
+if [ "$(id -u)" != 0 ]; then
+    echo "Warning: Docker-in-Earthly needs to be run as root user"
+fi
+
+distro=$(sed -n -e 's/^ID=\(.*\)/\1/p' /etc/os-release)
+case "$distro" in
+    alpine)
+        for_alpine
+        ;;
+
+    ubuntu)
+        for_debian
+        ;;
+
+    debian)
+        for_debian
+        ;;
+
+    *)
+        echo "Warning: Distribution $distro not yet supported for Docker-in-Earthly."
+        echo "Will attempt to treat like Debian."
+        for_debian
+        ;;
+esac

--- a/buildkitd/docker-auto-install.sh
+++ b/buildkitd/docker-auto-install.sh
@@ -58,6 +58,7 @@ install_dockerd() {
         *)
             echo "Warning: Distribution $distro not yet supported for Docker-in-Earthly."
             echo "Will attempt to treat like Debian."
+            echo "If you would like this distribution to be supported, please open a GitHub issue: https://github.com/earthly/earthly/issues"
             install_dockerd_debian_like
             ;;
     esac

--- a/buildkitd/dockerd-wrapper.sh
+++ b/buildkitd/dockerd-wrapper.sh
@@ -25,14 +25,13 @@ execute() {
 
     # Lock entire execution of a docker daemon - only one daemon can be used at a time
     # (dockerd race conditions in handling networking setup).
-    # shellcheck disable=SC2039
     (
-        flock -x 200
+        flock -x 8
         start_dockerd
         # Note that the lock will continue to be held after this subshell finishes,
         # becasue it spawns the dockerd background process. This is intentional.
         # The lock is meant to be held until dockerd exits.
-    ) 200>/var/earthly/dind/lock
+    ) 8>/var/earthly/dind/lock
     load_images
     if [ "$EARTHLY_START_COMPOSE" = "true" ]; then
         # shellcheck disable=SC2086
@@ -62,7 +61,10 @@ start_dockerd() {
         sleep 1
         if [ "$i" -gt "$timeout" ]; then
             # Print dockerd logs on start failure.
+            echo "==== Begin dockerd logs ===="
             cat /var/log/docker.log
+            echo "==== End dockerd logs ===="
+            echo "If you are having trouble running docker, try using the official earthly/dind image instead"
             exit 1
         fi
         i=$((i+1))

--- a/earthfile2llb/withdockerrun.go
+++ b/earthfile2llb/withdockerrun.go
@@ -53,11 +53,9 @@ type withDockerRun struct {
 }
 
 func (wdr *withDockerRun) Run(ctx context.Context, args []string, opt WithDockerOpt) error {
-	if len(opt.ComposeFiles) > 0 {
-		err := wdr.installDeps(ctx)
-		if err != nil {
-			return err
-		}
+	err := wdr.installDeps(ctx, opt)
+	if err != nil {
+		return err
 	}
 	// Grab relevant images from compose file(s).
 	composeImages, err := wdr.getComposeImages(ctx, opt)
@@ -146,13 +144,23 @@ func (wdr *withDockerRun) Run(ctx context.Context, args []string, opt WithDocker
 	return wdr.c.internalRun(ctx, finalArgs, opt.Secrets, opt.WithShell, shellWrap, false, false, runStr, runOpts...)
 }
 
-func (wdr *withDockerRun) installDeps(ctx context.Context) error {
-	var runOpts []llb.RunOption
-	runOpts = append(runOpts, llb.AddMount(
-		dockerAutoInstallScriptPath, llb.Scratch(), llb.HostBind(), llb.SourcePath(dockerAutoInstallScriptPath)))
-	args := []string{dockerAutoInstallScriptPath}
-	runStr := fmt.Sprintf("WITH DOCKER (install deps)")
-	return wdr.c.internalRun(ctx, args, nil, true, withShellAndEnvVars, false, false, runStr, runOpts...)
+func (wdr *withDockerRun) installDeps(ctx context.Context, opt WithDockerOpt) error {
+	params := composeParams(opt)
+	args := []string{
+		"/bin/sh", "-c",
+		fmt.Sprintf(
+			"%s %s",
+			strings.Join(params, " "),
+			dockerAutoInstallScriptPath),
+	}
+	runOpts := []llb.RunOption{
+		llb.AddMount(
+			dockerAutoInstallScriptPath, llb.Scratch(), llb.HostBind(), llb.SourcePath(dockerAutoInstallScriptPath)),
+		llb.Args(args),
+		llb.WithCustomNamef("%sWITH DOCKER (install deps)", wdr.c.vertexPrefix()),
+	}
+	wdr.c.mts.FinalStates.SideEffectsState = wdr.c.mts.FinalStates.SideEffectsState.Run(runOpts...).Root()
+	return nil
 }
 
 func (wdr *withDockerRun) getComposeImages(ctx context.Context, opt WithDockerOpt) ([]string, error) {
@@ -372,5 +380,6 @@ func composeParams(opt WithDockerOpt) []string {
 		fmt.Sprintf("EARTHLY_START_COMPOSE=\"%t\"", (len(opt.ComposeFiles) > 0)),
 		fmt.Sprintf("EARTHLY_COMPOSE_FILES=\"%s\"", strings.Join(opt.ComposeFiles, " ")),
 		fmt.Sprintf("EARTHLY_COMPOSE_SERVICES=\"%s\"", strings.Join(opt.ComposeServices, " ")),
+		fmt.Sprintf("EARTHLY_DEBUG=\"true\""), // @#
 	}
 }

--- a/earthfile2llb/withdockerrun.go
+++ b/earthfile2llb/withdockerrun.go
@@ -380,6 +380,6 @@ func composeParams(opt WithDockerOpt) []string {
 		fmt.Sprintf("EARTHLY_START_COMPOSE=\"%t\"", (len(opt.ComposeFiles) > 0)),
 		fmt.Sprintf("EARTHLY_COMPOSE_FILES=\"%s\"", strings.Join(opt.ComposeFiles, " ")),
 		fmt.Sprintf("EARTHLY_COMPOSE_SERVICES=\"%s\"", strings.Join(opt.ComposeServices, " ")),
-		fmt.Sprintf("EARTHLY_DEBUG=\"true\""), // @#
+		// fmt.Sprintf("EARTHLY_DEBUG=\"true\""),
 	}
 }

--- a/examples/tests/Earthfile
+++ b/examples/tests/Earthfile
@@ -7,6 +7,7 @@ WORKDIR /test
 
 all:
     BUILD +ga
+    BUILD +experimental
 
 ga:
     BUILD +privileged-test
@@ -36,6 +37,9 @@ ga:
     BUILD +env-test
     BUILD ./with-docker+all
     BUILD ./with-docker-compose+all
+
+experimental:
+    BUILD ./dind-auto-install+all
 
 privileged-test:
     COPY privileged.earth ./Earthfile

--- a/examples/tests/dind-auto-install/Earthfile
+++ b/examples/tests/dind-auto-install/Earthfile
@@ -1,0 +1,17 @@
+
+all:
+    BUILD --build-arg BASE_IMAGE=docker:dind +test
+    BUILD --build-arg BASE_IMAGE=alpine:latest +test
+    BUILD --build-arg BASE_IMAGE=debian:stable +test
+    BUILD --build-arg BASE_IMAGE=debian:stable-slim +test
+    BUILD --build-arg BASE_IMAGE=ubuntu:latest +test
+    BUILD --build-arg BASE_IMAGE=../../..+dind-alpine +test
+    BUILD --build-arg BASE_IMAGE=../../..+dind-ubuntu +test
+
+test:
+    ARG BASE_IMAGE
+    FROM $BASE_IMAGE
+    COPY ./docker-compose.yml ./
+    WITH DOCKER --compose docker-compose.yml
+        RUN true
+    END

--- a/examples/tests/dind-auto-install/docker-compose.yml
+++ b/examples/tests/dind-auto-install/docker-compose.yml
@@ -1,0 +1,5 @@
+version: "3"
+
+services:
+  hello:
+    image: hello-world:latest


### PR DESCRIPTION
Also, add official earthly/dind image, which contains docker-compose already installed. This is the recommended image to use for Docker-in-Earthly as it is the most cache-efficient.

CC @agbell 