### PR TITLE
WITH DOCKER release improvements

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -172,13 +172,15 @@ dind:
 dind-alpine:
     FROM docker:dind
     RUN apk add --update --no-cache docker-compose
-    SAVE IMAGE --push earthly/dind:alpine earthly/dind:latest
+    ARG DIND_ALPINE_TAG=alpine-$EARTHLY_TARGET_TAG_DOCKER
+    SAVE IMAGE --push earthly/dind:$DIND_ALPINE_TAG
 
 dind-ubuntu:
     FROM ubuntu:latest
     COPY ./buildkitd/docker-auto-install.sh /usr/local/bin/docker-auto-install.sh
     RUN docker-auto-install.sh
-    SAVE IMAGE --push earthly/dind:ubuntu
+    ARG DIND_ALPINE_TAG=ubuntu-$EARTHLY_TARGET_TAG_DOCKER
+    SAVE IMAGE --push earthly/dind:$DIND_UBUNTU_TAG
 
 for-linux:
     BUILD +buildkitd

--- a/Earthfile
+++ b/Earthfile
@@ -179,7 +179,7 @@ dind-ubuntu:
     FROM ubuntu:latest
     COPY ./buildkitd/docker-auto-install.sh /usr/local/bin/docker-auto-install.sh
     RUN docker-auto-install.sh
-    ARG DIND_ALPINE_TAG=ubuntu-$EARTHLY_TARGET_TAG_DOCKER
+    ARG DIND_UBUNTU_TAG=ubuntu-$EARTHLY_TARGET_TAG_DOCKER
     SAVE IMAGE --push earthly/dind:$DIND_UBUNTU_TAG
 
 for-linux:

--- a/earthfile2llb/listener.go
+++ b/earthfile2llb/listener.go
@@ -665,6 +665,7 @@ func (l *listener) ExitDockerLoadStmt(c *parser.DockerLoadStmtContext) {
 			l.err = fmt.Errorf("cannot DOCKER LOAD after the RUN command in a WITH DOCKER clause")
 			return
 		}
+		fmt.Printf("Warning: DOCKER LOAD is deprecated. Please use WITH DOCKER --load %s=%s instead\n", imageName, fullTargetName)
 		l.withDocker.Loads = append(l.withDocker.Loads, DockerLoadOpt{
 			Target:    fullTargetName,
 			ImageName: imageName,
@@ -697,6 +698,7 @@ func (l *listener) ExitDockerPullStmt(c *parser.DockerPullStmtContext) {
 			l.err = fmt.Errorf("cannot DOCKER PULL after the RUN command in a WITH DOCKER clause")
 			return
 		}
+		fmt.Printf("Warning: DOCKER PULL is deprecated. Please use WITH DOCKER --pull %s instead\n", imageName)
 		l.withDocker.Pulls = append(l.withDocker.Pulls, imageName)
 	}
 }

--- a/release/Earthfile
+++ b/release/Earthfile
@@ -10,6 +10,9 @@ release:
 release-dockerhub:
     ARG RELEASE_TAG
     RUN test -n "$RELEASE_TAG"
+    BUILD --build-arg DIND_ALPINE_TAG=alpine ../+dind-alpine
+    BUILD --build-arg DIND_ALPINE_TAG=latest ../+dind-alpine
+    BUILD --build-arg DIND_UBUNTU_TAG=ubuntu ../+dind-ubuntu
     BUILD --build-arg TAG="$RELEASE_TAG" ../+earth-docker
     BUILD --build-arg TAG="$RELEASE_TAG" ../buildkitd+buildkitd
     BUILD --build-arg TAG=latest ../+earth-docker


### PR DESCRIPTION

* Only push `earthly/dind:alpine` and `earthly/dind:ubuntu` during releases.
* Also add personalized messages for deprecated DOCKER LOAD and DOCKER PULL commands.