### PR TITLE
Hook in secrets provider with secrets server

### DIFF
--- a/cmd/earth/main.go
+++ b/cmd/earth/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/earthly/earthly/domain"
 	"github.com/earthly/earthly/earthfile2llb"
 	"github.com/earthly/earthly/earthfile2llb/variables"
+	"github.com/earthly/earthly/llbutil"
 	"github.com/earthly/earthly/logging"
 	"github.com/earthly/earthly/secretsclient"
 
@@ -44,7 +45,6 @@ import (
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/auth/authprovider"
-	"github.com/moby/buildkit/session/secrets/secretsprovider"
 	"github.com/moby/buildkit/session/sshforward/sshprovider"
 	"github.com/moby/buildkit/util/entitlements"
 	"github.com/pkg/errors"
@@ -1201,8 +1201,13 @@ func (app *earthApp) actionBuild(c *cli.Context) error {
 	}
 	secretsMap[debuggercommon.DebuggerSettingsSecretsKey] = debuggerSettingsData
 
+	sc, err := secretsclient.NewClient()
+	if err != nil {
+		app.console.Warnf("failed to create secrets client: %v\n", err)
+	}
+
 	attachables := []session.Attachable{
-		secretsprovider.FromMap(secretsMap),
+		llbutil.NewSecretProvider(sc, secretsMap),
 		authprovider.NewDockerAuthProvider(os.Stderr),
 	}
 

--- a/llbutil/secrets.go
+++ b/llbutil/secrets.go
@@ -1,0 +1,89 @@
+package llbutil
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/earthly/earthly/secretsclient"
+
+	"github.com/moby/buildkit/session"
+	"github.com/moby/buildkit/session/secrets"
+	"github.com/pkg/errors"
+	"google.golang.org/grpc"
+)
+
+// ErrNoSecretsClient occurs when the secrets client is referenced but was never provided
+var ErrNoSecretsClient = fmt.Errorf("no secrets client provided")
+
+type secretProvider struct {
+	store  secrets.SecretStore
+	client secretsclient.Client
+}
+
+// Register registers the secret provider
+func (sp *secretProvider) Register(server *grpc.Server) {
+	secrets.RegisterSecretsServer(server, sp)
+}
+
+func (sp *secretProvider) getSecretFromServer(path string) ([]byte, error) {
+	if sp.client == nil {
+		return nil, ErrNoSecretsClient
+	}
+	data, err := sp.client.Get(path)
+	if err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf("failed to lookup secret %q from secrets server", path))
+	}
+	return data, nil
+}
+
+// GetSecret returns a secret.
+// secrets are referenced via +secret/name or +secret/org/name (or +secret/org/subdir1/.../name)
+// however by the time GetSecret is called, the "+secret/" prefix is removed.
+// if the name contains a /, then we can infer that it references the shared secret service.
+func (sp *secretProvider) GetSecret(ctx context.Context, req *secrets.GetSecretRequest) (*secrets.GetSecretResponse, error) {
+	isSharedSecret := false
+	secretName := req.ID
+	if strings.Contains(req.ID, "/") {
+		isSharedSecret = true
+		if req.ID[0] == '/' {
+			panic("secret name starts with '/'; this should never happen")
+		}
+		secretName = "/" + req.ID
+	}
+
+	dt, err := sp.store.GetSecret(ctx, secretName)
+	if err != nil {
+		if errors.Is(err, secrets.ErrNotFound) && isSharedSecret {
+			dt, err = sp.getSecretFromServer(secretName)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			return nil, err
+		}
+	}
+
+	return &secrets.GetSecretResponse{
+		Data: dt,
+	}, nil
+}
+
+// NewSecretProvider returns a new secrets provider
+func NewSecretProvider(client secretsclient.Client, overrides map[string][]byte) session.Attachable {
+	return &secretProvider{
+		store:  mapStore(overrides),
+		client: client,
+	}
+}
+
+type mapStore map[string][]byte
+
+// GetSecret gets a secret from the map store
+func (m mapStore) GetSecret(ctx context.Context, id string) ([]byte, error) {
+	v, ok := m[id]
+	if !ok {
+		return nil, errors.WithStack(secrets.ErrNotFound)
+	}
+	return v, nil
+}


### PR DESCRIPTION
Here's an example of it working:
```
alex@mah:~/gh/earthly/earthly$ ./build/linux/amd64/earth register --email alex@example.com
An email has been sent to "alex@example.com" containing a registration token
alex@mah:~/gh/earthly/earthly$ ./build/linux/amd64/earth register --email alex@example.com --token 57271328
pick a password: 
confirm password: 
Which of the following keys do you want to register?
1) ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDtCpWpjWyMAPRDE8Kchr0u6eD/uhyPSyVy8dQfYx7/LLLvXQ9am1jZp0O44nkly92ETWY+TZdSIuNDSTMaeqhioKBKFF2cCertXzwKdHLuWzB3VAe9PeSiDejMn9TzGPih9XRFUsgPhDadxLEXJnZZVRNAMWwXFD4NlAHUtz0GULoZ8FB76tC1AmzT0CaM721NbkR94bKQweizvyXzPFBh75Ad13VIi6BX7JXgN2wai/z3Kka1puEH5C0IJL/V5OO2sfhvRa+4+ZQvxn0Cbs6MN1AOEYjagdCootOcmImo2AXezym9Rm6F524EEm+24KM9y+uvKacpxIZ0pmYuPB2f /home/alex/.ssh/id_rsa
enter key number: 1
Account registration complete
alex@mah:~/gh/earthly/earthly$ ./build/linux/amd64/earth org create myorg
alex@mah:~/gh/earthly/earthly$ ./build/linux/amd64/earth secrets set /myorg/data "hello secret world"
alex@mah:~/gh/earthly/earthly$ cat ~/broken/secrets/Earthfile 
FROM ubuntu:latest

test:
    RUN --secret PASS=+secrets/myorg/data echo password is :$PASS: && false
alex@mah:~/gh/earthly/earthly$ ./build/linux/amd64/earth ~/broken/secrets+test 
buildkitd | Found buildkit daemon as docker container (earthly-buildkitd)
/home/alex/broken/secrets+base | --> FROM ubuntu:latest
/home/alex/broken/secrets+base | resolve docker.io/library/ubuntu:latest@sha256:bc2f7250f69267c9c6b66d7b6a81a54d3878bb85f1ebb5f951c896d13e6ba537 100%
/home/alex/broken/secrets+test | --> RUN echo password is :$PASS: && false

/home/alex/broken/secrets+test | password is :hello secret world:  <--- WOOHOO here's the password. *****

/home/alex/broken/secrets+test | Command /bin/sh -c 'echo password is :$PASS: && false' failed with exit code 1
/home/alex/broken/secrets+test | /home/alex/broken/secrets+test | ERROR: Command exited with non-zero code: RUN echo password is :$PASS: && false
Repeating the output of the command that caused the failure
=========================== FAILURE ===========================
/home/alex/broken/secrets+test *failed* | --> RUN echo password is :$PASS: && false
/home/alex/broken/secrets+test *failed* | password is :hello secret world:   
/home/alex/broken/secrets+test *failed* | Command /bin/sh -c 'echo password is :$PASS: && false' failed with exit code 1
/home/alex/broken/secrets+test *failed* | /home/alex/broken/secrets+test *failed* | ERROR: Command exited with non-zero code: RUN echo password is :$PASS: && false
Error: solve side effects: solve: failed to solve: rpc error: code = Unknown desc = executor failed running [/bin/sh -c PASS="$(cat /run/secrets/myorg/data)" /usr/bin/earth_debugger /bin/sh -c 'echo password is :$PASS: && false']: buildkit-runc did not terminate successfully
```
(not that in this example I intentially call `&& false` to prevent the RUN command from being cached)