### PR TITLE
Workaround for making prerelease earth use the right buildkitd tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,3 +88,5 @@ jobs:
         run: ./build/linux/amd64/earth prune --reset
       - name: Rebuild and push
         run: ./build/linux/amd64/earth --push +all
+      - name: Push prerelease
+        run: ./build/linux/amd64/earth --push +prerelease-docker

--- a/Earthfile
+++ b/Earthfile
@@ -172,6 +172,7 @@ dind:
 dind-alpine:
     FROM docker:dind
     RUN apk add --update --no-cache docker-compose
+    ARG EARTHLY_TARGET_TAG_DOCKER
     ARG DIND_ALPINE_TAG=alpine-$EARTHLY_TARGET_TAG_DOCKER
     SAVE IMAGE --push earthly/dind:$DIND_ALPINE_TAG
 
@@ -196,7 +197,6 @@ all:
     BUILD +buildkitd
     BUILD +earth-all
     BUILD +earth-docker
-    BUILD +prerelease-docker
     BUILD +dind
 
 test:


### PR DESCRIPTION
There seems to be an earthly bug where pre-release version is tagged as master instead of prerelease. This also causes it to use builkitd master rather than buildkitd prerelease. This needs to be investigated separately. In the meantime, this change seems to be a good workaround.