### PR TITLE
Make cache size limit 0 by default

### DIFF
--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -4,16 +4,17 @@ buildkitd:
     FROM $BUILDKIT_BASE_IMAGE
 
     # Install some missing binaries.
-    RUN apk add --update --no-cache openssh-client pigz xz fuse3 e2fsprogs util-linux
+    RUN apk add --update --no-cache openssh-client gettext pigz xz e2fsprogs util-linux
 
     # Add github and gitlab to known hosts.
     RUN mkdir -p ~/.ssh
     RUN echo "github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==" >> ~/.ssh/known_hosts
     RUN echo "gitlab.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCsj2bNKTBSpIYDEGk9KxsGh3mySTRgMtXL583qmBpzeQ+jqCMRgBqB98u3z++J1sKlXHWfM9dyhSevkMwSbhoR8XIq/U0tCNyokEi/ueaBMCvbcTHhO7FcwzY92WK4Yt0aGROY5qX2UKSeOvuP4D6TPqKF1onrSzH9bx9XUf2lEdWT/ia1NEKjunUqu1xOB/StKDHMoX4/OKyIzuS0q/T1zOATthvasJFoPrAjkohTyaDUz2LN5JoH839hViyEG82yB+MjcFV5MU3N1l1QL3cVUCh93xSaua1N85qivl+siMkPGbO5xR/En4iEY6K2XPASUEMaieWVNTRCtJ4S8H+9" >> ~/.ssh/known_hosts
 
-    # Add the config and our own wrapper script.
+    # Add the config templates and our own wrapper script.
     COPY ./entrypoint.sh /usr/bin/entrypoint.sh
     COPY ./buildkitd.toml.template /etc/buildkitd.toml.template
+    COPY ./buildkitd.cache.template /etc/buildkitd.cache.template
 
     COPY ../+shellrepeater/shellrepeater /usr/bin/shellrepeater
     COPY ../+debugger/earth_debugger /usr/bin/earth_debugger
@@ -25,8 +26,7 @@ buildkitd:
     ENV ENABLE_LOOP_DEVICE=true
     ENV FORCE_LOOP_DEVICE=true
     ENV BUILDKIT_DEBUG=false
-    # 10GB
-    ENV CACHE_SIZE_MB=10000
+    ENV CACHE_SIZE_MB=0
     VOLUME /tmp/earthly
     ENTRYPOINT ["/usr/bin/entrypoint.sh", "buildkitd", "--config=/etc/buildkitd.toml"]
     ARG EARTHLY_TARGET_TAG_DOCKER

--- a/buildkitd/buildkitd.cache.template
+++ b/buildkitd/buildkitd.cache.template
@@ -1,0 +1,12 @@
+  # Please note the required indentation to fit in buildkit.toml.template accordingly.
+
+  # 1/100 of total cache size.
+  gckeepstorage = ${CACHE_SIZE_MB}0000
+  [[worker.oci.gcpolicy]]
+    # 1/10 of total cache size.
+    keepBytes = ${CACHE_SIZE_MB}00000
+    filters = [ "type==source.local", "type==source.git.checkout"]
+  [[worker.oci.gcpolicy]]
+    all = true
+    # Cache size MB with 6 zeros, to turn it into bytes.
+    keepBytes = ${CACHE_SIZE_MB}000000

--- a/buildkitd/buildkitd.go
+++ b/buildkitd/buildkitd.go
@@ -218,12 +218,6 @@ func Start(ctx context.Context, image string, settings Settings, reset bool) err
 		args = append(args,
 			"-p", fmt.Sprintf("127.0.0.1:%d:8373", settings.DebuggerPort))
 	}
-	// Apply some buildkitd-related settings.
-	if settings.CacheSizeMb > 0 {
-		args = append(args,
-			"-e", fmt.Sprintf("CACHE_SIZE_MB=%d", settings.CacheSizeMb),
-		)
-	}
 	// Apply some git-related settings.
 	if settings.SSHAuthSock != "" {
 		args = append(args,
@@ -233,6 +227,7 @@ func Start(ctx context.Context, image string, settings Settings, reset bool) err
 	}
 
 	args = append(args,
+		"-e", fmt.Sprintf("CACHE_SIZE_MB=%d", settings.CacheSizeMb),
 		"-e", "EARTHLY_GIT_CONFIG",
 		"-e", fmt.Sprintf("GIT_URL_INSTEAD_OF=%s", settings.GitURLInsteadOf),
 	)

--- a/buildkitd/buildkitd.toml.template
+++ b/buildkitd/buildkitd.toml.template
@@ -1,18 +1,9 @@
-debug = :BUILDKIT_DEBUG:
-root = ":BUILDKIT_ROOT_DIR:"
+debug = ${BUILDKIT_DEBUG}
+root = "${BUILDKIT_ROOT_DIR}"
 insecure-entitlements = [ "security.insecure" ]
 
 [worker.oci]
   enabled = true
   snapshotter = "auto"
   gc = true
-  # 1/100 of total cache size.
-  gckeepstorage = :CACHE_SIZE_MB:0000
-  [[worker.oci.gcpolicy]]
-    # 1/10 of total cache size.
-    keepBytes = :CACHE_SIZE_MB:00000
-    filters = [ "type==source.local", "type==source.git.checkout"]
-  [[worker.oci.gcpolicy]]
-    all = true
-    # Cache size MB with 6 zeros, to turn it into bytes.
-    keepBytes = :CACHE_SIZE_MB:000000
+  ${CACHE_SETTINGS}

--- a/buildkitd/entrypoint.sh
+++ b/buildkitd/entrypoint.sh
@@ -67,8 +67,6 @@ if [ "$CACHE_SIZE_MB" -gt "0" ]; then
 fi
 export CACHE_SETTINGS
 cat /etc/buildkitd.toml.template | envsubst >/etc/buildkitd.toml
-# sed 's^:BUILDKIT_ROOT_DIR:^'"$BUILDKIT_ROOT_DIR"'^g; s/:BUILDKIT_DEBUG:/'"$BUILDKIT_DEBUG"'/g' \
-#     /etc/buildkitd.toml.template >/etc/buildkitd.toml
 echo "BUILDKIT_ROOT_DIR=$BUILDKIT_ROOT_DIR"
 echo "CACHE_SIZE_MB=$CACHE_SIZE_MB"
 echo "Buildkitd config"

--- a/buildkitd/entrypoint.sh
+++ b/buildkitd/entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 
 set -e
+if [ "$BUILDKIT_DEBUG" == "true" ]; then
+    set -x
+fi
 
 if [ -z "$CACHE_SIZE_MB" ]; then
     echo "CACHE_SIZE_MB not set"
@@ -35,14 +38,14 @@ do
     # shellcheck disable=SC2154
     if [ -n "$data" ]
     then
-        echo 'echo $'$varname' | base64 -d' > /usr/bin/git_credentials_"$i"
+        echo 'echo $'$varname' | base64 -d' >/usr/bin/git_credentials_"$i"
         chmod +x /usr/bin/git_credentials_"$i"
     else
         break
     fi
     i=$((i+1))
 done
-echo "$EARTHLY_GIT_CONFIG" | base64 -d > /root/.gitconfig
+echo "$EARTHLY_GIT_CONFIG" | base64 -d >/root/.gitconfig
 
 if [ -n "$GIT_URL_INSTEAD_OF" ]; then
     # GIT_URL_INSTEAD_OF can support multiple comma-separated values
@@ -56,13 +59,22 @@ if [ -n "$GIT_URL_INSTEAD_OF" ]; then
 fi
 
 # Set up buildkit cache.
-BUILDKIT_ROOT_DIR="$EARTHLY_TMP_DIR"/buildkit
+export BUILDKIT_ROOT_DIR="$EARTHLY_TMP_DIR"/buildkit
 mkdir -p "$BUILDKIT_ROOT_DIR"
+CACHE_SETTINGS=
+if [ "$CACHE_SIZE_MB" -gt "0" ]; then
+    CACHE_SETTINGS="$(cat /etc/buildkitd.cache.template | envsubst)"
+fi
+export CACHE_SETTINGS
+cat /etc/buildkitd.toml.template | envsubst >/etc/buildkitd.toml
+# sed 's^:BUILDKIT_ROOT_DIR:^'"$BUILDKIT_ROOT_DIR"'^g; s/:BUILDKIT_DEBUG:/'"$BUILDKIT_DEBUG"'/g' \
+#     /etc/buildkitd.toml.template >/etc/buildkitd.toml
 echo "BUILDKIT_ROOT_DIR=$BUILDKIT_ROOT_DIR"
 echo "CACHE_SIZE_MB=$CACHE_SIZE_MB"
-sed 's^:BUILDKIT_ROOT_DIR:^'"$BUILDKIT_ROOT_DIR"'^g; s/:CACHE_SIZE_MB:/'"$CACHE_SIZE_MB"'/g; s/:BUILDKIT_DEBUG:/'"$BUILDKIT_DEBUG"'/g' \
-    /etc/buildkitd.toml.template > /etc/buildkitd.toml
-
+echo "Buildkitd config"
+echo "=================="
+cat /etc/buildkitd.toml
+echo "=================="
 echo "ENABLE_LOOP_DEVICE=$ENABLE_LOOP_DEVICE"
 echo "FORCE_LOOP_DEVICE=$FORCE_LOOP_DEVICE"
 use_loop_device=false
@@ -129,13 +141,14 @@ shellrepeaterpid=$!
 execpid=$!
 
 # quit if either buildkit or shellrepeater die
+set +x
 while true
 do
-    if ! kill -0 $shellrepeaterpid > /dev/null 2>&1; then
+    if ! kill -0 $shellrepeaterpid >/dev/null 2>&1; then
         echo "Error: shellrepeater process has exited"
         exit 1
     fi
-    if ! kill -0 $execpid > /dev/null 2>&1; then
+    if ! kill -0 $execpid >/dev/null 2>&1; then
         echo "Error: buildkit process has exited"
         exit 1
     fi

--- a/buildkitd/entrypoint.sh
+++ b/buildkitd/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 set -e
-if [ "$BUILDKIT_DEBUG" == "true" ]; then
+if [ "$BUILDKIT_DEBUG" = "true" ]; then
     set -x
 fi
 
@@ -63,10 +63,10 @@ export BUILDKIT_ROOT_DIR="$EARTHLY_TMP_DIR"/buildkit
 mkdir -p "$BUILDKIT_ROOT_DIR"
 CACHE_SETTINGS=
 if [ "$CACHE_SIZE_MB" -gt "0" ]; then
-    CACHE_SETTINGS="$(cat /etc/buildkitd.cache.template | envsubst)"
+    CACHE_SETTINGS="$(envsubst </etc/buildkitd.cache.template)"
 fi
 export CACHE_SETTINGS
-cat /etc/buildkitd.toml.template | envsubst >/etc/buildkitd.toml
+envsubst </etc/buildkitd.toml.template >/etc/buildkitd.toml
 echo "BUILDKIT_ROOT_DIR=$BUILDKIT_ROOT_DIR"
 echo "CACHE_SIZE_MB=$CACHE_SIZE_MB"
 echo "Buildkitd config"

--- a/config/config.go
+++ b/config/config.go
@@ -66,7 +66,7 @@ func ParseConfigFile(yamlData []byte) (*Config, error) {
 		Global: GlobalConfig{
 			RunPath:                 defaultRunPath(),
 			DisableLoopDevice:       true,
-			BuildkitCacheSizeMb:     10000,
+			BuildkitCacheSizeMb:     0,
 			DebuggerPort:            8373,
 			BuildkitRestartTimeoutS: 60,
 		},


### PR DESCRIPTION
Also, 0 now means to use buildkit's default, which automatically adapts to backing storage size.

This should improve performance as less GC is necessary.