### PR TITLE
lazy init of ssh agent to avoid unneeded warnings

### DIFF
--- a/cmd/earth/main.go
+++ b/cmd/earth/main.go
@@ -898,11 +898,8 @@ func (app *earthApp) actionOrgCreate(c *cli.Context) error {
 		return errors.New("invalid number of arguments provided")
 	}
 	org := c.Args().Get(0)
-	sc, err := secretsclient.NewClient(app.apiServer, app.sshAuthSock)
-	if err != nil {
-		return err
-	}
-	err = sc.CreateOrg(org)
+	sc := secretsclient.NewClient(app.apiServer, app.sshAuthSock)
+	err := sc.CreateOrg(org)
 	if err != nil {
 		return errors.Wrap(err, "failed to create org")
 	}
@@ -917,10 +914,7 @@ func (app *earthApp) actionSecretsList(c *cli.Context) error {
 	if !strings.HasSuffix(path, "/") {
 		path += "/"
 	}
-	sc, err := secretsclient.NewClient(app.apiServer, app.sshAuthSock)
-	if err != nil {
-		return err
-	}
+	sc := secretsclient.NewClient(app.apiServer, app.sshAuthSock)
 	paths, err := sc.List(path)
 	if err != nil {
 		return errors.Wrap(err, "failed to list secret")
@@ -936,10 +930,7 @@ func (app *earthApp) actionSecretsGet(c *cli.Context) error {
 		return errors.New("invalid number of arguments provided")
 	}
 	path := c.Args().Get(0)
-	sc, err := secretsclient.NewClient(app.apiServer, app.sshAuthSock)
-	if err != nil {
-		return err
-	}
+	sc := secretsclient.NewClient(app.apiServer, app.sshAuthSock)
 	data, err := sc.Get(path)
 	if err != nil {
 		return errors.Wrap(err, "failed to get secret")
@@ -956,11 +947,8 @@ func (app *earthApp) actionSecretsRemove(c *cli.Context) error {
 		return errors.New("invalid number of arguments provided")
 	}
 	path := c.Args().Get(0)
-	sc, err := secretsclient.NewClient(app.apiServer, app.sshAuthSock)
-	if err != nil {
-		return err
-	}
-	err = sc.Remove(path)
+	sc := secretsclient.NewClient(app.apiServer, app.sshAuthSock)
+	err := sc.Remove(path)
 	if err != nil {
 		return errors.Wrap(err, "failed to remove secret")
 	}
@@ -988,11 +976,8 @@ func (app *earthApp) actionSecretsSet(c *cli.Context) error {
 		value = string(data)
 	}
 
-	sc, err := secretsclient.NewClient(app.apiServer, app.sshAuthSock)
-	if err != nil {
-		return err
-	}
-	err = sc.Set(path, []byte(value))
+	sc := secretsclient.NewClient(app.apiServer, app.sshAuthSock)
+	err := sc.Set(path, []byte(value))
 	if err != nil {
 		return errors.Wrap(err, "failed to set secret")
 	}
@@ -1008,13 +993,10 @@ func (app *earthApp) actionRegister(c *cli.Context) error {
 		return errors.New("email is invalid")
 	}
 
-	sc, err := secretsclient.NewClient(app.apiServer, app.sshAuthSock)
-	if err != nil {
-		return err
-	}
+	sc := secretsclient.NewClient(app.apiServer, app.sshAuthSock)
 
 	if app.verificationToken == "" {
-		err = sc.RegisterEmail(app.email)
+		err := sc.RegisterEmail(app.email)
 		if err != nil {
 			return errors.Wrap(err, "failed to register email")
 		}
@@ -1272,10 +1254,7 @@ func (app *earthApp) actionBuild(c *cli.Context) error {
 	}
 	secretsMap[debuggercommon.DebuggerSettingsSecretsKey] = debuggerSettingsData
 
-	sc, err := secretsclient.NewClient(app.apiServer, app.sshAuthSock)
-	if err != nil {
-		app.console.Warnf("failed to create secrets client: %v\n", err)
-	}
+	sc := secretsclient.NewClient(app.apiServer, app.sshAuthSock)
 
 	attachables := []session.Attachable{
 		llbutil.NewSecretProvider(sc, secretsMap),

--- a/secretsclient/client.go
+++ b/secretsclient/client.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net"
 	"net/http"
 	"os"
 	"strings"
@@ -129,19 +128,13 @@ type client struct {
 }
 
 // NewClient provides a new client
-func NewClient(secretServer, agentSockPath string) (Client, error) {
-	agentSock, err := net.Dial("unix", agentSockPath)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to connect to ssh-agent")
-	}
-
-	sshAgent := agent.NewClient(agentSock)
-
-	c := client{
+func NewClient(secretServer, agentSockPath string) Client {
+	return &client{
 		secretServer: secretServer,
-		sshAgent:     sshAgent,
+		sshAgent: &lazySSHAgent{
+			sockPath: agentSockPath,
+		},
 	}
-	return &c, nil
 }
 
 func (c *client) GetPublicKeys() ([]*agent.Key, error) {

--- a/secretsclient/lazy_ssh_agent.go
+++ b/secretsclient/lazy_ssh_agent.go
@@ -1,0 +1,107 @@
+package secretsclient
+
+import (
+	"net"
+
+	"github.com/pkg/errors"
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
+)
+
+type lazySSHAgent struct {
+	sockPath string
+	sshAgent agent.ExtendedAgent
+}
+
+func (lsa *lazySSHAgent) maybeInit() error {
+	if lsa.sshAgent != nil {
+		return nil
+	}
+	agentSock, err := net.Dial("unix", lsa.sockPath)
+	if err != nil {
+		return errors.Wrap(err, "failed to connect to ssh-agent")
+	}
+
+	lsa.sshAgent = agent.NewClient(agentSock)
+	return nil
+}
+
+func (lsa *lazySSHAgent) List() ([]*agent.Key, error) {
+	err := lsa.maybeInit()
+	if err != nil {
+		return nil, err
+	}
+	return lsa.sshAgent.List()
+}
+
+func (lsa *lazySSHAgent) Sign(key ssh.PublicKey, data []byte) (*ssh.Signature, error) {
+	err := lsa.maybeInit()
+	if err != nil {
+		return nil, err
+	}
+	return lsa.sshAgent.Sign(key, data)
+}
+
+func (lsa *lazySSHAgent) Add(key agent.AddedKey) error {
+	err := lsa.maybeInit()
+	if err != nil {
+		return err
+	}
+	return lsa.sshAgent.Add(key)
+}
+
+func (lsa *lazySSHAgent) Remove(key ssh.PublicKey) error {
+	err := lsa.maybeInit()
+	if err != nil {
+		return err
+	}
+	return lsa.sshAgent.Remove(key)
+}
+
+func (lsa *lazySSHAgent) RemoveAll() error {
+	err := lsa.maybeInit()
+	if err != nil {
+		return err
+	}
+	return lsa.sshAgent.RemoveAll()
+}
+
+func (lsa *lazySSHAgent) Lock(passphrase []byte) error {
+	err := lsa.maybeInit()
+	if err != nil {
+		return err
+	}
+	return lsa.sshAgent.Lock(passphrase)
+}
+
+func (lsa *lazySSHAgent) Unlock(passphrase []byte) error {
+	err := lsa.maybeInit()
+	if err != nil {
+		return err
+	}
+	return lsa.sshAgent.Unlock(passphrase)
+}
+
+func (lsa *lazySSHAgent) Signers() ([]ssh.Signer, error) {
+	err := lsa.maybeInit()
+	if err != nil {
+		return nil, err
+	}
+	return lsa.sshAgent.Signers()
+}
+
+func (lsa *lazySSHAgent) SignWithFlags(key ssh.PublicKey, data []byte, flags agent.SignatureFlags) (*ssh.Signature, error) {
+	err := lsa.maybeInit()
+	if err != nil {
+		return nil, err
+	}
+	return lsa.sshAgent.SignWithFlags(key, data, flags)
+}
+
+func (lsa *lazySSHAgent) Extension(extensionType string, contents []byte) ([]byte, error) {
+	err := lsa.maybeInit()
+	if err != nil {
+		return nil, err
+	}
+	return lsa.sshAgent.Extension(extensionType, contents)
+}


### PR DESCRIPTION
- prevent initializing the ssh agent client unless it's needed. This is
to prevent warning messages occuring if the SSH_AUTH_SOCK isn't set,
which shouldn't matter unless the secrets server is required.