### PR TITLE
Add ability to align and control size of target name column in logs

### DIFF
--- a/cmd/debugger/main.go
+++ b/cmd/debugger/main.go
@@ -190,7 +190,7 @@ func main() {
 		return
 	}
 
-	conslogger := conslogging.Current(conslogging.ForceColor)
+	conslogger := conslogging.Current(conslogging.ForceColor, conslogging.NoPadding)
 	color.NoColor = false
 
 	debuggerSettings, err := getSettings(fmt.Sprintf("/run/secrets/%s", common.DebuggerSettingsSecretsKey))

--- a/cmd/earth/main.go
+++ b/cmd/earth/main.go
@@ -171,7 +171,21 @@ func main() {
 		color.NoColor = true
 	}
 
-	app := newEarthApp(ctx, conslogging.Current(colorMode))
+	padding := conslogging.DefaultPadding
+	customPadding, ok := os.LookupEnv("TARGET_PADDING")
+	if ok {
+		targetPadding, err := strconv.Atoi(customPadding)
+		if err == nil {
+			padding = targetPadding
+		}
+	}
+
+	_, fullTarget := os.LookupEnv("FULL_TARGET")
+	if fullTarget {
+		padding = conslogging.NoPadding
+	}
+
+	app := newEarthApp(ctx, conslogging.Current(colorMode, padding))
 	app.autoComplete()
 
 	os.Exit(app.run(ctx, os.Args))

--- a/conslogging/conslogging.go
+++ b/conslogging/conslogging.go
@@ -24,6 +24,14 @@ const (
 	ForceColor
 )
 
+const (
+	// NoPadding means the old behavior of printing the full target only.
+	NoPadding int = -1
+	// DefaultPadding always prints 20 characters for the target, right
+	// justified. If it is longer, it prints the right 20 characters.
+	DefaultPadding int = 20
+)
+
 var currentConsoleMutex sync.Mutex
 
 // ConsoleLogger is a writer for consoles.
@@ -42,15 +50,17 @@ type ConsoleLogger struct {
 	nextColorIndex *int
 	w              io.Writer
 	trailingLine   bool
+	prefixPadding  int
 }
 
 // Current returns the current console.
-func Current(colorMode ColorMode) ConsoleLogger {
+func Current(colorMode ColorMode, prefixPadding int) ConsoleLogger {
 	return ConsoleLogger{
 		w:              os.Stdout,
 		colorMode:      colorMode,
 		saltColors:     make(map[string]*color.Color),
 		nextColorIndex: new(int),
+		prefixPadding:  prefixPadding,
 		mu:             &currentConsoleMutex,
 	}
 }
@@ -65,6 +75,7 @@ func (cl ConsoleLogger) clone() ConsoleLogger {
 		saltColors:     cl.saltColors,
 		colorMode:      cl.colorMode,
 		nextColorIndex: cl.nextColorIndex,
+		prefixPadding:  cl.prefixPadding,
 		mu:             cl.mu,
 	}
 }
@@ -193,7 +204,7 @@ func (cl ConsoleLogger) printPrefix() {
 		*cl.nextColorIndex = (*cl.nextColorIndex + 1) % len(availablePrefixColors)
 	}
 	c = cl.color(c)
-	c.Fprintf(cl.w, "%s", cl.prefix)
+	c.Fprintf(cl.w, cl.prettyPrefix())
 	if cl.isFailed {
 		cl.w.Write([]byte(" *"))
 		cl.color(warnColor).Fprintf(cl.w, "failed")
@@ -220,4 +231,20 @@ func (cl ConsoleLogger) color(c *color.Color) *color.Color {
 		return c
 	}
 	return noColor
+}
+
+func (cl ConsoleLogger) prettyPrefix() string {
+	if cl.prefixPadding == NoPadding {
+		return cl.prefix
+	}
+
+	formatString := fmt.Sprintf("%%%vv", cl.prefixPadding)
+	substringStart := len(cl.prefix) - cl.prefixPadding
+
+	clampedPadding := substringStart
+	if clampedPadding < 0 {
+		clampedPadding = 0
+	}
+
+	return fmt.Sprintf(formatString, cl.prefix[clampedPadding:])
 }

--- a/docs/guides/ci-integration.md
+++ b/docs/guides/ci-integration.md
@@ -61,7 +61,11 @@ docker login --username '<username>' --password '<password>'
 Make sure that secrets (like `<password>` above) are not exposed in plain text. You may need to configure an environment variable with your CI vendor.
 {% endhint %}
 
-## Step 4: (Optional) Force or disable color output
+## Step 4: (Optional) Choose log formatting options
+
+There are a few options you can configure to make the log formatting look best in your CI environment.
+
+### Force or disable color output
 
 The CLI `earth` automatically detects the presence of a TTY for the purpose of deciding whether to use colorized output or not. In some CI environments, this kind of detection is not enough in order to infer support for colorized output. However, two environment variables can be used to either disable or force it:
 
@@ -72,6 +76,13 @@ The following environments are known to require additional settings:
 
 * GitHub Actions: requires `FORCE_COLOR=1`
 * Jenkins: requires `NO_COLOR=1`
+
+### Tweak target name column
+
+The CLI defaults to a right-aligned, 20-character width to display the name of the target that the log originated from. When a target name exceeds 20 characters, the name is truncated and the last 20 characters are used.
+
+ * `TARGET_PADDING=n` will set the column to the width of `n` characters.
+ * `FULL_TARGET=1` will always print the full target name, and nothing more. This may result in unaligned logs.
 
 ## Step 5: Run the build
 

--- a/docs/guides/ci-integration.md
+++ b/docs/guides/ci-integration.md
@@ -61,11 +61,7 @@ docker login --username '<username>' --password '<password>'
 Make sure that secrets (like `<password>` above) are not exposed in plain text. You may need to configure an environment variable with your CI vendor.
 {% endhint %}
 
-## Step 4: (Optional) Choose log formatting options
-
-There are a few options you can configure to make the log formatting look best in your CI environment.
-
-### Force or disable color output
+## Step 4: (Optional) Force or disable color output
 
 The CLI `earth` automatically detects the presence of a TTY for the purpose of deciding whether to use colorized output or not. In some CI environments, this kind of detection is not enough in order to infer support for colorized output. However, two environment variables can be used to either disable or force it:
 
@@ -76,13 +72,6 @@ The following environments are known to require additional settings:
 
 * GitHub Actions: requires `FORCE_COLOR=1`
 * Jenkins: requires `NO_COLOR=1`
-
-### Tweak target name column
-
-The CLI defaults to a right-aligned, 20-character width to display the name of the target that the log originated from. When a target name exceeds 20 characters, the name is truncated and the last 20 characters are used.
-
- * `TARGET_PADDING=n` will set the column to the width of `n` characters.
- * `FULL_TARGET=1` will always print the full target name, and nothing more. This may result in unaligned logs.
 
 ## Step 5: Run the build
 


### PR DESCRIPTION
Willing and ready for suggestions on this idea. I think this improves readability of the logs. Would love to detect max width of target names; and size down if possible on top of this, to make it feel less dead with small target names. But, this is a start toward that for now.

Still needs documentation pending decision on if this is worth doing.

Some examples of what this accomplishes:

Old (also now, but with `FULL_TARGETS`):
```
buildkitd | Found buildkit daemon as docker container (earthly-buildkitd)
Deprecation: using SAVE IMAGE with no arguments is no longer necessary and can be safely removed
+base | --> FROM golang:1.13-alpine3.11
context | --> local context ./examples/go
+base | resolve docker.io/library/golang:1.13-alpine3.11@sha256:ec6dcf15073c307fbcfc3149efe8835f3ec2bd0a0cb49aaaee4949cfc4c86b65 100%
context | transferring ./examples/go: 100%
+base | *cached* --> RUN apk add --update --no-cache bash bash-completion binutils ca-certificates coreutils curl findutils g++ git grep less make openssl shellcheck util-linux
+base | *cached* --> WORKDIR /earthly
./examples/go+base | *cached* --> WORKDIR /go-example
./examples/go+deps | *cached* --> COPY go.mod go.sum ./
./examples/go+deps | *cached* --> RUN go mod download
./examples/go+build | *cached* --> COPY main.go .
./examples/go+build | *cached* --> RUN go build -o build/go-example main.go
./examples/go+build | *cached* --> SAVE ARTIFACT build/go-example ./examples/go+build/go-example
./examples/go+docker | *cached* --> COPY ./examples/go+build/go-example .
+examples | Target github.com/earthly/earthly:corey/align-logs+examples built successfully
=========================== SUCCESS ===========================
Loaded image: go-example:latest
./examples/go+docker | Image github.com/earthly/earthly/examples/go:corey/align-logs+docker as go-example:latest
./examples/go+build | *cached* --> SAVE ARTIFACT build/go-example ./examples/go+build/go-example AS LOCAL build/go-example
./examples/go+build | Artifact github.com/earthly/earthly/examples/go:corey/align-logs+build/go-example as local build/go-example
./examples/go+deps | *cached* --> SAVE ARTIFACT go.mod ./examples/go+deps/go.mod AS LOCAL go.mod
./examples/go+deps | Artifact github.com/earthly/earthly/examples/go:corey/align-logs+deps/go.mod as local go.mod
./examples/go+deps | *cached* --> SAVE ARTIFACT go.sum ./examples/go+deps/go.sum AS LOCAL go.sum
./examples/go+deps | Artifact github.com/earthly/earthly/examples/go:corey/align-logs+deps/go.sum as local go.sum

```

New default of 20 width:
```
❯ ./testearth -P +examples
           buildkitd | Found buildkit daemon as docker container (earthly-buildkitd)
           buildkitd | Newer image available. Restarting buildkit daemon...
           buildkitd | ...Done
Deprecation: using SAVE IMAGE with no arguments is no longer necessary and can be safely removed
             context | --> local context ./examples/go
               +base | --> FROM golang:1.13-alpine3.11
               +base | resolve docker.io/library/golang:1.13-alpine3.11@sha256:ec6dcf15073c307fbcfc3149efe8835f3ec2bd0a0cb49aaaee4949cfc4c86b65 100%
             context | transferring ./examples/go: 100%
               +base | *cached* --> RUN apk add --update --no-cache bash bash-completion binutils ca-certificates coreutils curl findutils g++ git grep less make openssl shellcheck util-linux
               +base | *cached* --> WORKDIR /earthly
  ./examples/go+base | *cached* --> WORKDIR /go-example
  ./examples/go+deps | *cached* --> COPY go.mod go.sum ./
  ./examples/go+deps | *cached* --> RUN go mod download
 ./examples/go+build | *cached* --> COPY main.go .
 ./examples/go+build | *cached* --> RUN go build -o build/go-example main.go
 ./examples/go+build | *cached* --> SAVE ARTIFACT build/go-example ./examples/go+build/go-example
./examples/go+docker | *cached* --> COPY ./examples/go+build/go-example .
           +examples | Target github.com/earthly/earthly:corey/align-logs+examples built successfully
=========================== SUCCESS ===========================
Loaded image: go-example:latest
./examples/go+docker | Image github.com/earthly/earthly/examples/go:corey/align-logs+docker as go-example:latest
 ./examples/go+build | *cached* --> SAVE ARTIFACT build/go-example ./examples/go+build/go-example AS LOCAL build/go-example
 ./examples/go+build | Artifact github.com/earthly/earthly/examples/go:corey/align-logs+build/go-example as local build/go-example
  ./examples/go+deps | *cached* --> SAVE ARTIFACT go.mod ./examples/go+deps/go.mod AS LOCAL go.mod
  ./examples/go+deps | Artifact github.com/earthly/earthly/examples/go:corey/align-logs+deps/go.mod as local go.mod
  ./examples/go+deps | *cached* --> SAVE ARTIFACT go.sum ./examples/go+deps/go.sum AS LOCAL go.sum
  ./examples/go+deps | Artifact github.com/earthly/earthly/examples/go:corey/align-logs+deps/go.sum as local go.sum

```

