### PR TITLE
Fix environment variables, clever truncation on /, and allow ragged when wider than column

### DIFF
--- a/cmd/earth/main.go
+++ b/cmd/earth/main.go
@@ -172,7 +172,7 @@ func main() {
 	}
 
 	padding := conslogging.DefaultPadding
-	customPadding, ok := os.LookupEnv("TARGET_PADDING")
+	customPadding, ok := os.LookupEnv("EARTHLY_TARGET_PADDING")
 	if ok {
 		targetPadding, err := strconv.Atoi(customPadding)
 		if err == nil {
@@ -180,7 +180,7 @@ func main() {
 		}
 	}
 
-	_, fullTarget := os.LookupEnv("FULL_TARGET")
+	_, fullTarget := os.LookupEnv("EARTHLY_FULL_TARGET")
 	if fullTarget {
 		padding = conslogging.NoPadding
 	}

--- a/conslogging/conslogging.go
+++ b/conslogging/conslogging.go
@@ -239,12 +239,24 @@ func (cl ConsoleLogger) prettyPrefix() string {
 	}
 
 	formatString := fmt.Sprintf("%%%vv", cl.prefixPadding)
-	substringStart := len(cl.prefix) - cl.prefixPadding
 
-	clampedPadding := substringStart
-	if clampedPadding < 0 {
-		clampedPadding = 0
+	prettyPrefix := cl.prefix
+	if len(cl.prefix) > cl.prefixPadding {
+		parts := strings.Split(cl.prefix, "/")
+		target := parts[len(parts)-1]
+
+		truncated := ""
+		for _, part := range parts[:len(parts)-1] {
+			letter := ""
+			if len(part) > 0 {
+				letter = string(part[0])
+			}
+
+			truncated += letter + "/"
+		}
+
+		prettyPrefix = truncated + target
 	}
 
-	return fmt.Sprintf(formatString, cl.prefix[clampedPadding:])
+	return fmt.Sprintf(formatString, prettyPrefix)
 }

--- a/conslogging/conslogging.go
+++ b/conslogging/conslogging.go
@@ -247,8 +247,8 @@ func (cl ConsoleLogger) prettyPrefix() string {
 
 		truncated := ""
 		for _, part := range parts[:len(parts)-1] {
-			letter := ""
-			if len(part) > 0 {
+			letter := part
+			if len(part) > 0 && part != ".." {
 				letter = string(part[0])
 			}
 


### PR DESCRIPTION
Some sample for how it will look with these changes:

```
           buildkitd | Found buildkit daemon as docker container (earthly-buildkitd)
           buildkitd | Newer image available. Restarting buildkit daemon...
           buildkitd | ...Done
g/e/hello-world:master+base | --> FROM busybox:1.32.0
               +base | --> FROM golang:1.13-alpine3.11
             context | --> local context ./examples/go
g/e/hello-world:master+base | resolve docker.io/library/busybox:1.32.0@sha256:a9286defaba7b3a519d585ba0e37d0b2cbee74ebfe590960b0b1d6a5e97d1e1d 100%
               +base | resolve docker.io/library/golang:1.13-alpine3.11@sha256:ec6dcf15073c307fbcfc3149efe8835f3ec2bd0a0cb49aaaee4949cfc4c86b65 100%
             context | transferring ./examples/go: 100%
               +base | *cached* --> RUN apk add --update --no-cache bash bash-completion binutils ca-certificates coreutils curl findutils g++ git grep less make openssl shellcheck util-linux
               +base | *cached* --> WORKDIR /earthly
  ./examples/go+base | *cached* --> WORKDIR /go-example
  ./examples/go+deps | *cached* --> COPY go.mod go.sum ./
  ./examples/go+deps | *cached* --> RUN go mod download
 ./examples/go+build | *cached* --> COPY main.go .
 ./examples/go+build | *cached* --> RUN go build -o build/go-example main.go
 ./examples/go+build | *cached* --> SAVE ARTIFACT build/go-example ./examples/go+build/go-example
./examples/go+docker | *cached* --> COPY ./examples/go+build/go-example .
g/e/hello-world:master+hello | *cached* --> RUN echo 'Hello, world!'
           +examples | Target github.com/earthly/earthly:corey/logging-alignment-truncation+examples built successfully
=========================== SUCCESS ===========================
Loaded image: go-example:latest
./examples/go+docker | Image github.com/earthly/earthly/examples/go:corey/logging-alignment-truncation+docker as go-example:latest
 ./examples/go+build | *cached* --> SAVE ARTIFACT build/go-example ./examples/go+build/go-example AS LOCAL build/go-example
 ./examples/go+build | Artifact github.com/earthly/earthly/examples/go:corey/logging-alignment-truncation+build/go-example as local build/go-example
  ./examples/go+deps | *cached* --> SAVE ARTIFACT go.mod ./examples/go+deps/go.mod AS LOCAL go.mod
  ./examples/go+deps | Artifact github.com/earthly/earthly/examples/go:corey/logging-alignment-truncation+deps/go.mod as local go.mod
  ./examples/go+deps | *cached* --> SAVE ARTIFACT go.sum ./examples/go+deps/go.sum AS LOCAL go.sum
  ./examples/go+deps | Artifact github.com/earthly/earthly/examples/go:corey/logging-alignment-truncation+deps/go.sum as local go.sum

```