### PR TITLE
allow overriding install id

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -30,8 +30,8 @@ deps:
 
 code:
     FROM +deps
-    COPY --dir autocomplete buildcontext builder cleanup cmd config conslogging debugger dockertar \
-        domain llbutil logging secretsclient states ./
+    COPY --dir analytics autocomplete buildcontext builder cleanup cmd config conslogging debugger dockertar \
+        domain llbutil logging secretsclient states utils ./
     COPY --dir buildkitd/buildkitd.go buildkitd/settings.go buildkitd/
     COPY --dir earthfile2llb/antlrhandler \
         earthfile2llb/variables earthfile2llb/*.go earthfile2llb/

--- a/Earthfile
+++ b/Earthfile
@@ -31,7 +31,7 @@ deps:
 code:
     FROM +deps
     COPY --dir analytics autocomplete buildcontext builder cleanup cmd config conslogging debugger dockertar \
-        domain llbutil logging secretsclient states utils ./
+        domain fileutils llbutil logging secretsclient states ./
     COPY --dir buildkitd/buildkitd.go buildkitd/settings.go buildkitd/
     COPY --dir earthfile2llb/antlrhandler \
         earthfile2llb/variables earthfile2llb/*.go earthfile2llb/

--- a/analytics/analytics.go
+++ b/analytics/analytics.go
@@ -1,0 +1,146 @@
+package analytics
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/earthly/earthly/utils"
+
+	uuid "github.com/nu7hatch/gouuid"
+	"github.com/pkg/errors"
+	"gopkg.in/segmentio/analytics-go.v3"
+)
+
+func detectCI() string {
+	for k, v := range map[string]string{
+		"GITHUB_WORKFLOW": "github-actions",
+		"CIRCLECI":        "circle-ci",
+		"JENKINS_HOME":    "jenkins",
+		"BUILDKITE":       "buildkite",
+		"DRONE_BRANCH":    "drone",
+		"TRAVIS":          "travis",
+	} {
+		if _, ok := os.LookupEnv(k); ok {
+			return v
+		}
+	}
+
+	// default catch-all
+	if v, ok := os.LookupEnv("CI"); ok {
+		if strings.ToLower(v) == "true" {
+			return "unknown"
+		}
+		return v
+	}
+
+	return "false"
+}
+
+func getRepo() string {
+	cmd := exec.Command("git", "config", "--get", "remote.origin.url")
+	out, err := cmd.Output()
+	if err == nil {
+		return string(out)
+	}
+
+	for _, k := range []string{
+		"GITHUB_REPOSITORY",
+		"CIRCLE_PROJECT_REPONAME",
+		"GIT_URL",
+		"BUILDKITE_REPO",
+		"DRONE_REPO",
+		"TRAVIS_REPO_SLUG",
+	} {
+		if v, ok := os.LookupEnv(k); ok {
+			return v
+		}
+	}
+
+	for _, e := range os.Environ() {
+		pair := strings.SplitN(e, "=", 2)
+		if len(pair) == 2 {
+			if strings.Contains(pair[1], "git") {
+				return pair[1]
+			}
+		}
+	}
+
+	return "unknown"
+}
+
+func getRepoHash() string {
+	repo := getRepo()
+	if repo == "unknown" || repo == "" {
+		return repo
+	}
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(repo)))
+}
+
+func getInstallID() (string, error) {
+	installID, ok := os.LookupEnv("EARTHLY_INSTALL_ID")
+	if ok {
+		return installID, nil
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", errors.Wrap(err, "failed to get user home dir")
+	}
+
+	path := filepath.Join(homeDir, ".earthly", "install_id")
+	if !utils.FileExists(path) {
+
+		u, err := uuid.NewV4()
+		if err != nil {
+			return "", errors.Wrap(err, "failed to generate uuid")
+		}
+
+		ID := u.String()
+
+		err = ioutil.WriteFile(path, []byte(ID), 0644)
+		if err != nil {
+			return "", errors.Wrapf(err, "failed to write %q", path)
+		}
+		return ID, nil
+	}
+
+	s, err := ioutil.ReadFile(path)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to read %q", path)
+	}
+	return string(s), nil
+}
+
+func CollectAnalytics(version, gitSha, commandName string, exitCode int, realtime time.Duration) {
+	installID, err := getInstallID()
+	if err != nil {
+		installID = "unknown"
+	}
+	segmentClient := analytics.New("RtwJaMBswcW3CNMZ7Ops79dV6lEZqsXf")
+	segmentClient.Enqueue(analytics.Track{
+		Event:  "cli-" + commandName,
+		UserId: installID,
+		Properties: analytics.NewProperties().
+			Set("version", version).
+			Set("gitsha", gitSha).
+			Set("exitcode", exitCode).
+			Set("ci", detectCI()).
+			Set("repo", getRepoHash()).
+			Set("realtime", realtime.Seconds()),
+	})
+	done := make(chan bool, 1)
+	go func() {
+		segmentClient.Close()
+		done <- true
+	}()
+	select {
+	case <-time.After(time.Millisecond * 500):
+	case <-done:
+	}
+}

--- a/analytics/analytics.go
+++ b/analytics/analytics.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/earthly/earthly/utils"
+	"github.com/earthly/earthly/fileutils"
 
 	uuid "github.com/nu7hatch/gouuid"
 	"github.com/pkg/errors"
@@ -89,7 +89,7 @@ func getInstallID() (string, error) {
 	}
 
 	path := filepath.Join(homeDir, ".earthly", "install_id")
-	if !utils.FileExists(path) {
+	if !fileutils.FileExists(path) {
 		u, err := uuid.NewV4()
 		if err != nil {
 			return "", errors.Wrap(err, "failed to generate uuid")

--- a/analytics/analytics.go
+++ b/analytics/analytics.go
@@ -109,6 +109,7 @@ func getInstallID() (string, error) {
 	return string(s), nil
 }
 
+// CollectAnalytics sends analytics to segment.io
 func CollectAnalytics(version, gitSha, commandName string, exitCode int, realtime time.Duration) {
 	var err error
 	ciName, ci := detectCI()

--- a/analytics/analytics.go
+++ b/analytics/analytics.go
@@ -133,7 +133,7 @@ func CollectAnalytics(version, gitSha, commandName string, exitCode int, realtim
 			Set("gitsha", gitSha).
 			Set("exitcode", exitCode).
 			Set("ci", ciName).
-			Set("repo", repoHash).
+			Set("repohash", repoHash).
 			Set("realtime", realtime.Seconds()),
 	})
 	done := make(chan bool, 1)

--- a/analytics/analytics.go
+++ b/analytics/analytics.go
@@ -90,14 +90,11 @@ func getInstallID() (string, error) {
 
 	path := filepath.Join(homeDir, ".earthly", "install_id")
 	if !utils.FileExists(path) {
-
 		u, err := uuid.NewV4()
 		if err != nil {
 			return "", errors.Wrap(err, "failed to generate uuid")
 		}
-
 		ID := u.String()
-
 		err = ioutil.WriteFile(path, []byte(ID), 0644)
 		if err != nil {
 			return "", errors.Wrapf(err, "failed to write %q", path)

--- a/cmd/earth/main.go
+++ b/cmd/earth/main.go
@@ -36,9 +36,9 @@ import (
 	"github.com/earthly/earthly/domain"
 	"github.com/earthly/earthly/earthfile2llb"
 	"github.com/earthly/earthly/earthfile2llb/variables"
+	"github.com/earthly/earthly/fileutils"
 	"github.com/earthly/earthly/llbutil"
 	"github.com/earthly/earthly/secretsclient"
-	"github.com/earthly/earthly/utils"
 
 	"github.com/fatih/color"
 	"github.com/joho/godotenv"
@@ -155,7 +155,7 @@ func main() {
 
 	// Load .env into current global env's. This is mainly for applying Earthly settings.
 	// Separate call is made for build args and secrets.
-	if utils.FileExists(dotEnvPath) {
+	if fileutils.FileExists(dotEnvPath) {
 		err := godotenv.Load(dotEnvPath)
 		if err != nil {
 			fmt.Printf("Error loading dot-env file %s: %s\n", dotEnvPath, err.Error())
@@ -615,7 +615,7 @@ func (app *earthApp) before(context *cli.Context) error {
 		}
 	}
 
-	if !utils.DirExists(app.cfg.Global.RunPath) {
+	if !fileutils.DirExists(app.cfg.Global.RunPath) {
 		err := os.MkdirAll(app.cfg.Global.RunPath, 0755)
 		if err != nil {
 			return errors.Wrapf(err, "failed to create run directory %s", app.cfg.Global.RunPath)
@@ -749,12 +749,12 @@ func (app *earthApp) insertBashCompleteEntry() error {
 	}
 	dirPath := filepath.Dir(path)
 
-	if !utils.DirExists(dirPath) {
+	if !fileutils.DirExists(dirPath) {
 		fmt.Fprintf(os.Stderr, "Warning: unable to enable bash-completion: %s does not exist\n", dirPath)
 		return nil // bash-completion isn't available, silently fail.
 	}
 
-	if utils.FileExists(path) {
+	if fileutils.FileExists(path) {
 		return nil // file already exists, don't update it.
 	}
 
@@ -815,12 +815,12 @@ func (app *earthApp) insertZSHCompleteEntry() error {
 	path := "/usr/local/share/zsh/site-functions/_earth"
 	dirPath := filepath.Dir(path)
 
-	if !utils.DirExists(dirPath) {
+	if !fileutils.DirExists(dirPath) {
 		fmt.Fprintf(os.Stderr, "Warning: unable to enable zsh-completion: %s does not exist\n", dirPath)
 		return nil // zsh-completion isn't available, silently fail.
 	}
 
-	if utils.FileExists(path) {
+	if fileutils.FileExists(path) {
 		return nil // file already exists, don't update it.
 	}
 
@@ -1335,7 +1335,7 @@ func (app *earthApp) actionBuild(c *cli.Context) error {
 	secrets := app.secrets.Value()
 	//interactive debugger settings are passed as secrets to avoid having it affect the cache hash
 	dotEnvMap := make(map[string]string)
-	if utils.FileExists(dotEnvPath) {
+	if fileutils.FileExists(dotEnvPath) {
 		dotEnvMap, err = godotenv.Read(dotEnvPath)
 		if err != nil {
 			return errors.Wrapf(err, "read %s", dotEnvPath)
@@ -1492,7 +1492,7 @@ func defaultConfigPath() string {
 
 	oldConfig := filepath.Join(homeDir, ".earthly", "config.yaml")
 	newConfig := filepath.Join(homeDir, ".earthly", "config.yml")
-	if utils.FileExists(oldConfig) && !utils.FileExists(newConfig) {
+	if fileutils.FileExists(oldConfig) && !fileutils.FileExists(newConfig) {
 		return oldConfig
 	}
 	return newConfig

--- a/fileutils/fileutils.go
+++ b/fileutils/fileutils.go
@@ -1,4 +1,4 @@
-package utils
+package fileutils
 
 import (
 	"os"

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/golang/protobuf v1.4.2
 	github.com/joho/godotenv v1.3.0
 	github.com/moby/buildkit v0.7.1-0.20200708233707-488130002abb
-	github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d // indirect
+	github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.1
 	github.com/otiai10/copy v1.1.1
@@ -31,7 +31,7 @@ require (
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	google.golang.org/grpc v1.28.1
 	google.golang.org/protobuf v1.24.0
-	gopkg.in/segmentio/analytics-go.v3 v3.1.0 // indirect
+	gopkg.in/segmentio/analytics-go.v3 v3.1.0
 	gopkg.in/yaml.v2 v2.2.8
 )
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,0 +1,23 @@
+package utils
+
+import (
+	"os"
+)
+
+// FileExists returns true if the file exists
+func FileExists(filename string) bool {
+	info, err := os.Stat(filename)
+	if os.IsNotExist(err) {
+		return false
+	}
+	return !info.IsDir()
+}
+
+// DirExists returns true if the directory exists
+func DirExists(filename string) bool {
+	info, err := os.Stat(filename)
+	if os.IsNotExist(err) {
+		return false
+	}
+	return info.IsDir()
+}


### PR DESCRIPTION
How about we allow overriding `EARTHLY_INSTALL_ID`, so we can exclude our own builds.
Then we'll track if it was triggered via a CI (assuming the CI env is set), which we could then use to filter out CI vs CLI executions.