### PR TITLE
Allow DIND auto install on Amazon Linux

### DIFF
--- a/examples/tests/dind-auto-install/Earthfile
+++ b/examples/tests/dind-auto-install/Earthfile
@@ -5,6 +5,8 @@ all:
     BUILD --build-arg BASE_IMAGE=debian:stable +test
     BUILD --build-arg BASE_IMAGE=debian:stable-slim +test
     BUILD --build-arg BASE_IMAGE=ubuntu:latest +test
+    BUILD --build-arg BASE_IMAGE=amazonlinux:1 +test
+    BUILD --build-arg BASE_IMAGE=amazonlinux:2 +test
     BUILD --build-arg BASE_IMAGE=../../..+dind-alpine +test
     BUILD --build-arg BASE_IMAGE=../../..+dind-ubuntu +test
 


### PR DESCRIPTION
This will let you do a `WITH DOCKER` in an Amazon Linux container. This is especially advantageous for using other containers in combination with "amazon/aws-cli:<version>"

Amazon Linux 1 and 2 are supported.