### PR TITLE
Add early ECR example

### DIFF
--- a/examples/ecr-push/Earthfile
+++ b/examples/ecr-push/Earthfile
@@ -1,0 +1,24 @@
+
+some-thing:
+    FROM hashicorp/http-echo:latest
+
+ecr-push:
+    FROM ubuntu:20.04
+
+    ARG AWS_DEFAULT_REGION=us-west-2
+    ARG AWS_ACCOUNT_ID=404851345508
+
+    RUN apt update && \
+        apt -y install curl jq unzip && \
+        curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+        unzip awscliv2.zip && \
+        ./aws/install
+
+    WITH DOCKER --load $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/test-repo=+some-thing
+        RUN \
+            --secret AWS_ACCESS_KEY_ID=+secrets/AWS_ACCESS_KEY_ID \
+            --secret AWS_SECRET_ACCESS_KEY=+secrets/AWS_SECRET_ACCESS_KEY \
+            --secret AWS_SESSION_TOKEN=+secrets/AWS_SESSION_TOKEN \
+            aws ecr get-login-password | docker login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com && \
+            docker push $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/test-repo:latest
+    END

--- a/examples/ecr-push/Earthfile
+++ b/examples/ecr-push/Earthfile
@@ -6,7 +6,7 @@ ecr-push:
     FROM ubuntu:20.04
 
     ARG AWS_DEFAULT_REGION=us-west-2
-    ARG AWS_ACCOUNT_ID=404851345508
+    ARG AWS_ACCOUNT_ID
 
     RUN apt update && \
         apt -y install curl jq unzip && \
@@ -22,3 +22,11 @@ ecr-push:
             aws ecr get-login-password | docker login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com && \
             docker push $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/test-repo:latest
     END
+
+some-thing-pre-logged-in:
+    FROM hashicorp/http-echo:latest
+
+    ARG AWS_DEFAULT_REGION=us-west-2
+    ARG AWS_ACCOUNT_ID
+
+    SAVE IMAGE $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/test-repo:latest

--- a/examples/ecr-push/README.md
+++ b/examples/ecr-push/README.md
@@ -26,3 +26,17 @@ If you do not have the environment variables, you can set the AWS credentials li
     --secret AWS_SESSION_TOKEN=$(aws configure get default.aws_session_token)
 ...
 ```
+
+Here, you do not have to have the `aws` tool installed! But you cannot pull from the same ECR registry.
+
+## Alternative method
+
+`earth` uses the hosts docker credentials. You can also login on the host, and then invoke `earth` like so:
+
+```
+$ aws ecr get-login-password | docker login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com
+$ earth -P +some-thing-pre-logged-in
+
+```
+
+This has the advantage that you can also pull images from your ECR registry! But, it also requires the user to also have the `aws` CLI tool set up and configured.

--- a/examples/ecr-push/Readme.md
+++ b/examples/ecr-push/Readme.md
@@ -1,0 +1,28 @@
+# Push an image to ECR with Earthly
+
+We are still making this easier, we hope it gets much shorter!
+
+The steps to build your image go in the `+some-thing` target. The `+ecr-push` target will push it to ECS. Assuming you keep your AWS credentials in the standard environment variables, you can build your image and push it to ECR like this:
+
+```
+earth -P \
+    --secret AWS_ACCESS_KEY_ID \
+    --secret AWS_SECRET_ACCESS_KEY \
+    --secret AWS_SESSION_TOKEN \
+    --build-arg AWS_DEFAULT_REGION \
+    --build-arg AWS_ACCOUNT_ID=<your-id> \
+     +ecr-push
+
+```
+
+You can omit the session token if you are not using `assume-role`.
+
+If you do not have the environment variables, you can set the AWS credentials like this via the already existing AWS CLI setup:
+
+```
+...
+    --secret AWS_ACCESS_KEY_ID=$(aws configure get default.aws_access_key_id)
+    --secret AWS_SECRET_ACCESS_KEY=$(aws configure get default.aws_secret_access_key)
+    --secret AWS_SESSION_TOKEN=$(aws configure get default.aws_session_token)
+...
+```


### PR DESCRIPTION
The current state of the world when pushing to ECR. Did not add it to the main Earthfile for running all the tests, because the only option would be localstack... and that seems to be flaky inside a `WITH DOCKER` (see the terraform example).