### PR TITLE
Ignore analytics for --version command

### DIFF
--- a/cmd/earth/main.go
+++ b/cmd/earth/main.go
@@ -196,7 +196,9 @@ func main() {
 	app.autoComplete()
 
 	exitCode := app.run(ctx, os.Args)
-	if app.cfg == nil || !app.cfg.Global.DisableAnalytics {
+	// app.cfg will be nil when a user runs `earth --version`;
+	// however in all other regular commands app.cfg will be set in app.Before
+	if app.cfg != nil && !app.cfg.Global.DisableAnalytics {
 		analytics.CollectAnalytics(Version, GitSha, app.commandName, exitCode, time.Since(startTime))
 	}
 	os.Exit(exitCode)


### PR DESCRIPTION
When --version is run, urfav/cli does not invoke the app.Before
function, this causes the config not to be parsed.

If a user had a config option to disable analytics, and ran the
--version flag, it would cause analytics to be reported.