### PR TITLE
expose earthly env variable

### DIFF
--- a/analytics/analytics.go
+++ b/analytics/analytics.go
@@ -21,7 +21,6 @@ func detectCI() (string, bool) {
 	for k, v := range map[string]string{
 		"GITHUB_WORKFLOW": "github-actions",
 		"CIRCLECI":        "circle-ci",
-		"EARTHLY":         "earthly",
 		"JENKINS_HOME":    "jenkins",
 		"BUILDKITE":       "buildkite",
 		"DRONE_BRANCH":    "drone",

--- a/analytics/analytics.go
+++ b/analytics/analytics.go
@@ -118,12 +118,16 @@ func CollectAnalytics(version, gitSha, commandName string, exitCode int, realtim
 	installID, overrideInstallID := os.LookupEnv("EARTHLY_INSTALL_ID")
 	repoHash := getRepoHash()
 	if !overrideInstallID {
-		if ci {
-			installID = fmt.Sprintf("%x", sha256.Sum256([]byte(ciName+repoHash)))
+		if repoHash == "unknown" {
+			installID = "unknown"
 		} else {
-			installID, err = getInstallID()
-			if err != nil {
-				installID = "unknown"
+			if ci {
+				installID = fmt.Sprintf("%x", sha256.Sum256([]byte(ciName+repoHash)))
+			} else {
+				installID, err = getInstallID()
+				if err != nil {
+					installID = "unknown"
+				}
 			}
 		}
 	}

--- a/analytics/analytics.go
+++ b/analytics/analytics.go
@@ -21,6 +21,7 @@ func detectCI() (string, bool) {
 	for k, v := range map[string]string{
 		"GITHUB_WORKFLOW": "github-actions",
 		"CIRCLECI":        "circle-ci",
+		"EARTHLY":         "earthly",
 		"JENKINS_HOME":    "jenkins",
 		"BUILDKITE":       "buildkite",
 		"DRONE_BRANCH":    "drone",
@@ -56,6 +57,7 @@ func getRepo() string {
 		"BUILDKITE_REPO",
 		"DRONE_REPO",
 		"TRAVIS_REPO_SLUG",
+		"EARTHLY_GIT_ORIGIN_URL",
 	} {
 		if v, ok := os.LookupEnv(k); ok {
 			return v

--- a/earthfile2llb/variables/collection.go
+++ b/earthfile2llb/variables/collection.go
@@ -175,7 +175,6 @@ func (c *Collection) WithBuiltinBuildArgs(target domain.Target, gitMeta *buildco
 		ret.overridingVariables[k] = true
 	}
 	// Add the builtin build args.
-	ret.variables["EARTHLY"] = NewConstant("true")
 	ret.variables["EARTHLY_TARGET"] = NewConstant(target.StringCanonical())
 	ret.variables["EARTHLY_TARGET_PROJECT"] = NewConstant(target.ProjectCanonical())
 	ret.variables["EARTHLY_TARGET_NAME"] = NewConstant(target.Target)

--- a/earthfile2llb/variables/collection.go
+++ b/earthfile2llb/variables/collection.go
@@ -175,6 +175,7 @@ func (c *Collection) WithBuiltinBuildArgs(target domain.Target, gitMeta *buildco
 		ret.overridingVariables[k] = true
 	}
 	// Add the builtin build args.
+	ret.variables["EARTHLY"] = NewConstant("true")
 	ret.variables["EARTHLY_TARGET"] = NewConstant(target.StringCanonical())
 	ret.variables["EARTHLY_TARGET_PROJECT"] = NewConstant(target.ProjectCanonical())
 	ret.variables["EARTHLY_TARGET_NAME"] = NewConstant(target.Target)


### PR DESCRIPTION
This will prevent having earth create a new installID when running the examples and other earth-in-earth tests.