### PR TITLE
Use CNI rather than host networking for buildkit

### DIFF
--- a/.buildkite/tests.sh
+++ b/.buildkite/tests.sh
@@ -46,9 +46,8 @@ echo "Build latest earth using released earth"
 echo "Execute tests"
 ./build/"$EARTH_OS"/amd64/earth --no-output -P +test
 
-# Temporarily disable until failure is addressed.
-#echo "Execute experimental tests"
-#./build/"$EARTH_OS"/amd64/earth --no-output -P ./examples/tests+experimental
+echo "Execute experimental tests"
+./build/"$EARTH_OS"/amd64/earth --no-output -P ./examples/tests+experimental
 
 echo "Execute fail test"
 bash -c "! ./build/$EARTH_OS/amd64/earth --no-output +test-fail"

--- a/.buildkite/tests.sh
+++ b/.buildkite/tests.sh
@@ -46,8 +46,9 @@ echo "Build latest earth using released earth"
 echo "Execute tests"
 ./build/"$EARTH_OS"/amd64/earth --no-output -P +test
 
-echo "Execute experimental tests"
-./build/"$EARTH_OS"/amd64/earth --no-output -P ./examples/tests+experimental
+# Temporarily disable until failure is addressed.
+#echo "Execute experimental tests"
+#./build/"$EARTH_OS"/amd64/earth --no-output -P ./examples/tests+experimental
 
 echo "Execute fail test"
 bash -c "! ./build/$EARTH_OS/amd64/earth --no-output +test-fail"

--- a/Earthfile
+++ b/Earthfile
@@ -148,6 +148,7 @@ earth-docker:
     RUN apk add --update --no-cache docker-cli
     ENV ENABLE_LOOP_DEVICE=false
     ENV FORCE_LOOP_DEVICE=false
+    ENV NETWORK_MODE=host
     COPY earth-buildkitd-wrapper.sh /usr/bin/earth-buildkitd-wrapper.sh
     ENTRYPOINT ["/usr/bin/earth-buildkitd-wrapper.sh"]
     ARG EARTHLY_TARGET_TAG_DOCKER

--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -36,6 +36,7 @@ buildkitd:
     ENV FORCE_LOOP_DEVICE=true
     ENV BUILDKIT_DEBUG=false
     ENV CACHE_SIZE_MB=0
+    ENV NETWORK_MODE=cni
     VOLUME /tmp/earthly
     ENTRYPOINT ["/usr/bin/entrypoint.sh", "buildkitd", "--config=/etc/buildkitd.toml"]
     ARG EARTHLY_TARGET_TAG_DOCKER

--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -2,9 +2,16 @@
 buildkitd:
     ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:earthly-main+build
     FROM $BUILDKIT_BASE_IMAGE
-
-    # Install some missing binaries.
-    RUN apk add --update --no-cache openssh-client gettext pigz xz e2fsprogs util-linux
+    RUN echo "@edge-community http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
+    RUN apk add --update --no-cache \
+        cni-plugins@edge-community \
+        e2fsprogs \
+        gettext \
+        iptables \
+        openssh-client \
+        pigz \
+        util-linux \
+        xz
 
     # Add github and gitlab to known hosts.
     RUN mkdir -p ~/.ssh
@@ -15,7 +22,9 @@ buildkitd:
     COPY ./entrypoint.sh /usr/bin/entrypoint.sh
     COPY ./buildkitd.toml.template /etc/buildkitd.toml.template
     COPY ./buildkitd.cache.template /etc/buildkitd.cache.template
+    COPY ./cni-conf.json /etc/cni/cni-conf.json
 
+    # Scripts and binaries used for the builds.
     COPY ../+shellrepeater/shellrepeater /usr/bin/shellrepeater
     COPY ../+debugger/earth_debugger /usr/bin/earth_debugger
     COPY ./dockerd-wrapper.sh /var/earthly/dockerd-wrapper.sh

--- a/buildkitd/buildkitd.toml.template
+++ b/buildkitd/buildkitd.toml.template
@@ -6,4 +6,7 @@ insecure-entitlements = [ "security.insecure" ]
   enabled = true
   snapshotter = "auto"
   gc = true
+  networkMode = "cni"
+  cniBinaryPath = "/usr/libexec/cni"
+  cniConfigPath = "/etc/cni/cni-conf.json"
   ${CACHE_SETTINGS}

--- a/buildkitd/buildkitd.toml.template
+++ b/buildkitd/buildkitd.toml.template
@@ -6,7 +6,7 @@ insecure-entitlements = [ "security.insecure" ]
   enabled = true
   snapshotter = "auto"
   gc = true
-  networkMode = "cni"
+  networkMode = "${NETWORK_MODE}"
   cniBinaryPath = "/usr/libexec/cni"
   cniConfigPath = "/etc/cni/cni-conf.json"
   ${CACHE_SETTINGS}

--- a/buildkitd/cni-conf.json
+++ b/buildkitd/cni-conf.json
@@ -7,7 +7,7 @@
 	"ipMasq": true,
 	"ipam": {
 		"type": "host-local",
-		"subnet": "10.22.0.0/16",
+		"subnet": "172.64.0.0/16",
 		"routes": [
 			{ "dst": "0.0.0.0/0" }
 		]

--- a/buildkitd/cni-conf.json
+++ b/buildkitd/cni-conf.json
@@ -7,7 +7,7 @@
 	"ipMasq": true,
 	"ipam": {
 		"type": "host-local",
-		"subnet": "172.64.0.0/16",
+		"subnet": "172.30.0.0/16",
 		"routes": [
 			{ "dst": "0.0.0.0/0" }
 		]

--- a/buildkitd/cni-conf.json
+++ b/buildkitd/cni-conf.json
@@ -1,0 +1,15 @@
+{
+	"cniVersion": "0.2.0",
+	"name": "buildkitbuild",
+	"type": "bridge",
+	"bridge": "cni0",
+	"isGateway": true,
+	"ipMasq": true,
+	"ipam": {
+		"type": "host-local",
+		"subnet": "10.22.0.0/16",
+		"routes": [
+			{ "dst": "0.0.0.0/0" }
+		]
+	}
+}

--- a/buildkitd/cni-conf.json
+++ b/buildkitd/cni-conf.json
@@ -1,5 +1,5 @@
 {
-	"cniVersion": "0.2.0",
+	"cniVersion": "0.3.0",
 	"name": "buildkitbuild",
 	"type": "bridge",
 	"bridge": "cni0",

--- a/buildkitd/dockerd-wrapper.sh
+++ b/buildkitd/dockerd-wrapper.sh
@@ -23,15 +23,7 @@ execute() {
         exit 1
     fi
 
-    # Lock entire execution of a docker daemon - only one daemon can be used at a time
-    # (dockerd race conditions in handling networking setup).
-    (
-        flock -x 8
-        start_dockerd
-        # Note that the lock will continue to be held after this subshell finishes,
-        # becasue it spawns the dockerd background process. This is intentional.
-        # The lock is meant to be held until dockerd exits.
-    ) 8>/var/earthly/dind/lock
+    start_dockerd
     load_images
     if [ "$EARTHLY_START_COMPOSE" = "true" ]; then
         # shellcheck disable=SC2086

--- a/buildkitd/entrypoint.sh
+++ b/buildkitd/entrypoint.sh
@@ -20,6 +20,11 @@ if [ -z "$EARTHLY_TMP_DIR" ]; then
     exit 1
 fi
 
+if [ -z "$NETWORK_MODE" ]; then
+    echo "NETWORK_MODE not set"
+    exit 1
+fi
+
 if [ "$EARTHLY_RESET_TMP_DIR" = "true" ]; then
     echo "Resetting dir $EARTHLY_TMP_DIR"
     rm -rf "${EARTHLY_TMP_DIR:?}"/* || true

--- a/examples/tests/with-docker-compose/Earthfile
+++ b/examples/tests/with-docker-compose/Earthfile
@@ -1,9 +1,12 @@
-FROM docker:19.03.7-dind
+FROM earthly/dind
 WORKDIR /test
 
 all:
     BUILD --build-arg INDEX=1 +test
     BUILD --build-arg INDEX=2 +test
+    BUILD --build-arg INDEX=3 +test
+    BUILD --build-arg INDEX=4 +test
+    BUILD --build-arg INDEX=5 +test
 
 print-countries:
     FROM jbergknoff/postgresql-client:latest

--- a/examples/tests/with-docker/Earthfile
+++ b/examples/tests/with-docker/Earthfile
@@ -41,3 +41,6 @@ docker-pull-test:
 load-parallel-test:
     BUILD --build-arg INDEX=1 +docker-load-test
     BUILD --build-arg INDEX=2 +docker-load-test
+    BUILD --build-arg INDEX=3 +docker-load-test
+    BUILD --build-arg INDEX=4 +docker-load-test
+    BUILD --build-arg INDEX=5 +docker-load-test


### PR DESCRIPTION
The net benefit of this is that `WITH DOCKER` can now run in parallel with other `WITH DOCKER`'s. No more networking-related race conditions. This also removes the lock that was preventing the race conditions before.