### PR TITLE
Print overridden args at the beginning of each target and also on failure

### DIFF
--- a/builder/solver_monitor.go
+++ b/builder/solver_monitor.go
@@ -202,7 +202,7 @@ func (sm *solverMonitor) printHeader(vm *vertexMonitor) {
 	if !seen {
 		sm.saltSeen[vm.salt] = true
 	}
-	vm.printHeader(!seen)
+	vm.printHeader(!seen || sm.verbose)
 }
 
 func (sm *solverMonitor) reprintFailure(errVertex *vertexMonitor) {

--- a/conslogging/color.go
+++ b/conslogging/color.go
@@ -4,7 +4,7 @@ import "github.com/fatih/color"
 
 var noColor = makeNoColor()
 var cachedColor = makeColor(color.FgHiGreen)
-var paramsColor = makeColor(color.FgHiBlack)
+var metadataModeColor = makeColor(color.FgHiBlack)
 var successColor = makeColor(color.FgHiGreen)
 var warnColor = makeColor(color.FgHiRed)
 

--- a/conslogging/color.go
+++ b/conslogging/color.go
@@ -4,6 +4,7 @@ import "github.com/fatih/color"
 
 var noColor = makeNoColor()
 var cachedColor = makeColor(color.FgHiGreen)
+var paramsColor = makeColor(color.FgHiBlack)
 var successColor = makeColor(color.FgHiGreen)
 var warnColor = makeColor(color.FgHiRed)
 


### PR DESCRIPTION
Some example of how this looks like (dark gray text):

![Screenshot from 2020-11-17 16-02-45](https://user-images.githubusercontent.com/446771/99466031-7d09fa00-28f0-11eb-866a-322a3f38fbcb.png)
![Screenshot from 2020-11-17 16-03-02](https://user-images.githubusercontent.com/446771/99466033-7da29080-28f0-11eb-86eb-9b91d2704dc7.png)
![Screenshot from 2020-11-17 16-09-32](https://user-images.githubusercontent.com/446771/99466042-8004ea80-28f0-11eb-94b1-ef29ddec7f8b.png)

Verbose mode prints the overridden build args before every single command.

![Screenshot from 2020-11-17 16-23-54](https://user-images.githubusercontent.com/446771/99466462-4f718080-28f1-11eb-9ad9-7633d0730969.png)

The information is passed via the buildkit vertex name, with any overridden build args encoded in brackets as `+target(<base64 build args string>)` and then interpreted by the solver monitor and printed accordingly.