### PR TITLE
Fix garbled output

### DIFF
--- a/builder/solver_monitor.go
+++ b/builder/solver_monitor.go
@@ -202,7 +202,7 @@ func (sm *solverMonitor) printHeader(vm *vertexMonitor) {
 	if !seen {
 		sm.saltSeen[vm.salt] = true
 	}
-	vm.printHeader(!seen)
+	vm.printHeader(!seen || sm.verbose)
 }
 
 func (sm *solverMonitor) reprintFailure(errVertex *vertexMonitor) {

--- a/conslogging/color.go
+++ b/conslogging/color.go
@@ -4,7 +4,7 @@ import "github.com/fatih/color"
 
 var noColor = makeNoColor()
 var cachedColor = makeColor(color.FgHiGreen)
-var paramsColor = makeColor(color.FgHiBlack)
+var metadataModeColor = makeColor(color.FgHiBlack)
 var successColor = makeColor(color.FgHiGreen)
 var warnColor = makeColor(color.FgHiRed)
 

--- a/conslogging/color.go
+++ b/conslogging/color.go
@@ -4,6 +4,7 @@ import "github.com/fatih/color"
 
 var noColor = makeNoColor()
 var cachedColor = makeColor(color.FgHiGreen)
+var paramsColor = makeColor(color.FgHiBlack)
 var successColor = makeColor(color.FgHiGreen)
 var warnColor = makeColor(color.FgHiRed)
 


### PR DESCRIPTION
Fixes https://github.com/earthly/earthly/issues/338

The way it works:
  * If output is not terminated by a `\n`, then we store the final line as an "open line" and repeat it on the next call. We print the open line as it is for now and append our own `\n`
  * On the next call, any open line is pre-pended to the output
  * So far this results in the following output for curl, which is an improvement:
    ![Screenshot from 2020-11-17 19-01-43](https://user-images.githubusercontent.com/446771/99481255-8f932c00-290e-11eb-9c88-e1b9b94a1876.png)
  * As an extra optimization, if there is an open line and the previous output was from the same vertex, then we go up one line using an ANSI control char and overwrite that line
  * This results in this final output for curl (as well as meaningful visual updates while it's ongoing):
    ![Screenshot from 2020-11-17 19-50-07](https://user-images.githubusercontent.com/446771/99481370-d08b4080-290e-11eb-9966-8d30bd304461.png)
