### PR TITLE
Fix for arg expansion in copy command

### DIFF
--- a/examples/tests/Earthfile
+++ b/examples/tests/Earthfile
@@ -347,6 +347,7 @@ empty-git-test:
 escape-test:
     COPY escape.earth ./Earthfile
     RUN printf "content" >file-with-+.txt
+    RUN printf "content" >regular-file.txt
     RUN --privileged \
         --entrypoint \
         --mount=type=tmpfs,target=/tmp/earthly \

--- a/examples/tests/escape.earth
+++ b/examples/tests/escape.earth
@@ -3,13 +3,31 @@ WORKDIR /test
 
 all:
     BUILD +test-copy-build-context
+    # TODO: FILE_IN_RUN shuoldn't need to be different. This is a bug.
+    BUILD \
+        --build-arg FILE="file-with-\+.txt" \
+        --build-arg FILE_IN_RUN="file-with-+.txt" \
+        +test-copy-build-arg
+    BUILD --build-arg FILE="regular-file.txt" +test-copy-build-arg
     BUILD +test-copy-artifact1
     BUILD +test-copy-artifact2
     BUILD +test-copy-artifact3
+    # TODO: FILE_IN_RUN shuoldn't need to be different. This is a bug.
+    BUILD \
+        --build-arg FILE="another-file-with-\+.txt" \
+        --build-arg FILE_IN_RUN="another-file-with-+.txt" \
+        +test-copy-artifact-with-plus-build-arg
+    BUILD --build-arg FILE="file.txt" +test-copy-artifact-without-plus-build-arg
 
 test-copy-build-context:
     COPY file-with-\+.txt ./
     RUN test "content" == "$(cat file-with-+.txt)"
+
+test-copy-build-arg:
+    ARG FILE
+    ARG FILE_IN_RUN=$FILE
+    COPY ${FILE} ./
+    RUN test "content" == "$(cat $FILE_IN_RUN)"
 
 test-copy-artifact1:
     COPY +artifact-with-plus1/another-file-with-\+.txt ./
@@ -33,3 +51,18 @@ artifact-with-plus2:
 artifact-with-plus3:
     RUN printf "test" >file.txt
     SAVE ARTIFACT ./file.txt AS LOCAL ./still-+.txt
+
+test-copy-artifact-with-plus-build-arg:
+    ARG FILE
+    ARG FILE_IN_RUN=$FILE
+    COPY +artifact-with-plus1/${FILE} ./
+    RUN test "test" == "$(cat $FILE_IN_RUN)"
+
+test-copy-artifact-without-plus-build-arg:
+    ARG FILE
+    COPY +artifact-without-plus/${FILE} ./
+    RUN test "test" == "$(cat $FILE)"
+
+artifact-without-plus:
+    RUN printf "test" >file.txt
+    SAVE ARTIFACT ./file.txt

--- a/examples/tests/escape.earth
+++ b/examples/tests/escape.earth
@@ -3,7 +3,7 @@ WORKDIR /test
 
 all:
     BUILD +test-copy-build-context
-    # TODO: FILE_IN_RUN shuoldn't need to be different. This is a bug.
+    # TODO: FILE_IN_RUN shouldn't need to be different. This is a bug.
     BUILD \
         --build-arg FILE="file-with-\+.txt" \
         --build-arg FILE_IN_RUN="file-with-+.txt" \
@@ -12,7 +12,7 @@ all:
     BUILD +test-copy-artifact1
     BUILD +test-copy-artifact2
     BUILD +test-copy-artifact3
-    # TODO: FILE_IN_RUN shuoldn't need to be different. This is a bug.
+    # TODO: FILE_IN_RUN shouldn't need to be different. This is a bug.
     BUILD \
         --build-arg FILE="another-file-with-\+.txt" \
         --build-arg FILE_IN_RUN="another-file-with-+.txt" \


### PR DESCRIPTION
A fix for the COPY issue @zenyui reported over on Gitter.

The fix is on line 233. The rest also addresses situations where files or artifacts with `+` are passed via build args.