### PR TITLE
Print timing info on verbose

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -109,6 +109,7 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 	successFun := func() {
 		if opt.PrintSuccess {
 			b.opt.Console.PrintSuccess()
+			b.s.sm.PrintTiming()
 		}
 	}
 	destPathWhitelist := make(map[string]bool)

--- a/builder/solver_monitor.go
+++ b/builder/solver_monitor.go
@@ -302,11 +302,6 @@ func (sm *solverMonitor) recordTiming(targetStr, targetBrackets, salt string, ve
 	sm.timingTable[key] += dur
 }
 
-type durationAndKey struct {
-	dur time.Duration
-	key timingKey
-}
-
 func (sm *solverMonitor) PrintTiming() {
 	if !sm.verbose {
 		return
@@ -316,10 +311,14 @@ func (sm *solverMonitor) PrintTiming() {
 		Printf("Summary of timing information\n" +
 			"Note that the times do not include the expansion of commands like BUILD, FROM, COPY (artifact).")
 	var total time.Duration
+	type durationAndKey struct {
+		dur time.Duration
+		key timingKey
+	}
 	durs := make([]durationAndKey, 0, len(sm.timingTable))
 	for key, dur := range sm.timingTable {
 		durs = append(durs, durationAndKey{
-			d:   dur,
+			dur: dur,
 			key: key,
 		})
 		total += dur
@@ -327,6 +326,12 @@ func (sm *solverMonitor) PrintTiming() {
 	sort.Slice(durs, func(i, j int) bool {
 		return durs[i].dur > durs[j].dur
 	})
+	for _, d := range durs {
+		sm.console.
+			WithPrefixAndSalt(d.key.targetStr, d.key.salt).
+			WithMetadataMode(true).
+			Printf("(%s) %s\n", d.key.targetBrackets, d.dur)
+	}
 	sm.console.
 		WithMetadataMode(true).
 		Printf("===============================================================\n")

--- a/builder/solver_monitor.go
+++ b/builder/solver_monitor.go
@@ -162,9 +162,8 @@ type solverMonitor struct {
 	vertices         map[digest.Digest]*vertexMonitor
 	saltSeen         map[string]bool
 	lastVertexOutput *vertexMonitor
-	// timingTable is a map of target+salt string -> total duration.
-	timingTable map[timingKey]time.Duration
-	startTime   time.Time
+	timingTable      map[timingKey]time.Duration
+	startTime        time.Time
 }
 
 type timingKey struct {

--- a/builder/solver_monitor.go
+++ b/builder/solver_monitor.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -147,20 +148,39 @@ func (vm *vertexMonitor) printError() {
 	}
 }
 
+func (vm *vertexMonitor) printTimingInfo() {
+	if vm.vertex.Started == nil || vm.vertex.Completed == nil {
+		return
+	}
+	vm.console.WithMetadataMode(true).
+		Printf("Completed in %s\n", vm.vertex.Completed.Sub(*vm.vertex.Started))
+}
+
 type solverMonitor struct {
 	console          conslogging.ConsoleLogger
 	verbose          bool
 	vertices         map[digest.Digest]*vertexMonitor
 	saltSeen         map[string]bool
 	lastVertexOutput *vertexMonitor
+	// timingTable is a map of target+salt string -> total duration.
+	timingTable map[timingKey]time.Duration
+	startTime   time.Time
+}
+
+type timingKey struct {
+	targetStr      string
+	targetBrackets string
+	salt           string
 }
 
 func newSolverMonitor(console conslogging.ConsoleLogger, verbose bool) *solverMonitor {
 	return &solverMonitor{
-		console:  console,
-		verbose:  verbose,
-		vertices: make(map[digest.Digest]*vertexMonitor),
-		saltSeen: make(map[string]bool),
+		console:     console,
+		verbose:     verbose,
+		vertices:    make(map[digest.Digest]*vertexMonitor),
+		saltSeen:    make(map[string]bool),
+		timingTable: make(map[timingKey]time.Duration),
+		startTime:   time.Now(),
 	}
 }
 
@@ -206,6 +226,10 @@ Loop:
 						vm.printError()
 					}
 				}
+				if sm.verbose {
+					vm.printTimingInfo()
+					sm.recordTiming(vm.targetStr, vm.targetBrackets, vm.salt, vertex)
+				}
 			}
 			for _, vs := range ss.Statuses {
 				vm, ok := sm.vertices[vs.Vertex]
@@ -240,7 +264,6 @@ Loop:
 				if err != nil {
 					return err
 				}
-
 			}
 		}
 	}
@@ -262,6 +285,60 @@ func (sm *solverMonitor) printHeader(vm *vertexMonitor) {
 		sm.saltSeen[vm.salt] = true
 	}
 	vm.printHeader(!seen || sm.verbose)
+}
+
+func (sm *solverMonitor) recordTiming(targetStr, targetBrackets, salt string, vertex *client.Vertex) {
+	if vertex.Started == nil || vertex.Completed == nil {
+		return
+	}
+	dur := vertex.Completed.Sub(*vertex.Started)
+	if dur == 0 {
+		return
+	}
+	key := timingKey{
+		targetStr:      targetStr,
+		targetBrackets: targetBrackets,
+		salt:           salt,
+	}
+	sm.timingTable[key] = sm.timingTable[key] + dur
+}
+
+func (sm *solverMonitor) PrintTiming() {
+	if !sm.verbose {
+		return
+	}
+	sm.console.
+		WithMetadataMode(true).
+		Printf("Summary of timing information\n" +
+			"Note that the times do not include the expansion of commands like BUILD, FROM, COPY (artifact).")
+	var total time.Duration
+	durs := make([]time.Duration, 0, len(sm.timingTable))
+	durMap := make(map[time.Duration][]timingKey)
+	for key, dur := range sm.timingTable {
+		durs = append(durs, dur)
+		durMap[dur] = append(durMap[dur], key)
+		total += dur
+	}
+	sort.Slice(durs, func(i, j int) bool {
+		return durs[i] > durs[j]
+	})
+	for _, dur := range durs {
+		for _, key := range durMap[dur] {
+			sm.console.
+				WithPrefixAndSalt(key.targetStr, key.salt).
+				WithMetadataMode(true).
+				Printf("(%s) %s\n", key.targetBrackets, dur)
+		}
+	}
+	sm.console.
+		WithMetadataMode(true).
+		Printf("===============================================================\n")
+	sm.console.
+		WithMetadataMode(true).
+		Printf("Total       \t%s\n", total)
+	sm.console.
+		WithMetadataMode(true).
+		Printf("Total (real)\t%s\n", time.Now().Sub(sm.startTime))
 }
 
 func (sm *solverMonitor) reprintFailure(errVertex *vertexMonitor) {

--- a/builder/solver_monitor.go
+++ b/builder/solver_monitor.go
@@ -300,7 +300,7 @@ func (sm *solverMonitor) recordTiming(targetStr, targetBrackets, salt string, ve
 		targetBrackets: targetBrackets,
 		salt:           salt,
 	}
-	sm.timingTable[key] = sm.timingTable[key] + dur
+	sm.timingTable[key] += dur
 }
 
 func (sm *solverMonitor) PrintTiming() {


### PR DESCRIPTION
Fixes https://github.com/earthly/earthly/issues/529
Fixes https://github.com/earthly/earthly/issues/496

Prints elapsed time after completing each command and also a summary at the end for total time spent on each target.

![Screenshot from 2020-11-20 16-47-01](https://user-images.githubusercontent.com/446771/99862894-737ecd00-2b50-11eb-8a74-e5661427a602.png)
![Screenshot from 2020-11-20 16-47-14](https://user-images.githubusercontent.com/446771/99862896-75e12700-2b50-11eb-8404-95cb4fd1d81a.png)

CC @agbell @dchw 