### PR TITLE
Print warning messages to stderr rather than stdout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       - name: "Experimental tests"
         run: ./build/linux/amd64/earth -P ./examples/tests+experimental
       - name: Execute test similar to homebrew test in https://github.com/Homebrew/homebrew-core/blob/master/Formula/earthly.rb
-        run: ./build/linux/amd64/earth --buildkit-host 127.0.0.1 ./examples/tests/with-docker+all | grep 'Error while dialing invalid address 127.0.0.1'
+        run: ./build/linux/amd64/earth --buildkit-host 127.0.0.1 ./examples/tests/with-docker+all 2>&1 | grep 'Error while dialing invalid address 127.0.0.1'
       - name: Docker Login
         run: docker login --username "${{ secrets.DOCKERHUB_USERNAME }}" --password "${{ secrets.DOCKERHUB_TOKEN }}"
         if: github.event.pull_request.head.repo.full_name == github.repository


### PR DESCRIPTION
- when fetching secrets, if a warning occurs it's printed to stdout
rather than stderr, which breaks accessing secrets via the cli.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>