### PR TITLE
Fix metadata text color not being visible on solarized terminal theme

### DIFF
--- a/conslogging/color.go
+++ b/conslogging/color.go
@@ -4,7 +4,7 @@ import "github.com/fatih/color"
 
 var noColor = makeNoColor()
 var cachedColor = makeColor(color.FgHiGreen)
-var metadataModeColor = makeColor(color.FgHiBlack)
+var metadataModeColor = makeColor(color.FgHiWhite, color.BgHiBlack)
 var successColor = makeColor(color.FgHiGreen)
 var warnColor = makeColor(color.FgHiRed)
 
@@ -21,9 +21,11 @@ var availablePrefixColors = []*color.Color{
 	makeColor(color.FgHiWhite),
 }
 
-func makeColor(att color.Attribute) *color.Color {
+func makeColor(attrs ...color.Attribute) *color.Color {
 	c := color.New()
-	c.Add(att)
+	for _, attr := range attrs {
+		c.Add(attr)
+	}
 	return c
 }
 

--- a/conslogging/conslogging.go
+++ b/conslogging/conslogging.go
@@ -170,7 +170,9 @@ func (cl ConsoleLogger) Printf(format string, args ...interface{}) {
 	text = strings.TrimSuffix(text, "\n")
 	for _, line := range strings.Split(text, "\n") {
 		cl.printPrefix(false)
-		c.Fprintf(cl.outW, "%s\n", line)
+		c.Fprintf(cl.outW, "%s", line)
+		// Don't use a background color for \n.
+		cl.color(noColor).Fprintf(cl.outW, "\n")
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/earthly/earthly/issues/548

![Screenshot from 2020-12-02 15-52-24](https://user-images.githubusercontent.com/446771/100945729-af058980-34b6-11eb-8965-fdea35505d88.png)
