### PR TITLE
Switch windows pipeline to use wsl2 buildkite agent

### DIFF
--- a/.buildkite/tests.sh
+++ b/.buildkite/tests.sh
@@ -18,24 +18,6 @@ while ! docker ps; do
         exit 1
     fi
 done
-# This strange workaround is needed to avoid "Text file busy" errors on Windows.
-# It's essentially a busy-waiting loop that waits for the error to go away.
-# It typically takes less than three minutes to right itself.
-SECONDS=0
-do_reset=false
-while ! echo "." >./earth-released; do
-    do_reset=true
-    echo "Waiting for ./earth-released to become available for writing..."
-    echo "Time elapsed: $SECONDS seconds"
-    sleep 1
-    if [ "$SECONDS" -gt "600" ]; then
-        echo "Timed out"
-        exit 1
-    fi
-done
-if [ "$do_reset" = "true" ]; then
-    docker stop earthly-buildkitd || true
-fi
 
 echo "Download latest Earthly binary"
 curl -o ./earth-released -L https://github.com/earthly/earthly/releases/latest/download/earth-"$EARTH_OS"-amd64 && chmod +x ./earth-released

--- a/.buildkite/windows.yml
+++ b/.buildkite/windows.yml
@@ -2,12 +2,11 @@
 steps:
   - label: Test
     commands:
-      - wsl -- bash ./.buildkite/tests.sh
+      - bash ./.buildkite/tests.sh
     env:
       GIT_URL_INSTEAD_OF: "https://github.com/=git@github.com:"
       FORCE_COLOR: 1
       EARTH_OS: linux
       EARTHLY_CONFIG: "./.buildkite/earthly-config-win.yml"
-      WSLENV: "GIT_URL_INSTEAD_OF:FORCE_COLOR:BUILDKITE_BRANCH:EARTH_OS:EARTHLY_CONFIG:BUILDKITE_BUILD_ID"
     agents:
-      os: windows
+      os: wsl2

--- a/.buildkite/windows.yml
+++ b/.buildkite/windows.yml
@@ -2,7 +2,7 @@
 steps:
   - label: Test
     commands:
-      - bash ./.buildkite/tests.sh
+      - ./.buildkite/tests.sh
     env:
       GIT_URL_INSTEAD_OF: "https://github.com/=git@github.com:"
       FORCE_COLOR: 1

--- a/examples/integration-test/Earthfile
+++ b/examples/integration-test/Earthfile
@@ -1,7 +1,6 @@
 FROM earthly/dind:alpine
 WORKDIR /scala-example
-RUN apk add openjdk11 bash wget
-
+RUN apk add openjdk11 bash wget postgresql-client
 
 sbt: 
     #Scala
@@ -40,7 +39,8 @@ integration-test:
     COPY src src
     COPY docker-compose.yml ./ 
     WITH DOCKER --compose docker-compose.yml
-       RUN sbt it:test
+        RUN while ! pg_isready --host=localhost --port=5432 --dbname=iso3166 --username=postgres; do sleep 1; done ;\
+            sbt it:test
     END
 
 docker:
@@ -55,7 +55,8 @@ smoke-test:
     COPY docker-compose.yml ./ 
     COPY src/smoketest ./ 
     WITH DOCKER --compose docker-compose.yml --load scala-example:latest=+docker
-        RUN ./smoketest.sh
+        RUN while ! pg_isready --host=localhost --port=5432 --dbname=iso3166 --username=postgres; do sleep 1; done ;\
+            ./smoketest.sh
     END
     
 all:

--- a/examples/integration-test/docker-compose.yml
+++ b/examples/integration-test/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     container_name: local-postgres
     image: aa8y/postgres-dataset:iso3166
     ports:
-      - 5432:5432
+      - 127.0.0.1:5432:5432
     hostname: postgres
     environment:
       - POSTGRES_USER=postgres
@@ -19,7 +19,7 @@ services:
     depends_on:
       - postgres
     ports:
-      - 8080:8080
+      - 127.0.0.1:8080:8080
     hostname: postgres-ui
     environment:
       - ADMINER_DEFAULT_SERVER=postgres

--- a/examples/tests/with-docker-compose/Earthfile
+++ b/examples/tests/with-docker-compose/Earthfile
@@ -13,15 +13,14 @@ print-countries:
     CMD ["-c", "SELECT * FROM country WHERE country_id = '76'"]
 
 test:
+    RUN apk add postgresql-client
     COPY docker-compose.yml .
     # Index is used to create parallel tests.
     ARG INDEX=0
-    RUN echo "$INDEX"
     WITH DOCKER \
             --compose docker-compose.yml \
             --service postgres \
             --load print-countries:latest=+print-countries
-        RUN for i in {1..30}; do nc -z localhost 5432 && break; sleep 1; done; \
-            sleep 60 ;\
+        RUN while ! pg_isready --host=localhost --port=5432 --dbname=iso3166 --username=postgres; do sleep 1; done ;\
             docker-compose up --exit-code-from print-countries print-countries | grep Brazil
     END

--- a/examples/tests/with-docker-compose/docker-compose.yml
+++ b/examples/tests/with-docker-compose/docker-compose.yml
@@ -14,7 +14,7 @@ services:
   postgres:
     image: aa8y/postgres-dataset:iso3166
     ports:
-      - 5432
+      - 127.0.0.1:5432:5432
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres


### PR DESCRIPTION
CC @alexcb FYI

We now use the Linux buildkite agent in Windows WSL2, rather than the Windows buildkite agent, outside of wsl2.