### PR TITLE
Automatically switch from password-based login to ssh

### DIFF
--- a/cmd/earth/main.go
+++ b/cmd/earth/main.go
@@ -1442,6 +1442,20 @@ func (app *earthApp) actionAccountAddKey(c *cli.Context) error {
 		return errors.Wrap(err, "failed to add public key to account")
 	}
 
+	//switch over to new key if the user is currently using password-based auth
+	email, authType, err := sc.WhoAmI()
+	if err != nil {
+		return errors.Wrap(err, "failed to validate auth token")
+	}
+	if authType == "password" {
+		err = sc.SetLoginSSH(email, publicKey)
+		if err != nil {
+			app.console.Warnf("failed to authenticate using newly added public key: %s", err.Error())
+			return nil
+		}
+		fmt.Printf("Switching from password-based login to ssh-based login\n")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
If a user is currently using password-based login, swtich to the newly
added ssh-key. Here's an example:

    alex@mah:~/gh/earthly/earthly$ cat ~/.earthly/auth.token
    plus+slash/under_hyphen-quote"@earthly.dev password MTIzNDU2Nzg5MA==

    alex@mah:~/gh/earthly/earthly$ go run cmd/earth/main.go account add-key
    Which of the following keys do you want to register?
    1) ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDtCpWpjWyMAPRDE8Kchr0u6eD/uhyPSyVy8dQfYx7/LLLvXQ9am1jZp0O44nkly92ETWY+TZdSIuNDSTMaeqhioKBKFF2cCertXzwKdHLuWzB3VAe9PeSiDejMn9TzGPih9XRFUsgPhDadxLEXJnZZVRNAMWwXFD4NlAHUtz0GULoZ8FB76tC1AmzT0CaM721NbkR94bKQweizvyXzPFBh75Ad13VIi6BX7JXgN2wai/z3Kka1puEH5C0IJL/V5OO2sfhvRa+4+ZQvxn0Cbs6MN1AOEYjagdCootOcmImo2AXezym9Rm6F524EEm+24KM9y+uvKacpxIZ0pmYuPB2f /home/alex/.ssh/id_rsa
    2) ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCaNBX0jGnjg0w+gyExKd8g2HBWQSHsypkV8G9Ffv6Di5chI/g8pr1mhnpFO+uvDpragUdvcXP1nNUHeQr9g1nGWETZL7ZxpFTZ+0LhVOLnaw3KKAcPcOcW8Hk7j5zIBYv4Dd6oE2EUV9ZlvV4/VXzqL+EfAimvblySPy6f5QtwPOXHqHiehXWlv8Onebu/5cotWlPFTJzkE4u23d3v218ZbWjZQo5+68hEORFob7o6xLhrdHrsRER+ZOmxsasxADRckNpOGpgk6ghoeUeXYEkEWERDoM+NEPRAYBW7rzOHbrmbl4brPOk9vB5Z2kEDSVngasvlZfzPQUpBRIlWLME8lE2Mkhl/tgRfKgRZ9sX2EB1VGQ4LTJn5mqfWiemuSGIOvD/4ZBPce7KHxsQrcy7Zl4TaEmkbWZzgi0BaUoSE5gXdhlmK8+JguyLtK+sUS8FdscjLBF+TaW5g5PE+PEWVImCRJQpATj3aJiz98ljmSWtKryucisZGdPpvYm9bxn8= cinnamonthecat
    enter key number (1=default): 1
    Switching from password-based login to ssh-based login

    alex@mah:~/gh/earthly/earthly$ cat ~/.earthly/auth.token
    plus+slash/under_hyphen-quote"@earthly.dev ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDtCpWpjWyMAPRDE8Kchr0u6eD/uhyPSyVy8dQfYx7/LLLvXQ9am1jZp0O44nkly92ETWY+TZdSIuNDSTMaeqhioKBKFF2cCertXzwKdHLuWzB3VAe9PeSiDejMn9TzGPih9XRFUsgPhDadxLEXJnZZVRNAMWwXFD4NlAHUtz0GULoZ8FB76tC1AmzT0CaM721NbkR94bKQweizvyXzPFBh75Ad13VIi6BX7JXgN2wai/z3Kka1puEH5C0IJL/V5OO2sfhvRa+4+ZQvxn0Cbs6MN1AOEYjagdCootOcmImo2AXezym9Rm6F524EEm+24KM9y+uvKacpxIZ0pmYuPB2falex@mah:~/gh/earthly/earthly$

    alex@mah:~/gh/earthly/earthly$ go run cmd/earth/main.go account login
    Logged in as "plus+slash/under_hyphen-quote\"@earthly.dev" using ssh auth

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>