### PR TITLE
Display token expiry after creation

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -289,6 +289,7 @@ github.com/docker/libtrust v0.0.0-20150114040149-fa567046d9b1/go.mod h1:cyGadeNE
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=


### PR DESCRIPTION
 - also allow expiry to be submitted as YYYY-MM-DD, or never

example outputs:

```
alex@mah:~/gh/earthly/earthly$ go run cmd/earth/main.go account create-token --expiry never poop
created token "dAkOPv9fzauiuqJljYCHOhGj2xI5JSMHet7CENt3Sbe9lYjCJ6YsH3pu3S5k54cK" which will expire in a long while from now; save this token somewhere, it can't be viewed again (only reset)
alex@mah:~/gh/earthly/earthly$ go run cmd/earth/main.go account create-token --expiry 2020-12-12 poop
created token "m2UcF6JeuHa6DF5BDxc77OMRs7jWXRr69DwVXVldYhXYOeEF7JLJlHc8EvKLUtc8" which will expire in 1 week from now; save this token somewhere, it can't be viewed again (only reset)
alex@mah:~/gh/earthly/earthly$ go run cmd/earth/main.go account create-token --expiry 2021-02-12 poop
created token "F6QIAlLFITfyLrqwzhelbmPs836mSWBwCptsvcTnakQmWxvjgEZbsfGo6jFJBg3S" which will expire in 2 months from now; save this token somewhere, it can't be viewed again (only reset)
alex@mah:~/gh/earthly/earthly$ go run cmd/earth/main.go account create-token --expiry 2020-12-25T19:00:00Z poop
created token "GCa1b91eBZrmEnfJnlUYhqQihxKn4lZtwQRcr4SX6AA4CTRBcfryPf6I9V05jQpA" which will expire in 2 weeks from now; save this token somewhere, it can't be viewed again (only reset)
```

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>