### PR TITLE
EARTHLY_SERVER is only meant for internal dev

### DIFF
--- a/cmd/earth/main.go
+++ b/cmd/earth/main.go
@@ -406,6 +406,7 @@ func newEarthApp(ctx context.Context, console conslogging.ConsoleLogger) *earthA
 			EnvVars:     []string{"EARTHLY_SERVER"},
 			Usage:       "API server override for dev purposes",
 			Destination: &app.apiServer,
+			Hidden:      true, // Experimental.
 		},
 	}
 


### PR DESCRIPTION
- this setting should have been hidden as it doesn't apply to end users.

fixes #590 

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>