### PR TITLE
Fix interactive mode in WITH DOCKER

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
         run: "! ./build/linux/amd64/earth --no-output +test-fail"
       - name: Execute interactive debugger test
         run: ./build/linux/amd64/earth --interactive -P +test-interactive
+      - name: Execute interactive debugger test (docker)
+        run: ./build/linux/amd64/earth --interactive -P +test-interactive-docker
       - name: Execute version test
         run: "./build/linux/amd64/earth --version"
       - name: Execute docker2earth test

--- a/Earthfile
+++ b/Earthfile
@@ -277,3 +277,12 @@ test-interactive:
     RUN apk add --update --no-cache \
         jq
     RUN cat /run/secrets/earthly_debugger_settings | jq -r .repeaterAddr | xargs nc
+
+test-interactive-docker:
+    FROM earthly/dind:alpine
+    RUN apk add --update --no-cache \
+        jq
+    WITH DOCKER
+        RUN docker ps && \
+            cat /run/secrets/earthly_debugger_settings | jq -r .repeaterAddr | xargs nc
+    END

--- a/buildkitd/dockerd-wrapper.sh
+++ b/buildkitd/dockerd-wrapper.sh
@@ -49,7 +49,7 @@ start_dockerd() {
     # Start with a rm -rf to make sure a previous interrupted build did not leave its state around.
     rm -rf "$EARTHLY_DOCKERD_DATA_ROOT"
     mkdir -p "$EARTHLY_DOCKERD_DATA_ROOT"
-    dockerd --data-root="$EARTHLY_DOCKERD_DATA_ROOT" >/var/log/docker.log 2>&1 &
+    dockerd --data-root="$EARTHLY_DOCKERD_DATA_ROOT" --bip=172.20.0.1/16 >/var/log/docker.log 2>&1 &
     dockerd_pid="$!"
     i=1
     timeout=300


### PR DESCRIPTION
There was a conflict between host docker's IP address and the inner docker IP address. This caused the interactive debugger to not be able to find the right IP when it wanted to connect to the debug proxy.