### PR TITLE
Validate email before registration

### DIFF
--- a/secretsclient/client.go
+++ b/secretsclient/client.go
@@ -328,6 +328,9 @@ func (c *client) savePublicKey(publicKey string) error {
 }
 
 func (c *client) CreateAccount(email, verificationToken, password, publicKey string, termsConditionsPrivacy bool) error {
+	if !IsValidEmail(email) {
+		return fmt.Errorf("invalid email: %q", email)
+	}
 	if publicKey != "" {
 		var err error
 		_, _, _, err = parseSSHKey(publicKey)


### PR DESCRIPTION
- this will make it easier to debug cases where an empty string is
passed to the client.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>