### PR TITLE
Update remote cache implementation

### DIFF
--- a/buildcontext/git.go
+++ b/buildcontext/git.go
@@ -163,7 +163,7 @@ func (gr *gitResolver) resolveGitProject(ctx context.Context, gwClient gwclient.
 	gitHashOp := opImg.Run(gitHashOpts...)
 	gitMetaAndEarthfileState := gitHashOp.AddMount("/dest", earthfileState)
 
-	gitMetaAndEarthfileRef, err := llbutil.StateToRef(ctx, gwClient, gitMetaAndEarthfileState)
+	gitMetaAndEarthfileRef, err := llbutil.StateToRef(ctx, gwClient, gitMetaAndEarthfileState, "")
 	if err != nil {
 		return nil, "", "", errors.Wrap(err, "state to ref git meta")
 	}

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -42,7 +42,8 @@ type Opt struct {
 	Attachables          []session.Attachable
 	Enttlmnts            []entitlements.Entitlement
 	NoCache              bool
-	RemoteCache          string
+	CacheImport          string
+	CacheExport          string
 	ImageResolveMode     llb.ResolveMode
 	CleanCollection      *cleanup.Collection
 	VarCollection        *variables.Collection
@@ -73,7 +74,8 @@ func NewBuilder(ctx context.Context, opt Opt) (*Builder, error) {
 		s: &solver{
 			sm:          newSolverMonitor(opt.Console, opt.Verbose),
 			bkClient:    opt.BkClient,
-			remoteCache: opt.RemoteCache,
+			cacheImport: opt.CacheImport,
+			cacheExport: opt.CacheExport,
 			attachables: opt.Attachables,
 			enttlmnts:   opt.Enttlmnts,
 		},
@@ -125,6 +127,7 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 			CleanCollection:      b.opt.CleanCollection,
 			VarCollection:        b.opt.VarCollection,
 			BuildContextProvider: b.opt.BuildContextProvider,
+			CacheImport:          b.opt.CacheImport,
 		})
 		if err != nil {
 			return nil, err
@@ -317,7 +320,7 @@ func (b *Builder) stateToRef(ctx context.Context, gwClient gwclient.Client, stat
 	if b.opt.NoCache {
 		state = state.SetMarshalDefaults(llb.IgnoreCache)
 	}
-	return llbutil.StateToRef(ctx, gwClient, state)
+	return llbutil.StateToRef(ctx, gwClient, state, b.opt.CacheImport)
 }
 
 func (b *Builder) buildOnlyLastImageAsTar(ctx context.Context, mts *states.MultiTarget, dockerTag string, outFile string, opt BuildOpt) error {

--- a/builder/solver_monitor.go
+++ b/builder/solver_monitor.go
@@ -144,10 +144,9 @@ func (vm *vertexMonitor) printError() bool {
 	if strings.Contains(vm.vertex.Error, "executor failed running") {
 		vm.console.Warnf("ERROR: Command exited with non-zero code: %s\n", vm.operation)
 		return true
-	} else {
-		vm.console.Printf("WARN: (%s) %s\n", vm.operation, vm.vertex.Error)
-		return false
 	}
+	vm.console.Printf("WARN: (%s) %s\n", vm.operation, vm.vertex.Error)
+	return false
 }
 
 func (vm *vertexMonitor) printTimingInfo() {

--- a/earthfile2llb/earthfile2llb.go
+++ b/earthfile2llb/earthfile2llb.go
@@ -44,6 +44,8 @@ type ConvertOpt struct {
 	BuildContextProvider *provider.BuildContextProvider
 	// MetaResolver is the image meta resolver to use for resolving image metadata.
 	MetaResolver llb.ImageMetaResolver
+	// CacheImport is the docker tag that can be used to import cache.
+	CacheImport string
 }
 
 // Earthfile2LLB parses a earthfile and executes the statements for a given target.

--- a/earthfile2llb/withdockerrun.go
+++ b/earthfile2llb/withdockerrun.go
@@ -338,7 +338,7 @@ func (wdr *withDockerRun) getComposeConfig(ctx context.Context, opt WithDockerOp
 		llb.WithCustomNamef("%sWITH DOCKER (docker-compose config)", wdr.c.vertexPrefix()),
 	}
 	state := wdr.c.mts.Final.MainState.Run(runOpts...).Root()
-	ref, err := llbutil.StateToRef(ctx, wdr.c.gwClient, state)
+	ref, err := llbutil.StateToRef(ctx, wdr.c.gwClient, state, wdr.c.cacheImport)
 	if err != nil {
 		return nil, errors.Wrap(err, "state to ref compose config")
 	}

--- a/llbutil/statetoref.go
+++ b/llbutil/statetoref.go
@@ -9,16 +9,26 @@ import (
 )
 
 // StateToRef takes an LLB state, solves it using gateway and returns the ref.
-func StateToRef(ctx context.Context, gwClient gwclient.Client, state llb.State) (gwclient.Reference, error) {
+func StateToRef(ctx context.Context, gwClient gwclient.Client, state llb.State, cacheImport string) (gwclient.Reference, error) {
+	var coe []gwclient.CacheOptionsEntry
+	if cacheImport != "" {
+		coe = []gwclient.CacheOptionsEntry{
+			{
+				Type:  "registry",
+				Attrs: map[string]string{"ref": cacheImport},
+			},
+		}
+	}
 	def, err := state.Marshal(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "marshal main state")
+		return nil, errors.Wrap(err, "marshal state")
 	}
 	r, err := gwClient.Solve(ctx, gwclient.SolveRequest{
-		Definition: def.ToPB(),
+		Definition:   def.ToPB(),
+		CacheImports: coe,
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "solve main state")
+		return nil, errors.Wrap(err, "solve state")
 	}
 	ref, err := r.SingleRef()
 	if err != nil {


### PR DESCRIPTION
### How to use

Developer (cache read-only):
```
earth --remote-cache=<some-docker-tag> +<target>
```

CI (cache read-write):
```
earth --remote-cache=<some-docker-tag> --ci +<target>
```

The docker tag has to be a docker registry tag that is not used for anything else (eg should not overlap with a production docker tag). Good example: `my-company/my-service:cache`. Bad example: `my-company/my-service:latest`. The recommendation is to use a different Docker tag per each CI pipeline, in order to maximize efficiency.

### Performance

See results of experimentation on this branch: https://github.com/earthly/earthly/issues/11#issuecomment-741307678