### PR TITLE
Support for inline cache

### DIFF
--- a/buildcontext/git.go
+++ b/buildcontext/git.go
@@ -163,7 +163,7 @@ func (gr *gitResolver) resolveGitProject(ctx context.Context, gwClient gwclient.
 	gitHashOp := opImg.Run(gitHashOpts...)
 	gitMetaAndEarthfileState := gitHashOp.AddMount("/dest", earthfileState)
 
-	gitMetaAndEarthfileRef, err := llbutil.StateToRef(ctx, gwClient, gitMetaAndEarthfileState, "")
+	gitMetaAndEarthfileRef, err := llbutil.StateToRef(ctx, gwClient, gitMetaAndEarthfileState, nil)
 	if err != nil {
 		return nil, "", "", errors.Wrap(err, "state to ref git meta")
 	}

--- a/builder/solver.go
+++ b/builder/solver.go
@@ -29,8 +29,9 @@ type solver struct {
 	bkClient     *client.Client
 	attachables  []session.Attachable
 	enttlmnts    []entitlements.Entitlement
-	cacheImports []string
+	cacheImports map[string]bool
 	cacheExport  string
+	inlineCache  bool
 }
 
 func (s *solver) solveDockerTar(ctx context.Context, state llb.State, img *image.Image, dockerTag string, outFile string) error {
@@ -160,7 +161,7 @@ func (s *solver) newSolveOptDocker(img *image.Image, dockerTag string, w io.Writ
 		return nil, errors.Wrap(err, "image json marshal")
 	}
 	var cacheImports []client.CacheOptionsEntry
-	for _, ci := range s.cacheImports {
+	for ci := range s.cacheImports {
 		cacheImports = append(cacheImports, newRegistryCacheOpt(ci))
 	}
 	return &client.SolveOpt{
@@ -184,14 +185,16 @@ func (s *solver) newSolveOptDocker(img *image.Image, dockerTag string, w io.Writ
 
 func (s *solver) newSolveOptMulti(ctx context.Context, eg *errgroup.Group, onImage onImageFunc, onArtifact onArtifactFunc, onFinalArtifact onFinalArtifactFunc) (*client.SolveOpt, error) {
 	var cacheImports []client.CacheOptionsEntry
-	for _, ci := range s.cacheImports {
+	for ci := range s.cacheImports {
 		cacheImports = append(cacheImports, newRegistryCacheOpt(ci))
 	}
 	var cacheExports []client.CacheOptionsEntry
 	if s.cacheExport != "" {
 		cacheExports = append(cacheExports, newRegistryCacheOpt(s.cacheExport))
 	}
-	cacheExports = append(cacheExports, newInlineCacheOpt())
+	if s.inlineCache {
+		cacheExports = append(cacheExports, newInlineCacheOpt())
+	}
 	return &client.SolveOpt{
 		Exports: []client.ExportEntry{
 			{
@@ -243,7 +246,7 @@ func (s *solver) newSolveOptMulti(ctx context.Context, eg *errgroup.Group, onIma
 
 func (s *solver) newSolveOptMain() (*client.SolveOpt, error) {
 	var cacheImports []client.CacheOptionsEntry
-	for _, ci := range s.cacheImports {
+	for ci := range s.cacheImports {
 		cacheImports = append(cacheImports, newRegistryCacheOpt(ci))
 	}
 	var cacheExports []client.CacheOptionsEntry

--- a/builder/solver_monitor.go
+++ b/builder/solver_monitor.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	durationBetweenProgressUpdate = time.Second * 5
+	durationBetweenProgressUpdate = time.Second
 	durationBetweenOpenLineUpdate = time.Second
 	tailErrorBufferSizeBytes      = 80 * 1024 // About as much as 1024 lines of 80 chars each.
 )
@@ -29,8 +29,8 @@ type vertexMonitor struct {
 	targetBrackets string
 	salt           string
 	operation      string
-	lastOutput     time.Time
-	lastPercentage int
+	lastProgress   map[string]time.Time
+	lastPercentage map[string]int
 	console        conslogging.ConsoleLogger
 	headerPrinted  bool
 	isInternal     bool
@@ -60,22 +60,43 @@ func (vm *vertexMonitor) printHeader(printMetadata bool) {
 	c.Printf("%s\n", strings.Join(out, " "))
 }
 
-func (vm *vertexMonitor) shouldPrintProgress(percent int) bool {
+var internalProgress = map[string]bool{
+	"exporting manifest": true,
+	"sending tarballs":   true,
+	"exporting config":   true,
+	"exporting layers":   true,
+	"copying files":      true,
+}
+
+func (vm *vertexMonitor) shouldPrintProgress(id string, percent int, verbose bool) bool {
 	if !vm.headerPrinted {
 		return false
 	}
 	if vm.targetStr == "" {
 		return false
 	}
+	if !verbose {
+		for prefix := range internalProgress {
+			if strings.HasPrefix(id, prefix) {
+				return false
+			}
+		}
+	}
 	now := time.Now()
-	if now.Sub(vm.lastOutput) < durationBetweenProgressUpdate && percent < 100 {
+	lastProgress := vm.lastProgress[id]
+	lastPercentage := -1
+	lastPercentageStored, ok := vm.lastPercentage[id]
+	if ok {
+		lastPercentage = lastPercentageStored
+	}
+	if now.Sub(lastProgress) < durationBetweenProgressUpdate && percent < 100 {
 		return false
 	}
-	if vm.lastPercentage >= percent {
+	if lastPercentage >= percent {
 		return false
 	}
-	vm.lastOutput = now
-	vm.lastPercentage = percent
+	vm.lastProgress[id] = now
+	vm.lastPercentage[id] = percent
 	return true
 }
 
@@ -205,6 +226,8 @@ Loop:
 						operation:      operation,
 						isInternal:     (targetStr == "internal" && !sm.verbose),
 						console:        sm.console.WithPrefixAndSalt(targetStr, salt),
+						lastPercentage: make(map[string]int),
+						lastProgress:   make(map[string]time.Time),
 					}
 					sm.vertices[vertex.Digest] = vm
 				}
@@ -243,7 +266,7 @@ Loop:
 				if vs.Completed != nil {
 					progress = 100
 				}
-				if vm.shouldPrintProgress(progress) {
+				if vm.shouldPrintProgress(vs.ID, progress, sm.verbose) {
 					if !vm.headerPrinted {
 						sm.printHeader(vm)
 					}

--- a/builder/solver_monitor.go
+++ b/builder/solver_monitor.go
@@ -270,7 +270,7 @@ Loop:
 					if !vm.headerPrinted {
 						sm.printHeader(vm)
 					}
-					vm.console.Printf("%s %d%%\n", vs.ID, progress)
+					vm.console.Printf("%s ... %d%%\n", vs.ID, progress)
 				}
 			}
 			for _, logLine := range ss.Logs {

--- a/cmd/earth/main.go
+++ b/cmd/earth/main.go
@@ -1946,9 +1946,9 @@ func (app *earthApp) actionBuild(c *cli.Context) error {
 	if app.ci {
 		cacheExport = app.remoteCache
 	}
-	var cacheImports []string
+	cacheImports := make(map[string]bool)
 	if app.remoteCache != "" {
-		cacheImports = append(cacheImports, app.remoteCache)
+		cacheImports[app.remoteCache] = true
 	}
 	builderOpts := builder.Opt{
 		BkClient:             bkClient,

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -16,8 +16,6 @@ import (
 
 	"github.com/docker/distribution/reference"
 	"github.com/earthly/earthly/buildcontext"
-	"github.com/earthly/earthly/buildcontext/provider"
-	"github.com/earthly/earthly/cleanup"
 	"github.com/earthly/earthly/debugger/common"
 	"github.com/earthly/earthly/domain"
 	"github.com/earthly/earthly/llbutil"
@@ -34,23 +32,16 @@ import (
 
 // Converter turns earth commands to buildkit LLB representation.
 type Converter struct {
-	gitMeta              *buildcontext.GitMetadata
-	gwClient             gwclient.Client
-	resolver             *buildcontext.Resolver
-	mts                  *states.MultiTarget
-	directDeps           []*states.SingleTarget
-	directDepIndices     []int
-	buildContext         llb.State
-	cacheContext         llb.State
-	varCollection        *variables.Collection
-	dockerBuilderFun     states.DockerBuilderFun
-	cleanCollection      *cleanup.Collection
-	nextArgIndex         int
-	solveCache           map[string]llb.State
-	imageResolveMode     llb.ResolveMode
-	buildContextProvider *provider.BuildContextProvider
-	metaResolver         llb.ImageMetaResolver
-	cacheImport          string
+	gitMeta          *buildcontext.GitMetadata
+	opt              ConvertOpt
+	mts              *states.MultiTarget
+	directDeps       []*states.SingleTarget
+	directDepIndices []int
+	buildContext     llb.State
+	cacheContext     llb.State
+	varCollection    *variables.Collection
+	nextArgIndex     int
+	cacheImports     []string
 }
 
 // NewConverter constructs a new converter for a given earth target.
@@ -78,20 +69,13 @@ func NewConverter(ctx context.Context, target domain.Target, bc *buildcontext.Da
 	targetStr := target.String()
 	opt.Visited.Add(targetStr, sts)
 	return &Converter{
-		gitMeta:              bc.GitMetadata,
-		gwClient:             opt.GwClient,
-		resolver:             opt.Resolver,
-		imageResolveMode:     opt.ImageResolveMode,
-		mts:                  mts,
-		buildContext:         bc.BuildContext,
-		cacheContext:         makeCacheContext(target),
-		varCollection:        opt.VarCollection.WithBuiltinBuildArgs(target, bc.GitMetadata),
-		dockerBuilderFun:     opt.DockerBuilderFun,
-		cleanCollection:      opt.CleanCollection,
-		solveCache:           opt.SolveCache,
-		buildContextProvider: opt.BuildContextProvider,
-		metaResolver:         opt.MetaResolver,
-		cacheImport:          opt.CacheImport,
+		gitMeta:       bc.GitMetadata,
+		opt:           opt,
+		mts:           mts,
+		buildContext:  bc.BuildContext,
+		cacheContext:  makeCacheContext(target),
+		varCollection: opt.VarCollection.WithBuiltinBuildArgs(target, bc.GitMetadata),
+		cacheImports:  opt.CacheImports[:],
 	}, nil
 }
 
@@ -199,7 +183,7 @@ func (c *Converter) FromDockerfile(ctx context.Context, contextPath string, dfPa
 		if err != nil {
 			return errors.Wrap(err, "join targets")
 		}
-		data, err := c.resolver.Resolve(ctx, c.gwClient, dockerfileMetaTarget)
+		data, err := c.opt.Resolver.Resolve(ctx, c.opt.GwClient, dockerfileMetaTarget)
 		if err != nil {
 			return errors.Wrap(err, "resolve build context for dockerfile")
 		}
@@ -222,8 +206,8 @@ func (c *Converter) FromDockerfile(ctx context.Context, contextPath string, dfPa
 	state, dfImg, err := dockerfile2llb.Dockerfile2LLB(ctx, dfData, dockerfile2llb.ConvertOpt{
 		BuildContext:     &buildContext,
 		ContextLocalName: c.mts.FinalTarget().String(),
-		MetaResolver:     c.metaResolver,
-		ImageResolveMode: c.imageResolveMode,
+		MetaResolver:     c.opt.MetaResolver,
+		ImageResolveMode: c.opt.ImageResolveMode,
 		Target:           dfTarget,
 		TargetPlatform:   &llbutil.TargetPlatform,
 		LLBCaps:          &caps,
@@ -386,6 +370,9 @@ func (c *Converter) SaveImage(ctx context.Context, imageNames []string, pushImag
 			DockerTag: imageName,
 			Push:      pushImages,
 		})
+		if pushImages && imageName != "" && c.opt.InlineCache {
+			c.cacheImports = append(c.cacheImports, imageName)
+		}
 	}
 	return nil
 }
@@ -409,20 +396,10 @@ func (c *Converter) Build(ctx context.Context, fullTargetName string, buildArgs 
 		return nil, errors.Wrap(err, "parse build args")
 	}
 	// Recursion.
-	mts, err := Earthfile2LLB(
-		ctx, target, ConvertOpt{
-			GwClient:             c.gwClient,
-			Resolver:             c.resolver,
-			ImageResolveMode:     c.imageResolveMode,
-			DockerBuilderFun:     c.dockerBuilderFun,
-			CleanCollection:      c.cleanCollection,
-			Visited:              c.mts.Visited,
-			VarCollection:        newVarCollection,
-			SolveCache:           c.solveCache,
-			BuildContextProvider: c.buildContextProvider,
-			MetaResolver:         c.metaResolver,
-			CacheImport:          c.cacheImport,
-		})
+	opt := c.opt
+	opt.Visited = c.mts.Visited
+	opt.VarCollection = newVarCollection
+	mts, err := Earthfile2LLB(ctx, target, opt)
 	if err != nil {
 		return nil, errors.Wrapf(err, "earthfile2llb for %s", fullTargetName)
 	}
@@ -582,13 +559,13 @@ func (c *Converter) Healthcheck(ctx context.Context, isNone bool, cmdArgs []stri
 func (c *Converter) FinalizeStates(ctx context.Context) (*states.MultiTarget, error) {
 	// Store refs for all dep states.
 	for _, depStates := range c.directDeps {
-		ref, err := llbutil.StateToRef(ctx, c.gwClient, depStates.MainState, c.cacheImport)
+		ref, err := llbutil.StateToRef(ctx, c.opt.GwClient, depStates.MainState, c.cacheImports)
 		if err != nil {
 			return nil, errors.Wrap(err, "state2ref")
 		}
 		c.mts.Final.DepsRefs = append(c.mts.Final.DepsRefs, ref)
 	}
-	c.buildContextProvider.AddDirs(c.mts.Final.LocalDirs)
+	c.opt.BuildContextProvider.AddDirs(c.mts.Final.LocalDirs)
 	c.mts.Final.VarCollection = c.varCollection
 
 	c.mts.Final.Ongoing = false
@@ -683,7 +660,7 @@ func (c *Converter) readArtifact(ctx context.Context, mts *states.MultiTarget, a
 		// ArtifactsState is scratch - no artifact has been copied.
 		return nil, errors.Errorf("artifact %s not found; no SAVE ARTIFACT command was issued in %s", artifact.String(), artifact.Target.String())
 	}
-	ref, err := llbutil.StateToRef(ctx, c.gwClient, mts.Final.ArtifactsState, c.cacheImport)
+	ref, err := llbutil.StateToRef(ctx, c.opt.GwClient, mts.Final.ArtifactsState, c.cacheImports)
 	if err != nil {
 		return nil, errors.Wrap(err, "state to ref solve artifact")
 	}
@@ -707,11 +684,11 @@ func (c *Converter) internalFromClassical(ctx context.Context, imageName string,
 		return llb.State{}, nil, nil, errors.Wrapf(err, "parse normalized named %s", imageName)
 	}
 	baseImageName := reference.TagNameOnly(ref).String()
-	dgst, dt, err := c.metaResolver.ResolveImageConfig(
+	dgst, dt, err := c.opt.MetaResolver.ResolveImageConfig(
 		ctx, baseImageName,
 		llb.ResolveImageConfigOpt{
 			Platform:    &llbutil.TargetPlatform,
-			ResolveMode: c.imageResolveMode.String(),
+			ResolveMode: c.opt.ImageResolveMode.String(),
 			LogName:     fmt.Sprintf("%sLoad metadata", c.imageVertexPrefix(imageName)),
 		})
 	if err != nil {
@@ -728,7 +705,7 @@ func (c *Converter) internalFromClassical(ctx context.Context, imageName string,
 			return llb.State{}, nil, nil, errors.Wrapf(err, "reference add digest %v for %s", dgst, imageName)
 		}
 	}
-	allOpts := append(opts, llb.Platform(llbutil.TargetPlatform), c.imageResolveMode)
+	allOpts := append(opts, llb.Platform(llbutil.TargetPlatform), c.opt.ImageResolveMode)
 	state := llb.Image(ref.String(), allOpts...)
 	state, img2, newVarCollection := c.applyFromImage(state, &img)
 	return state, img2, newVarCollection, nil

--- a/earthfile2llb/earthfile2llb.go
+++ b/earthfile2llb/earthfile2llb.go
@@ -44,8 +44,9 @@ type ConvertOpt struct {
 	BuildContextProvider *provider.BuildContextProvider
 	// MetaResolver is the image meta resolver to use for resolving image metadata.
 	MetaResolver llb.ImageMetaResolver
-	// CacheImports are docker tags that can be used to import cache.
-	CacheImports []string
+	// CacheImports is a set of docker tags that can be used to import cache. Note that this
+	// set is modified by the converter if InlineCache is enabled.
+	CacheImports map[string]bool
 	// InlineCache enables the inline caching feature (use any SAVE IMAGE --push declaration as
 	// cache import).
 	InlineCache bool

--- a/earthfile2llb/earthfile2llb.go
+++ b/earthfile2llb/earthfile2llb.go
@@ -44,8 +44,11 @@ type ConvertOpt struct {
 	BuildContextProvider *provider.BuildContextProvider
 	// MetaResolver is the image meta resolver to use for resolving image metadata.
 	MetaResolver llb.ImageMetaResolver
-	// CacheImport is the docker tag that can be used to import cache.
-	CacheImport string
+	// CacheImports are docker tags that can be used to import cache.
+	CacheImports []string
+	// InlineCache enables the inline caching feature (use any SAVE IMAGE --push declaration as
+	// cache import).
+	InlineCache bool
 }
 
 // Earthfile2LLB parses a earthfile and executes the statements for a given target.

--- a/earthfile2llb/withdockerrun.go
+++ b/earthfile2llb/withdockerrun.go
@@ -338,7 +338,7 @@ func (wdr *withDockerRun) getComposeConfig(ctx context.Context, opt WithDockerOp
 		llb.WithCustomNamef("%sWITH DOCKER (docker-compose config)", wdr.c.vertexPrefix()),
 	}
 	state := wdr.c.mts.Final.MainState.Run(runOpts...).Root()
-	ref, err := llbutil.StateToRef(ctx, wdr.c.opt.GwClient, state, wdr.c.cacheImports)
+	ref, err := llbutil.StateToRef(ctx, wdr.c.opt.GwClient, state, wdr.c.opt.CacheImports)
 	if err != nil {
 		return nil, errors.Wrap(err, "state to ref compose config")
 	}

--- a/earthfile2llb/withdockerrun.go
+++ b/earthfile2llb/withdockerrun.go
@@ -262,7 +262,7 @@ func (wdr *withDockerRun) solveImage(ctx context.Context, mts *states.MultiTarge
 	if err != nil {
 		return errors.Wrap(err, "target input hash")
 	}
-	tarContext, found := wdr.c.solveCache[solveID]
+	tarContext, found := wdr.c.opt.SolveCache[solveID]
 	if found {
 		wdr.tarLoads = append(wdr.tarLoads, tarContext)
 		return nil
@@ -273,11 +273,11 @@ func (wdr *withDockerRun) solveImage(ctx context.Context, mts *states.MultiTarge
 	if err != nil {
 		return errors.Wrap(err, "mk temp dir for docker load")
 	}
-	wdr.c.cleanCollection.Add(func() error {
+	wdr.c.opt.CleanCollection.Add(func() error {
 		return os.RemoveAll(outDir)
 	})
 	outFile := path.Join(outDir, "image.tar")
-	err = wdr.c.dockerBuilderFun(ctx, mts, dockerTag, outFile)
+	err = wdr.c.opt.DockerBuilderFun(ctx, mts, dockerTag, outFile)
 	if err != nil {
 		return errors.Wrapf(err, "build target %s for docker load", opName)
 	}
@@ -301,7 +301,7 @@ func (wdr *withDockerRun) solveImage(ctx context.Context, mts *states.MultiTarge
 	)
 	wdr.tarLoads = append(wdr.tarLoads, tarContext)
 	wdr.c.mts.Final.LocalDirs[solveID] = outDir
-	wdr.c.solveCache[solveID] = tarContext
+	wdr.c.opt.SolveCache[solveID] = tarContext
 	return nil
 }
 
@@ -338,7 +338,7 @@ func (wdr *withDockerRun) getComposeConfig(ctx context.Context, opt WithDockerOp
 		llb.WithCustomNamef("%sWITH DOCKER (docker-compose config)", wdr.c.vertexPrefix()),
 	}
 	state := wdr.c.mts.Final.MainState.Run(runOpts...).Root()
-	ref, err := llbutil.StateToRef(ctx, wdr.c.gwClient, state, wdr.c.cacheImport)
+	ref, err := llbutil.StateToRef(ctx, wdr.c.opt.GwClient, state, wdr.c.cacheImports)
 	if err != nil {
 		return nil, errors.Wrap(err, "state to ref compose config")
 	}

--- a/llbutil/statetoref.go
+++ b/llbutil/statetoref.go
@@ -2,7 +2,6 @@ package llbutil
 
 import (
 	"context"
-	"fmt"
 	"sort"
 
 	"github.com/moby/buildkit/client/llb"
@@ -17,7 +16,6 @@ func StateToRef(ctx context.Context, gwClient gwclient.Client, state llb.State, 
 		cacheImportsSlice = append(cacheImportsSlice, ci)
 	}
 	sort.Strings(cacheImportsSlice)
-	fmt.Printf("@#@#@#@# statetoref with cacheImports %+v\n", cacheImportsSlice)
 	var coes []gwclient.CacheOptionsEntry
 	for _, ci := range cacheImportsSlice {
 		coe := gwclient.CacheOptionsEntry{

--- a/llbutil/statetoref.go
+++ b/llbutil/statetoref.go
@@ -2,6 +2,8 @@ package llbutil
 
 import (
 	"context"
+	"fmt"
+	"sort"
 
 	"github.com/moby/buildkit/client/llb"
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
@@ -9,9 +11,15 @@ import (
 )
 
 // StateToRef takes an LLB state, solves it using gateway and returns the ref.
-func StateToRef(ctx context.Context, gwClient gwclient.Client, state llb.State, cacheImports []string) (gwclient.Reference, error) {
+func StateToRef(ctx context.Context, gwClient gwclient.Client, state llb.State, cacheImports map[string]bool) (gwclient.Reference, error) {
+	cacheImportsSlice := make([]string, 0, len(cacheImports))
+	for ci := range cacheImports {
+		cacheImportsSlice = append(cacheImportsSlice, ci)
+	}
+	sort.Strings(cacheImportsSlice)
+	fmt.Printf("@#@#@#@# statetoref with cacheImports %+v\n", cacheImportsSlice)
 	var coes []gwclient.CacheOptionsEntry
-	for _, ci := range cacheImports {
+	for _, ci := range cacheImportsSlice {
 		coe := gwclient.CacheOptionsEntry{
 			Type:  "registry",
 			Attrs: map[string]string{"ref": ci},

--- a/llbutil/statetoref.go
+++ b/llbutil/statetoref.go
@@ -9,15 +9,14 @@ import (
 )
 
 // StateToRef takes an LLB state, solves it using gateway and returns the ref.
-func StateToRef(ctx context.Context, gwClient gwclient.Client, state llb.State, cacheImport string) (gwclient.Reference, error) {
-	var coe []gwclient.CacheOptionsEntry
-	if cacheImport != "" {
-		coe = []gwclient.CacheOptionsEntry{
-			{
-				Type:  "registry",
-				Attrs: map[string]string{"ref": cacheImport},
-			},
+func StateToRef(ctx context.Context, gwClient gwclient.Client, state llb.State, cacheImports []string) (gwclient.Reference, error) {
+	var coes []gwclient.CacheOptionsEntry
+	for _, ci := range cacheImports {
+		coe := gwclient.CacheOptionsEntry{
+			Type:  "registry",
+			Attrs: map[string]string{"ref": ci},
 		}
+		coes = append(coes, coe)
 	}
 	def, err := state.Marshal(ctx)
 	if err != nil {
@@ -25,7 +24,7 @@ func StateToRef(ctx context.Context, gwClient gwclient.Client, state llb.State, 
 	}
 	r, err := gwClient.Solve(ctx, gwclient.SolveRequest{
 		Definition:   def.ToPB(),
-		CacheImports: coe,
+		CacheImports: coes,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "solve state")

--- a/states/states.go
+++ b/states/states.go
@@ -6,7 +6,6 @@ import (
 	"github.com/earthly/earthly/states/image"
 	"github.com/earthly/earthly/variables"
 	"github.com/moby/buildkit/client/llb"
-	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 )
 
 // MultiTarget holds LLB states representing multiple earth targets,
@@ -45,7 +44,6 @@ type SingleTarget struct {
 	LocalDirs              map[string]string
 	Ongoing                bool
 	Salt                   string
-	DepsRefs               []gwclient.Reference
 }
 
 // LastSaveImage returns the last save image available (if any).


### PR DESCRIPTION
Re https://github.com/earthly/earthly/issues/11

This does not provide proper full support as there are many cases that need to be dealt with in order to properly use the cache. However since this is behind a feature flag, it can be merged as it is.

Changes:
* Push inline caches with every image push ~(should be very lightweight - no performance difference)~ EDIT: There is a significant performance penalty on subsequent run, in certain conditions. This has now been placed behind a flag that the user needs to activate manually (via `--inline-cache`).
* Support using any image declared in `SAVE IMAGE --push` as cache import too (if `--inline-cache` feature flag is enabled)
* Perform image pushes from within buildkit directly, rather than via `docker push`. This is necessary so that metadata related to the inline cache is kept in the image.

-----------------------------------

TODO:

- [x] Provide better progress report for pushes