### PR TITLE
Optimize inline cache for CI mode

### DIFF
--- a/builder/solver.go
+++ b/builder/solver.go
@@ -25,13 +25,13 @@ type onArtifactFunc func(context.Context, int, domain.Artifact, string, string) 
 type onFinalArtifactFunc func(context.Context) (string, error)
 
 type solver struct {
-	sm           *solverMonitor
-	bkClient     *client.Client
-	attachables  []session.Attachable
-	enttlmnts    []entitlements.Entitlement
-	cacheImports map[string]bool
-	cacheExport  string
-	inlineCache  bool
+	sm              *solverMonitor
+	bkClient        *client.Client
+	attachables     []session.Attachable
+	enttlmnts       []entitlements.Entitlement
+	cacheImports    map[string]bool
+	cacheExport     string
+	saveInlineCache bool
 }
 
 func (s *solver) solveDockerTar(ctx context.Context, state llb.State, img *image.Image, dockerTag string, outFile string) error {
@@ -192,7 +192,7 @@ func (s *solver) newSolveOptMulti(ctx context.Context, eg *errgroup.Group, onIma
 	if s.cacheExport != "" {
 		cacheExports = append(cacheExports, newRegistryCacheOpt(s.cacheExport))
 	}
-	if s.inlineCache {
+	if s.saveInlineCache {
 		cacheExports = append(cacheExports, newInlineCacheOpt())
 	}
 	return &client.SolveOpt{
@@ -264,6 +264,7 @@ func (s *solver) newSolveOptMain() (*client.SolveOpt, error) {
 func newRegistryCacheOpt(ref string) client.CacheOptionsEntry {
 	registryCacheOptAttrs := make(map[string]string)
 	registryCacheOptAttrs["ref"] = ref
+	registryCacheOptAttrs["mode"] = "max"
 	return client.CacheOptionsEntry{
 		Type:  "registry",
 		Attrs: registryCacheOptAttrs,

--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -1,6 +1,6 @@
 
 buildkitd:
-    ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:vlad/push-with-no-export+build
+    ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:earthly-main+build
     FROM $BUILDKIT_BASE_IMAGE
     RUN echo "@edge-community http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
     RUN apk add --update --no-cache \

--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -1,6 +1,6 @@
 
 buildkitd:
-    ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:earthly-main+build
+    ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:vlad/push-with-no-export+build
     FROM $BUILDKIT_BASE_IMAGE
     RUN echo "@edge-community http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
     RUN apk add --update --no-cache \

--- a/cmd/earth/main.go
+++ b/cmd/earth/main.go
@@ -294,7 +294,7 @@ func newEarthApp(ctx context.Context, console conslogging.ConsoleLogger) *earthA
 		&cli.BoolFlag{
 			Name:        "ci",
 			EnvVars:     []string{"EARTHLY_CI"},
-			Usage:       "Execute in CI mode (implies --use-inline-cache --save-inline-cache --push --no-output)",
+			Usage:       "Execute in CI mode (implies --use-inline-cache --save-inline-cache --no-output)",
 			Destination: &app.ci,
 			Hidden:      true, // Experimental.
 		},
@@ -1811,7 +1811,6 @@ func (app *earthApp) actionBuild(c *cli.Context) error {
 		app.useInlineCache = true
 		app.saveInlineCache = true
 		app.noOutput = true
-		app.push = true
 	}
 	if app.imageMode && app.artifactMode {
 		return errors.New("both image and artifact modes cannot be active at the same time")

--- a/earthfile2llb/earthfile2llb.go
+++ b/earthfile2llb/earthfile2llb.go
@@ -47,9 +47,9 @@ type ConvertOpt struct {
 	// CacheImports is a set of docker tags that can be used to import cache. Note that this
 	// set is modified by the converter if InlineCache is enabled.
 	CacheImports map[string]bool
-	// InlineCache enables the inline caching feature (use any SAVE IMAGE --push declaration as
+	// UseInlineCache enables the inline caching feature (use any SAVE IMAGE --push declaration as
 	// cache import).
-	InlineCache bool
+	UseInlineCache bool
 }
 
 // Earthfile2LLB parses a earthfile and executes the statements for a given target.

--- a/earthfile2llb/listener.go
+++ b/earthfile2llb/listener.go
@@ -447,7 +447,7 @@ func (l *listener) ExitBuildStmt(c *parser.BuildStmtContext) {
 	for i, arg := range buildArgs.Args {
 		buildArgs.Args[i] = l.expandArgs(arg, true)
 	}
-	_, err = l.converter.Build(l.ctx, fullTargetName, buildArgs.Args)
+	err = l.converter.Build(l.ctx, fullTargetName, buildArgs.Args)
 	if err != nil {
 		l.err = errors.Wrapf(err, "apply BUILD %s", fullTargetName)
 		return

--- a/earthfile2llb/withdockerrun.go
+++ b/earthfile2llb/withdockerrun.go
@@ -234,7 +234,7 @@ func (wdr *withDockerRun) load(ctx context.Context, opt DockerLoadOpt) error {
 	if err != nil {
 		return errors.Wrapf(err, "parse target %s", opt.Target)
 	}
-	mts, err := wdr.c.Build(ctx, depTarget.String(), opt.BuildArgs)
+	mts, err := wdr.c.buildTarget(ctx, depTarget.String(), opt.BuildArgs, false)
 	if err != nil {
 		return err
 	}

--- a/states/states.go
+++ b/states/states.go
@@ -44,6 +44,9 @@ type SingleTarget struct {
 	LocalDirs              map[string]string
 	Ongoing                bool
 	Salt                   string
+	// IsMandatory represents whether there are any non-SAVE commands after the first SAVE command,
+	// or if the target is invoked via BUILD command (not COPY nor FROM).
+	IsMandatory bool
 }
 
 // LastSaveImage returns the last save image available (if any).


### PR DESCRIPTION
Depends on https://github.com/earthly/buildkit/pull/17
Re #11 

Changes:

* Separates some cache-related flags into import and export counterparts:
  * `--use-inline-cache` - whether to attempt to import inline cache
  * `--save-inline-cache` - whether to save inline cache in output image
  * `--cache-from` - explicitly import cache from a docker tag (multiple can be specified by repeating the flag)
  * `--cache-to` - save full (max-mode) cache to a specified docker tag (meant only for cache)
* Allows the user to push images without outputting them to the local Docker (this is now faster for CI use-cases). So `--no-output` + `--push` is now perfectly valid.
* Expands on the CI mode (`--ci`) from a previous PR. CI mode is now equivalent to using the flags
  ```
  --use-inline-cache --save-inline-cache --no-output
  ```
* In the special conditions of CI mode, optimize the LLB to make maximum use of the inline cache (avoid using LLB states that are outside of image layers). Essentially this works by executing parts of the build only if they are "mandatory" - if they have layers that are not included in the layers of a final target - plus the final target.

Interesting preliminary results
* cpp example runs in `22s` (push included) with just remote inline cache. Compare to `~2m` (push not included) when running with no cache.
* scala example runs in `29s` (push included) with just remote inline cache. Compare to `~1m30s` (push not included) when running with no cache.