### PR TITLE
Display startup message in earthly-buildkit

### DIFF
--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -1,5 +1,6 @@
 
 buildkitd:
+    ARG EARTHLY_GIT_HASH
     ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:earthly-main+build
     FROM $BUILDKIT_BASE_IMAGE
     RUN echo "@edge-community http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
@@ -34,6 +35,8 @@ buildkitd:
     ENV BUILDKIT_DEBUG=false
     ENV CACHE_SIZE_MB=0
     ENV NETWORK_MODE=cni
+    ENV EARTHLY_GIT_HASH=$EARTHLY_GIT_HASH
+    ENV BUILDKIT_BASE_IMAGE=$BUILDKIT_BASE_IMAGE
     VOLUME /tmp/earthly
     ENTRYPOINT ["/usr/bin/entrypoint.sh", "buildkitd", "--config=/etc/buildkitd.toml"]
     ARG EARTHLY_TARGET_TAG_DOCKER

--- a/buildkitd/entrypoint.sh
+++ b/buildkitd/entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
-
 set -e
+echo "starting earthly-buildkit with EARTHLY_GIT_HASH=$EARTHLY_GIT_HASH BUILDKIT_BASE_IMAGE=$BUILDKIT_BASE_IMAGE"
+
 if [ "$BUILDKIT_DEBUG" = "true" ]; then
     set -x
 fi


### PR DESCRIPTION
Display both the earthly git sha1 and buildkit image used for the release; this is to make debugging issues easier.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>