### PR TITLE
Further tweaks to remote cache abilities

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -30,11 +30,11 @@ deps:
 
 code:
     FROM +deps
+    COPY ./earthfile2llb/parser+parser/*.go ./earthfile2llb/parser/
     COPY --dir analytics autocomplete buildcontext builder cleanup cmd config conslogging debugger dockertar \
         docker2earth domain fileutils llbutil logging secretsclient stringutil states variables ./
     COPY --dir buildkitd/buildkitd.go buildkitd/settings.go buildkitd/
     COPY --dir earthfile2llb/antlrhandler earthfile2llb/*.go earthfile2llb/
-    COPY ./earthfile2llb/parser+parser/*.go ./earthfile2llb/parser/
 
 lint-scripts:
     FROM +deps

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -44,6 +44,7 @@ type Opt struct {
 	NoCache              bool
 	CacheImports         map[string]bool
 	CacheExport          string
+	MaxCacheExport       string
 	UseInlineCache       bool
 	SaveInlineCache      bool
 	ImageResolveMode     llb.ResolveMode
@@ -79,6 +80,7 @@ func NewBuilder(ctx context.Context, opt Opt) (*Builder, error) {
 			bkClient:        opt.BkClient,
 			cacheImports:    opt.CacheImports,
 			cacheExport:     opt.CacheExport,
+			maxCacheExport:  opt.MaxCacheExport,
 			attachables:     opt.Attachables,
 			enttlmnts:       opt.Enttlmnts,
 			saveInlineCache: opt.SaveInlineCache,
@@ -160,7 +162,7 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 		imageIndex := 0
 		dirIndex := 0
 		for _, sts := range mts.All() {
-			if sts.IsMandatory && !b.opt.UseFakeDep {
+			if sts.HasDangling && !b.opt.UseFakeDep {
 				depRef, err := b.stateToRef(ctx, gwClient, sts.MainState)
 				if err != nil {
 					return nil, err
@@ -173,7 +175,8 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 			for _, saveImage := range sts.SaveImages {
 				shouldPush := opt.Push && saveImage.Push && !sts.Target.IsRemote()
 				shouldExport := !opt.NoOutput && opt.OnlyArtifact == nil && !(opt.OnlyFinalTargetImages && sts != mts.Final)
-				if !shouldPush && !shouldExport {
+				useCacheHint := saveImage.CacheHint && b.opt.CacheExport != ""
+				if !shouldPush && !shouldExport && !useCacheHint {
 					// Short-circuit.
 					continue
 				}

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -51,6 +51,7 @@ type Opt struct {
 	VarCollection        *variables.Collection
 	BuildContextProvider *provider.BuildContextProvider
 	GitLookup            *buildcontext.GitLookup
+	UseFakeDep           bool
 }
 
 // BuildOpt is a collection of build options.
@@ -132,6 +133,7 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 			BuildContextProvider: b.opt.BuildContextProvider,
 			CacheImports:         b.opt.CacheImports,
 			UseInlineCache:       b.opt.UseInlineCache,
+			UseFakeDep:           b.opt.UseFakeDep,
 		})
 		if err != nil {
 			return nil, err
@@ -158,7 +160,7 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 		imageIndex := 0
 		dirIndex := 0
 		for _, sts := range mts.All() {
-			if sts.IsMandatory {
+			if sts.IsMandatory && !b.opt.UseFakeDep {
 				depRef, err := b.stateToRef(ctx, gwClient, sts.MainState)
 				if err != nil {
 					return nil, err

--- a/cmd/earth/main.go
+++ b/cmd/earth/main.go
@@ -115,6 +115,7 @@ type cliFlags struct {
 	expiry                 string
 	termsConditionsPrivacy bool
 	authToken              string
+	useFakeDep             bool
 }
 
 var (
@@ -438,7 +439,14 @@ func newEarthApp(ctx context.Context, console conslogging.ConsoleLogger) *earthA
 			EnvVars:     []string{"EARTHLY_SERVER"},
 			Usage:       "API server override for dev purposes",
 			Destination: &app.apiServer,
-			Hidden:      true, // Experimental.
+			Hidden:      true, // Internal.
+		},
+		&cli.BoolFlag{
+			Name:        "fake-dep",
+			EnvVars:     []string{"EARTHLY_FAKE_DEP"},
+			Usage:       "Internal feature flag for fake-dep",
+			Destination: &app.useFakeDep,
+			Hidden:      true, // Internal.
 		},
 	}
 
@@ -1985,6 +1993,7 @@ func (app *earthApp) actionBuild(c *cli.Context) error {
 		VarCollection:        varCollection,
 		BuildContextProvider: buildContextProvider,
 		GitLookup:            gitLookup,
+		UseFakeDep:           app.useFakeDep,
 	}
 	b, err := builder.NewBuilder(c.Context, builderOpts)
 	if err != nil {

--- a/earthfile2llb/earthfile2llb.go
+++ b/earthfile2llb/earthfile2llb.go
@@ -50,6 +50,8 @@ type ConvertOpt struct {
 	// UseInlineCache enables the inline caching feature (use any SAVE IMAGE --push declaration as
 	// cache import).
 	UseInlineCache bool
+	// UseFakeDep is an internal feature flag for fake dep.
+	UseFakeDep bool
 }
 
 // Earthfile2LLB parses a earthfile and executes the statements for a given target.

--- a/llbutil/fakedep.go
+++ b/llbutil/fakedep.go
@@ -1,0 +1,39 @@
+package llbutil
+
+import (
+	"github.com/moby/buildkit/client/llb"
+)
+
+const fakeDepImg = "busybox:1.31.1"
+
+// WithDependency creates a fake dependency between two states.
+func WithDependency(state llb.State, depState llb.State, stateStr, depStr string, opts ...llb.RunOption) llb.State {
+	// TODO: Is there a better way to mark two states as depending on each other?
+	if depState.Output() == nil {
+		// depState is Scratch.
+		return state
+	}
+
+	// Copy a file that is known to exist in (almost) all images.
+	// (The copy is necessary to prevent situation where BuildKit needs to re-hash the entire
+	// depState).
+	interm := llb.Scratch().Platform(TargetPlatform)
+	interm = CopyOp(
+		depState, []string{"/bin/sh"}, interm, "/bin/sh", false, true, "",
+		llb.WithCustomNamef("[internal] (copy) %s depends on %s", stateStr, depStr))
+
+	// Execute a command which doesn't do anything (but it creates a new layer, which casues it
+	// to depend on depState).
+	runOpts := []llb.RunOption{
+		llb.Args([]string{"/bin/sh", "-c", "true"}),
+		llb.Dir("/"),
+		llb.ReadonlyRootFS(),
+		llb.AddMount("/fake-dep", interm, llb.Readonly),
+		llb.WithCustomNamef("[internal] (run) %s depends on %s", stateStr, depStr),
+	}
+	runOpts = append(runOpts, opts...)
+	opImg := llb.Image(
+		fakeDepImg, llb.MarkImageInternal, llb.Platform(TargetPlatform),
+		llb.WithCustomNamef("[internal] helper image for fake dep operations"))
+	return opImg.Run(runOpts...).AddMount("/fake", state)
+}

--- a/states/states.go
+++ b/states/states.go
@@ -44,9 +44,10 @@ type SingleTarget struct {
 	LocalDirs              map[string]string
 	Ongoing                bool
 	Salt                   string
-	// IsMandatory represents whether there are any non-SAVE commands after the first SAVE command,
+	// HasDangling represents whether the target has dangling instructions -
+	// ie if there are any non-SAVE commands after the first SAVE command,
 	// or if the target is invoked via BUILD command (not COPY nor FROM).
-	IsMandatory bool
+	HasDangling bool
 }
 
 // LastSaveImage returns the last save image available (if any).
@@ -77,6 +78,9 @@ type SaveImage struct {
 	Image     *image.Image
 	DockerTag string
 	Push      bool
+	// CacheHint instructs Earthly to save a separate ref for this image, even if no tag is
+	// provided.
+	CacheHint bool
 }
 
 // RunPush is a series of RUN --push commands to be run after the build has been deemed as


### PR DESCRIPTION
Re #11

Changes:
* Merge back `--from-cache` and `--to-cache` into a single flag: `--remote-cache`. The behavior is now such that pushing cache only happens if `--push` is used.
* Bring back fakedep from the dead. But improve its performance. There is a flag to disable it in case we suspect that it's causing performance issues. Fakedep allows us to tie back dangling layers not associated with any image (and therefore would otherwise require their own image which we would not export). This makes it possible for targets invoked with `BUILD` to still be associated with the inline cache of another image. eg
  ```Dockerfile
  FROM ...
  BUILD +something-else
  SAVE IMAGE --push docker:tag
  ```
  In this example, `+something-else` is now covered by the cache of `docker:tag`, assuming none of its inputs have changed.
* Introduce `SAVE IMAGE --cache-from` to be able to specify additional cache imports. Example use-case - access inline cache for PR inline:
  ```Dockerfile
  FROM ...
  ...
  SAVE IMAGE --cache-from=my-image:master --push my-image:$BRANCH
  ```
  If the user uses `--push` on `master` branch, they could use cache from that image.
* Introduce `SAVE IMAGE --cache-hint`. This option is meant to be used in conjunction with `earth --push --remote-cache` and has no effect otherwise. It instructs Earthly to expressly cache that target too. No image name needs to be provided.
  ```Dockerfile
  FROM ...
  ... (lots of processing)
  SAVE IMAGE --cache-hint
  ```
