### PR TITLE
Show status progress updates as progress bars

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -117,8 +117,7 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 	var successOnce sync.Once
 	successFun := func() {
 		if opt.PrintSuccess {
-			b.opt.Console.PrintSuccess()
-			b.s.sm.PrintTiming()
+			b.s.sm.SetSuccess()
 		}
 	}
 	destPathWhitelist := make(map[string]bool)

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/fatih/color v1.9.0
 	github.com/golang/protobuf v1.4.2
 	github.com/joho/godotenv v1.3.0
+	github.com/mattn/go-isatty v0.0.12
 	github.com/moby/buildkit v0.7.1-0.20200708233707-488130002abb
 	github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d
 	github.com/opencontainers/go-digest v1.0.0


### PR DESCRIPTION
* If the progress related to a vertex and an update ID that we have just printed, go up one line and overwrite it
* In such cases, also don't delay the update (unless ANSI escape sequences are not supported)
* Use visual progress bars for these updates

### What this looks like in practice

#### BuildKite

![Screenshot from 2020-12-12 09-13-53](https://user-images.githubusercontent.com/446771/101990205-71dd8c00-3c5a-11eb-8427-73171c9745f6.png)

#### GitHub actions

![Screenshot from 2020-12-12 09-16-52](https://user-images.githubusercontent.com/446771/101990257-cc76e800-3c5a-11eb-9ceb-195cdd3f44f4.png)

#### Local

![Screenshot from 2020-12-12 12-01-09](https://user-images.githubusercontent.com/446771/101993738-c809f980-3c71-11eb-98ee-6349580a51c9.png)

The progress bar uses some special unicode characters for sub-character progress. Here are the different states of the progress bar:

![Screenshot from 2020-12-12 08-45-30](https://user-images.githubusercontent.com/446771/101990067-676ec280-3c59-11eb-81f8-3182f7451738.png)
