### PR TITLE
Renaming earth to earthly

### DIFF
--- a/.buildkite/blog-examples-test.sh
+++ b/.buildkite/blog-examples-test.sh
@@ -2,7 +2,7 @@
 
 set -xeuo pipefail
 
-earth --version
+earthly --version
 
-earth github.com/earthly/earthly-example-scala/simple:main+test
-earth github.com/earthly/earthly-example-scala/simple:main+docker
+earthly github.com/earthly/earthly-example-scala/simple:main+test
+earthly github.com/earthly/earthly-example-scala/simple:main+docker

--- a/.buildkite/brew-upgrade-test.sh
+++ b/.buildkite/brew-upgrade-test.sh
@@ -4,6 +4,6 @@ set -xeuo pipefail
 
 brew upgrade earthly
 
-earth --version
+earthly --version
 
-earth github.com/earthly/earthly/examples/go:main+docker
+earthly github.com/earthly/earthly/examples/go:main+docker

--- a/.buildkite/tests.sh
+++ b/.buildkite/tests.sh
@@ -20,20 +20,20 @@ while ! docker ps; do
 done
 
 echo "Download latest Earthly binary"
-curl -o ./earth-released -L https://github.com/earthly/earthly/releases/latest/download/earth-"$EARTH_OS"-amd64 && chmod +x ./earth-released
+curl -o ./earthly-released -L https://github.com/earthly/earthly/releases/latest/download/earth-"$EARTH_OS"-amd64 && chmod +x ./earthly-released
 
-echo "Build latest earth using released earth"
-./earth-released +for-"$EARTH_OS"
+echo "Build latest earthly using released earthly"
+./earthly-released +for-"$EARTH_OS"
 
 echo "Execute tests"
-./build/"$EARTH_OS"/amd64/earth --no-output -P +test
+./build/"$EARTH_OS"/amd64/earthly --no-output -P +test
 
 # Temporarily disable until failure is addressed.
 #echo "Execute experimental tests"
-#./build/"$EARTH_OS"/amd64/earth --no-output -P ./examples/tests+experimental
+#./build/"$EARTH_OS"/amd64/earthly --no-output -P ./examples/tests+experimental
 
 echo "Execute fail test"
-bash -c "! ./build/$EARTH_OS/amd64/earth --no-output +test-fail"
+bash -c "! ./build/$EARTH_OS/amd64/earthly --no-output +test-fail"
 
 echo "Build examples"
-./build/"$EARTH_OS"/amd64/earth --no-output -P +examples
+./build/"$EARTH_OS"/amd64/earthly --no-output -P +examples

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,17 +12,17 @@ jobs:
           name: Docker Login
           command: "docker login --username $DOCKERHUB_USERNAME --password $DOCKERHUB_TOKEN"
       - run:
-          name: Install released earth
-          command: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/latest/download/earth-linux-amd64 -O /usr/local/bin/earth && chmod +x /usr/local/bin/earth'"
+          name: Install released earthly
+          command: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/latest/download/earth-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly'"
       - run:
-          name: Build latest earth
-          command: earth +for-linux
+          name: Build latest earthly
+          command: earthly +for-linux
       - run:
           name: Run tests
-          command: ./build/linux/amd64/earth -P --no-output +test
+          command: ./build/linux/amd64/earthly -P --no-output +test
       - run:
           name: Execute fail test
-          command: "! ./build/linux/amd64/earth --no-output +test-fail"
+          command: "! ./build/linux/amd64/earthly --no-output +test-fail"
 workflows:
   version: 2
   circle-ci:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,29 +16,29 @@ jobs:
       EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"
     steps:
       - uses: actions/checkout@v2
-      - name: Download released earth
-        run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/latest/download/earth-linux-amd64 -O /usr/local/bin/earth && chmod +x /usr/local/bin/earth'"
+      - name: Download released earthly
+        run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/latest/download/earth-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly'"
       - name: Docker Login (non fork only)
         run: docker login --username "${{ secrets.DOCKERHUB_USERNAME }}" --password "${{ secrets.DOCKERHUB_TOKEN }}"
         if: github.event.pull_request.head.repo.full_name == github.repository
-      - name: Build latest earth using released earth
-        run: earth +for-linux
+      - name: Build latest earthly using released earthly
+        run: earthly +for-linux
       - name: Execute tests (not a fork)
         run: |
           export EARTHLY_BUILD_ARGS="DOCKERHUB_USER_SECRET=+secrets/earthly-technologies/dockerhub/user,DOCKERHUB_TOKEN_SECRET=+secrets/earthly-technologies/dockerhub/token"
-          ./build/linux/amd64/earth --no-output -P +test
+          ./build/linux/amd64/earthly --no-output -P +test
         if: github.event.pull_request.head.repo.full_name == github.repository
       - name: Execute tests (fork)
-        run: ./build/linux/amd64/earth --no-output -P +test
+        run: ./build/linux/amd64/earthly --no-output -P +test
         if: github.event.pull_request.head.repo.full_name != github.repository
       - name: Execute fail test
-        run: "! ./build/linux/amd64/earth --no-output +test-fail"
+        run: "! ./build/linux/amd64/earthly --no-output +test-fail"
       - name: Execute interactive debugger test
-        run: ./build/linux/amd64/earth --interactive -P +test-interactive
+        run: ./build/linux/amd64/earthly --interactive -P +test-interactive
       - name: Execute interactive debugger test (docker)
-        run: ./build/linux/amd64/earth --interactive -P +test-interactive-docker
+        run: ./build/linux/amd64/earthly --interactive -P +test-interactive-docker
       - name: Execute version test
-        run: "./build/linux/amd64/earth --version"
+        run: "./build/linux/amd64/earthly --version"
       - name: Execute docker2earth test
         run: "./examples/tests/docker2earth/test.sh"
   misc-tests:
@@ -50,28 +50,28 @@ jobs:
       EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"
     steps:
       - uses: actions/checkout@v2
-      - name: Download released earth
-        run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/latest/download/earth-linux-amd64 -O /usr/local/bin/earth && chmod +x /usr/local/bin/earth'"
+      - name: Download released earthly
+        run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/latest/download/earth-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly'"
       - name: Docker Login (non fork only)
         run: docker login --username "${{ secrets.DOCKERHUB_USERNAME }}" --password "${{ secrets.DOCKERHUB_TOKEN }}"
         if: github.event.pull_request.head.repo.full_name == github.repository
-      - name: Build latest earth using released earth
-        run: earth +for-linux
+      - name: Build latest earthly using released earthly
+        run: earthly +for-linux
       - name: "Experimental tests (not a fork)"
         run: |
           export EARTHLY_BUILD_ARGS="DOCKERHUB_USER_SECRET=+secrets/earthly-technologies/dockerhub/user,DOCKERHUB_TOKEN_SECRET=+secrets/earthly-technologies/dockerhub/token"
-          ./build/linux/amd64/earth -P ./examples/tests+experimental
+          ./build/linux/amd64/earthly -P ./examples/tests+experimental
         if: github.event.pull_request.head.repo.full_name == github.repository
       - name: "Experimental tests (fork)"
-        run: ./build/linux/amd64/earth -P ./examples/tests+experimental
+        run: ./build/linux/amd64/earthly -P ./examples/tests+experimental
         if: github.event.pull_request.head.repo.full_name != github.repository
       - name: Execute test similar to homebrew test in https://github.com/Homebrew/homebrew-core/blob/master/Formula/earthly.rb
-        run: ./build/linux/amd64/earth --buildkit-host 127.0.0.1 ./examples/tests/with-docker+all 2>&1 | grep 'Error while dialing invalid address 127.0.0.1'
+        run: ./build/linux/amd64/earthly --buildkit-host 127.0.0.1 ./examples/tests/with-docker+all 2>&1 | grep 'Error while dialing invalid address 127.0.0.1'
       - name: Docker Login
         run: docker login --username "${{ secrets.DOCKERHUB_USERNAME }}" --password "${{ secrets.DOCKERHUB_TOKEN }}"
         if: github.event.pull_request.head.repo.full_name == github.repository
       - name: Execute private image test
-        run: ./build/linux/amd64/earth --no-output ./examples/tests+private-image-test
+        run: ./build/linux/amd64/earthly --no-output ./examples/tests+private-image-test
         if: github.event.pull_request.head.repo.full_name == github.repository
   examples:
     name: +examples
@@ -82,15 +82,15 @@ jobs:
       EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"
     steps:
       - uses: actions/checkout@v2
-      - name: Download released earth
-        run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/latest/download/earth-linux-amd64 -O /usr/local/bin/earth && chmod +x /usr/local/bin/earth'"
+      - name: Download released earthly
+        run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/latest/download/earth-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly'"
       - name: Docker Login (non fork only)
         run: docker login --username "${{ secrets.DOCKERHUB_USERNAME }}" --password "${{ secrets.DOCKERHUB_TOKEN }}"
         if: github.event.pull_request.head.repo.full_name == github.repository
-      - name: Build latest earth using released earth
-        run: earth +for-linux
+      - name: Build latest earthly using released earthly
+        run: earthly +for-linux
       - name: Build examples
-        run: ./build/linux/amd64/earth --no-output --allow-privileged +examples
+        run: ./build/linux/amd64/earthly --no-output --allow-privileged +examples
   secrets:
     name: secrets-integration
     runs-on: ubuntu-latest
@@ -100,15 +100,15 @@ jobs:
       EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"
     steps:
       - uses: actions/checkout@v2
-      - name: Download released earth
-        run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/latest/download/earth-linux-amd64 -O /usr/local/bin/earth && chmod +x /usr/local/bin/earth'"
+      - name: Download released earthly
+        run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/latest/download/earth-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly'"
       - name: Docker Login (non fork only)
         run: docker login --username "${{ secrets.DOCKERHUB_USERNAME }}" --password "${{ secrets.DOCKERHUB_TOKEN }}"
         if: github.event.pull_request.head.repo.full_name == github.repository
-      - name: Build latest earth using released earth
-        run: earth +for-linux
+      - name: Build latest earthly using released earthly
+        run: earthly +for-linux
       - name: run ssh-based tests
-        run: env -u GIT_URL_INSTEAD_OF earth=./build/linux/amd64/earth scripts/tests/private-repo.sh
+        run: env -u GIT_URL_INSTEAD_OF earthly=./build/linux/amd64/earthly scripts/tests/private-repo.sh
   private-repo-test:
     services:
       sshd:
@@ -126,14 +126,14 @@ jobs:
       - uses: actions/checkout@v2
       - name: install sshpass
         run: sudo apt-get install -y sshpass
-      - name: Download released earth
-        run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/latest/download/earth-linux-amd64 -O /usr/local/bin/earth && chmod +x /usr/local/bin/earth'"
+      - name: Download released earthly
+        run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/latest/download/earth-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly'"
       - name: Docker Login
         run: docker login --username "${{ secrets.DOCKERHUB_USERNAME }}" --password "${{ secrets.DOCKERHUB_TOKEN }}"
-      - name: Build latest earth using released earth
-        run: earth +for-linux
+      - name: Build latest earthly using released earthly
+        run: earthly +for-linux
       - name: run ssh-based tests
-        run: env -u GIT_URL_INSTEAD_OF earth=./build/linux/amd64/earth scripts/tests/self-hosted-private-repo.sh
+        run: env -u GIT_URL_INSTEAD_OF earthly=./build/linux/amd64/earthly scripts/tests/self-hosted-private-repo.sh
 
   push:
     name: --push +all
@@ -155,11 +155,11 @@ jobs:
             branch="${GITHUB_REF##*/}"
           fi
           git checkout -b "$branch" || true
-      - name: Download released earth
-        run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/latest/download/earth-linux-amd64 -O /usr/local/bin/earth && chmod +x /usr/local/bin/earth'"
+      - name: Download released earthly
+        run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/latest/download/earth-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly'"
       - name: Docker Login
         run: docker login --username "${{ secrets.DOCKERHUB_USERNAME }}" --password "${{ secrets.DOCKERHUB_TOKEN }}"
-      - name: Build latest earth using released earth
-        run: earth +for-linux
+      - name: Build latest earthly using released earthly
+        run: earthly +for-linux
       - name: Rebuild and push
-        run: ./build/linux/amd64/earth --push +all
+        run: ./build/linux/amd64/earthly --push +all

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Please refer to [code-of-conduct.md](./code-of-conduct.md) for details.
 
 ## Using Earthly pre-release
 
-To build Earthly from source, you need the same requirements as Earthly. We recommend that you use the pre-prelease version of Earthly for development purposes. To launch the pre-release Earthly, simply use the `./earth` script provided in the root of the earthly repository. The pre-release Earthly tracks the version on main. You can use `./earth --version` to identify which Git hash was used to build it.
+To build Earthly from source, you need the same requirements as Earthly. We recommend that you use the pre-prelease version of Earthly for development purposes. To launch the pre-release Earthly, simply use the `./earthly` script provided in the root of the earthly repository. The pre-release Earthly tracks the version on main. You can use `./earthly --version` to identify which Git hash was used to build it.
 
 ## Building from source
 
@@ -14,27 +14,27 @@ To build Earthly from source for your target system, use
 
 * Linux and WSL
     ```bash
-    ./earth +for-linux
+    ./earthly +for-linux
     ```
 * Mac
     ```bash
-    ./earth +for-darwin
+    ./earthly +for-darwin
     ```
 
-This builds the earth binary in `./build/<platform>/amd64/earth` and also the buildkitd image.
+This builds the earthly binary in `./build/<platform>/amd64/earthly` and also the buildkitd image.
 
 The buildkitd image is tagged with your current branch name and also the built binary defaults to using that built image. The built binary will always check on startup whether it has the latest buildkitd running for its configured image name and will restart buildkitd automatically to update. If during your development you end up making changes to just the buildkitd image, the binary will pick up the change on its next run.
 
-For development purposes, you may use the built `earth` binary to rebuild itself. It's usually faster than switching between the built binary and the prerelease binary because it avoids constant buildkitd restarts. After the first initial build, you'll end up using:
+For development purposes, you may use the built `earthly` binary to rebuild itself. It's usually faster than switching between the built binary and the prerelease binary because it avoids constant buildkitd restarts. After the first initial build, you'll end up using:
 
 
 * Linux and WSL
     ```bash
-    ./build/linux/amd64/earth +for-linux
+    ./build/linux/amd64/earthly +for-linux
     ```
 * Mac
     ```bash
-    ./build/darwin/amd64/earth +for-darwin
+    ./build/darwin/amd64/earthly +for-darwin
     ```
 
 ## Running tests
@@ -42,13 +42,13 @@ For development purposes, you may use the built `earth` binary to rebuild itself
 To run most tests you can issue
 
 ```bash
-./build/<platform>/amd64/earth -P +test
+./build/<platform>/amd64/earthly -P +test
 ```
 
 To also build the examples, you can run
 
 ```bash
-./build/<platform>/amd64/earth -P +test-all
+./build/<platform>/amd64/earthly -P +test-all
 ```
 
 ## Gotchas

--- a/Earthfile
+++ b/Earthfile
@@ -38,7 +38,7 @@ code:
 
 lint-scripts:
     FROM +deps
-    COPY ./earth ./scripts/install-all-versions.sh ./buildkitd/entrypoint.sh ./earth-buildkitd-wrapper.sh \
+    COPY ./earthly ./scripts/install-all-versions.sh ./buildkitd/entrypoint.sh ./earthly-buildkitd-wrapper.sh \
         ./buildkitd/dockerd-wrapper.sh ./buildkitd/docker-auto-install.sh \
         ./release/envcredhelper.sh ./.buildkite/*.sh \
         ./scripts/tests/private-repo.sh ./scripts/tests/self-hosted-private-repo.sh \
@@ -99,7 +99,7 @@ debugger:
             cmd/debugger/*.go
     SAVE ARTIFACT build/earth_debugger
 
-earth:
+earthly:
     FROM +code
     ARG GOOS=linux
     ARG GOARCH=amd64
@@ -126,67 +126,67 @@ earth:
         go build \
             -tags "$(cat ./build/tags)" \
             -ldflags "$(cat ./build/ldflags)" \
-            -o build/earth \
-            cmd/earth/*.go
+            -o build/earthly \
+            cmd/earthly/*.go
     SAVE ARTIFACT ./build/tags
     SAVE ARTIFACT ./build/ldflags
-    SAVE ARTIFACT build/earth AS LOCAL "build/$GOOS/$GOARCH$GOARM/earth"
+    SAVE ARTIFACT build/earthly AS LOCAL "build/$GOOS/$GOARCH$GOARM/earthly"
 
-earth-arm5:
+earthly-arm5:
     COPY \
         --build-arg GOARCH=arm \
         --build-arg GOARM=5 \
         --build-arg GO_EXTRA_LDFLAGS= \
-        +earth/* ./
+        +earthly/* ./
     SAVE ARTIFACT ./*
 
-earth-arm6:
+earthly-arm6:
     COPY \
         --build-arg GOARCH=arm \
         --build-arg GOARM=6 \
         --build-arg GO_EXTRA_LDFLAGS= \
-        +earth/* ./
+        +earthly/* ./
     SAVE ARTIFACT ./*
 
-earth-arm7:
+earthly-arm7:
     COPY \
         --build-arg GOARCH=arm \
         --build-arg GOARM=7 \
         --build-arg GO_EXTRA_LDFLAGS= \
-        +earth/* ./
+        +earthly/* ./
     SAVE ARTIFACT ./*
 
-earth-darwin:
+earthly-darwin:
     COPY \
         --build-arg GOOS=darwin \
         --build-arg GOARCH=amd64 \
         --build-arg GO_EXTRA_LDFLAGS= \
-        +earth/* ./
+        +earthly/* ./
     SAVE ARTIFACT ./*
 
-earth-all:
-    COPY +earth/earth ./earth-linux-amd64
-    COPY +earth-darwin/earth ./earth-darwin-amd64
-    COPY +earth-arm5/earth ./earth-linux-arm5
-    COPY +earth-arm6/earth ./earth-linux-arm6
-    COPY +earth-arm7/earth ./earth-linux-arm7
+earthly-all:
+    COPY +earthly/earthly ./earthly-linux-amd64
+    COPY +earthly-darwin/earthly ./earthly-darwin-amd64
+    COPY +earthly-arm5/earthly ./earthly-linux-arm5
+    COPY +earthly-arm6/earthly ./earthly-linux-arm6
+    COPY +earthly-arm7/earthly ./earthly-linux-arm7
     SAVE ARTIFACT ./*
 
-earth-docker:
+earthly-docker:
     FROM ./buildkitd+buildkitd
     RUN apk add --update --no-cache docker-cli
     ENV NETWORK_MODE=host
-    COPY earth-buildkitd-wrapper.sh /usr/bin/earth-buildkitd-wrapper.sh
-    ENTRYPOINT ["/usr/bin/earth-buildkitd-wrapper.sh"]
+    COPY earthly-buildkitd-wrapper.sh /usr/bin/earthly-buildkitd-wrapper.sh
+    ENTRYPOINT ["/usr/bin/earthly-buildkitd-wrapper.sh"]
     ARG EARTHLY_TARGET_TAG_DOCKER
     ARG TAG=$EARTHLY_TARGET_TAG_DOCKER
-    COPY --build-arg VERSION=$TAG +earth/earth /usr/bin/earth
-    SAVE IMAGE --push earthly/earth:$TAG
+    COPY --build-arg VERSION=$TAG +earthly/earthly /usr/bin/earthly
+    SAVE IMAGE --push earthly/earthly:$TAG
 
 prerelease:
     FROM alpine:3.11
     BUILD --build-arg TAG=prerelease ./buildkitd+buildkitd
-    COPY --build-arg VERSION=prerelease +earth-all/* ./
+    COPY --build-arg VERSION=prerelease +earthly-all/* ./
     SAVE IMAGE --push earthly/earthlybinaries:prerelease
 
 dind:
@@ -209,18 +209,18 @@ dind-ubuntu:
 
 for-linux:
     BUILD +buildkitd
-    COPY +earth/earth ./
-    SAVE ARTIFACT ./earth
+    COPY +earthly/earthly ./
+    SAVE ARTIFACT ./earthly
 
 for-darwin:
     BUILD +buildkitd
-    COPY +earth-darwin/earth ./
-    SAVE ARTIFACT ./earth
+    COPY +earthly-darwin/earthly ./
+    SAVE ARTIFACT ./earthly
 
 all:
     BUILD +buildkitd
-    BUILD +earth-all
-    BUILD +earth-docker
+    BUILD +earthly-all
+    BUILD +earthly-docker
     BUILD +prerelease
     BUILD +dind
 

--- a/autocomplete/complete.go
+++ b/autocomplete/complete.go
@@ -22,7 +22,7 @@ func hasTargetOrCommand(line string) bool {
 	splits := strings.Split(line, " ")
 	for i, s := range splits {
 		if i == 0 {
-			continue // skip earth command
+			continue // skip earthly command
 		}
 		if len(s) == 0 {
 			continue // skip empty commands
@@ -36,7 +36,7 @@ func hasTargetOrCommand(line string) bool {
 }
 
 // parseLine parses a bash COMP_LINE and COMP_POINT variables into the argument to expand
-// e.g. line="earth --argum", cursorLoc=10; this will return "--ar"
+// e.g. line="earthly --argum", cursorLoc=10; this will return "--ar"
 func parseLine(line string, cursorLoc int) string {
 	var i int
 	for i = cursorLoc; i > 0; i-- {

--- a/autocomplete/complete_test.go
+++ b/autocomplete/complete_test.go
@@ -70,49 +70,49 @@ func getApp() *cli.App {
 
 func TestFlagCompletion(t *testing.T) {
 
-	matches, err := GetPotentials("earth --fl", 10, getApp())
+	matches, err := GetPotentials("earthly --fl", 12, getApp())
 	NoError(t, err, "GetPotentials failed")
 	Equal(t, []string{"--flag ", "--fleet "}, matches)
 }
 
 func TestCommandCompletion(t *testing.T) {
-	matches, err := GetPotentials("earth pru", 9, getApp())
+	matches, err := GetPotentials("earthly pru", 11, getApp())
 	NoError(t, err, "GetPotentials failed")
 	Equal(t, []string{"prune "}, matches)
 }
 
 func TestCommandCompletionHidden(t *testing.T) {
-	matches, err := GetPotentials("earth hid", 9, getApp())
+	matches, err := GetPotentials("earthly hid", 11, getApp())
 	NoError(t, err, "GetPotentials failed")
 	Equal(t, []string{}, matches)
 }
 
 func TestCommandSubCompletion(t *testing.T) {
-	matches, err := GetPotentials("earth sub -", 11, getApp())
+	matches, err := GetPotentials("earthly sub -", 13, getApp())
 	NoError(t, err, "GetPotentials failed")
 	Equal(t, []string{"--subflag "}, matches)
 }
 
 func TestCommandSubCompletion2(t *testing.T) {
-	matches, err := GetPotentials("earth sub --subflag abba --s", 28, getApp())
+	matches, err := GetPotentials("earthly sub --subflag abba --s", 30, getApp())
 	NoError(t, err, "GetPotentials failed")
 	Equal(t, []string{"--subsubflag ", "--surf-the-internet "}, matches)
 }
 
 func TestCommandSubSubCompletion(t *testing.T) {
-	matches, err := GetPotentials("earth sub --subflag abba --sub", 30, getApp())
+	matches, err := GetPotentials("earthly sub --subflag abba --sub", 32, getApp())
 	NoError(t, err, "GetPotentials failed")
 	Equal(t, []string{"--subsubflag "}, matches)
 }
 
 func TestCommandSubSubCompletion2(t *testing.T) {
-	matches, err := GetPotentials("earth sub --subflag abba ", 25, getApp())
+	matches, err := GetPotentials("earthly sub --subflag abba ", 27, getApp())
 	NoError(t, err, "GetPotentials failed")
 	Equal(t, []string{"dancing-queen "}, matches)
 }
 
 func TestPathCompletion(t *testing.T) {
-	matches, err := GetPotentials("earth .", 7, getApp())
+	matches, err := GetPotentials("earthly .", 9, getApp())
 	NoError(t, err, "GetPotentials failed")
 	Equal(t, []string{"./", "../"}, matches)
 }

--- a/buildcontext/excludes.go
+++ b/buildcontext/excludes.go
@@ -8,12 +8,12 @@ import (
 	"github.com/pkg/errors"
 )
 
-// EarthIgnoreFile is the name of the earth ignore file.
+// EarthIgnoreFile is the name of the earthly ignore file.
 const EarthIgnoreFile = ".earthignore"
 
 // ImplicitExcludes is a list of implicit patterns to exclude.
 var ImplicitExcludes = []string{
-	".tmp-earth-out/",
+	".tmp-earthly-out/",
 	"build.earth",
 	"Earthfile",
 	EarthIgnoreFile,

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -72,7 +72,7 @@ type Builder struct {
 	resolver *buildcontext.Resolver
 }
 
-// NewBuilder returns a new earth Builder.
+// NewBuilder returns a new earthly Builder.
 func NewBuilder(ctx context.Context, opt Opt) (*Builder, error) {
 	b := &Builder{
 		s: &solver{
@@ -109,7 +109,7 @@ func (b *Builder) MakeImageAsTarBuilderFun() states.DockerBuilderFun {
 }
 
 func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt BuildOpt) (*states.MultiTarget, error) {
-	outDir, err := ioutil.TempDir(".", ".tmp-earth-out")
+	outDir, err := ioutil.TempDir(".", ".tmp-earthly-out")
 	if err != nil {
 		return nil, errors.Wrap(err, "mk temp dir for artifacts")
 	}
@@ -278,7 +278,7 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 			}
 			console.Printf("Image %s as %s%s\n", mts.Final.Target.StringCanonical(), saveImage.DockerTag, pushStr)
 			if saveImage.Push && !opt.Push {
-				console.Printf("Did not push %s. Use earth --push to enable pushing\n", saveImage.DockerTag)
+				console.Printf("Did not push %s. Use earthly --push to enable pushing\n", saveImage.DockerTag)
 			}
 		}
 	} else {
@@ -295,7 +295,7 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 				}
 				console.Printf("Image %s as %s%s\n", sts.Target.StringCanonical(), saveImage.DockerTag, pushStr)
 				if saveImage.Push && !opt.Push && !sts.Target.IsRemote() {
-					console.Printf("Did not push %s. Use earth --push to enable pushing\n", saveImage.DockerTag)
+					console.Printf("Did not push %s. Use earthly --push to enable pushing\n", saveImage.DockerTag)
 				}
 			}
 			if !sts.Target.IsRemote() {
@@ -363,7 +363,7 @@ func (b *Builder) executeRunPush(ctx context.Context, states *states.SingleTarge
 	console := b.opt.Console.WithPrefixAndSalt(states.Target.String(), states.Salt)
 	if !opt.Push {
 		for _, commandStr := range states.RunPush.CommandStrs {
-			console.Printf("Did not execute push command %s. Use earth --push to enable pushing\n", commandStr)
+			console.Printf("Did not execute push command %s. Use earthly --push to enable pushing\n", commandStr)
 		}
 		return nil
 	}

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -63,7 +63,7 @@ import (
 
 var dotEnvPath = ".env"
 
-type earthApp struct {
+type earthlyApp struct {
 	cliApp      *cli.App
 	console     conslogging.ConsoleLogger
 	cfg         *config.Config
@@ -206,11 +206,11 @@ func main() {
 		padding = conslogging.NoPadding
 	}
 
-	app := newEarthApp(ctx, conslogging.Current(colorMode, padding))
+	app := newEarthlyApp(ctx, conslogging.Current(colorMode, padding))
 	app.autoComplete()
 
 	exitCode := app.run(ctx, os.Args)
-	// app.cfg will be nil when a user runs `earth --version`;
+	// app.cfg will be nil when a user runs `earthly --version`;
 	// however in all other regular commands app.cfg will be set in app.Before
 	if app.cfg != nil && !app.cfg.Global.DisableAnalytics {
 		analytics.CollectAnalytics(Version, GitSha, app.commandName, exitCode, time.Since(startTime))
@@ -226,13 +226,13 @@ func getVersion() string {
 	return fmt.Sprintf("%s-%s", Version, GitSha)
 }
 
-func newEarthApp(ctx context.Context, console conslogging.ConsoleLogger) *earthApp {
+func newEarthlyApp(ctx context.Context, console conslogging.ConsoleLogger) *earthlyApp {
 	sessionIDBytes := make([]byte, 64)
 	_, err := rand.Read(sessionIDBytes)
 	if err != nil {
 		panic(err)
 	}
-	app := &earthApp{
+	app := &earthlyApp{
 		cliApp:    cli.NewApp(),
 		console:   console,
 		sessionID: base64.StdEncoding.EncodeToString(sessionIDBytes),
@@ -250,7 +250,7 @@ func newEarthApp(ctx context.Context, console conslogging.ConsoleLogger) *earthA
 		"\n" +
 		"   \tearth [options] command [command options]\n" +
 		"\n" +
-		"Executes Earthly builds. For more information see https://docs.earthly.dev/earth-command.\n" +
+		"Executes Earthly builds. For more information see https://docs.earthly.dev/earthly-command.\n" +
 		"To get started with using Earthly, check out the getting started guide at https://docs.earthly.dev/guides/basics."
 	app.cliApp.UseShortOptionHandling = true
 	app.cliApp.Action = app.actionBuild
@@ -367,7 +367,7 @@ func newEarthApp(ctx context.Context, console conslogging.ConsoleLogger) *earthA
 		&cli.StringFlag{
 			Name:        "buildkit-host",
 			EnvVars:     []string{"EARTHLY_BUILDKIT_HOST"},
-			Usage:       "The URL to use for connecting to a buildkit host. If empty, earth will attempt to start a buildkitd instance via docker run",
+			Usage:       "The URL to use for connecting to a buildkit host. If empty, earthly will attempt to start a buildkitd instance via docker run",
 			Destination: &app.buildkitHost,
 		},
 		&cli.IntFlag{
@@ -453,8 +453,8 @@ func newEarthApp(ctx context.Context, console conslogging.ConsoleLogger) *earthA
 	app.cliApp.Commands = []*cli.Command{
 		{
 			Name:        "bootstrap",
-			Usage:       "Bootstraps earth bash autocompletion",
-			Description: "Performs initial earth bootstrapping for bash autocompletion",
+			Usage:       "Bootstraps earthly bash autocompletion",
+			Description: "Performs initial earthly bootstrapping for bash autocompletion",
 			Hidden:      false,
 			Action:      app.actionBootstrap,
 			Flags: []cli.Flag{
@@ -501,25 +501,25 @@ func newEarthApp(ctx context.Context, console conslogging.ConsoleLogger) *earthA
 				{
 					Name:      "create",
 					Usage:     "Create a new organization",
-					UsageText: "earth [options] org create <org-name>",
+					UsageText: "earthly [options] org create <org-name>",
 					Action:    app.actionOrgCreate,
 				},
 				{
 					Name:      "list",
 					Usage:     "List organizations you belong to",
-					UsageText: "earth [options] org list",
+					UsageText: "earthly [options] org list",
 					Action:    app.actionOrgList,
 				},
 				{
 					Name:      "list-permissions",
 					Usage:     "List permissions and membership of an organization",
-					UsageText: "earth [options] org list-permissions <org-name>",
+					UsageText: "earthly [options] org list-permissions <org-name>",
 					Action:    app.actionOrgListPermissions,
 				},
 				{
 					Name:      "invite",
 					Usage:     "Invite accounts to your organization",
-					UsageText: "earth [options] org invite [options] <org-name> <email> [<email> ...]",
+					UsageText: "earthly [options] org invite [options] <org-name> <email> [<email> ...]",
 					Action:    app.actionOrgInvite,
 					Flags: []cli.Flag{
 						&cli.BoolFlag{
@@ -532,7 +532,7 @@ func newEarthApp(ctx context.Context, console conslogging.ConsoleLogger) *earthA
 				{
 					Name:      "revoke",
 					Usage:     "Remove accounts from your organization",
-					UsageText: "earth [options] org revoke <org-name> <email> [<email> ...]",
+					UsageText: "earthly [options] org revoke <org-name> <email> [<email> ...]",
 					Action:    app.actionOrgRevoke,
 				},
 			},
@@ -547,7 +547,7 @@ func newEarthApp(ctx context.Context, console conslogging.ConsoleLogger) *earthA
 					Name:      "get",
 					Action:    app.actionSecretsGet,
 					Usage:     "Retrieve a secret from the secrets store",
-					UsageText: "earth [options] secrets get [options] <path>",
+					UsageText: "earthly [options] secrets get [options] <path>",
 					Flags: []cli.Flag{
 						&cli.BoolFlag{
 							Aliases:     []string{"n"},
@@ -559,20 +559,20 @@ func newEarthApp(ctx context.Context, console conslogging.ConsoleLogger) *earthA
 				{
 					Name:      "ls",
 					Usage:     "List secrets in the secrets store",
-					UsageText: "earth [options] secrets ls [<path>]",
+					UsageText: "earthly [options] secrets ls [<path>]",
 					Action:    app.actionSecretsList,
 				},
 				{
 					Name:      "rm",
 					Usage:     "Removes a secret from the secrets store",
-					UsageText: "earth [options] secrets rm <path>",
+					UsageText: "earthly [options] secrets rm <path>",
 					Action:    app.actionSecretsRemove,
 				},
 				{
 					Name:  "set",
 					Usage: "Stores a secret in the secrets store",
-					UsageText: "earth [options] secrets set <path> <value>\n" +
-						"   earth [options] secrets set --file <local-path> <path>",
+					UsageText: "earthly [options] secrets set <path> <value>\n" +
+						"   earthly [options] secrets set --file <local-path> <path>",
 					Action: app.actionSecretsSet,
 					Flags: []cli.Flag{
 						&cli.StringFlag{
@@ -595,10 +595,10 @@ func newEarthApp(ctx context.Context, console conslogging.ConsoleLogger) *earthA
 					Usage:       "Register for an Earthly account",
 					Description: "Register for an Earthly account",
 					UsageText: "first, request a token with:\n" +
-						"     earth [options] account register --email <email>\n" +
+						"     earthly [options] account register --email <email>\n" +
 						"\n" +
 						"   then check your email to retrieve the token, then continue by running:\n" +
-						"     earth [options] account register --email <email> --token <token> [options]",
+						"     earthly [options] account register --email <email> --token <token> [options]",
 					Action: app.actionRegister,
 					Flags: []cli.Flag{
 						&cli.StringFlag{
@@ -634,31 +634,31 @@ func newEarthApp(ctx context.Context, console conslogging.ConsoleLogger) *earthA
 				{
 					Name:      "list-keys",
 					Usage:     "List associated public keys used for authentication",
-					UsageText: "earth [options] account list-keys",
+					UsageText: "earthly [options] account list-keys",
 					Action:    app.actionAccountListKeys,
 				},
 				{
 					Name:      "add-key",
 					Usage:     "Associate a new public key with your account",
-					UsageText: "earth [options] add-key [<key>]",
+					UsageText: "earthly [options] add-key [<key>]",
 					Action:    app.actionAccountAddKey,
 				},
 				{
 					Name:      "remove-key",
 					Usage:     "Removes an existing public key from your account",
-					UsageText: "earth [options] remove-key <key>",
+					UsageText: "earthly [options] remove-key <key>",
 					Action:    app.actionAccountRemoveKey,
 				},
 				{
 					Name:      "list-tokens",
 					Usage:     "List associated tokens used for authentication",
-					UsageText: "earth [options] account list-tokens",
+					UsageText: "earthly [options] account list-tokens",
 					Action:    app.actionAccountListTokens,
 				},
 				{
 					Name:      "create-token",
 					Usage:     "Create a new authentication token for your account",
-					UsageText: "earth [options] account create-token [options] <token name>",
+					UsageText: "earthly [options] account create-token [options] <token name>",
 					Action:    app.actionAccountCreateToken,
 					Flags: []cli.Flag{
 						&cli.BoolFlag{
@@ -676,17 +676,17 @@ func newEarthApp(ctx context.Context, console conslogging.ConsoleLogger) *earthA
 				{
 					Name:      "remove-token",
 					Usage:     "Remove an authentication token from your account",
-					UsageText: "earth [options] account remove-token <token>",
+					UsageText: "earthly [options] account remove-token <token>",
 					Action:    app.actionAccountRemoveToken,
 				},
 				{
 					Name:        "login",
 					Usage:       "Login to an Earthly account",
 					Description: "Login to an Earthly account",
-					UsageText: "earth [options] account login\n" +
-						"   earth [options] account login --email <email>\n" +
-						"   earth [options] account login --email <email> --password <password>\n" +
-						"   earth [options] account login --token <token>\n",
+					UsageText: "earthly [options] account login\n" +
+						"   earthly [options] account login --email <email>\n" +
+						"   earthly [options] account login --email <email> --password <password>\n" +
+						"   earthly [options] account login --token <token>\n",
 					Action: app.actionAccountLogin,
 					Flags: []cli.Flag{
 						&cli.StringFlag{
@@ -750,7 +750,7 @@ func newEarthApp(ctx context.Context, console conslogging.ConsoleLogger) *earthA
 	return app
 }
 
-func (app *earthApp) before(context *cli.Context) error {
+func (app *earthlyApp) before(context *cli.Context) error {
 	if app.enableProfiler {
 		go profhandler()
 	}
@@ -797,14 +797,14 @@ func (app *earthApp) before(context *cli.Context) error {
 	return nil
 }
 
-func (app *earthApp) processDeprecatedCommandOptions(context *cli.Context, cfg *config.Config) error {
+func (app *earthlyApp) processDeprecatedCommandOptions(context *cli.Context, cfg *config.Config) error {
 	if cfg.Global.CachePath != "" {
 		app.console.Warnf("Warning: the setting cache_path is now obsolete and will be ignored")
 	}
 
 	// command line overrides the config file
 	if app.gitUsernameOverride != "" || app.gitPasswordOverride != "" {
-		app.console.Warnf("Warning: the --git-username and --git-password command flags are deprecated and are now configured in the ~/.earthly/config.yml file under the git section; see https://docs.earthly.dev/earth-config for reference.\n")
+		app.console.Warnf("Warning: the --git-username and --git-password command flags are deprecated and are now configured in the ~/.earthly/config.yml file under the git section; see https://docs.earthly.dev/earthly-config for reference.\n")
 		if _, ok := cfg.Git["github.com"]; !ok {
 			cfg.Git["github.com"] = config.GitConfig{}
 		}
@@ -825,7 +825,7 @@ func (app *earthApp) processDeprecatedCommandOptions(context *cli.Context, cfg *
 	}
 
 	if context.IsSet("git-url-instead-of") {
-		app.console.Warnf("Warning: the --git-url-instead-of command flag is deprecated and is now configured in the ~/.earthly/config.yml file under the git global url_instead_of setting; see https://docs.earthly.dev/earth-config for reference.\n")
+		app.console.Warnf("Warning: the --git-url-instead-of command flag is deprecated and is now configured in the ~/.earthly/config.yml file under the git global url_instead_of setting; see https://docs.earthly.dev/earthly-config for reference.\n")
 	} else {
 		if gitGlobal, ok := cfg.Git["global"]; ok {
 			if gitGlobal.GitURLInsteadOf != "" {
@@ -835,7 +835,7 @@ func (app *earthApp) processDeprecatedCommandOptions(context *cli.Context, cfg *
 	}
 
 	if context.IsSet("buildkit-cache-size-mb") {
-		app.console.Warnf("Warning: the --buildkit-cache-size-mb command flag is deprecated and is now configured in the ~/.earthly/config.yml file under the buildkit_cache_size setting; see https://docs.earthly.dev/earth-config for reference.\n")
+		app.console.Warnf("Warning: the --buildkit-cache-size-mb command flag is deprecated and is now configured in the ~/.earthly/config.yml file under the buildkit_cache_size setting; see https://docs.earthly.dev/earthly-config for reference.\n")
 	} else {
 		app.buildkitdSettings.CacheSizeMb = cfg.Global.BuildkitCacheSizeMb
 	}
@@ -844,8 +844,8 @@ func (app *earthApp) processDeprecatedCommandOptions(context *cli.Context, cfg *
 }
 
 // to enable autocomplete, enter
-// complete -o nospace -C "/path/to/earth" earth
-func (app *earthApp) autoComplete() {
+// complete -o nospace -C "/path/to/earthly" earthly
+func (app *earthlyApp) autoComplete() {
 	_, found := os.LookupEnv("COMP_LINE")
 	if !found {
 		return
@@ -874,7 +874,7 @@ func (app *earthApp) autoComplete() {
 	os.Exit(0)
 }
 
-func (app *earthApp) autoCompleteImp() (err error) {
+func (app *earthlyApp) autoCompleteImp() (err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			err = fmt.Errorf("recovered panic in autocomplete %s: %s", r, debug.Stack())
@@ -900,14 +900,14 @@ func (app *earthApp) autoCompleteImp() (err error) {
 	return err
 }
 
-const bashCompleteEntry = "complete -o nospace -C '/usr/local/bin/earth' earth\n"
+const bashCompleteEntry = "complete -o nospace -C '/usr/local/bin/earthly' earthly\n"
 
-func (app *earthApp) insertBashCompleteEntry() error {
+func (app *earthlyApp) insertBashCompleteEntry() error {
 	var path string
 	if runtime.GOOS == "darwin" {
-		path = "/usr/local/etc/bash_completion.d/earth"
+		path = "/usr/local/etc/bash_completion.d/earthly"
 	} else {
-		path = "/usr/share/bash-completion/completions/earth"
+		path = "/usr/share/bash-completion/completions/earthly"
 	}
 	dirPath := filepath.Dir(path)
 
@@ -930,7 +930,7 @@ func (app *earthApp) insertBashCompleteEntry() error {
 	return err
 }
 
-func (app *earthApp) deleteZcompdump() error {
+func (app *earthlyApp) deleteZcompdump() error {
 	var homeDir string
 	sudoUser, found := os.LookupEnv("SUDO_USER")
 	if !found {
@@ -962,17 +962,17 @@ func (app *earthApp) deleteZcompdump() error {
 	return nil
 }
 
-const zshCompleteEntry = `#compdef _earth earth
+const zshCompleteEntry = `#compdef _earth earthly
 
 function _earth {
     autoload -Uz bashcompinit
     bashcompinit
-    complete -o nospace -C '/usr/local/bin/earth' earth
+    complete -o nospace -C '/usr/local/bin/earthly' earthly
 }
 `
 
 // If debugging this, it might be required to run `rm ~/.zcompdump*` to remove the cache
-func (app *earthApp) insertZSHCompleteEntry() error {
+func (app *earthlyApp) insertZSHCompleteEntry() error {
 	// should be the same on linux and macOS
 	path := "/usr/local/share/zsh/site-functions/_earth"
 	dirPath := filepath.Dir(path)
@@ -1001,7 +1001,7 @@ func (app *earthApp) insertZSHCompleteEntry() error {
 	return app.deleteZcompdump()
 }
 
-func (app *earthApp) run(ctx context.Context, args []string) int {
+func (app *earthlyApp) run(ctx context.Context, args []string) int {
 	err := app.cliApp.RunContext(ctx, args)
 
 	rpcRegex := regexp.MustCompile(`rpc error: code = .+ desc = .+:\s`)
@@ -1031,7 +1031,7 @@ func (app *earthApp) run(ctx context.Context, args []string) int {
 	return 0
 }
 
-func (app *earthApp) actionBootstrap(c *cli.Context) error {
+func (app *earthlyApp) actionBootstrap(c *cli.Context) error {
 	app.commandName = "bootstrap"
 	switch app.homebrewSource {
 	case "bash":
@@ -1071,7 +1071,7 @@ func promptInput(question string) string {
 	return strings.TrimRight(line, "\n")
 }
 
-func (app *earthApp) actionOrgCreate(c *cli.Context) error {
+func (app *earthlyApp) actionOrgCreate(c *cli.Context) error {
 	app.commandName = "orgCreate"
 	if c.NArg() != 1 {
 		return errors.New("invalid number of arguments provided")
@@ -1088,7 +1088,7 @@ func (app *earthApp) actionOrgCreate(c *cli.Context) error {
 	return nil
 }
 
-func (app *earthApp) actionOrgList(c *cli.Context) error {
+func (app *earthlyApp) actionOrgList(c *cli.Context) error {
 	app.commandName = "orgList"
 	sc, err := secretsclient.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
@@ -1114,7 +1114,7 @@ func (app *earthApp) actionOrgList(c *cli.Context) error {
 	return nil
 }
 
-func (app *earthApp) actionOrgListPermissions(c *cli.Context) error {
+func (app *earthlyApp) actionOrgListPermissions(c *cli.Context) error {
 	app.commandName = "orgListPermissions"
 	if c.NArg() != 1 {
 		return errors.New("invalid number of arguments provided")
@@ -1146,7 +1146,7 @@ func (app *earthApp) actionOrgListPermissions(c *cli.Context) error {
 	return nil
 }
 
-func (app *earthApp) actionOrgInvite(c *cli.Context) error {
+func (app *earthlyApp) actionOrgInvite(c *cli.Context) error {
 	app.commandName = "orgInvite"
 	if c.NArg() < 2 {
 		return errors.New("invalid number of arguments provided")
@@ -1168,7 +1168,7 @@ func (app *earthApp) actionOrgInvite(c *cli.Context) error {
 	return nil
 }
 
-func (app *earthApp) actionOrgRevoke(c *cli.Context) error {
+func (app *earthlyApp) actionOrgRevoke(c *cli.Context) error {
 	app.commandName = "orgRevoke"
 	if c.NArg() < 2 {
 		return errors.New("invalid number of arguments provided")
@@ -1190,7 +1190,7 @@ func (app *earthApp) actionOrgRevoke(c *cli.Context) error {
 	return nil
 }
 
-func (app *earthApp) actionSecretsList(c *cli.Context) error {
+func (app *earthlyApp) actionSecretsList(c *cli.Context) error {
 	app.commandName = "secretsList"
 
 	path := "/"
@@ -1216,7 +1216,7 @@ func (app *earthApp) actionSecretsList(c *cli.Context) error {
 	return nil
 }
 
-func (app *earthApp) actionSecretsGet(c *cli.Context) error {
+func (app *earthlyApp) actionSecretsGet(c *cli.Context) error {
 	app.commandName = "secretsGet"
 	if c.NArg() != 1 {
 		return errors.New("invalid number of arguments provided")
@@ -1237,7 +1237,7 @@ func (app *earthApp) actionSecretsGet(c *cli.Context) error {
 	return nil
 }
 
-func (app *earthApp) actionSecretsRemove(c *cli.Context) error {
+func (app *earthlyApp) actionSecretsRemove(c *cli.Context) error {
 	app.commandName = "secretsRemove"
 	if c.NArg() != 1 {
 		return errors.New("invalid number of arguments provided")
@@ -1254,7 +1254,7 @@ func (app *earthApp) actionSecretsRemove(c *cli.Context) error {
 	return nil
 }
 
-func (app *earthApp) actionSecretsSet(c *cli.Context) error {
+func (app *earthlyApp) actionSecretsSet(c *cli.Context) error {
 	app.commandName = "secretsSet"
 	var path string
 	var value string
@@ -1287,7 +1287,7 @@ func (app *earthApp) actionSecretsSet(c *cli.Context) error {
 	return nil
 }
 
-func (app *earthApp) actionRegister(c *cli.Context) error {
+func (app *earthlyApp) actionRegister(c *cli.Context) error {
 	app.commandName = "secretsRegister"
 	if app.email == "" {
 		return errors.New("no email given")
@@ -1403,7 +1403,7 @@ func (app *earthApp) actionRegister(c *cli.Context) error {
 	return nil
 }
 
-func (app *earthApp) actionAccountListKeys(c *cli.Context) error {
+func (app *earthlyApp) actionAccountListKeys(c *cli.Context) error {
 	app.commandName = "accountListKeys"
 	sc, err := secretsclient.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
@@ -1419,7 +1419,7 @@ func (app *earthApp) actionAccountListKeys(c *cli.Context) error {
 	return nil
 }
 
-func (app *earthApp) actionAccountAddKey(c *cli.Context) error {
+func (app *earthlyApp) actionAccountAddKey(c *cli.Context) error {
 	app.commandName = "accountAddKey"
 	sc, err := secretsclient.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
@@ -1486,7 +1486,7 @@ func (app *earthApp) actionAccountAddKey(c *cli.Context) error {
 	return nil
 }
 
-func (app *earthApp) actionAccountRemoveKey(c *cli.Context) error {
+func (app *earthlyApp) actionAccountRemoveKey(c *cli.Context) error {
 	app.commandName = "accountRemoveKey"
 	sc, err := secretsclient.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
@@ -1500,7 +1500,7 @@ func (app *earthApp) actionAccountRemoveKey(c *cli.Context) error {
 	}
 	return nil
 }
-func (app *earthApp) actionAccountListTokens(c *cli.Context) error {
+func (app *earthlyApp) actionAccountListTokens(c *cli.Context) error {
 	app.commandName = "accountListTokens"
 	sc, err := secretsclient.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
@@ -1535,7 +1535,7 @@ func (app *earthApp) actionAccountListTokens(c *cli.Context) error {
 	w.Flush()
 	return nil
 }
-func (app *earthApp) actionAccountCreateToken(c *cli.Context) error {
+func (app *earthlyApp) actionAccountCreateToken(c *cli.Context) error {
 	app.commandName = "accountCreateToken"
 	if c.NArg() != 1 {
 		return errors.New("invalid number of arguments provided")
@@ -1577,7 +1577,7 @@ func (app *earthApp) actionAccountCreateToken(c *cli.Context) error {
 	fmt.Printf("created token %q which will expire in %s; save this token somewhere, it can't be viewed again (only reset)\n", token, expiryStr)
 	return nil
 }
-func (app *earthApp) actionAccountRemoveToken(c *cli.Context) error {
+func (app *earthlyApp) actionAccountRemoveToken(c *cli.Context) error {
 	app.commandName = "accountRemoveToken"
 	if c.NArg() != 1 {
 		return errors.New("invalid number of arguments provided")
@@ -1594,7 +1594,7 @@ func (app *earthApp) actionAccountRemoveToken(c *cli.Context) error {
 	return nil
 }
 
-func (app *earthApp) actionAccountLogin(c *cli.Context) error {
+func (app *earthlyApp) actionAccountLogin(c *cli.Context) error {
 	app.commandName = "accountLogin"
 	email := app.email
 	token := app.token
@@ -1715,7 +1715,7 @@ func (app *earthApp) actionAccountLogin(c *cli.Context) error {
 	return nil
 }
 
-func (app *earthApp) actionAccountLogout(c *cli.Context) error {
+func (app *earthlyApp) actionAccountLogout(c *cli.Context) error {
 	app.commandName = "accountLogout"
 	sc, err := secretsclient.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
@@ -1728,7 +1728,7 @@ func (app *earthApp) actionAccountLogout(c *cli.Context) error {
 	return nil
 }
 
-func (app *earthApp) actionDebug(c *cli.Context) error {
+func (app *earthlyApp) actionDebug(c *cli.Context) error {
 	app.commandName = "debug"
 	if c.NArg() > 1 {
 		return errors.New("invalid number of arguments provided")
@@ -1746,7 +1746,7 @@ func (app *earthApp) actionDebug(c *cli.Context) error {
 	return nil
 }
 
-func (app *earthApp) actionPrune(c *cli.Context) error {
+func (app *earthlyApp) actionPrune(c *cli.Context) error {
 	app.commandName = "prune"
 	if c.NArg() != 0 {
 		return errors.New("invalid arguments")
@@ -1808,11 +1808,11 @@ func (app *earthApp) actionPrune(c *cli.Context) error {
 	return nil
 }
 
-func (app *earthApp) actionDocker2Earth(c *cli.Context) error {
+func (app *earthlyApp) actionDocker2Earth(c *cli.Context) error {
 	return docker2earth.Docker2Earth(app.dockerfilePath, app.earthfilePath, app.earthfileFinalImage)
 }
 
-func (app *earthApp) actionBuild(c *cli.Context) error {
+func (app *earthlyApp) actionBuild(c *cli.Context) error {
 	app.commandName = "build"
 
 	if app.ci {
@@ -2029,7 +2029,7 @@ func (app *earthApp) actionBuild(c *cli.Context) error {
 	return nil
 }
 
-func (app *earthApp) newBuildkitdClient(ctx context.Context, opts ...client.ClientOpt) (*client.Client, string, error) {
+func (app *earthlyApp) newBuildkitdClient(ctx context.Context, opts ...client.ClientOpt) (*client.Client, string, error) {
 	if app.buildkitHost == "" {
 		// Start our own.
 		app.buildkitdSettings.Debug = app.debug
@@ -2054,7 +2054,7 @@ func (app *earthApp) newBuildkitdClient(ctx context.Context, opts ...client.Clie
 	return bkClient, "", nil
 }
 
-func (app *earthApp) updateGitLookupConfig(gitLookup *buildcontext.GitLookup) error {
+func (app *earthlyApp) updateGitLookupConfig(gitLookup *buildcontext.GitLookup) error {
 
 	autoProtocol := "ssh"
 	if app.sshAuthSock == "" {

--- a/docker2earth/convert.go
+++ b/docker2earth/convert.go
@@ -127,6 +127,6 @@ func Docker2Earth(dockerfilePath, EarthfilePath, imageTag string) error {
 
 	fmt.Fprintf(out, "\nbuild:\n    BUILD +subbuild%d\n", i)
 
-	fmt.Fprintf(os.Stderr, "An Earthfile has been generated; to run it use: earth +build; then run with docker run -ti %s\n", imageTag)
+	fmt.Fprintf(os.Stderr, "An Earthfile has been generated; to run it use: earthly +build; then run with docker run -ti %s\n", imageTag)
 	return nil
 }

--- a/domain/artifact.go
+++ b/domain/artifact.go
@@ -8,7 +8,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Artifact is a earth artifact identifier.
+// Artifact is an earthly artifact identifier.
 type Artifact struct {
 	Target   Target
 	Artifact string

--- a/domain/target.go
+++ b/domain/target.go
@@ -8,7 +8,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Target is a earth target identifier.
+// Target is an earthly target identifier.
 type Target struct {
 	GitURL string // e.g. "github.com/earthly/earthly/examples/go"
 	Tag    string // e.g. "main"

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -30,7 +30,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Converter turns earth commands to buildkit LLB representation.
+// Converter turns earthly commands to buildkit LLB representation.
 type Converter struct {
 	gitMeta          *buildcontext.GitMetadata
 	opt              ConvertOpt
@@ -44,7 +44,7 @@ type Converter struct {
 	ranSave          bool
 }
 
-// NewConverter constructs a new converter for a given earth target.
+// NewConverter constructs a new converter for a given earthly target.
 func NewConverter(ctx context.Context, target domain.Target, bc *buildcontext.Data, opt ConvertOpt) (*Converter, error) {
 	sts := &states.SingleTarget{
 		Target: target,
@@ -78,7 +78,7 @@ func NewConverter(ctx context.Context, target domain.Target, bc *buildcontext.Da
 	}, nil
 }
 
-// From applies the earth FROM command.
+// From applies the earthly FROM command.
 func (c *Converter) From(ctx context.Context, imageName string, buildArgs []string) error {
 	c.nonSaveCommand()
 	if strings.Contains(imageName, "+") {
@@ -134,7 +134,7 @@ func (c *Converter) fromTarget(ctx context.Context, targetName string, buildArgs
 	return nil
 }
 
-// FromDockerfile applies the earth FROM DOCKERFILE command.
+// FromDockerfile applies the earthly FROM DOCKERFILE command.
 func (c *Converter) FromDockerfile(ctx context.Context, contextPath string, dfPath string, dfTarget string, buildArgs []string) error {
 	c.nonSaveCommand()
 	if dfPath != "" {
@@ -235,7 +235,7 @@ func (c *Converter) FromDockerfile(ctx context.Context, contextPath string, dfPa
 	return nil
 }
 
-// CopyArtifact applies the earth COPY artifact command.
+// CopyArtifact applies the earthly COPY artifact command.
 func (c *Converter) CopyArtifact(ctx context.Context, artifactName string, dest string, buildArgs []string, isDir bool, chown string) error {
 	c.nonSaveCommand()
 	artifact, err := domain.ParseArtifact(artifactName)
@@ -265,7 +265,7 @@ func (c *Converter) CopyArtifact(ctx context.Context, artifactName string, dest 
 	return nil
 }
 
-// CopyClassical applies the earth COPY command, with classical args.
+// CopyClassical applies the earthly COPY command, with classical args.
 func (c *Converter) CopyClassical(ctx context.Context, srcs []string, dest string, isDir bool, chown string) {
 	c.nonSaveCommand()
 	c.mts.Final.MainState = llbutil.CopyOp(
@@ -278,7 +278,7 @@ func (c *Converter) CopyClassical(ctx context.Context, srcs []string, dest strin
 			dest))
 }
 
-// Run applies the earth RUN command.
+// Run applies the earthly RUN command.
 func (c *Converter) Run(ctx context.Context, args []string, mounts []string, secretKeyValues []string, privileged bool, withEntrypoint bool, withDocker bool, isWithShell bool, pushFlag bool, withSSH bool) error {
 	c.nonSaveCommand()
 	if withDocker {
@@ -316,7 +316,7 @@ func (c *Converter) Run(ctx context.Context, args []string, mounts []string, sec
 	return c.internalRun(ctx, finalArgs, secretKeyValues, isWithShell, shellWrap, pushFlag, withSSH, runStr, opts...)
 }
 
-// SaveArtifact applies the earth SAVE ARTIFACT command.
+// SaveArtifact applies the earthly SAVE ARTIFACT command.
 func (c *Converter) SaveArtifact(ctx context.Context, saveFrom string, saveTo string, saveAsLocalTo string) error {
 	saveToAdjusted := saveTo
 	if saveTo == "" || saveTo == "." || strings.HasSuffix(saveTo, "/") {
@@ -364,7 +364,7 @@ func (c *Converter) SaveArtifact(ctx context.Context, saveFrom string, saveTo st
 	return nil
 }
 
-// SaveImage applies the earth SAVE IMAGE command.
+// SaveImage applies the earthly SAVE IMAGE command.
 func (c *Converter) SaveImage(ctx context.Context, imageNames []string, pushImages bool, cacheHint bool, cacheFrom []string) error {
 	for _, cf := range cacheFrom {
 		c.opt.CacheImports[cf] = true
@@ -394,7 +394,7 @@ func (c *Converter) SaveImage(ctx context.Context, imageNames []string, pushImag
 	return nil
 }
 
-// Build applies the earth BUILD command.
+// Build applies the earthly BUILD command.
 func (c *Converter) Build(ctx context.Context, fullTargetName string, buildArgs []string) error {
 	c.nonSaveCommand()
 	_, err := c.buildTarget(ctx, fullTargetName, buildArgs, true)
@@ -558,7 +558,7 @@ func (c *Converter) ExpandArgs(word string) string {
 func (c *Converter) buildTarget(ctx context.Context, fullTargetName string, buildArgs []string, isDangling bool) (*states.MultiTarget, error) {
 	relTarget, err := domain.ParseTarget(fullTargetName)
 	if err != nil {
-		return nil, errors.Wrapf(err, "earth target parse %s", fullTargetName)
+		return nil, errors.Wrapf(err, "earthly target parse %s", fullTargetName)
 	}
 	target, err := domain.JoinTargets(c.mts.Final.Target, relTarget)
 	if err != nil {

--- a/earthfile2llb/lexer.go
+++ b/earthfile2llb/lexer.go
@@ -5,7 +5,7 @@ import (
 	"github.com/earthly/earthly/earthfile2llb/parser"
 )
 
-// lexer is a lexer for an earth file, which also emits indentation
+// lexer is a lexer for an earthly file, which also emits indentation
 // and dedentation tokens.
 type lexer struct {
 	*parser.EarthLexer

--- a/earthfile2llb/listener.go
+++ b/earthfile2llb/listener.go
@@ -270,7 +270,7 @@ func (l *listener) ExitRunStmt(c *parser.RunStmtContext) {
 	fs := flag.NewFlagSet("RUN", flag.ContinueOnError)
 	pushFlag := fs.Bool(
 		"push", false,
-		"Execute this command only if the build succeeds and also if earth is invoked in push mode")
+		"Execute this command only if the build succeeds and also if earthly is invoked in push mode")
 	privileged := fs.Bool("privileged", false, "Enable privileged mode")
 	withEntrypoint := fs.Bool(
 		"entrypoint", false,
@@ -390,7 +390,7 @@ func (l *listener) ExitSaveImage(c *parser.SaveImageContext) {
 	fs := flag.NewFlagSet("SAVE IMAGE", flag.ContinueOnError)
 	pushFlag := fs.Bool(
 		"push", false,
-		"Push the image to the remote registry provided that the build succeeds and also that earth is invoked in push mode")
+		"Push the image to the remote registry provided that the build succeeds and also that earthly is invoked in push mode")
 	cacheHint := fs.Bool(
 		"cache-hint", false,
 		"Instruct Earthly that the current target shuold be saved entirely as part of the remote cache")

--- a/earthly
+++ b/earthly
@@ -6,7 +6,7 @@ if [ ! -d "$bindir" ]; then
   mkdir -p "$bindir"
 fi
 
-last_check_state_path=/tmp/last-earth-prerelease-check
+last_check_state_path=/tmp/last-earthly-prerelease-check
 
 get_latest_binary() {
     docker rm --force earthly_binary 2>/dev/null || true
@@ -15,12 +15,12 @@ get_latest_binary() {
     docker pull earthly/earthlybinaries:prerelease
     docker create --name earthly_binary earthly/earthlybinaries:prerelease
 
-    earth_bin_path=/earth-linux-amd64
+    earth_bin_path=/earthly-linux-amd64
     if [ "$(uname)" == "Darwin" ]; then
-        earth_bin_path=/earth-darwin-amd64
+        earth_bin_path=/earthly-darwin-amd64
     fi
 
-    docker cp earthly_binary:"$earth_bin_path" "$bindir/earth-prerelease"
+    docker cp earthly_binary:"$earth_bin_path" "$bindir/earthly-prerelease"
     docker rm earthly_binary
 }
 
@@ -28,7 +28,7 @@ do_reset() {
     rm -f "$last_check_state_path"
     docker stop earthly-buildkitd || true
     docker rm -f earthly-buildkitd || true
-    rm -f "$bindir/earth-prerelease"
+    rm -f "$bindir/earthly-prerelease"
     docker rm --force earthly_binary 2>/dev/null || true
     docker rmi -f earthly/buildkitd:prerelease || true
     docker rmi -f earthly/earthlybinaries:prerelease || true
@@ -50,6 +50,6 @@ case "$1" in
             echo "$now" >"$last_check_state_path"
         fi
 
-        "$bindir/earth-prerelease" "$@"
+        "$bindir/earthly-prerelease" "$@"
         ;;
 esac

--- a/earthly-buildkitd-wrapper.sh
+++ b/earthly-buildkitd-wrapper.sh
@@ -30,9 +30,9 @@ while [ ! -S "/run/buildkit/buildkitd.sock" ]; do
     fi
 done
 
-# Run earth with given args.
+# Run earthly with given args.
 set +e
-earth "$@"
+earthly "$@"
 exit_code="$?"
 set -e
 

--- a/examples/ecr-push/README.md
+++ b/examples/ecr-push/README.md
@@ -5,7 +5,7 @@ We are still making this easier, we hope it gets much shorter!
 The steps to build your image go in the `+some-thing` target. The `+ecr-push` target will push it to ECS. Assuming you keep your AWS credentials in the standard environment variables, you can build your image and push it to ECR like this:
 
 ```
-earth -P \
+earthly -P \
     --secret AWS_ACCESS_KEY_ID \
     --secret AWS_SECRET_ACCESS_KEY \
     --secret AWS_SESSION_TOKEN \
@@ -31,11 +31,11 @@ Here, you do not have to have the `aws` tool installed! But you cannot pull from
 
 ## Alternative method
 
-`earth` uses the hosts docker credentials. You can also login on the host, and then invoke `earth` like so:
+`earthly` uses the hosts docker credentials. You can also login on the host, and then invoke `earthly` like so:
 
 ```
 $ aws ecr get-login-password | docker login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com
-$ earth -P +some-thing-pre-logged-in
+$ earthly -P +some-thing-pre-logged-in
 
 ```
 

--- a/examples/tests/Earthfile
+++ b/examples/tests/Earthfile
@@ -1,4 +1,4 @@
-FROM ../..+earth-docker
+FROM ../..+earthly-docker
 
 RUN apk add --update --no-cache \
     perl
@@ -30,7 +30,7 @@ ga:
     BUILD +lc-test
     BUILD +from-expose-test
     BUILD +scratch-test
-    BUILD +build-earth-test
+    BUILD +build-earthly-test
     BUILD +host-bind-test
     BUILD +remote-test
     BUILD +transitive-args-test
@@ -143,7 +143,7 @@ scratch-test:
         --mount=type=tmpfs,target=/tmp/earthly \
         -- --no-output +test
 
-build-earth-test:
+build-earthly-test:
     # Test that build.earth is supported.
     COPY config.earth ./build.earth
     RUN --privileged \
@@ -255,22 +255,22 @@ fail-test:
     # test that an error code is correctly returned
     RUN --privileged \
         --mount=type=tmpfs,target=/tmp/earthly \
-        ! /usr/bin/earth-buildkitd-wrapper.sh +test
+        ! /usr/bin/earthly-buildkitd-wrapper.sh +test
     # test that the 'failed with exit code' text is printed out
     RUN --privileged \
         --mount=type=tmpfs,target=/tmp/earthly \
-        /usr/bin/earth-buildkitd-wrapper.sh +test 2>&1 | perl -pe 'BEGIN {$status=1} END {exit $status} $status=0 if /this-will-fail/;'
+        /usr/bin/earthly-buildkitd-wrapper.sh +test 2>&1 | perl -pe 'BEGIN {$status=1} END {exit $status} $status=0 if /this-will-fail/;'
 
 fail-push-test:
     COPY fail.earth ./Earthfile
     # test that an error code is correctly returned
     RUN --privileged \
         --mount=type=tmpfs,target=/tmp/earthly \
-        ! /usr/bin/earth-buildkitd-wrapper.sh --push +test-push
+        ! /usr/bin/earthly-buildkitd-wrapper.sh --push +test-push
     # test that the 'failed with exit code' text is printed out
     RUN --privileged \
         --mount=type=tmpfs,target=/tmp/earthly \
-        /usr/bin/earth-buildkitd-wrapper.sh --push +test-push 2>&1 | perl -pe 'BEGIN {$status=1} END {exit $status} $status=0 if /this-too-will-fail/;'
+        /usr/bin/earthly-buildkitd-wrapper.sh --push +test-push 2>&1 | perl -pe 'BEGIN {$status=1} END {exit $status} $status=0 if /this-too-will-fail/;'
     RUN echo hello world
 
 fail-invalid-artifact-test:
@@ -278,21 +278,21 @@ fail-invalid-artifact-test:
     COPY fail-invalid-artifact.earth ./Earthfile
     RUN --privileged \
         --mount=type=tmpfs,target=/tmp/earthly \
-        ! /usr/bin/earth-buildkitd-wrapper.sh --artifact +test/foo /tmp/stuff
+        ! /usr/bin/earthly-buildkitd-wrapper.sh --artifact +test/foo /tmp/stuff
     # test that we echo a message containing the invalid artifact name
     COPY fail-invalid-artifact.earth ./Earthfile
     RUN --privileged \
         --mount=type=tmpfs,target=/tmp/earthly \
-        /usr/bin/earth-buildkitd-wrapper.sh --artifact +test/foo /tmp/stuff 2>&1 | perl -pe 'BEGIN {$status=1} END {exit $status} $status=0 if /\+test\/foo/;'
+        /usr/bin/earthly-buildkitd-wrapper.sh --artifact +test/foo /tmp/stuff 2>&1 | perl -pe 'BEGIN {$status=1} END {exit $status} $status=0 if /\+test\/foo/;'
 
 push-test:
     COPY push.earth ./Earthfile
     RUN --privileged \
         --mount=type=tmpfs,target=/tmp/earthly \
-        /usr/bin/earth-buildkitd-wrapper.sh +push-test | grep 'Use earth --push to enable pushing'
+        /usr/bin/earthly-buildkitd-wrapper.sh +push-test | grep 'Use earthly --push to enable pushing'
     RUN --privileged \
         --mount=type=tmpfs,target=/tmp/earthly \
-        /usr/bin/earth-buildkitd-wrapper.sh --push +push-test | grep 'hello world'
+        /usr/bin/earthly-buildkitd-wrapper.sh --push +push-test | grep 'hello world'
 
 private-image-test:
     FROM earthly/private-test:latest
@@ -389,7 +389,7 @@ escape-dir-test:
 eine-test-base:
     FROM docker:19.03.12-dind
     RUN apk --update --no-cache add git
-    COPY ../..+earth/earth /usr/local/bin/
+    COPY ../..+earthly/earthly /usr/local/bin/
     ENV EARTHLY_BUILDKIT_IMAGE=earthly/buildkitd:dind-test
     WORKDIR /test
 
@@ -397,14 +397,14 @@ eine-config-test:
     FROM +eine-test-base
     COPY config.earth ./Earthfile
     WITH DOCKER --load earthly/buildkitd:dind-test=../../buildkitd+buildkitd
-        RUN earth +test
+        RUN earthly +test
     END
 
 eine-privileged-test:
     FROM +eine-test-base
     COPY privileged.earth ./Earthfile
     WITH DOCKER --load earthly/buildkitd:dind-test=../../buildkitd+buildkitd
-        RUN earth --allow-privileged +test
+        RUN earthly --allow-privileged +test
     END
 
 target-first-line:

--- a/examples/tests/autocompletion/Earthfile
+++ b/examples/tests/autocompletion/Earthfile
@@ -1,20 +1,20 @@
-FROM ../../..+earth-docker
+FROM ../../..+earthly-docker
 
 test-root-commands:
     RUN echo "./
 bootstrap 
 prune " > expected
-    RUN COMP_LINE="earth " COMP_POINT=6 earth > actual
+    RUN COMP_LINE="earthly " COMP_POINT=8 earthly > actual
     RUN diff expected actual
 
 test-targets:
     COPY fake.earth ./Earthfile
     RUN echo "+mytarget 
 +othertarget " > expected
-    RUN COMP_LINE="earth +" COMP_POINT=7 earth > actual
+    RUN COMP_LINE="earthly +" COMP_POINT=9 earthly > actual
     RUN diff expected actual
     RUN echo "+mytarget " > expected
-    RUN COMP_LINE="earth +m" COMP_POINT=8 earth > actual
+    RUN COMP_LINE="earthly +m" COMP_POINT=10 earthly > actual
     RUN diff expected actual
 
 test-relative-dir-targets:
@@ -22,11 +22,11 @@ test-relative-dir-targets:
     COPY fake.earth /test/foo/Earthfile
     WORKDIR /test/
     RUN echo "./foo+" > expected
-    RUN COMP_LINE="earth ./" COMP_POINT=8 earth > actual
+    RUN COMP_LINE="earthly ./" COMP_POINT=10 earthly > actual
     RUN diff expected actual
     RUN echo "./foo+mytarget 
 ./foo+othertarget " > expected
-    RUN COMP_LINE="earth ./foo+" COMP_POINT=12 earth > actual
+    RUN COMP_LINE="earthly ./foo+" COMP_POINT=14 earthly > actual
     RUN diff expected actual
 
 test-all:

--- a/examples/tests/docker2earth/test.sh
+++ b/examples/tests/docker2earth/test.sh
@@ -1,21 +1,21 @@
 #!/bin/bash
 set -eu
 
-earth=`pwd`/build/linux/amd64/earth
+earthly=`pwd`/build/linux/amd64/earthly
 dockerfiles="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 echo === Testing Dockerfile1 ===
 cd $(mktemp -d)
 echo "working out of $(pwd)"
 cp $dockerfiles/Dockerfile1 Dockerfile
-$earth docker2earth
-$earth +build
+$earthly docker2earth
+$earthly +build
 docker run --rm myimage:latest say-hi | grep hello
 
 echo === Testing Dockerfile2 ===
 cd $(mktemp -d)
 echo "working out of $(pwd)"
-cat $dockerfiles/Dockerfile2 | $earth docker2earth --dockerfile - --tag myotherimage:test
+cat $dockerfiles/Dockerfile2 | $earthly docker2earth --dockerfile - --tag myotherimage:test
 cp $dockerfiles/app.go .
-$earth +build
+$earthly +build
 docker run --rm myotherimage:test | grep greetings

--- a/release/Earthfile
+++ b/release/Earthfile
@@ -18,9 +18,9 @@ release-dockerhub:
     BUILD --build-arg DIND_ALPINE_TAG=alpine ../+dind-alpine
     BUILD --build-arg DIND_ALPINE_TAG=latest ../+dind-alpine
     BUILD --build-arg DIND_UBUNTU_TAG=ubuntu ../+dind-ubuntu
-    BUILD --build-arg TAG="$RELEASE_TAG" ../+earth-docker
+    BUILD --build-arg TAG="$RELEASE_TAG" ../+earthly-docker
     BUILD --build-arg TAG="$RELEASE_TAG" ../buildkitd+buildkitd
-    BUILD --build-arg TAG=latest ../+earth-docker
+    BUILD --build-arg TAG=latest ../+earthly-docker
     BUILD --build-arg TAG=latest ../buildkitd+buildkitd
 
 release-github:
@@ -31,13 +31,13 @@ release-github:
     ARG EARTHLY_GIT_HASH
     RUN test -n "$RELEASE_TAG" && test -n "$EARTHLY_GIT_HASH"
     COPY --build-arg VERSION=$RELEASE_TAG \
-        ../+earth-all/* ./release/
+        ../+earthly-all/* ./release/
     RUN ls ./release
-    RUN test -f ./release/earth-linux-amd64 && \
-        test -f ./release/earth-darwin-amd64 && \
-        test -f ./release/earth-linux-arm5 && \
-        test -f ./release/earth-linux-arm6 && \
-        test -f ./release/earth-linux-arm7
+    RUN test -f ./release/earthly-linux-amd64 && \
+        test -f ./release/earthly-darwin-amd64 && \
+        test -f ./release/earthly-linux-arm5 && \
+        test -f ./release/earthly-linux-arm6 && \
+        test -f ./release/earthly-linux-arm7
     ARG BODY="No details provided"
     RUN --secret GITHUB_TOKEN=+secrets/earthly-technologies/github/griswoldthecat/token test -n "$GITHUB_TOKEN"
     RUN --push \
@@ -106,7 +106,7 @@ release-homebrew:
     RUN mkdir -p /params
     RUN curl -L "$NEW_URL" | sha256sum | cut -f 1 -d ' ' > /params/downloadsha256
     COPY --build-arg VERSION=$RELEASE_TAG \
-        ../+earth-darwin/tags ../+earth-darwin/ldflags /params/
+        ../+earthly-darwin/tags ../+earthly-darwin/ldflags /params/
 
     # Split /params/ldflags over two lines (to satisfy ruby linter).
     RUN split --numeric-suffixes=1 --suffix-length=1 --bytes=80 /params/ldflags /params/ldflags && \

--- a/scripts/install-all-versions.sh
+++ b/scripts/install-all-versions.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 #
-# This script will install all released versions of earth under ~/bin/earth-v<X.Y.Z>
-# It is intended for earth developers who need to test against previous versions of earth
+# This script will install all released versions of earthly under ~/bin/earthly-v<X.Y.Z>
+# It is intended for earthly developers who need to test against previous versions of earthly
 # (e.g. making sure a new change doesn't break older versions, or testing out bug reports
 # against older versions).
 set -e
 
-release_name="earth-linux-amd64"
+release_name="earthly-linux-amd64"
 if [ "$(uname)" == "Darwin" ]; then
-    release_name="earth-darwin-amd64"
+    release_name="earthly-darwin-amd64"
 fi
 
 curl -s -L "https://api.github.com/repos/earthly/earthly/releases" > "/tmp/releases.1"
@@ -31,7 +31,7 @@ for row in $releases; do
     pattern="$version/$release_name"
     url=$(echo "$row" | base64 -d | jq -r '.assets' | jq -r '.[] | [.browser_download_url] | @csv' | grep "$pattern" | jq -r .)
 
-    outfile="$HOME/bin/earth-$version"
+    outfile="$HOME/bin/earthly-$version"
     if [ ! -f "$outfile" ]; then
         wget "$url" -O "$outfile"
         chmod +x "$outfile"

--- a/scripts/tests/private-repo.sh
+++ b/scripts/tests/private-repo.sh
@@ -1,19 +1,19 @@
 #!/usr/bin/env bash
 set -eu # don't use -x as it will leak the private key
 
-earth=${earth:=earth}
-echo "running tests with $earth"
+earthly=${earthly:=earthly}
+echo "running tests with $earthly"
 
-# prevent the self-update of earth from running (this ensures no bogus data is printed to stdout,
+# prevent the self-update of earthly from running (this ensures no bogus data is printed to stdout,
 # which would mess with the secrets data being fetched)
-date +%s > /tmp/last-earth-prerelease-check
+date +%s > /tmp/last-earthly-prerelease-check
 
 # ensure earthly login works (and print out who gets logged in)
-$earth account login
+$earthly account login
 
 # fetch shared secret key (this step assumes your personal user has access to the /earthly-technologies/ secrets org
-ID_RSA=$($earth secrets get -n /earthly-technologies/github/other-service+github-cinnamon@earthly.dev/id_rsa)
-GITHUB_PASSWORD=$($earth secrets get -n /earthly-technologies/github/other-service+github-cinnamon@earthly.dev/password)
+ID_RSA=$($earthly secrets get -n /earthly-technologies/github/other-service+github-cinnamon@earthly.dev/id_rsa)
+GITHUB_PASSWORD=$($earthly secrets get -n /earthly-technologies/github/other-service+github-cinnamon@earthly.dev/password)
 
 # now that we grabbed the cinnamonthecat credentials, unset our token, to ensure that we're only testing using cinnamonthecat's credentials
 unset EARTHLY_TOKEN
@@ -39,13 +39,13 @@ ssh git@github.com 2>&1 | perl -pe 'BEGIN {$status=1} END {exit $status} $status
 # Test a private repo can be cloned
 echo === Test 1 ===
 docker image rm -f test-private:latest
-$earth -VD github.com/cinnamonthecat/test-private:main+docker
+$earthly -VD github.com/cinnamonthecat/test-private:main+docker
 docker run --rm test-private:latest | grep "Salut Lume"
 
 # Test public repo can be cloned without ssh, when GIT_URL_INSTEAD_OF is set as recommended by our CI docs
 echo === Test 2 ===
 docker image rm -f cpp-example:latest
-SSH_AUTH_SOCK="" GIT_URL_INSTEAD_OF="https://github.com/=git@github.com:" $earth -VD github.com/earthly/earthly/examples/cpp:main+docker
+SSH_AUTH_SOCK="" GIT_URL_INSTEAD_OF="https://github.com/=git@github.com:" $earthly -VD github.com/earthly/earthly/examples/cpp:main+docker
 docker run --rm cpp-example:latest | grep fib
 
 # Test a private repo can be cloned using https
@@ -61,14 +61,14 @@ EOF
 cat /tmp/earthconfig.https
 
 docker image rm -f other-test-private:latest
-SSH_AUTH_SOCK="" $earth -VD --config /tmp/earthconfig.https github.com/cinnamonthecat/other-test-private:main+docker
+SSH_AUTH_SOCK="" $earthly -VD --config /tmp/earthconfig.https github.com/cinnamonthecat/other-test-private:main+docker
 docker run --rm other-test-private:latest | grep "Salut le monde"
 
 # Test a private repo can be cloned using https, as setup via args
 echo === Test 4 ===
 
 docker image rm -f other-test-private:latest
-SSH_AUTH_SOCK="" $earth -VD --git-username=cinnamonthecat --git-password="$GITHUB_PASSWORD" github.com/cinnamonthecat/another-test-private:main+docker
+SSH_AUTH_SOCK="" $earthly -VD --git-username=cinnamonthecat --git-password="$GITHUB_PASSWORD" github.com/cinnamonthecat/another-test-private:main+docker
 docker run --rm another-test-private:latest | grep "Hola Mundo"
 
 

--- a/scripts/tests/self-hosted-private-repo.sh
+++ b/scripts/tests/self-hosted-private-repo.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 set -eu
 
-earth=${earth:=earth}
-earth=$(realpath $earth)
-echo "running tests with $earth"
+earthly=${earthly:=earthly}
+earthly=$(realpath $earthly)
+echo "running tests with $earthly"
 
 # use host IP, otherwise earthly-buildkit won't be able to connect to it
 ip=$(ifconfig eth0 | grep -w 'inet' | awk '{print $2}')
@@ -76,7 +76,7 @@ git:
     auth: ssh
 EOF
 
-if ! $earth myserver/project:trunk+docker; then
+if ! $earthly myserver/project:trunk+docker; then
     docker ps -a
     docker logs earthly-buildkitd
     exit 1

--- a/states/states.go
+++ b/states/states.go
@@ -8,7 +8,7 @@ import (
 	"github.com/moby/buildkit/client/llb"
 )
 
-// MultiTarget holds LLB states representing multiple earth targets,
+// MultiTarget holds LLB states representing multiple earthly targets,
 // in the order in which they should be built.
 type MultiTarget struct {
 	// Visited represents the previously visited states, grouped by target
@@ -29,7 +29,7 @@ func (mts *MultiTarget) All() []*SingleTarget {
 	return mts.Visited.VisitedList
 }
 
-// SingleTarget holds LLB states representing a earth target.
+// SingleTarget holds LLB states representing an earthly target.
 type SingleTarget struct {
 	Target                 domain.Target
 	TargetInput            dedup.TargetInput


### PR DESCRIPTION
 - when a user installs via brew, they type `brew install earthly`, so one would expect to find a command named `earthly` rather than `earth`
 - this git repo is located at `github.com/earthly/earthly.git` and not `github.com/earthly/earth.git`
 - Googling for `earthly` manages to find our documentation, where as the search-space for `earth` is much more crowded
 - `earth` easily tabs completes into `earthly`