### PR TITLE
Symlink earth to earthly during bootstrap

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -32,7 +32,7 @@ code:
     FROM +deps
     COPY ./earthfile2llb/parser+parser/*.go ./earthfile2llb/parser/
     COPY --dir analytics autocomplete buildcontext builder cleanup cmd config conslogging debugger dockertar \
-        docker2earthly domain fileutils llbutil logging secretsclient stringutil states variables ./
+        docker2earthly domain fileutils llbutil logging secretsclient stringutil states termutil variables ./
     COPY --dir buildkitd/buildkitd.go buildkitd/settings.go buildkitd/
     COPY --dir earthfile2llb/antlrhandler earthfile2llb/*.go earthfile2llb/
 

--- a/termutil/is_tty.go
+++ b/termutil/is_tty.go
@@ -1,0 +1,11 @@
+package termutil
+
+import "os"
+
+// IsTTY returns true if a terminal is detected
+func IsTTY() bool {
+	if fileInfo, _ := os.Stdout.Stat(); (fileInfo.Mode() & os.ModeCharDevice) != 0 {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
- if earth exists, delete it and symlink it to new earthly install

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>