### PR TITLE
Remove GIT_INSTEAD_OF now that auto mode is supported

### DIFF
--- a/.buildkite/windows.yml
+++ b/.buildkite/windows.yml
@@ -5,7 +5,6 @@ steps:
       - ./.buildkite/tests.sh
     env:
       EARTHLY_BUILD_ARGS: "DOCKERHUB_USER_SECRET=+secrets/earthly-technologies/dockerhub/user,DOCKERHUB_TOKEN_SECRET=+secrets/earthly-technologies/dockerhub/token"
-      GIT_URL_INSTEAD_OF: "https://github.com/=git@github.com:"
       FORCE_COLOR: 1
       EARTH_OS: linux
       EARTHLY_CONFIG: "./.buildkite/earthly-config-win.yml"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,6 @@ jobs:
     machine:
       image: ubuntu-1604:201903-01
     environment:
-      - GIT_URL_INSTEAD_OF: "https://github.com/=git@github.com:"
       - EARTHLY_BUILD_ARGS: "DOCKERHUB_USER_SECRET=+secrets/earthly-technologies/dockerhub/user,DOCKERHUB_TOKEN_SECRET=+secrets/earthly-technologies/dockerhub/token"
     steps:
       - checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ jobs:
     name: +test +test-fail
     runs-on: ubuntu-latest
     env:
-      GIT_URL_INSTEAD_OF: "https://github.com/=git@github.com:"
       FORCE_COLOR: 1
       EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"
     steps:
@@ -41,7 +40,6 @@ jobs:
     name: Misc tests
     runs-on: ubuntu-latest
     env:
-      GIT_URL_INSTEAD_OF: "https://github.com/=git@github.com:"
       FORCE_COLOR: 1
       EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"
     steps:
@@ -82,7 +80,6 @@ jobs:
     name: +examples
     runs-on: ubuntu-latest
     env:
-      GIT_URL_INSTEAD_OF: "https://github.com/=git@github.com:"
       FORCE_COLOR: 1
       EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"
     steps:
@@ -112,7 +109,6 @@ jobs:
     name: secrets-integration
     runs-on: ubuntu-latest
     env:
-      GIT_URL_INSTEAD_OF: "https://github.com/=git@github.com:"
       FORCE_COLOR: 1
       EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"
     steps:
@@ -125,7 +121,7 @@ jobs:
       - name: Build latest earthly using released earthly
         run: earthly --use-inline-cache +for-linux
       - name: run ssh-based tests
-        run: env -u GIT_URL_INSTEAD_OF earthly=./build/linux/amd64/earthly scripts/tests/private-repo.sh
+        run: env earthly=./build/linux/amd64/earthly scripts/tests/private-repo.sh
       - name: Buildkit logs (runs on failure)
         run: docker logs earthly-buildkitd
         if: ${{ failure() }}
@@ -139,7 +135,6 @@ jobs:
     name: private repo test
     runs-on: ubuntu-latest
     env:
-      GIT_URL_INSTEAD_OF: "https://github.com/=git@github.com:"
       FORCE_COLOR: 1
       EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"
       SSH_PORT: "2222"
@@ -154,7 +149,7 @@ jobs:
       - name: Build latest earthly using released earthly
         run: earthly --use-inline-cache +for-linux
       - name: run ssh-based tests
-        run: env -u GIT_URL_INSTEAD_OF earthly=./build/linux/amd64/earthly scripts/tests/self-hosted-private-repo.sh
+        run: env earthly=./build/linux/amd64/earthly scripts/tests/self-hosted-private-repo.sh
       - name: Buildkit logs (runs on failure)
         run: docker logs earthly-buildkitd
         if: ${{ failure() }}
@@ -165,7 +160,6 @@ jobs:
     needs: ["tests", "misc-tests", "examples"]
     runs-on: ubuntu-latest
     env:
-      GIT_URL_INSTEAD_OF: "https://github.com/=git@github.com:"
       FORCE_COLOR: 1
       EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"
     steps:

--- a/go.sum
+++ b/go.sum
@@ -306,6 +306,7 @@ github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
 github.com/earthly/buildkit v0.7.1-0.20201204211015-b5787f368c39 h1:ZXiKOR6RaXuPHF2MXWiMSqqxT1+JsVFwtOYk50Y3Zi4=
 github.com/earthly/buildkit v0.7.1-0.20201204211015-b5787f368c39/go.mod h1:/kyU1hKy/aYCuP39GZA9MaKioovHku57N6cqlKZIaiQ=
+github.com/earthly/buildkit v0.7.1-0.20201215191153-a070b6efa62d h1:SkbXmynbji+082vwCziF21i9QTukMNSnxq3r69k4a8k=
 github.com/earthly/buildkit v0.7.1-0.20201215191153-a070b6efa62d/go.mod h1:bKMxvrnFTubnm4FL9lT8Nhz1JwYeJPEuYKN/sr7z+KA=
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=


### PR DESCRIPTION
- rather than rely on GIT_INSTEAD_OF to switch from ssh to https, we can
make use of earthly's auto mode which detects to use https when no keys
are present.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>