### PR TITLE
Update auth guide to remove git-instead-of

### DIFF
--- a/docs/earthly-command/earthly-command.md
+++ b/docs/earthly-command/earthly-command.md
@@ -204,11 +204,12 @@ Also available as an env var setting: `GIT_PASSWORD=<git-pass>`.
 
 This option is now deprecated. Please use the [configuration file](../earthly-config/earthly-config.md) instead.
 
-##### `--git-url-instead-of <git-instead-of>` (deprecated)
+##### `--git-url-instead-of <git-instead-of>` (obsolete)
 
-Also available as an env var setting: `GIT_URL_INSTEAD_OF=<git-instead-of>`.
+Also used to be available as an env var setting: `GIT_URL_INSTEAD_OF=<git-instead-of>`.
 
-This option is now deprecated. Please use the [configuration file](../earthly-config/earthly-config.md) instead.
+This option is now obsolete. By default, `earthly` will automatically switch from ssh to https when no keys are found or the ssh-agent isn't running.
+Please use the [configuration file](../earthly-config/earthly-config.md) to override the default behavior.
 
 ##### `--interactive|-i` (**beta**)
 

--- a/docs/earthly-config/earthly-config.md
+++ b/docs/earthly-config/earthly-config.md
@@ -85,8 +85,10 @@ The git repository hostname. For example `github.com`, or `gitlab.com`
 
 #### auth
 
-Either `https` or `ssh` (default). If https is specified, user and password fields are used
-to authenticate over https when pulling from git for the corresponding site.
+Either `ssh`, `https`, or `auto` (default). If https is specified, user and password fields are used
+to authenticate over https when pulling from git for the corresponding site. If `auto` is specified
+earthly will use `ssh` when the ssh-agent is running and has at least one key loaded, and will fallback
+to using `https` when no ssh-keys are present.
 
 See the [Authentication guide](../guides/auth.md) for a guide on setting up authentication.
 

--- a/docs/earthly-config/earthly-config.md
+++ b/docs/earthly-config/earthly-config.md
@@ -57,25 +57,7 @@ This option is obsolete and it is ignored. Earthly cache has moved to a Docker v
 
 ## Git configuration reference
 
-The git configuration is split up into global config options, or site-specific options.
-
-### global options
-
-The global git options.
-
-#### url_instead_of
-
-Rewrites git URLs of a certain pattern. Similar to [`git-config url.<base>.insteadOf`](https://git-scm.com/docs/git-config#Documentation/git-config.txt-urlltbasegtinsteadOf).
-Multiple values can be separated by commas. Format: `<base>=<instead-of>[,...]`.
-
-This setting allows rewriting all git URLs of the form `https://example...` into `git@example.com:...`, or vice-versa.
-
-For example:
-
-* `--git-url-instead-of='git@example.com:=https://example.com/'` forces use of SSH-based URLs rather than HTTPS
-* `--git-url-instead-of='https://localmirror.example.com/=git@example.com:'` forces use of HTTPS-based local mirror for ssh-based example.com repositories
-
-NOTE: if the `auth` option is configured under a site-specific configuration, then the appropriate rewriting rule will be automatically applied.
+All git configuration is contained under site-specific options.
 
 ### site-specific options
 
@@ -85,7 +67,7 @@ The git repository hostname. For example `github.com`, or `gitlab.com`
 
 #### auth
 
-Either `ssh`, `https`, or `auto` (default). If https is specified, user and password fields are used
+Either `ssh`, `https`, or `auto` (default). If `https` is specified, user and password fields are used
 to authenticate over https when pulling from git for the corresponding site. If `auto` is specified
 earthly will use `ssh` when the ssh-agent is running and has at least one key loaded, and will fallback
 to using `https` when no ssh-keys are present.
@@ -99,3 +81,20 @@ The https username to use when auth is set to `https`. This setting is ignored w
 #### password
 
 The https password to use when auth is set to `https`. This setting is ignored when auth is `ssh`.
+
+#### pattern
+
+A regular expression defined to match git urls, defaults to the `<site>/([^/]+)/([^/]+)`. For example if the site is `github.com`, then the default pattern will
+match which match `github.com/<user>/<repo>`.
+
+See the [Authentication guide](../guides/auth.md) for a guide on setting up authentication with self-hosted git repositories.
+
+See the [RE2 docs](https://github.com/google/re2/wiki/Syntax) for a complete definition of the supported regular expression syntax.
+
+
+#### substitute
+
+If specified, a regular expression substitution will be preformed to determine which URL is cloned by git. Values like `$1`, `$2`, ... will be replaced
+with matched subgroup data. If no substitute is given, a URL will be created based on the requested SSH authentication mode.
+
+See the [Authentication guide](../guides/auth.md) for a guide on setting up authentication with self-hosted git repositories.

--- a/docs/earthly-config/earthly-config.md
+++ b/docs/earthly-config/earthly-config.md
@@ -85,7 +85,7 @@ The https password to use when auth is set to `https`. This setting is ignored w
 #### pattern
 
 A regular expression defined to match git URLs, defaults to the `<site>/([^/]+)/([^/]+)`. For example if the site is `github.com`, then the default pattern will
-match which match `github.com/<user>/<repo>`.
+match `github.com/<user>/<repo>`.
 
 See the [Authentication guide](../guides/auth.md) for a guide on setting up authentication with self-hosted git repositories.
 

--- a/docs/earthly-config/earthly-config.md
+++ b/docs/earthly-config/earthly-config.md
@@ -84,7 +84,7 @@ The https password to use when auth is set to `https`. This setting is ignored w
 
 #### pattern
 
-A regular expression defined to match git urls, defaults to the `<site>/([^/]+)/([^/]+)`. For example if the site is `github.com`, then the default pattern will
+A regular expression defined to match git URLs, defaults to the `<site>/([^/]+)/([^/]+)`. For example if the site is `github.com`, then the default pattern will
 match which match `github.com/<user>/<repo>`.
 
 See the [Authentication guide](../guides/auth.md) for a guide on setting up authentication with self-hosted git repositories.

--- a/docs/examples/circle-integration.md
+++ b/docs/examples/circle-integration.md
@@ -11,8 +11,6 @@ jobs:
   build:
     machine:
       image: ubuntu-1604:201903-01
-    environment:
-      - GIT_URL_INSTEAD_OF: "https://github.com/=git@github.com:"
     steps:
       - checkout
       - run: docker login --username "$DOCKERHUB_USERNAME" --password "$DOCKERHUB_TOKEN"

--- a/docs/examples/codebuild-integration.md
+++ b/docs/examples/codebuild-integration.md
@@ -15,10 +15,6 @@ in order to allow Earthly build Docker images.
 # ./buildspec.yml
 version: 0.2
 
-env:
-  variables:
-    GIT_URL_INSTEAD_OF: "https://github.com/=git@github.com:"
-
 phases:
   install:
     commands:

--- a/docs/examples/gh-actions-integration.md
+++ b/docs/examples/gh-actions-integration.md
@@ -20,7 +20,6 @@ jobs:
     env:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-      GIT_URL_INSTEAD_OF: "https://github.com/=git@github.com:"
       FORCE_COLOR: 1
     steps:
     - uses: actions/checkout@v2

--- a/docs/guides/auth.md
+++ b/docs/guides/auth.md
@@ -15,12 +15,6 @@ A number of Earthly features use Git credentials to perform remote Git operation
 * Resolving a build context when referencing remote targets
 * The `GIT CLONE` command
 
-{% hint style='info' %}
-##### Note
-
-Currently, only `github.com`, and `gitlab.com` have been tested as SCM providers. If you need support for others, please [open a new GitHub issue](https://github.com/earthly/earthly/issues/new).
-{% endhint %}
-
 There are two possible ways to pass Git authentication to Earthly builds:
 
 * Via SSH agent socket (for SSH-based authentication)
@@ -34,7 +28,9 @@ If you need to override the SSH agent socket, you can set the environment variab
 
 In order for the SSH agent to have the right credentials available, make sure you run `ssh-add` before executing Earthly builds.
 
-Another key setting is the `auth` mode for the git site that hosts the repository. By default `github.com` and `gitlab.com` automatically default to `ssh` authentication, making SSH-based authentication work out of the box. Other sites will have to be explicitly added to the [earthly config file](../earthly-config/earthly-config.md) under the git section:
+Another key setting is the `auth` mode for the git site that hosts the repository. By default earthly automatically default to `ssh` authentication if the ssh auth agent is running and has at least 1 key loaded, otherwise `earthly` will fallback to using non-authenticated https.
+
+Sites can be explicitly added to the [earthly config file](../earthly-config/earthly-config.md) under the git section in order to override the auto-authentication mode:
 
 ```yaml
 git:
@@ -64,6 +60,19 @@ Alternatively, environment variables can be set which will be override all host 
 * `GIT_PASSWORD`
 
 However, environment variable authentication are now deprecated in favor of using the configuration file instead.
+
+#### Self-hosted and private Git Repositories
+
+Currently, `github.com`, `gitlab.com`, and `bitbucket.org` have been tested as SCM providers; we have experimental support for self-hosted git repositories
+such as github enterprise which will need to be configured using a regular expression:
+
+```yaml
+git:
+    ghe.internal.mycompany.com:
+        pattern: 'ghe.internal.mycompany.com/([^/]+)/([^/]+)'
+        substitute: 'ssh://git@ghe.internal.mycompany.com:22/\$1/\$2.git'
+        auth: ssh
+```
 
 ## Docker authentication
 

--- a/docs/guides/ci-integration.md
+++ b/docs/guides/ci-integration.md
@@ -41,13 +41,7 @@ In certain CI environments, such as Jenkins, where you have access to the host, 
 
 Depending on your needs, you may need to ensure that Git has authenticated access and / or that Docker is logged in so that it has access to private repositories.
 
-To authenticate Git, you may either use SSH-based authentication, or username-password-based authentication. See the [Authentication page for more information](./auth.md). In case you don't need any Git authentication, you might want to force all GitHub URLs to be transformed to `https://github.com/...` instead of `git@github.com:...`. For this, you can add an environment variable to configure this behavior:
-
-```bash
-export GIT_URL_INSTEAD_OF="https://github.com/=git@github.com:"
-```
-
-The way you configure environment variables in your CI will vary.
+To authenticate Git, you may either use SSH-based authentication, or username-password-based authentication. See the [Authentication page for more information](./auth.md). If no authentication is configured, `earthly` will fall back to using public https access.
 
 To log in Docker, simply run
 


### PR DESCRIPTION
- git-instead-of is no longer required for CI setups
- document experimental setup of self-hosted git repos

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>