### PR TITLE
Flatten out file metadata as much as possible

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -101,7 +101,6 @@ debugger:
 
 earthly:
     FROM +code
-    RUN echo "@#@#@#@#@#@ ====================================> $(ls -l go.sum)"
     ARG GOOS=linux
     ARG GOARCH=amd64
     ARG GOARM

--- a/Earthfile
+++ b/Earthfile
@@ -101,6 +101,7 @@ debugger:
 
 earthly:
     FROM +code
+    RUN echo "@#@#@#@#@#@ ====================================> $(ls -l go.sum)"
     ARG GOOS=linux
     ARG GOARCH=amd64
     ARG GOARM

--- a/buildcontext/git.go
+++ b/buildcontext/git.go
@@ -60,7 +60,7 @@ func (gr *gitResolver) resolveEarthProject(ctx context.Context, gwClient gwclien
 	} else {
 		buildContext = llb.Scratch().Platform(llbutil.TargetPlatform)
 		buildContext = llbutil.CopyOp(
-			rgp.state, []string{subDir}, buildContext, "./", false, false, "",
+			rgp.state, []string{subDir}, buildContext, "./", false, false, false, "",
 			llb.WithCustomNamef("[internal] COPY git context %s", target.String()))
 	}
 

--- a/buildcontext/git.go
+++ b/buildcontext/git.go
@@ -60,7 +60,7 @@ func (gr *gitResolver) resolveEarthProject(ctx context.Context, gwClient gwclien
 	} else {
 		buildContext = llb.Scratch().Platform(llbutil.TargetPlatform)
 		buildContext = llbutil.CopyOp(
-			rgp.state, []string{subDir}, buildContext, "./", false, false, false, "",
+			rgp.state, []string{subDir}, buildContext, "./", false, false, false, "root:root",
 			llb.WithCustomNamef("[internal] COPY git context %s", target.String()))
 	}
 

--- a/buildcontext/local.go
+++ b/buildcontext/local.go
@@ -56,7 +56,6 @@ func (lr *localResolver) resolveLocal(ctx context.Context, target domain.Target)
 		BuildFilePath: buildFilePath,
 		BuildContext: llb.Local(
 			target.LocalPath,
-			llb.SharedKeyHint(target.LocalPath),
 			llb.ExcludePatterns(excludes),
 			llb.SessionID(lr.sessionID),
 			llb.Platform(llbutil.TargetPlatform),

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -164,7 +164,7 @@ func (c *Converter) FromDockerfile(ctx context.Context, contextPath string, dfPa
 		buildContext = llb.Scratch().Platform(llbutil.TargetPlatform)
 		buildContext = llbutil.CopyOp(
 			mts.Final.ArtifactsState, []string{contextArtifact.Artifact},
-			buildContext, "/", true, true, "",
+			buildContext, "/", true, true, false, "",
 			llb.WithCustomNamef(
 				"[internal] FROM DOCKERFILE (copy build context from) %s%s",
 				joinWrap(buildArgs, "(", " ", ") "), contextArtifact.String()))
@@ -236,7 +236,7 @@ func (c *Converter) FromDockerfile(ctx context.Context, contextPath string, dfPa
 }
 
 // CopyArtifact applies the earthly COPY artifact command.
-func (c *Converter) CopyArtifact(ctx context.Context, artifactName string, dest string, buildArgs []string, isDir bool, chown string) error {
+func (c *Converter) CopyArtifact(ctx context.Context, artifactName string, dest string, buildArgs []string, isDir bool, keepTs bool, chown string) error {
 	c.nonSaveCommand()
 	artifact, err := domain.ParseArtifact(artifactName)
 	if err != nil {
@@ -254,7 +254,7 @@ func (c *Converter) CopyArtifact(ctx context.Context, artifactName string, dest 
 	// Copy.
 	c.mts.Final.MainState = llbutil.CopyOp(
 		relevantDepState.ArtifactsState, []string{artifact.Artifact},
-		c.mts.Final.MainState, dest, true, isDir, chown,
+		c.mts.Final.MainState, dest, true, isDir, keepTs, chown,
 		llb.WithCustomNamef(
 			"%sCOPY %s%s%s %s",
 			c.vertexPrefix(),
@@ -266,10 +266,10 @@ func (c *Converter) CopyArtifact(ctx context.Context, artifactName string, dest 
 }
 
 // CopyClassical applies the earthly COPY command, with classical args.
-func (c *Converter) CopyClassical(ctx context.Context, srcs []string, dest string, isDir bool, chown string) {
+func (c *Converter) CopyClassical(ctx context.Context, srcs []string, dest string, isDir bool, keepTs bool, chown string) {
 	c.nonSaveCommand()
 	c.mts.Final.MainState = llbutil.CopyOp(
-		c.buildContext, srcs, c.mts.Final.MainState, dest, true, isDir, chown,
+		c.buildContext, srcs, c.mts.Final.MainState, dest, true, isDir, keepTs, chown,
 		llb.WithCustomNamef(
 			"%sCOPY %s%s %s",
 			c.vertexPrefix(),
@@ -317,7 +317,7 @@ func (c *Converter) Run(ctx context.Context, args []string, mounts []string, sec
 }
 
 // SaveArtifact applies the earthly SAVE ARTIFACT command.
-func (c *Converter) SaveArtifact(ctx context.Context, saveFrom string, saveTo string, saveAsLocalTo string) error {
+func (c *Converter) SaveArtifact(ctx context.Context, saveFrom string, saveTo string, saveAsLocalTo string, keepTs bool) error {
 	saveToAdjusted := saveTo
 	if saveTo == "" || saveTo == "." || strings.HasSuffix(saveTo, "/") {
 		absSaveFrom, err := llbutil.Abs(ctx, c.mts.Final.MainState, saveFrom)
@@ -341,14 +341,14 @@ func (c *Converter) SaveArtifact(ctx context.Context, saveFrom string, saveTo st
 	}
 	c.mts.Final.ArtifactsState = llbutil.CopyOp(
 		c.mts.Final.MainState, []string{saveFrom}, c.mts.Final.ArtifactsState,
-		saveToAdjusted, true, true, "",
+		saveToAdjusted, true, true, keepTs, "",
 		llb.WithCustomNamef(
 			"%sSAVE ARTIFACT %s %s", c.vertexPrefix(), saveFrom, artifact.String()))
 	if saveAsLocalTo != "" {
 		separateArtifactsState := llb.Scratch().Platform(llbutil.TargetPlatform)
 		separateArtifactsState = llbutil.CopyOp(
 			c.mts.Final.MainState, []string{saveFrom}, separateArtifactsState,
-			saveToAdjusted, true, false, "",
+			saveToAdjusted, true, false, keepTs, "",
 			llb.WithCustomNamef(
 				"%sSAVE ARTIFACT %s %s AS LOCAL %s",
 				c.vertexPrefix(), saveFrom, artifact.String(), saveAsLocalTo))
@@ -487,7 +487,7 @@ func (c *Converter) Label(ctx context.Context, labels map[string]string) {
 }
 
 // GitClone applies the GIT CLONE command.
-func (c *Converter) GitClone(ctx context.Context, gitURL string, branch string, dest string) error {
+func (c *Converter) GitClone(ctx context.Context, gitURL string, branch string, dest string, keepTs bool) error {
 	c.nonSaveCommand()
 	gitOpts := []llb.GitOption{
 		llb.WithCustomNamef(
@@ -496,7 +496,7 @@ func (c *Converter) GitClone(ctx context.Context, gitURL string, branch string, 
 	}
 	gitState := llb.Git(gitURL, branch, gitOpts...)
 	c.mts.Final.MainState = llbutil.CopyOp(
-		gitState, []string{"."}, c.mts.Final.MainState, dest, false, false, "",
+		gitState, []string{"."}, c.mts.Final.MainState, dest, false, false, keepTs, "",
 		llb.WithCustomNamef(
 			"%sCOPY GIT CLONE (--branch %s) %s TO %s", c.vertexPrefix(),
 			branch, gitURL, dest))
@@ -803,7 +803,7 @@ func (c *Converter) processNonConstantBuildArgFunc(ctx context.Context) variable
 		buildArgState := llb.Scratch().Platform(llbutil.TargetPlatform)
 		buildArgState = llbutil.CopyOp(
 			c.mts.Final.MainState, []string{srcBuildArgPath},
-			buildArgState, buildArgPath, false, false, "",
+			buildArgState, buildArgPath, false, false, false, "",
 			llb.WithCustomNamef("[internal] copy buildarg %s", name))
 		// Store the state with the expression result for later use.
 		argIndex := c.nextArgIndex

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -236,7 +236,7 @@ func (c *Converter) FromDockerfile(ctx context.Context, contextPath string, dfPa
 }
 
 // CopyArtifact applies the earthly COPY artifact command.
-func (c *Converter) CopyArtifact(ctx context.Context, artifactName string, dest string, buildArgs []string, isDir bool, keepTs bool, chown string) error {
+func (c *Converter) CopyArtifact(ctx context.Context, artifactName string, dest string, buildArgs []string, isDir bool, keepTs bool, keepOwn bool, chown string) error {
 	c.nonSaveCommand()
 	artifact, err := domain.ParseArtifact(artifactName)
 	if err != nil {
@@ -254,7 +254,7 @@ func (c *Converter) CopyArtifact(ctx context.Context, artifactName string, dest 
 	// Copy.
 	c.mts.Final.MainState = llbutil.CopyOp(
 		relevantDepState.ArtifactsState, []string{artifact.Artifact},
-		c.mts.Final.MainState, dest, true, isDir, keepTs, chown,
+		c.mts.Final.MainState, dest, true, isDir, keepTs, c.copyOwner(keepOwn, chown),
 		llb.WithCustomNamef(
 			"%sCOPY %s%s%s %s",
 			c.vertexPrefix(),
@@ -266,10 +266,10 @@ func (c *Converter) CopyArtifact(ctx context.Context, artifactName string, dest 
 }
 
 // CopyClassical applies the earthly COPY command, with classical args.
-func (c *Converter) CopyClassical(ctx context.Context, srcs []string, dest string, isDir bool, keepTs bool, chown string) {
+func (c *Converter) CopyClassical(ctx context.Context, srcs []string, dest string, isDir bool, keepTs bool, keepOwn bool, chown string) {
 	c.nonSaveCommand()
 	c.mts.Final.MainState = llbutil.CopyOp(
-		c.buildContext, srcs, c.mts.Final.MainState, dest, true, isDir, keepTs, chown,
+		c.buildContext, srcs, c.mts.Final.MainState, dest, true, isDir, keepTs, c.copyOwner(keepOwn, chown),
 		llb.WithCustomNamef(
 			"%sCOPY %s%s %s",
 			c.vertexPrefix(),
@@ -317,7 +317,7 @@ func (c *Converter) Run(ctx context.Context, args []string, mounts []string, sec
 }
 
 // SaveArtifact applies the earthly SAVE ARTIFACT command.
-func (c *Converter) SaveArtifact(ctx context.Context, saveFrom string, saveTo string, saveAsLocalTo string, keepTs bool) error {
+func (c *Converter) SaveArtifact(ctx context.Context, saveFrom string, saveTo string, saveAsLocalTo string, keepTs bool, keepOwn bool) error {
 	saveToAdjusted := saveTo
 	if saveTo == "" || saveTo == "." || strings.HasSuffix(saveTo, "/") {
 		absSaveFrom, err := llbutil.Abs(ctx, c.mts.Final.MainState, saveFrom)
@@ -339,16 +339,20 @@ func (c *Converter) SaveArtifact(ctx context.Context, saveFrom string, saveTo st
 		Target:   c.mts.Final.Target,
 		Artifact: artifactPath,
 	}
+	own := "root:root"
+	if keepOwn {
+		own = ""
+	}
 	c.mts.Final.ArtifactsState = llbutil.CopyOp(
 		c.mts.Final.MainState, []string{saveFrom}, c.mts.Final.ArtifactsState,
-		saveToAdjusted, true, true, keepTs, "",
+		saveToAdjusted, true, true, keepTs, own,
 		llb.WithCustomNamef(
 			"%sSAVE ARTIFACT %s %s", c.vertexPrefix(), saveFrom, artifact.String()))
 	if saveAsLocalTo != "" {
 		separateArtifactsState := llb.Scratch().Platform(llbutil.TargetPlatform)
 		separateArtifactsState = llbutil.CopyOp(
 			c.mts.Final.MainState, []string{saveFrom}, separateArtifactsState,
-			saveToAdjusted, true, false, keepTs, "",
+			saveToAdjusted, true, false, keepTs, "root:root",
 			llb.WithCustomNamef(
 				"%sSAVE ARTIFACT %s %s AS LOCAL %s",
 				c.vertexPrefix(), saveFrom, artifact.String(), saveAsLocalTo))
@@ -496,7 +500,8 @@ func (c *Converter) GitClone(ctx context.Context, gitURL string, branch string, 
 	}
 	gitState := llb.Git(gitURL, branch, gitOpts...)
 	c.mts.Final.MainState = llbutil.CopyOp(
-		gitState, []string{"."}, c.mts.Final.MainState, dest, false, false, keepTs, "",
+		gitState, []string{"."}, c.mts.Final.MainState, dest, false, false, keepTs,
+		c.mts.Final.MainImage.Config.User,
 		llb.WithCustomNamef(
 			"%sCOPY GIT CLONE (--branch %s) %s TO %s", c.vertexPrefix(),
 			branch, gitURL, dest))
@@ -803,7 +808,7 @@ func (c *Converter) processNonConstantBuildArgFunc(ctx context.Context) variable
 		buildArgState := llb.Scratch().Platform(llbutil.TargetPlatform)
 		buildArgState = llbutil.CopyOp(
 			c.mts.Final.MainState, []string{srcBuildArgPath},
-			buildArgState, buildArgPath, false, false, false, "",
+			buildArgState, buildArgPath, false, false, false, "root:root",
 			llb.WithCustomNamef("[internal] copy buildarg %s", name))
 		// Store the state with the expression result for later use.
 		argIndex := c.nextArgIndex
@@ -896,4 +901,18 @@ func strIf(condition bool, str string) string {
 		return str
 	}
 	return ""
+}
+
+func (c *Converter) copyOwner(keepOwn bool, chown string) string {
+	own := c.mts.Final.MainImage.Config.User
+	if own == "" {
+		own = "root:root"
+	}
+	if keepOwn {
+		own = ""
+	}
+	if chown != "" {
+		own = chown
+	}
+	return own
 }

--- a/earthfile2llb/listener.go
+++ b/earthfile2llb/listener.go
@@ -204,6 +204,7 @@ func (l *listener) ExitCopyStmt(c *parser.CopyStmtContext) {
 	isDirCopy := fs.Bool("dir", false, "Copy entire directories, not just the contents")
 	chown := fs.String("chown", "", "Apply a specific group and/or owner to the copied files and directories")
 	keepTs := fs.Bool("keep-ts", false, "Keep created time file timestamps")
+	keepOwn := fs.Bool("keep-own", false, "Keep owner info")
 	buildArgs := new(StringSliceFlag)
 	fs.Var(buildArgs, "build-arg", "A build arg override passed on to a referenced Earthly target")
 	err := fs.Parse(l.stmtWords)
@@ -244,7 +245,7 @@ func (l *listener) ExitCopyStmt(c *parser.CopyStmtContext) {
 	}
 	if allArtifacts {
 		for _, src := range srcs {
-			err = l.converter.CopyArtifact(l.ctx, src, dest, buildArgs.Args, *isDirCopy, *keepTs, *chown)
+			err = l.converter.CopyArtifact(l.ctx, src, dest, buildArgs.Args, *isDirCopy, *keepTs, *keepOwn, *chown)
 			if err != nil {
 				l.err = errors.Wrapf(err, "copy artifact")
 				return
@@ -255,7 +256,7 @@ func (l *listener) ExitCopyStmt(c *parser.CopyStmtContext) {
 			l.err = fmt.Errorf("build args not supported for non +artifact arguments case %v", l.stmtWords)
 			return
 		}
-		l.converter.CopyClassical(l.ctx, srcs, dest, *isDirCopy, *keepTs, *chown)
+		l.converter.CopyClassical(l.ctx, srcs, dest, *isDirCopy, *keepTs, *keepOwn, *chown)
 	}
 }
 
@@ -348,6 +349,7 @@ func (l *listener) ExitSaveArtifact(c *parser.SaveArtifactContext) {
 	}
 	fs := flag.NewFlagSet("SAVE ARTIFACT", flag.ContinueOnError)
 	keepTs := fs.Bool("keep-ts", false, "Keep created time file timestamps")
+	keepOwn := fs.Bool("keep-own", false, "Keep owner info")
 	err := fs.Parse(l.stmtWords)
 	if err != nil {
 		l.err = errors.Wrapf(err, "invalid SAVE arguments %v", l.stmtWords)
@@ -384,7 +386,7 @@ func (l *listener) ExitSaveArtifact(c *parser.SaveArtifactContext) {
 	saveFrom := l.expandArgs(fs.Args()[0], false)
 	saveTo = l.expandArgs(saveTo, false)
 	saveAsLocalTo = l.expandArgs(saveAsLocalTo, false)
-	err = l.converter.SaveArtifact(l.ctx, saveFrom, saveTo, saveAsLocalTo, *keepTs)
+	err = l.converter.SaveArtifact(l.ctx, saveFrom, saveTo, saveAsLocalTo, *keepTs, *keepOwn)
 	if err != nil {
 		l.err = errors.Wrap(err, "apply SAVE ARTIFACT")
 		return

--- a/earthfile2llb/listener.go
+++ b/earthfile2llb/listener.go
@@ -203,6 +203,7 @@ func (l *listener) ExitCopyStmt(c *parser.CopyStmtContext) {
 	from := fs.String("from", "", "Not supported")
 	isDirCopy := fs.Bool("dir", false, "Copy entire directories, not just the contents")
 	chown := fs.String("chown", "", "Apply a specific group and/or owner to the copied files and directories")
+	keepTs := fs.Bool("keep-ts", false, "Keep created time file timestamps")
 	buildArgs := new(StringSliceFlag)
 	fs.Var(buildArgs, "build-arg", "A build arg override passed on to a referenced Earthly target")
 	err := fs.Parse(l.stmtWords)
@@ -243,7 +244,7 @@ func (l *listener) ExitCopyStmt(c *parser.CopyStmtContext) {
 	}
 	if allArtifacts {
 		for _, src := range srcs {
-			err = l.converter.CopyArtifact(l.ctx, src, dest, buildArgs.Args, *isDirCopy, *chown)
+			err = l.converter.CopyArtifact(l.ctx, src, dest, buildArgs.Args, *isDirCopy, *keepTs, *chown)
 			if err != nil {
 				l.err = errors.Wrapf(err, "copy artifact")
 				return
@@ -254,7 +255,7 @@ func (l *listener) ExitCopyStmt(c *parser.CopyStmtContext) {
 			l.err = fmt.Errorf("build args not supported for non +artifact arguments case %v", l.stmtWords)
 			return
 		}
-		l.converter.CopyClassical(l.ctx, srcs, dest, *isDirCopy, *chown)
+		l.converter.CopyClassical(l.ctx, srcs, dest, *isDirCopy, *keepTs, *chown)
 	}
 }
 
@@ -345,37 +346,45 @@ func (l *listener) ExitSaveArtifact(c *parser.SaveArtifactContext) {
 		l.err = fmt.Errorf("no non-push commands allowed after a --push: %s", c.GetText())
 		return
 	}
-	if len(l.stmtWords) == 0 {
+	fs := flag.NewFlagSet("SAVE ARTIFACT", flag.ContinueOnError)
+	keepTs := fs.Bool("keep-ts", false, "Keep created time file timestamps")
+	err := fs.Parse(l.stmtWords)
+	if err != nil {
+		l.err = errors.Wrapf(err, "invalid SAVE arguments %v", l.stmtWords)
+		return
+	}
+
+	if fs.NArg() == 0 {
 		l.err = fmt.Errorf("no arguments provided to the SAVE ARTIFACT command")
 		return
 	}
-	if len(l.stmtWords) > 5 {
+	if fs.NArg() > 5 {
 		l.err = fmt.Errorf("too many arguments provided to the SAVE ARTIFACT command: %v", l.stmtWords)
 		return
 	}
 	saveAsLocalTo := ""
 	saveTo := "./"
-	if len(l.stmtWords) >= 4 {
-		if strings.Join(l.stmtWords[len(l.stmtWords)-3:len(l.stmtWords)-1], " ") == "AS LOCAL" {
-			saveAsLocalTo = l.stmtWords[len(l.stmtWords)-1]
-			if len(l.stmtWords) == 5 {
-				saveTo = l.stmtWords[1]
+	if fs.NArg() >= 4 {
+		if strings.Join(fs.Args()[fs.NArg()-3:fs.NArg()-1], " ") == "AS LOCAL" {
+			saveAsLocalTo = fs.Args()[fs.NArg()-1]
+			if fs.NArg() == 5 {
+				saveTo = fs.Args()[1]
 			}
 		} else {
 			l.err = fmt.Errorf("invalid arguments for SAVE ARTIFACT command: %v", l.stmtWords)
 			return
 		}
-	} else if len(l.stmtWords) == 2 {
-		saveTo = l.stmtWords[1]
-	} else if len(l.stmtWords) == 3 {
+	} else if fs.NArg() == 2 {
+		saveTo = fs.Args()[1]
+	} else if fs.NArg() == 3 {
 		l.err = fmt.Errorf("invalid arguments for SAVE ARTIFACT command: %v", l.stmtWords)
 		return
 	}
 
-	saveFrom := l.expandArgs(l.stmtWords[0], false)
+	saveFrom := l.expandArgs(fs.Args()[0], false)
 	saveTo = l.expandArgs(saveTo, false)
 	saveAsLocalTo = l.expandArgs(saveAsLocalTo, false)
-	err := l.converter.SaveArtifact(l.ctx, saveFrom, saveTo, saveAsLocalTo)
+	err = l.converter.SaveArtifact(l.ctx, saveFrom, saveTo, saveAsLocalTo, *keepTs)
 	if err != nil {
 		l.err = errors.Wrap(err, "apply SAVE ARTIFACT")
 		return
@@ -629,6 +638,7 @@ func (l *listener) ExitGitCloneStmt(c *parser.GitCloneStmtContext) {
 	}
 	fs := flag.NewFlagSet("GIT CLONE", flag.ContinueOnError)
 	branch := fs.String("branch", "", "The git ref to use when cloning")
+	keepTs := fs.Bool("keep-ts", false, "Keep created time file timestamps")
 	err := fs.Parse(l.stmtWords)
 	if err != nil {
 		l.err = errors.Wrapf(err, "invalid GIT CLONE arguments %v", l.stmtWords)
@@ -641,7 +651,7 @@ func (l *listener) ExitGitCloneStmt(c *parser.GitCloneStmtContext) {
 	gitURL := l.expandArgs(fs.Arg(0), false)
 	gitCloneDest := l.expandArgs(fs.Arg(1), false)
 	*branch = l.expandArgs(*branch, false)
-	err = l.converter.GitClone(l.ctx, gitURL, *branch, gitCloneDest)
+	err = l.converter.GitClone(l.ctx, gitURL, *branch, gitCloneDest, *keepTs)
 	if err != nil {
 		l.err = errors.Wrap(err, "git clone")
 		return

--- a/earthfile2llb/withdockerrun.go
+++ b/earthfile2llb/withdockerrun.go
@@ -294,7 +294,6 @@ func (wdr *withDockerRun) solveImage(ctx context.Context, mts *states.MultiTarge
 	// Add the tar to the local context.
 	tarContext = llb.Local(
 		solveID,
-		llb.SharedKeyHint(opName),
 		llb.SessionID(sessionID),
 		llb.Platform(llbutil.TargetPlatform),
 		llb.WithCustomNamef("[internal] docker tar context %s %s", opName, sessionID),

--- a/llbutil/copyop.go
+++ b/llbutil/copyop.go
@@ -4,13 +4,15 @@ import (
 	"context"
 	"path/filepath"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/moby/buildkit/client/llb"
 	"github.com/pkg/errors"
 )
 
 // CopyOp is a simplified llb copy operation.
-func CopyOp(srcState llb.State, srcs []string, destState llb.State, dest string, allowWildcard bool, isDir bool, chown string, opts ...llb.ConstraintsOpt) llb.State {
+func CopyOp(srcState llb.State, srcs []string, destState llb.State, dest string, allowWildcard bool, isDir bool, keepTs bool, chown string, opts ...llb.ConstraintsOpt) llb.State {
 	destAdjusted := dest
 	if dest == "." || dest == "" || strings.HasSuffix(dest, string(filepath.Separator)) {
 		destAdjusted += string(filepath.Separator)
@@ -20,6 +22,11 @@ func CopyOp(srcState llb.State, srcs []string, destState llb.State, dest string,
 		baseCopyOpts = append(baseCopyOpts, llb.WithUser(chown))
 	}
 	var fa *llb.FileAction
+	if !keepTs {
+		baseCopyOpts = append(baseCopyOpts, llb.WithCreatedTime(*defaultTs()))
+	}
+	// mode := os.FileMode(0700)                                      // @#
+	baseCopyOpts = append(baseCopyOpts, llb.WithUser("root:root")) // @#
 	for _, src := range srcs {
 		copyOpts := append([]llb.CopyOption{
 			&llb.CopyInfo{
@@ -29,6 +36,7 @@ func CopyOp(srcState llb.State, srcs []string, destState llb.State, dest string,
 				CreateDestPath:      true,
 				AllowWildcard:       allowWildcard,
 				AllowEmptyWildcard:  false,
+				// Mode:                &mode,
 			},
 		}, baseCopyOpts...)
 		if fa == nil {
@@ -54,4 +62,18 @@ func Abs(ctx context.Context, s llb.State, p string) (string, error) {
 		return "", errors.Wrap(err, "get dir")
 	}
 	return filepath.Join(dir, p), nil
+}
+
+var defaultTsValue time.Time
+var defaultTsParse sync.Once
+
+func defaultTs() *time.Time {
+	defaultTsParse.Do(func() {
+		var err error
+		defaultTsValue, err = time.Parse(time.RFC3339, "2020-04-16T12:00:00+00:00")
+		if err != nil {
+			panic(err)
+		}
+	})
+	return &defaultTsValue
 }

--- a/llbutil/copyop.go
+++ b/llbutil/copyop.go
@@ -25,8 +25,6 @@ func CopyOp(srcState llb.State, srcs []string, destState llb.State, dest string,
 	if !keepTs {
 		baseCopyOpts = append(baseCopyOpts, llb.WithCreatedTime(*defaultTs()))
 	}
-	// mode := os.FileMode(0700)                                      // @#
-	baseCopyOpts = append(baseCopyOpts, llb.WithUser("root:root")) // @#
 	for _, src := range srcs {
 		copyOpts := append([]llb.CopyOption{
 			&llb.CopyInfo{
@@ -36,7 +34,6 @@ func CopyOp(srcState llb.State, srcs []string, destState llb.State, dest string,
 				CreateDestPath:      true,
 				AllowWildcard:       allowWildcard,
 				AllowEmptyWildcard:  false,
-				// Mode:                &mode,
 			},
 		}, baseCopyOpts...)
 		if fa == nil {


### PR DESCRIPTION
These changes, together with https://github.com/moby/buildkit/pull/1905 allow us to use maximum cache.

Changes:

* Use `root:root` in misc copy operations and destination user in main copy operations. (Escape hatch: `COPY --keep-own` to keep source owner).
* Set a constant time for the creation time of all files. The constant is the day Earthly was first released ;-). (Escape hatch: `COPY --keep-ts` to keep timestamps).
* https://github.com/moby/buildkit/pull/1905 makes file modes consistent between `llb.Local` and `llb.Git`