### PR TITLE
Support for mounting secrets as files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,8 @@ jobs:
         run: earthly --use-inline-cache +for-linux
       - name: run ssh-based tests
         run: env earthly=./build/linux/amd64/earthly scripts/tests/private-repo.sh
+      - name: run secrets-integration
+        run: env earthly=./build/linux/amd64/earthly scripts/tests/secrets-integration.sh
       - name: Buildkit logs (runs on failure)
         run: docker logs earthly-buildkitd
         if: ${{ failure() }}

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -131,7 +131,7 @@ func (c *Converter) fromTarget(ctx context.Context, targetName string, platform 
 		c.mts.Final.LocalDirs[dirKey] = dirValue
 	}
 	for _, kv := range saveImage.Image.Config.Env {
-		k, v := variables.ParseKeyValue(kv)
+		k, v, _ := variables.ParseKeyValue(kv)
 		c.varCollection.AddActive(k, variables.NewConstantEnvVar(v), true, false)
 	}
 	c.mts.Final.MainImage = saveImage.Image.Clone()
@@ -286,7 +286,7 @@ func (c *Converter) CopyClassical(ctx context.Context, srcs []string, dest strin
 }
 
 // Run applies the earthly RUN command.
-func (c *Converter) Run(ctx context.Context, args []string, mounts []string, secretKeyValues []string, privileged bool, withEntrypoint bool, withDocker bool, isWithShell bool, pushFlag bool, withSSH bool) error {
+func (c *Converter) Run(ctx context.Context, args, mounts, secretKeyValues []string, privileged, withEntrypoint, withDocker, isWithShell, pushFlag, withSSH bool) error {
 	c.nonSaveCommand()
 	if withDocker {
 		return errors.New("RUN --with-docker is obsolete. Please use WITH DOCKER ... RUN ... END instead")
@@ -615,7 +615,7 @@ func (c *Converter) buildTarget(ctx context.Context, fullTargetName string, plat
 	return mts, nil
 }
 
-func (c *Converter) internalRun(ctx context.Context, args []string, secretKeyValues []string, isWithShell bool, shellWrap shellWrapFun, pushFlag bool, withSSH bool, commandStr string, opts ...llb.RunOption) error {
+func (c *Converter) internalRun(ctx context.Context, args, secretKeyValues []string, isWithShell bool, shellWrap shellWrapFun, pushFlag, withSSH bool, commandStr string, opts ...llb.RunOption) error {
 	finalOpts := opts
 	var extraEnvVars []string
 	// Secrets.
@@ -761,7 +761,7 @@ func (c *Converter) applyFromImage(state llb.State, img *image.Image) (llb.State
 	// Reset variables.
 	newVarCollection := c.varCollection.WithResetEnvVars()
 	for _, envVar := range img.Config.Env {
-		k, v := variables.ParseKeyValue(envVar)
+		k, v, _ := variables.ParseKeyValue(envVar)
 		newVarCollection.AddActive(k, variables.NewConstantEnvVar(v), true, false)
 		state = state.AddEnv(k, v)
 	}

--- a/earthfile2llb/runmount.go
+++ b/earthfile2llb/runmount.go
@@ -158,6 +158,18 @@ func parseMount(mount string, target domain.Target, ti dedup.TargetInput, cacheC
 			sshOpts = append(sshOpts, llb.SSHSocketTarget(mountTarget))
 		}
 		return []llb.RunOption{llb.AddSSHSocket(sshOpts...)}, nil
+	case "secret":
+		if mountTarget == "" {
+			return nil, fmt.Errorf("mount target not specified")
+		}
+		secretID := strings.TrimPrefix(mountID, "+secrets/")
+		secretOpts := []llb.SecretOption{
+			llb.SecretID(secretID),
+			// TODO: Perhaps this should just default to the current user automatically from
+			//       buildkit side. Then we wouldn't need to open this up to everyone.
+			llb.SecretFileOpt(0, 0, 0444),
+		}
+		return []llb.RunOption{llb.AddSecret(mountTarget, secretOpts...)}, nil
 	default:
 		return nil, fmt.Errorf("invalid mount type %s", mountType)
 	}

--- a/examples/tests/Earthfile
+++ b/examples/tests/Earthfile
@@ -110,10 +110,11 @@ secrets-test:
     COPY secrets.earth ./Earthfile
     ENV SECRET1=foo
     ENV SECRET2=wrong
+    RUN echo -n "secretfilecontents" > /my-secret-file
     RUN --privileged \
         --entrypoint \
         --mount=type=tmpfs,target=/tmp/earthly \
-        -- --secret SECRET1 --secret SECRET2=bar +test
+        -- --secret SECRET1 --secret SECRET2=bar --secret-file SECRET3=/my-secret-file +test
 
 build-arg-test:
     COPY build-arg.earth ./Earthfile

--- a/examples/tests/secrets.earth
+++ b/examples/tests/secrets.earth
@@ -5,3 +5,11 @@ test:
     RUN test -z "$SECRET1"
     RUN --secret=SECRET2=+secrets/SECRET2 test "$SECRET2" == "bar"
     RUN test -z "$SECRET2"
+    RUN --secret=SECRET2=+secrets/SECRET3 test "$SECRET2" == "secretfilecontents"
+    RUN test -z "$SECRET3"
+    RUN --mount=type=secret,id=+secrets/SECRET1,target=/root/secret1 test "$(cat /root/secret1)" == "foo"
+    RUN ! /root/secret1
+    RUN --mount=type=secret,id=+secrets/SECRET2,target=/root/secret2 test "$(cat /root/secret2)" == "bar"
+    RUN ! /root/secret2
+    RUN --mount=type=secret,id=+secrets/SECRET3,target=/root/secret3 test "$(cat /root/secret3)" == "secretfilecontents"
+    RUN ! /root/secret3

--- a/scripts/tests/secrets-integration.sh
+++ b/scripts/tests/secrets-integration.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -eu # don't use -x as it will leak the private key
+
+earthly=${earthly:=earthly}
+echo "running tests with $earthly"
+
+# prevent the self-update of earthly from running (this ensures no bogus data is printed to stdout,
+# which would mess with the secrets data being fetched)
+date +%s > /tmp/last-earthly-prerelease-check
+
+# ensure earthly login works (and print out who gets logged in)
+$earthly account login
+
+# fetch shared secret key (this step assumes your personal user has access to the /earthly-technologies/ secrets org
+ID_RSA=$($earthly secrets get -n /earthly-technologies/github/other-service+github-cinnamon@earthly.dev/id_rsa)
+GITHUB_PASSWORD=$($earthly secrets get -n /earthly-technologies/github/other-service+github-cinnamon@earthly.dev/password)
+
+# now that we grabbed the cinnamonthecat credentials, unset our token, to ensure that we're only testing using cinnamonthecat's credentials
+unset EARTHLY_TOKEN
+
+echo starting new instance of ssh-agent, and loading credentials
+eval "$(ssh-agent)"
+
+# grab first 6chars of md5sum of key to help sanity check that the same key is consistently used
+md5sum=$(echo -n "$ID_RSA" | md5sum | awk '{ print $1 }' | head -c6)
+
+echo "Adding key (with md5sum $md5sum...) into ssh-agent"
+echo "$ID_RSA" | ssh-add -
+
+echo testing that key was correctly loaded into ssh-agent
+ssh-add -l | perl -pe 'BEGIN {$status=1} END {exit $status} $status=0 if /cinnamonthecat/;'
+
+echo testing that the ssh-agent only contains a single key
+test "$(ssh-add -l | wc -l)" = "1"
+
+echo "testing earthly account login works (and is using the earthly-cinnamon account)"
+$earthly account login | perl -pe 'BEGIN {$status=1} END {exit $status} $status=0 if /other-service\+earthly-cinnamon\@earthly.dev/;'
+
+mkdir -p /tmp/earthtest
+cat << EOF > /tmp/earthtest/Earthfile
+FROM alpine:3.11
+test-local-secret:
+    WORKDIR /test
+    RUN --mount=type=secret,target=/tmp/test_file,id=+secrets/my_secret test "\$(cat /tmp/test_file)" = "secret-value"
+test-server-secret:
+    WORKDIR /test
+    RUN --mount=type=secret,target=/tmp/test_file,id=+secrets/user/earthly_integration_tests/my_test_file test "\$(cat /tmp/test_file)" = "secret-value"
+EOF
+
+# set and test get returns the correct value
+$earthly secrets set /user/earthly_integration_tests/my_test_file "secret-value"
+$earthly secrets get /user/earthly_integration_tests/my_test_file | perl -pe 'BEGIN {$status=1} END {exit $status} $status=0 if /secret-value/;'
+
+echo === test 1 ===
+# test RUN --mount can reference a secret from the command line
+$earthly --no-cache --secret my_secret=secret-value /tmp/earthtest+test-local-secret
+
+echo === test 2 ===
+# test RUN --mount can reference a secret from the server that is only specified in the Earthfile
+$earthly --no-cache /tmp/earthtest+test-server-secret
+
+echo === All tests have passed ===
+

--- a/variables/util.go
+++ b/variables/util.go
@@ -5,15 +5,36 @@ import (
 	"strings"
 )
 
-// ParseKeyValue parses a key-value type into its parts.
-func ParseKeyValue(env string) (string, string) {
-	parts := strings.SplitN(env, "=", 2)
-	v := ""
-	if len(parts) > 1 {
-		v = parts[1]
+// ParseKeyValue pases a key-value type into its parts
+// if a key value needs to contain a = or \, it must be escapped using '\=', and '\\' respectively
+// once an unescaped '=' is found, all remaining chars will be used as-is without the need to be escaped.
+// the key and value are returned, along with a bool that is true if a value was defined (i.e. an equal was found)
+//
+// e.g. ParseKeyValue("foo")       -> `foo`,  ``,       false
+//      ParseKeyValue("foo=")      -> `foo`,  ``,       true
+//      ParseKeyValue("foo=bar")   -> `foo`,  `bar`,    true
+//      ParseKeyValue(`f\=oo=bar`) -> `f=oo`, `bar`,    true
+//      ParseKeyValue(`foo=bar=`)  -> `foo",  `bar=`,   true
+//      ParseKeyValue(`foo=bar\=`) -> `foo",  `bar\=`,  true
+func ParseKeyValue(s string) (string, string, bool) {
+	key := []string{}
+	var escaped bool
+	for i, c := range s {
+		if escaped {
+			key = append(key, string(c))
+			escaped = false
+			continue
+		}
+		if c == '\\' {
+			escaped = true
+			continue
+		}
+		if c == '=' {
+			return strings.Join(key, ""), s[i+1:], true
+		}
+		key = append(key, string(c))
 	}
-
-	return parts[0], v
+	return strings.Join(key, ""), "", false
 }
 
 // AddEnv takes in a slice of env vars in key-value format and a new key-value
@@ -22,7 +43,7 @@ func AddEnv(envVars []string, key, value string) []string {
 	// Note that this mutates the original slice.
 	found := false
 	for i, envVar := range envVars {
-		k, _ := ParseKeyValue(envVar)
+		k, _, _ := ParseKeyValue(envVar)
 		if k == key {
 			envVars[i] = fmt.Sprintf("%s=%s", key, value)
 			found = true

--- a/variables/util_test.go
+++ b/variables/util_test.go
@@ -1,0 +1,36 @@
+package variables
+
+import (
+	"testing"
+
+	. "github.com/stretchr/testify/assert"
+)
+
+func TestParseEscapedKeyValue(t *testing.T) {
+	var tests = []struct {
+		kv string
+		k  string
+		v  string
+		ok bool
+	}{
+		{"", "", "", false},
+		{"=", "", "", true},
+		{"key", "key", "", false},
+		{"key=", "key", "", true},
+		{"key=val", "key", "val", true},
+		{"key=val=value=VALUE", "key", "val=value=VALUE", true},
+		{"with space=val with space", "with space", "val with space", true},
+		{`\==\`, "=", `\`, true},
+		{`\===`, "=", `=`, true},
+		{`\==\=`, "=", `\=`, true},
+		{`value=dmFsdWU=`, "value", `dmFsdWU=`, true},
+		{`color\=red=yes!`, "color=red", `yes!`, true},
+	}
+
+	for _, tt := range tests {
+		k, v, ok := ParseKeyValue(tt.kv)
+		Equal(t, tt.k, k)
+		Equal(t, tt.v, v)
+		Equal(t, tt.ok, ok)
+	}
+}


### PR DESCRIPTION
Implements a new `--secret-file` flag within the RUN command.
```
    RUN --secret-file=/root/this-my-secret=+secrets/SECRET1 cat /root/this-my-secret)
```

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>