### PR TITLE
Ignore installID on CI

### DIFF
--- a/analytics/analytics.go
+++ b/analytics/analytics.go
@@ -161,7 +161,9 @@ func CollectAnalytics(ctx context.Context, earthlyServer string, displayErrors b
 	installID, overrideInstallID := os.LookupEnv("EARTHLY_INSTALL_ID")
 	repoHash := getRepoHash()
 	if !overrideInstallID {
-		if repoHash == "unknown" {
+		if ciName != "false" {
+			installID = "ci"
+		} else if repoHash == "unknown" {
 			installID = "unknown"
 		} else {
 			if ci {


### PR DESCRIPTION
- containerized CI systems will always generate a new install-ID, we
should ignore them.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>