### PR TITLE
Support for multi-platform outputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,13 @@ jobs:
       EARTHLY_INSTALL_ID: "earthly-githubactions"
     steps:
       - uses: actions/checkout@v2
+      -
+        name: Set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@v1
+        with:
+          image: tonistiigi/binfmt:latest
+          platforms: all
       - name: Download released earthly
         run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/latest/download/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly'"
       - name: Docker Login (non fork only)
@@ -100,6 +107,10 @@ jobs:
       - name: Build examples (main build)
         run: ./build/linux/amd64/earthly --ci --push -P +examples
         if: github.event_name == 'push'
+      - name: Build and test multi-platform example
+        run: |
+          ./build/linux/amd64/earthly ./examples/multiplatform+all
+          docker run --it --rm earthly/examples:multiplatform_linux_arm64 | grep aarch64
       - name: Buildkit logs (runs on failure)
         run: docker logs earthly-buildkitd
         if: ${{ failure() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Build and test multi-platform example
         run: |
           ./build/linux/amd64/earthly ./examples/multiplatform+all
-          docker run --it --rm earthly/examples:multiplatform_linux_arm64 | grep aarch64
+          docker run -it --rm earthly/examples:multiplatform_linux_arm64 | grep aarch64
       - name: Buildkit logs (runs on failure)
         run: docker logs earthly-buildkitd
         if: ${{ failure() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Build and test multi-platform example
         run: |
           ./build/linux/amd64/earthly ./examples/multiplatform+all
-          docker run -it --rm earthly/examples:multiplatform_linux_arm64 | grep aarch64
+          docker run --rm earthly/examples:multiplatform_linux_arm64 | grep aarch64
       - name: Buildkit logs (runs on failure)
         run: docker logs earthly-buildkitd
         if: ${{ failure() }}

--- a/Earthfile
+++ b/Earthfile
@@ -158,6 +158,13 @@ earthly-arm7:
         +earthly/* ./
     SAVE ARTIFACT ./*
 
+earthly-arm64:
+    COPY \
+        --build-arg GOARCH=arm64 \
+        --build-arg GO_EXTRA_LDFLAGS= \
+        +earthly/* ./
+    SAVE ARTIFACT ./*
+
 earthly-darwin:
     COPY \
         --build-arg GOOS=darwin \
@@ -172,6 +179,7 @@ earthly-all:
     COPY +earthly-arm5/earthly ./earthly-linux-arm5
     COPY +earthly-arm6/earthly ./earthly-linux-arm6
     COPY +earthly-arm7/earthly ./earthly-linux-arm7
+    COPY +earthly-arm64/earthly ./earthly-linux-arm64
     SAVE ARTIFACT ./*
 
 earthly-docker:

--- a/Earthfile
+++ b/Earthfile
@@ -132,6 +132,7 @@ earthly:
     SAVE ARTIFACT ./build/tags
     SAVE ARTIFACT ./build/ldflags
     SAVE ARTIFACT build/earthly AS LOCAL "build/$GOOS/$GOARCH$GOARM/earthly"
+    SAVE IMAGE --cache-from=earthly/earthly:main
 
 earthly-arm5:
     COPY \
@@ -272,3 +273,16 @@ examples:
 
 test-fail:
     RUN false
+
+test-platform-multi:
+    BUILD \
+        --platform=linux/amd64 \
+        --platform=linux/arm64 \
+        --platform=linux/arm/v7 \
+        +test-platform
+
+test-platform:
+    FROM alpine:3.11
+    RUN uname -m
+    CMD ["uname", "-m"]
+    SAVE IMAGE --push earthly/test-cache:mplat

--- a/Earthfile
+++ b/Earthfile
@@ -277,20 +277,8 @@ examples:
     BUILD ./examples/ruby-on-rails+docker
     BUILD ./examples/scala+docker
     BUILD ./examples/cobol+docker
+    BUILD ./examples/multiplatform+all
     BUILD github.com/earthly/hello-world:main+hello
 
 test-fail:
     RUN false
-
-test-platform-multi:
-    BUILD \
-        --platform=linux/amd64 \
-        --platform=linux/arm64 \
-        --platform=linux/arm/v7 \
-        +test-platform
-
-test-platform:
-    FROM alpine:3.11
-    RUN uname -m
-    CMD ["uname", "-m"]
-    SAVE IMAGE --push earthly/test-cache:mplat

--- a/buildcontext/git.go
+++ b/buildcontext/git.go
@@ -164,7 +164,7 @@ func (gr *gitResolver) resolveGitProject(ctx context.Context, gwClient gwclient.
 	gitHashOp := opImg.Run(gitHashOpts...)
 	gitMetaAndEarthfileState := gitHashOp.AddMount("/dest", earthfileState)
 
-	gitMetaAndEarthfileRef, err := llbutil.StateToRef(ctx, gwClient, gitMetaAndEarthfileState, nil)
+	gitMetaAndEarthfileRef, err := llbutil.StateToRef(ctx, gwClient, gitMetaAndEarthfileState, nil, nil)
 	if err != nil {
 		return nil, "", "", errors.Wrap(err, "state to ref git meta")
 	}

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/containerd/containerd/platforms"
 	"github.com/earthly/earthly/buildcontext"
 	"github.com/earthly/earthly/buildcontext/provider"
 	"github.com/earthly/earthly/cleanup"
@@ -59,7 +58,7 @@ type Opt struct {
 
 // BuildOpt is a collection of build options.
 type BuildOpt struct {
-	Platform              specs.Platform
+	Platform              *specs.Platform
 	PrintSuccess          bool
 	Push                  bool
 	NoOutput              bool
@@ -144,13 +143,13 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 			return nil, err
 		}
 		res := gwclient.NewResult()
-		ref, err := b.stateToRef(ctx, gwClient, mts.Final.MainState)
+		ref, err := b.stateToRef(ctx, gwClient, mts.Final.MainState, mts.Final.Platform)
 		if err != nil {
 			return nil, err
 		}
 		res.AddRef("main", ref)
 		if !opt.NoOutput && opt.OnlyArtifact != nil && !opt.OnlyFinalTargetImages {
-			ref, err = b.stateToRef(ctx, gwClient, mts.Final.ArtifactsState)
+			ref, err = b.stateToRef(ctx, gwClient, mts.Final.ArtifactsState, mts.Final.Platform)
 			if err != nil {
 				return nil, err
 			}
@@ -166,7 +165,7 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 		dirIndex := 0
 		for _, sts := range mts.All() {
 			if sts.HasDangling && !b.opt.UseFakeDep {
-				depRef, err := b.stateToRef(ctx, gwClient, sts.MainState)
+				depRef, err := b.stateToRef(ctx, gwClient, sts.MainState, sts.Platform)
 				if err != nil {
 					return nil, err
 				}
@@ -183,7 +182,7 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 					// Short-circuit.
 					continue
 				}
-				ref, err := b.stateToRef(ctx, gwClient, saveImage.State)
+				ref, err := b.stateToRef(ctx, gwClient, saveImage.State, sts.Platform)
 				if err != nil {
 					return nil, err
 				}
@@ -195,7 +194,9 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 				refKey := fmt.Sprintf("image-%d", imageIndex)
 				refPrefix := fmt.Sprintf("ref/%s", refKey)
 				res.AddMeta(fmt.Sprintf("%s/image.name", refPrefix), []byte(saveImage.DockerTag))
-				res.AddMeta(fmt.Sprintf("%s/platform", refPrefix), []byte(platforms.Format(sts.Platform)))
+				if sts.Platform != nil {
+					res.AddMeta(fmt.Sprintf("%s/platform", refPrefix), []byte(llbutil.PlatformToString(sts.Platform)))
+				}
 				if shouldPush {
 					res.AddMeta(fmt.Sprintf("%s/export-image-push", refPrefix), []byte("true"))
 					if saveImage.InsecurePush {
@@ -212,7 +213,7 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 			}
 			if !sts.Target.IsRemote() && !opt.NoOutput && !opt.OnlyFinalTargetImages && opt.OnlyArtifact == nil {
 				for _, saveLocal := range sts.SaveLocals {
-					ref, err := b.stateToRef(ctx, gwClient, sts.SeparateArtifactsState[saveLocal.Index])
+					ref, err := b.stateToRef(ctx, gwClient, sts.SeparateArtifactsState[saveLocal.Index], sts.Platform)
 					if err != nil {
 						return nil, err
 					}
@@ -330,11 +331,11 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 	return mts, nil
 }
 
-func (b *Builder) stateToRef(ctx context.Context, gwClient gwclient.Client, state llb.State) (gwclient.Reference, error) {
+func (b *Builder) stateToRef(ctx context.Context, gwClient gwclient.Client, state llb.State, platform *specs.Platform) (gwclient.Reference, error) {
 	if b.opt.NoCache {
 		state = state.SetMarshalDefaults(llb.IgnoreCache)
 	}
-	return llbutil.StateToRef(ctx, gwClient, state, b.opt.CacheImports)
+	return llbutil.StateToRef(ctx, gwClient, state, platform, b.opt.CacheImports)
 }
 
 func (b *Builder) buildOnlyLastImageAsTar(ctx context.Context, mts *states.MultiTarget, dockerTag string, outFile string, opt BuildOpt) error {
@@ -344,7 +345,12 @@ func (b *Builder) buildOnlyLastImageAsTar(ctx context.Context, mts *states.Multi
 		return err
 	}
 
-	err = b.outputImageTar(ctx, saveImage, dockerTag, outFile)
+	platform, err := llbutil.ResolvePlatform(mts.Final.Platform, opt.Platform)
+	if err != nil {
+		platform = mts.Final.Platform
+	}
+	plat := llbutil.PlatformWithDefault(platform)
+	err = b.outputImageTar(ctx, saveImage, plat, dockerTag, outFile)
 	if err != nil {
 		return err
 	}
@@ -356,34 +362,44 @@ func (b *Builder) buildMain(ctx context.Context, mts *states.MultiTarget, opt Bu
 	if b.opt.NoCache {
 		state = state.SetMarshalDefaults(llb.IgnoreCache)
 	}
-	err := b.s.solveMain(ctx, state)
+	platform, err := llbutil.ResolvePlatform(mts.Final.Platform, opt.Platform)
+	if err != nil {
+		platform = mts.Final.Platform
+	}
+	plat := llbutil.PlatformWithDefault(platform)
+	err = b.s.solveMain(ctx, state, plat)
 	if err != nil {
 		return errors.Wrapf(err, "solve side effects")
 	}
 	return nil
 }
 
-func (b *Builder) executeRunPush(ctx context.Context, states *states.SingleTarget, opt BuildOpt) error {
-	if !states.RunPush.Initialized {
+func (b *Builder) executeRunPush(ctx context.Context, sts *states.SingleTarget, opt BuildOpt) error {
+	if !sts.RunPush.Initialized {
 		// No run --push commands here. Quick way out.
 		return nil
 	}
-	console := b.opt.Console.WithPrefixAndSalt(states.Target.String(), states.Salt)
+	console := b.opt.Console.WithPrefixAndSalt(sts.Target.String(), sts.Salt)
 	if !opt.Push {
-		for _, commandStr := range states.RunPush.CommandStrs {
+		for _, commandStr := range sts.RunPush.CommandStrs {
 			console.Printf("Did not execute push command %s. Use earthly --push to enable pushing\n", commandStr)
 		}
 		return nil
 	}
-	err := b.s.solveMain(ctx, states.RunPush.State)
+	platform, err := llbutil.ResolvePlatform(sts.Platform, opt.Platform)
+	if err != nil {
+		platform = sts.Platform
+	}
+	plat := llbutil.PlatformWithDefault(platform)
+	err = b.s.solveMain(ctx, sts.RunPush.State, plat)
 	if err != nil {
 		return errors.Wrapf(err, "solve run-push")
 	}
 	return nil
 }
 
-func (b *Builder) outputImageTar(ctx context.Context, saveImage states.SaveImage, dockerTag string, outFile string) error {
-	err := b.s.solveDockerTar(ctx, saveImage.State, saveImage.Image, dockerTag, outFile)
+func (b *Builder) outputImageTar(ctx context.Context, saveImage states.SaveImage, platform specs.Platform, dockerTag string, outFile string) error {
+	err := b.s.solveDockerTar(ctx, saveImage.State, platform, saveImage.Image, dockerTag, outFile)
 	if err != nil {
 		return errors.Wrapf(err, "solve image tar %s", outFile)
 	}

--- a/builder/docker.go
+++ b/builder/docker.go
@@ -1,0 +1,128 @@
+package builder
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/containerd/containerd/platforms"
+	"github.com/docker/distribution/reference"
+	"github.com/earthly/earthly/conslogging"
+	"github.com/earthly/earthly/llbutil"
+
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+)
+
+type manifest struct {
+	imageName string
+	platform  specs.Platform
+}
+
+func platformSpecificImageName(imgName string, platform specs.Platform) (string, error) {
+	r, err := reference.ParseNormalizedNamed(imgName)
+	if err != nil {
+		return "", errors.Wrapf(err, "parse %s", imgName)
+	}
+	taggedR, ok := reference.TagNameOnly(r).(reference.Tagged)
+	if !ok {
+		return "", errors.Wrapf(err, "not tagged %s", reference.TagNameOnly(r).String())
+	}
+	platformTag := llbutil.DockerTagSafe(fmt.Sprintf("%s_%s", taggedR.Tag(), platforms.Format(platform)))
+	r2, err := reference.WithTag(r, platformTag)
+	if err != nil {
+		return "", errors.Wrapf(err, "with tag %s - %s", r.String(), platformTag)
+	}
+	return reference.FamiliarString(r2), nil
+}
+
+func loadDockerManifest(ctx context.Context, console conslogging.ConsoleLogger, parentImageName string, children []manifest) error {
+	console = console.WithPrefix(parentImageName)
+	if len(children) == 0 {
+		return errors.Errorf("no images in manifest list for %s", parentImageName)
+	}
+	// Check if any child has the platform as the default platform (use the first one if none found).
+	defaultChild := 0
+	for i, child := range children {
+		if platforms.Format(child.platform) == platforms.Format(llbutil.DefaultPlatform()) {
+			defaultChild = i
+			break
+		}
+	}
+
+	var childImgs []string
+	for i, child := range children {
+		if i == defaultChild {
+			childImgs = append(childImgs, fmt.Sprintf("%s (=%s)", child.imageName, parentImageName))
+		} else {
+			childImgs = append(childImgs, child.imageName)
+		}
+	}
+	const noteDetail = "Note that when pushing a multi-platform image, " +
+		"it is pushed as a single multi-manifest image. " +
+		"Separate per-platform image tags are only available locally."
+	console.Printf(
+		"%s is a multi-platform image. The following per-platform images have been produced:\n\t%s\n%s\n",
+		parentImageName, strings.Join(childImgs, "\n\t"), noteDetail)
+
+	cmd := exec.CommandContext(ctx, "docker", "tag", children[defaultChild].imageName, parentImageName)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	if err != nil {
+		return errors.Wrap(err, "docker tag default platform image")
+	}
+	return nil
+}
+
+// TODO: This doesn't work with vanilla docker installations. Not currently used.
+func loadDockerManifestExperimental(ctx context.Context, parentImageName string, children []manifest) error {
+	createArgs := []string{"manifest", "create", parentImageName}
+	for _, child := range children {
+		createArgs = append(createArgs, child.imageName)
+	}
+	cmd := exec.CommandContext(ctx, "docker", createArgs...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	if err != nil {
+		return errors.Wrap(err, "docker manifest create")
+	}
+
+	for _, child := range children {
+		annotateArgs := []string{
+			"manifest", "annotate",
+			"--os", child.platform.OS,
+			"--arch", child.platform.Architecture,
+			"--variant", child.platform.Variant,
+			"--os-version", child.platform.OSVersion,
+			"--os-features", strings.Join(child.platform.OSFeatures, ","),
+		}
+		cmd := exec.CommandContext(ctx, "docker", annotateArgs...)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		err := cmd.Run()
+		if err != nil {
+			return errors.Wrap(err, "docker manifest annotate")
+		}
+	}
+	return nil
+}
+
+func loadDockerTar(ctx context.Context, r io.ReadCloser) error {
+	// TODO: This is a gross hack - should use proper docker client.
+	cmd := exec.CommandContext(ctx, "docker", "load")
+	// @#
+	// cmd := exec.CommandContext(ctx, "tee", "test.tar")
+	cmd.Stdin = r
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	if err != nil {
+		return errors.Wrap(err, "docker load")
+	}
+	return nil
+}

--- a/builder/solver.go
+++ b/builder/solver.go
@@ -15,6 +15,7 @@ import (
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/util/entitlements"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 )
@@ -34,8 +35,8 @@ type solver struct {
 	saveInlineCache bool
 }
 
-func (s *solver) solveDockerTar(ctx context.Context, state llb.State, img *image.Image, dockerTag string, outFile string) error {
-	dt, err := state.Marshal(ctx)
+func (s *solver) solveDockerTar(ctx context.Context, state llb.State, platform specs.Platform, img *image.Image, dockerTag string, outFile string) error {
+	dt, err := state.Marshal(ctx, llb.Platform(platform))
 	if err != nil {
 		return errors.Wrap(err, "state marshal")
 	}
@@ -124,8 +125,8 @@ func (s *solver) buildMainMulti(ctx context.Context, bf gwclient.BuildFunc, onIm
 	return nil
 }
 
-func (s *solver) solveMain(ctx context.Context, state llb.State) error {
-	dt, err := state.Marshal(ctx)
+func (s *solver) solveMain(ctx context.Context, state llb.State, platform specs.Platform) error {
+	dt, err := state.Marshal(ctx, llb.Platform(platform))
 	if err != nil {
 		return errors.Wrap(err, "state marshal")
 	}

--- a/builder/solver.go
+++ b/builder/solver.go
@@ -19,7 +19,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-type onImageFunc func(context.Context, *errgroup.Group, int, string, string) (io.WriteCloser, error)
+type onImageFunc func(context.Context, *errgroup.Group, string) (io.WriteCloser, error)
 type onArtifactFunc func(context.Context, int, domain.Artifact, string, string) (string, error)
 type onFinalArtifactFunc func(context.Context) (string, error)
 
@@ -207,14 +207,8 @@ func (s *solver) newSolveOptMulti(ctx context.Context, eg *errgroup.Group, onIma
 					if md["export-image"] != "true" {
 						return nil, nil
 					}
-					indexStr := md["image-index"]
-					index, err := strconv.Atoi(indexStr)
-					if err != nil {
-						return nil, errors.Wrapf(err, "parse image-index %s", indexStr)
-					}
 					imageName := md["image.name"]
-					digest := md["containerimage.digest"]
-					return onImage(ctx, eg, index, imageName, digest)
+					return onImage(ctx, eg, imageName)
 				},
 				OutputDirFunc: func(md map[string]string) (string, error) {
 					if md["export-dir"] != "true" {

--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -1,7 +1,7 @@
 
 buildkitd:
     ARG EARTHLY_GIT_HASH
-    ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:vlad/mplat+build
+    ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:earthly-main+build
     FROM $BUILDKIT_BASE_IMAGE
     RUN echo "@edge-community http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
     RUN apk add --update --no-cache \

--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -1,7 +1,7 @@
 
 buildkitd:
     ARG EARTHLY_GIT_HASH
-    ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:earthly-main+build
+    ARG BUILDKIT_BASE_IMAGE=../../buildkit+build
     FROM $BUILDKIT_BASE_IMAGE
     RUN echo "@edge-community http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
     RUN apk add --update --no-cache \

--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -1,7 +1,7 @@
 
 buildkitd:
     ARG EARTHLY_GIT_HASH
-    ARG BUILDKIT_BASE_IMAGE=../../buildkit+build
+    ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:vlad/mplat+build
     FROM $BUILDKIT_BASE_IMAGE
     RUN echo "@edge-community http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
     RUN apk add --update --no-cache \

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -2028,16 +2028,16 @@ func (app *earthlyApp) actionBuild(c *cli.Context) error {
 	}
 	defer bkClient.Close()
 
-	platformsSlice := make([]specs.Platform, 0, len(app.platformsStr.Value()))
+	platformsSlice := make([]*specs.Platform, 0, len(app.platformsStr.Value()))
 	for _, p := range app.platformsStr.Value() {
 		platform, err := platforms.Parse(p)
 		if err != nil {
 			return errors.Wrapf(err, "parse platform %s", p)
 		}
-		platformsSlice = append(platformsSlice, platform)
+		platformsSlice = append(platformsSlice, &platform)
 	}
 	if len(platformsSlice) == 0 {
-		platformsSlice = []specs.Platform{llbutil.DefaultPlatform()}
+		platformsSlice = []*specs.Platform{nil}
 	}
 
 	dotEnvMap := make(map[string]string)

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -51,9 +51,11 @@ type Converter struct {
 // NewConverter constructs a new converter for a given earthly target.
 func NewConverter(ctx context.Context, target domain.Target, bc *buildcontext.Data, opt ConvertOpt) (*Converter, error) {
 	sts := &states.SingleTarget{
-		Target: target,
+		Target:   target,
+		Platform: opt.Platform,
 		TargetInput: dedup.TargetInput{
 			TargetCanonical: target.StringCanonical(),
+			Platform:        llbutil.PlatformToString(&opt.Platform),
 		},
 		MainState:      llbutil.ScratchWithPlatform(),
 		MainImage:      image.NewImage(),

--- a/earthfile2llb/earthfile2llb.go
+++ b/earthfile2llb/earthfile2llb.go
@@ -39,7 +39,7 @@ type ConvertOpt struct {
 	// This is used for deduplication and infinite cycle detection.
 	Visited *states.VisitedCollection
 	// Platform is the target platform of the build.
-	Platform specs.Platform
+	Platform *specs.Platform
 	// VarCollection is a collection of build args used for overriding args in the build.
 	VarCollection *variables.Collection
 	// A cache for image solves. depTargetInputHash -> context containing image.tar.
@@ -72,7 +72,7 @@ func Earthfile2LLB(ctx context.Context, target domain.Target, opt ConvertOpt) (m
 	// Check if we have previously converted this target, with the same build args.
 	targetStr := target.String()
 	for _, sts := range opt.Visited.Visited[targetStr] {
-		same := (sts.TargetInput.Platform == llbutil.PlatformToString(&opt.Platform))
+		same := (sts.TargetInput.Platform == llbutil.PlatformToString(opt.Platform))
 		if same {
 			for _, bai := range sts.TargetInput.BuildArgs {
 				if sts.Ongoing && !bai.IsConstant {
@@ -96,7 +96,7 @@ func Earthfile2LLB(ctx context.Context, target domain.Target, opt ConvertOpt) (m
 		if same {
 			if sts.Ongoing {
 				return nil, fmt.Errorf(
-					"Infinite recursion detected for target %s", targetStr)
+					"infinite recursion detected for target %s", targetStr)
 			}
 			// Use the already built states.
 			return &states.MultiTarget{
@@ -133,10 +133,9 @@ func Earthfile2LLB(ctx context.Context, target domain.Target, opt ConvertOpt) (m
 		var errString []string
 		errString = append(errString,
 			fmt.Sprintf(
-				"Syntax error: line %d:%d when parsing %s",
+				"syntax error: line %d:%d",
 				errorStrategy.RE.GetOffendingToken().GetLine(),
-				errorStrategy.RE.GetOffendingToken().GetColumn(),
-				errorStrategy.ErrContext.GetText()))
+				errorStrategy.RE.GetOffendingToken().GetColumn()))
 		errString = append(errString,
 			fmt.Sprintf("Details: %s", errorStrategy.RE.GetMessage()))
 		return nil, errors.Wrapf(errorStrategy.Err, "%s", strings.Join(errString, "\n"))

--- a/earthfile2llb/withdockerrun.go
+++ b/earthfile2llb/withdockerrun.go
@@ -220,7 +220,7 @@ func (wdr *withDockerRun) getComposePulls(ctx context.Context, opt WithDockerOpt
 			// Image not specified in yaml.
 			continue
 		}
-		platform := &wdr.c.opt.Platform
+		platform := wdr.c.opt.Platform
 		if serviceInfo.Platform != "" {
 			p, err := platforms.Parse(serviceInfo.Platform)
 			if err != nil {
@@ -248,8 +248,9 @@ func (wdr *withDockerRun) getComposePulls(ctx context.Context, opt WithDockerOpt
 }
 
 func (wdr *withDockerRun) pull(ctx context.Context, opt DockerPullOpt) error {
+	plat := llbutil.PlatformWithDefault(opt.Platform)
 	state, image, _, err := wdr.c.internalFromClassical(
-		ctx, opt.ImageName, opt.Platform,
+		ctx, opt.ImageName, plat,
 		llb.WithCustomNamef("%sDOCKER PULL %s", wdr.c.imageVertexPrefix(opt.ImageName), opt.ImageName),
 	)
 	if err != nil {
@@ -384,7 +385,7 @@ func (wdr *withDockerRun) getComposeConfig(ctx context.Context, opt WithDockerOp
 		llb.WithCustomNamef("%sWITH DOCKER (docker-compose config)", wdr.c.vertexPrefix()),
 	}
 	state := wdr.c.mts.Final.MainState.Run(runOpts...).Root()
-	ref, err := llbutil.StateToRef(ctx, wdr.c.opt.GwClient, state, wdr.c.opt.CacheImports)
+	ref, err := llbutil.StateToRef(ctx, wdr.c.opt.GwClient, state, wdr.c.opt.Platform, wdr.c.opt.CacheImports)
 	if err != nil {
 		return nil, errors.Wrap(err, "state to ref compose config")
 	}

--- a/examples/multiplatform/Earthfile
+++ b/examples/multiplatform/Earthfile
@@ -1,0 +1,34 @@
+
+
+all:
+    BUILD \
+        --platform=linux/amd64 \
+        --platform=linux/arm64 \
+        --platform=linux/arm/v7 \
+        --platform=linux/arm/v6 \
+        +docker
+
+# This target definition will produce images for different platforms,
+# depending on the --platform flag used in the call to BUILD.
+#
+# To try this out, if you are using the Docker Desktop app, you are ready to try this example immediately.
+# On linux, make sure your system has QEMU set up. On Ubuntu you can run the following:
+#
+#     sudo apt-get install qemu binfmt-support qemu-user-static
+#     docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+#     docker stop earthly-buildkitd || true
+#
+# Then test this example:
+#
+#     earthly +all
+#     docker run --it --rm earthly/examples:multiplatform
+#     docker run --it --rm earthly/examples:multiplatform_linux_amd64
+#     docker run --it --rm earthly/examples:multiplatform_linux_arm64
+#     docker run --it --rm earthly/examples:multiplatform_linux_arm_v7
+#     docker run --it --rm earthly/examples:multiplatform_linux_arm_v6
+#
+docker:
+    FROM alpine:3.11
+    RUN uname -m
+    CMD ["uname", "-m"]
+    SAVE IMAGE --push earthly/examples:multiplatform

--- a/go.sum
+++ b/go.sum
@@ -130,6 +130,7 @@ github.com/alexflint/go-filemutex v0.0.0-20171022225611-72bdc8eae2ae/go.mod h1:C
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/antlr/antlr4 v0.0.0-20200225173536-225249fdaef5 h1:nkZ9axP+MvUFCu8JRN/MCY+DmTfs6lY7hE0QnJbxSdI=
 github.com/antlr/antlr4 v0.0.0-20200225173536-225249fdaef5/go.mod h1:T7PbCXFs94rrTttyxjbyT5+/1V8T2TYDejxUfHJjw1Y=
+github.com/antlr/antlr4 v0.0.0-20201214011320-c79b0fd80c9d h1:uA+3jkHfX7cieBgh5GBV++KZQbGdBz0VHJBWQTFvAss=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apex/log v1.1.4/go.mod h1:AlpoD9aScyQfJDVHmLMEcx4oU6LqzkWp4Mg9GdAcEvQ=
 github.com/apex/log v1.3.0/go.mod h1:jd8Vpsr46WAe3EZSQ/IUMs2qQD/GOycT5rPWCO1yGcs=

--- a/llbutil/docker_test.go
+++ b/llbutil/docker_test.go
@@ -1,4 +1,4 @@
-package variables
+package llbutil
 
 import "testing"
 
@@ -22,7 +22,7 @@ func TestDockerTagSafe(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		ans := dockerTagSafe(tt.tag)
+		ans := DockerTagSafe(tt.tag)
 		if ans != tt.safe {
 			t.Errorf("got %s, want %s", ans, tt.safe)
 		}

--- a/llbutil/dockertag.go
+++ b/llbutil/dockertag.go
@@ -1,0 +1,22 @@
+package llbutil
+
+import "regexp"
+
+var invalidDockerTagCharsBeginningRe = regexp.MustCompile(`^[^\w]`)
+var invalidDockerTagCharsMiddleRe = regexp.MustCompile(`[^\w.-]`)
+
+// DockerTagSafe turns a string into a safe Docker tag.
+func DockerTagSafe(tag string) string {
+	if len(tag) == 0 {
+		return "latest"
+	}
+	newTag := tag
+	if len(tag) > 128 {
+		newTag = newTag[:128]
+	}
+	newTag = invalidDockerTagCharsBeginningRe.ReplaceAllString(newTag, "_")
+	if len(newTag) > 1 {
+		newTag = string(newTag[0]) + invalidDockerTagCharsMiddleRe.ReplaceAllString(newTag[1:], "_")
+	}
+	return newTag
+}

--- a/llbutil/platform.go
+++ b/llbutil/platform.go
@@ -6,6 +6,7 @@ import (
 	"github.com/containerd/containerd/platforms"
 	"github.com/moby/buildkit/client/llb"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
 )
 
 // DefaultPlatform returns the default platform to use if none is specified.
@@ -29,4 +30,43 @@ func PlatformToString(p *specs.Platform) string {
 		return ""
 	}
 	return platforms.Format(*p)
+}
+
+// ResolvePlatform returns the non-nil platform provided. If both are nil, nil is returned.
+// If both are non-nil, they are compared to ensure they are identical. If they are not,
+// an error is returned.
+func ResolvePlatform(p1 *specs.Platform, p2 *specs.Platform) (*specs.Platform, error) {
+	if p1 == nil {
+		return p2, nil
+	}
+	if p2 == nil {
+		return p1, nil
+	}
+	plat1 := platforms.Normalize(*p1)
+	plat2 := platforms.Normalize(*p2)
+	if plat1.OS != plat2.OS {
+		return nil, errors.Errorf(
+			"platform contradiction %s vs %s",
+			platforms.Format(*p1), platforms.Format(*p2))
+	}
+	if plat1.Architecture != plat2.Architecture {
+		return nil, errors.Errorf(
+			"platform contradiction %s vs %s",
+			platforms.Format(*p1), platforms.Format(*p2))
+	}
+	if plat1.Variant != plat2.Variant {
+		return nil, errors.Errorf(
+			"platform contradiction %s vs %s",
+			platforms.Format(*p1), platforms.Format(*p2))
+	}
+	return p1, nil
+}
+
+// PlatformWithDefault returns the same platform provided if not nil, or the default
+// platform otherwise.
+func PlatformWithDefault(p *specs.Platform) specs.Platform {
+	if p != nil {
+		return *p
+	}
+	return DefaultPlatform()
 }

--- a/llbutil/statetoref.go
+++ b/llbutil/statetoref.go
@@ -6,11 +6,12 @@ import (
 
 	"github.com/moby/buildkit/client/llb"
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
 
 // StateToRef takes an LLB state, solves it using gateway and returns the ref.
-func StateToRef(ctx context.Context, gwClient gwclient.Client, state llb.State, cacheImports map[string]bool) (gwclient.Reference, error) {
+func StateToRef(ctx context.Context, gwClient gwclient.Client, state llb.State, platform *specs.Platform, cacheImports map[string]bool) (gwclient.Reference, error) {
 	cacheImportsSlice := make([]string, 0, len(cacheImports))
 	for ci := range cacheImports {
 		cacheImportsSlice = append(cacheImportsSlice, ci)
@@ -24,7 +25,7 @@ func StateToRef(ctx context.Context, gwClient gwclient.Client, state llb.State, 
 		}
 		coes = append(coes, coe)
 	}
-	def, err := state.Marshal(ctx)
+	def, err := state.Marshal(ctx, llb.Platform(PlatformWithDefault(platform)))
 	if err != nil {
 		return nil, errors.Wrap(err, "marshal state")
 	}

--- a/release/Earthfile
+++ b/release/Earthfile
@@ -35,7 +35,8 @@ release-github:
         test -f ./release/earthly-darwin-amd64 && \
         test -f ./release/earthly-linux-arm5 && \
         test -f ./release/earthly-linux-arm6 && \
-        test -f ./release/earthly-linux-arm7
+        test -f ./release/earthly-linux-arm7 && \
+        test -f ./release/earthly-linux-arm64
     ARG BODY="No details provided"
     RUN --secret GITHUB_TOKEN=+secrets/earthly-technologies/github/griswoldthecat/token test -n "$GITHUB_TOKEN"
     RUN --push \

--- a/states/dedup/targetinput.go
+++ b/states/dedup/targetinput.go
@@ -15,6 +15,8 @@ type TargetInput struct {
 	TargetCanonical string `json:"targetCanonical"`
 	// BuildArgs are the build args used to build this target.
 	BuildArgs []BuildArgInput `json:"buildArgs"`
+	// Platform is the target platform of the target.
+	Platform string `json:"platform"`
 }
 
 // WithBuildArgInput returns a clone of the current target input, with a
@@ -37,6 +39,9 @@ func (ti TargetInput) Equals(other TargetInput) bool {
 	if ti.TargetCanonical != other.TargetCanonical {
 		return false
 	}
+	if ti.Platform != other.Platform {
+		return false
+	}
 	if len(ti.BuildArgs) != len(other.BuildArgs) {
 		return false
 	}
@@ -52,6 +57,7 @@ func (ti TargetInput) clone() TargetInput {
 	tiCopy := TargetInput{
 		TargetCanonical: ti.TargetCanonical,
 		BuildArgs:       make([]BuildArgInput, 0, len(ti.BuildArgs)),
+		Platform:        ti.Platform,
 	}
 	for _, bai := range ti.BuildArgs {
 		baiCopy := bai.clone()
@@ -73,6 +79,7 @@ func (ti TargetInput) cloneNoTag() (TargetInput, error) {
 	tiCopy := TargetInput{
 		TargetCanonical: targetStr,
 		BuildArgs:       make([]BuildArgInput, 0, len(ti.BuildArgs)),
+		Platform:        ti.Platform,
 	}
 	for _, bai := range ti.BuildArgs {
 		baiCopy, err := bai.cloneNoTag()

--- a/states/states.go
+++ b/states/states.go
@@ -6,6 +6,7 @@ import (
 	"github.com/earthly/earthly/states/image"
 	"github.com/earthly/earthly/variables"
 	"github.com/moby/buildkit/client/llb"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // MultiTarget holds LLB states representing multiple earthly targets,
@@ -32,6 +33,7 @@ func (mts *MultiTarget) All() []*SingleTarget {
 // SingleTarget holds LLB states representing an earthly target.
 type SingleTarget struct {
 	Target                 domain.Target
+	Platform               specs.Platform
 	TargetInput            dedup.TargetInput
 	MainImage              *image.Image
 	MainState              llb.State

--- a/states/states.go
+++ b/states/states.go
@@ -33,7 +33,7 @@ func (mts *MultiTarget) All() []*SingleTarget {
 // SingleTarget holds LLB states representing an earthly target.
 type SingleTarget struct {
 	Target                 domain.Target
-	Platform               specs.Platform
+	Platform               *specs.Platform
 	TargetInput            dedup.TargetInput
 	MainImage              *image.Image
 	MainState              llb.State

--- a/variables/collection.go
+++ b/variables/collection.go
@@ -226,11 +226,7 @@ func (c *Collection) WithBuiltinBuildArgs(target domain.Target, platform specs.P
 	ret.variables["EARTHLY_TARGET_NAME"] = NewConstant(target.Target)
 	ret.variables["EARTHLY_TARGET_TAG"] = NewConstant(target.Tag)
 	ret.variables["EARTHLY_TARGET_TAG_DOCKER"] = NewConstant(dockerTagSafe(target.Tag))
-
-	ret.variables["TARGETPLATFORM"] = NewConstant(platforms.Format(platform))
-	ret.variables["TARGETOS"] = NewConstant(platform.OS)
-	ret.variables["TARGETARCH"] = NewConstant(platform.Architecture)
-	ret.variables["TARGETVARIANT"] = NewConstant(platform.Variant)
+	ret.SetPlatformArgs(platform)
 
 	if gitMeta != nil {
 		ret.variables["EARTHLY_GIT_HASH"] = NewConstant(gitMeta.Hash)
@@ -249,6 +245,14 @@ func (c *Collection) WithBuiltinBuildArgs(target domain.Target, platform specs.P
 		ret.variables["EARTHLY_GIT_PROJECT_NAME"] = NewConstant(getProjectName(gitMeta.RemoteURL))
 	}
 	return ret
+}
+
+// SetPlatformArgs set the platform-specific built-in args to a specific platform.
+func (c *Collection) SetPlatformArgs(platform specs.Platform) {
+	c.variables["TARGETPLATFORM"] = NewConstant(platforms.Format(platform))
+	c.variables["TARGETOS"] = NewConstant(platform.OS)
+	c.variables["TARGETARCH"] = NewConstant(platform.Architecture)
+	c.variables["TARGETVARIANT"] = NewConstant(platform.Variant)
 }
 
 // WithParseBuildArgs takes in a slice of build args to be parsed and returns another collection

--- a/variables/collection_test.go
+++ b/variables/collection_test.go
@@ -1,0 +1,29 @@
+package variables
+
+import (
+	"testing"
+
+	. "github.com/stretchr/testify/assert"
+)
+
+func TestGetProjectName(t *testing.T) {
+	var tests = []struct {
+		tag  string
+		safe string
+	}{
+		{"http://github.com/earthly/earthly", "earthly/earthly"},
+		{"http://gitlab.com/earthly/earthly", "earthly/earthly"},
+		{"https://github.com/earthly/earthly", "earthly/earthly"},
+		{"https://user@github.com/earthly/earthly", "earthly/earthly"},
+		{"https://user:password@github.com/earthly/earthly", "earthly/earthly"},
+		{"git@github.com:earthly/earthly", "earthly/earthly"},
+		{"git@bitbucket.com:earthly/earthly", "earthly/earthly"},
+		{"ssh://git@github.com/earthly/earthly", "earthly/earthly"},
+		{"ssh://git@github.com:22/earthly/earthly", "earthly/earthly"},
+	}
+
+	for _, tt := range tests {
+		ans := getProjectName(tt.tag)
+		Equal(t, tt.safe, ans)
+	}
+}


### PR DESCRIPTION
Re #536 
Depends on https://github.com/earthly/buildkit/pull/21

* If a build does not use any `--platform` flag, it should behave exactly the same as before
* Allows pushes with manifest lists (multiarch images)
* Locally multi-platform images are produced with separate tag suffixes
  ![Screenshot from 2020-12-22 16-14-00](https://user-images.githubusercontent.com/446771/102946167-ab8d6e80-4474-11eb-8ef8-ba855b968d53.png)
* Add an example that is also used as an integration test
* Propagate `--platform` setting similarly to build args (they do not cross Earthfile boundaries)
* Detect if there is a contradiction of platforms (eg call with `--platform linux/amd64` but it contains a `FROM --platform linux/arm/v7` command)
* Add arm64 earthly binary