### PR TITLE
Support for Apple M1

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -233,7 +233,12 @@ for-linux:
 
 for-darwin:
     BUILD ./buildkitd+buildkitd
-    COPY +earthly-darwin/earthly ./
+    COPY +earthly-darwin-amd64/earthly ./
+    SAVE ARTIFACT ./earthly
+
+for-darwin-m1:
+    BUILD ./buildkitd+buildkitd
+    COPY +earthly-darwin-arm64/earthly ./
     SAVE ARTIFACT ./earthly
 
 all:

--- a/Earthfile
+++ b/Earthfile
@@ -237,7 +237,10 @@ for-darwin:
     SAVE ARTIFACT ./earthly
 
 all:
-    BUILD ./buildkitd+buildkitd
+    BUILD \
+        --platform=linux/amd64 \
+        --platform=linux/arm64 \
+        ./buildkitd+buildkitd
     BUILD +earthly-all
     BUILD +earthly-docker
     BUILD +prerelease

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -190,10 +190,12 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 				if err != nil {
 					return nil, errors.Wrapf(err, "marshal save image config")
 				}
-				refKey := fmt.Sprintf("image-%d", imageIndex)
-				refPrefix := fmt.Sprintf("ref/%s", refKey)
-				imageIndex++
+
 				if sts.Platform == nil {
+					refKey := fmt.Sprintf("image-%d", imageIndex)
+					refPrefix := fmt.Sprintf("ref/%s", refKey)
+					imageIndex++
+
 					res.AddMeta(fmt.Sprintf("%s/image.name", refPrefix), []byte(saveImage.DockerTag))
 					if shouldPush {
 						res.AddMeta(fmt.Sprintf("%s/export-image-push", refPrefix), []byte("true"))
@@ -215,6 +217,10 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 
 					// For push.
 					if shouldPush {
+						refKey := fmt.Sprintf("image-%d", imageIndex)
+						refPrefix := fmt.Sprintf("ref/%s", refKey)
+						imageIndex++
+
 						res.AddMeta(fmt.Sprintf("%s/image.name", refPrefix), []byte(saveImage.DockerTag))
 						res.AddMeta(fmt.Sprintf("%s/platform", refPrefix), []byte(llbutil.PlatformToString(sts.Platform)))
 						res.AddMeta(fmt.Sprintf("%s/export-image-push", refPrefix), []byte("true"))
@@ -228,6 +234,10 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 
 					// For local.
 					if shouldExport {
+						refKey := fmt.Sprintf("image-%d", imageIndex)
+						refPrefix := fmt.Sprintf("ref/%s", refKey)
+						imageIndex++
+
 						platformImgName, err := platformSpecificImageName(saveImage.DockerTag, *sts.Platform)
 						if err != nil {
 							return nil, err

--- a/release/Earthfile
+++ b/release/Earthfile
@@ -17,9 +17,17 @@ release-dockerhub:
     BUILD --build-arg DIND_ALPINE_TAG=latest ../+dind-alpine
     BUILD --build-arg DIND_UBUNTU_TAG=ubuntu ../+dind-ubuntu
     BUILD --build-arg TAG="$RELEASE_TAG" ../+earthly-docker
-    BUILD --build-arg TAG="$RELEASE_TAG" ../buildkitd+buildkitd
+    BUILD \
+        --platform=linux/amd64 \
+        --platform=linux/arm64 \
+        --build-arg TAG="$RELEASE_TAG" \
+        ../buildkitd+buildkitd
     BUILD --build-arg TAG=latest ../+earthly-docker
-    BUILD --build-arg TAG=latest ../buildkitd+buildkitd
+    BUILD \
+        --platform=linux/amd64 \
+        --platform=linux/arm64 \
+        --build-arg TAG=latest \
+        ../buildkitd+buildkitd
 
 release-github:
     FROM node:13.10.1-alpine3.11
@@ -33,6 +41,7 @@ release-github:
     RUN ls ./release
     RUN test -f ./release/earthly-linux-amd64 && \
         test -f ./release/earthly-darwin-amd64 && \
+        test -f ./release/earthly-darwin-arm64 && \
         test -f ./release/earthly-linux-arm5 && \
         test -f ./release/earthly-linux-arm6 && \
         test -f ./release/earthly-linux-arm7 && \


### PR DESCRIPTION
* Build buildkit image for both amd64 and arm64
* Don't install shellcheck unless running `+lint-scripts` (shellcheck not available on arm)
* Fix a bug where platform suffixes were being pushed but shouldn't have