### PR TITLE
Add --if-exists to COPY and SAVE ARTIFACT

### DIFF
--- a/.buildkite/macOS.yml
+++ b/.buildkite/macOS.yml
@@ -8,3 +8,4 @@ steps:
       EARTHLY_BUILD_ARGS: "DOCKERHUB_USER_SECRET=+secrets/earthly-technologies/dockerhub/user,DOCKERHUB_TOKEN_SECRET=+secrets/earthly-technologies/dockerhub/token"
     agents:
       os: macOS
+      arch: amd64

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.interp
 .antlr/
 .env
+.vscode

--- a/buildcontext/git.go
+++ b/buildcontext/git.go
@@ -61,7 +61,7 @@ func (gr *gitResolver) resolveEarthProject(ctx context.Context, gwClient gwclien
 	} else {
 		buildContext = llbutil.ScratchWithPlatform()
 		buildContext = llbutil.CopyOp(
-			rgp.state, []string{subDir}, buildContext, "./", false, false, false, "root:root",
+			rgp.state, []string{subDir}, buildContext, "./", false, false, false, "root:root", false,
 			llb.WithCustomNamef("[internal] COPY git context %s", target.String()))
 	}
 

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -274,9 +274,10 @@ func (c *Converter) CopyArtifact(ctx context.Context, artifactName string, dest 
 		relevantDepState.ArtifactsState, []string{artifact.Artifact},
 		c.mts.Final.MainState, dest, true, isDir, keepTs, c.copyOwner(keepOwn, chown), ifExists,
 		llb.WithCustomNamef(
-			"%sCOPY %s%s%s %s",
+			"%sCOPY %s%s%s%s %s",
 			c.vertexPrefix(),
 			strIf(isDir, "--dir "),
+			strIf(ifExists, "--if-exists "),
 			joinWrap(buildArgs, "(", " ", ") "),
 			artifact.String(),
 			dest))
@@ -365,15 +366,15 @@ func (c *Converter) SaveArtifact(ctx context.Context, saveFrom string, saveTo st
 		c.mts.Final.MainState, []string{saveFrom}, c.mts.Final.ArtifactsState,
 		saveToAdjusted, true, true, keepTs, own, ifExists,
 		llb.WithCustomNamef(
-			"%sSAVE ARTIFACT %s %s", c.vertexPrefix(), saveFrom, artifact.String()))
+			"%sSAVE ARTIFACT %s %s %s", c.vertexPrefix(), strIf(ifExists, "--if-exists"), saveFrom, artifact.String()))
 	if saveAsLocalTo != "" {
 		separateArtifactsState := llbutil.ScratchWithPlatform()
 		separateArtifactsState = llbutil.CopyOp(
 			c.mts.Final.MainState, []string{saveFrom}, separateArtifactsState,
 			saveToAdjusted, true, false, keepTs, "root:root", ifExists,
 			llb.WithCustomNamef(
-				"%sSAVE ARTIFACT %s %s AS LOCAL %s",
-				c.vertexPrefix(), saveFrom, artifact.String(), saveAsLocalTo))
+				"%sSAVE ARTIFACT %s %s %s AS LOCAL %s",
+				c.vertexPrefix(), strIf(ifExists, "--if-exists"), saveFrom, artifact.String(), saveAsLocalTo))
 		c.mts.Final.SeparateArtifactsState = append(c.mts.Final.SeparateArtifactsState, separateArtifactsState)
 		c.mts.Final.SaveLocals = append(c.mts.Final.SaveLocals, states.SaveLocal{
 			DestPath:     saveAsLocalTo,

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -380,6 +380,7 @@ func (c *Converter) SaveArtifact(ctx context.Context, saveFrom string, saveTo st
 			DestPath:     saveAsLocalTo,
 			ArtifactPath: artifactPath,
 			Index:        len(c.mts.Final.SeparateArtifactsState) - 1,
+			IfExists:     ifExists,
 		})
 	}
 	c.ranSave = true

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -366,15 +366,15 @@ func (c *Converter) SaveArtifact(ctx context.Context, saveFrom string, saveTo st
 		c.mts.Final.MainState, []string{saveFrom}, c.mts.Final.ArtifactsState,
 		saveToAdjusted, true, true, keepTs, own, ifExists,
 		llb.WithCustomNamef(
-			"%sSAVE ARTIFACT %s %s %s", c.vertexPrefix(), strIf(ifExists, "--if-exists"), saveFrom, artifact.String()))
+			"%sSAVE ARTIFACT %s%s %s", c.vertexPrefix(), strIf(ifExists, "--if-exists "), saveFrom, artifact.String()))
 	if saveAsLocalTo != "" {
 		separateArtifactsState := llbutil.ScratchWithPlatform()
 		separateArtifactsState = llbutil.CopyOp(
 			c.mts.Final.MainState, []string{saveFrom}, separateArtifactsState,
 			saveToAdjusted, true, false, keepTs, "root:root", ifExists,
 			llb.WithCustomNamef(
-				"%sSAVE ARTIFACT %s %s %s AS LOCAL %s",
-				c.vertexPrefix(), strIf(ifExists, "--if-exists"), saveFrom, artifact.String(), saveAsLocalTo))
+				"%sSAVE ARTIFACT %s%s %s AS LOCAL %s",
+				c.vertexPrefix(), strIf(ifExists, "--if-exists "), saveFrom, artifact.String(), saveAsLocalTo))
 		c.mts.Final.SeparateArtifactsState = append(c.mts.Final.SeparateArtifactsState, separateArtifactsState)
 		c.mts.Final.SaveLocals = append(c.mts.Final.SaveLocals, states.SaveLocal{
 			DestPath:     saveAsLocalTo,

--- a/earthfile2llb/listener.go
+++ b/earthfile2llb/listener.go
@@ -229,6 +229,7 @@ func (l *listener) ExitCopyStmt(c *parser.CopyStmtContext) {
 	chown := fs.String("chown", "", "Apply a specific group and/or owner to the copied files and directories")
 	keepTs := fs.Bool("keep-ts", false, "Keep created time file timestamps")
 	keepOwn := fs.Bool("keep-own", false, "Keep owner info")
+	ifExists := fs.Bool("if-exists", false, "Do not fail if the artifact does not exist")
 	platformStr := fs.String("platform", "", "The platform to use")
 	buildArgs := new(StringSliceFlag)
 	fs.Var(buildArgs, "build-arg", "A build arg override passed on to a referenced Earthly target")
@@ -280,7 +281,7 @@ func (l *listener) ExitCopyStmt(c *parser.CopyStmtContext) {
 	}
 	if allArtifacts {
 		for _, src := range srcs {
-			err = l.converter.CopyArtifact(l.ctx, src, dest, platform, buildArgs.Args, *isDirCopy, *keepTs, *keepOwn, *chown)
+			err = l.converter.CopyArtifact(l.ctx, src, dest, platform, buildArgs.Args, *isDirCopy, *keepTs, *keepOwn, *chown, *ifExists)
 			if err != nil {
 				l.err = errors.Wrapf(err, "copy artifact")
 				return
@@ -385,6 +386,7 @@ func (l *listener) ExitSaveArtifact(c *parser.SaveArtifactContext) {
 	fs := flag.NewFlagSet("SAVE ARTIFACT", flag.ContinueOnError)
 	keepTs := fs.Bool("keep-ts", false, "Keep created time file timestamps")
 	keepOwn := fs.Bool("keep-own", false, "Keep owner info")
+	ifExists := fs.Bool("if-exists", false, "Do not fail if the artifact does not exist")
 	err := fs.Parse(l.stmtWords)
 	if err != nil {
 		l.err = errors.Wrapf(err, "invalid SAVE arguments %v", l.stmtWords)
@@ -395,7 +397,7 @@ func (l *listener) ExitSaveArtifact(c *parser.SaveArtifactContext) {
 		l.err = fmt.Errorf("no arguments provided to the SAVE ARTIFACT command")
 		return
 	}
-	if fs.NArg() > 5 {
+	if fs.NArg() > 6 {
 		l.err = fmt.Errorf("too many arguments provided to the SAVE ARTIFACT command: %v", l.stmtWords)
 		return
 	}
@@ -421,7 +423,7 @@ func (l *listener) ExitSaveArtifact(c *parser.SaveArtifactContext) {
 	saveFrom := l.expandArgs(fs.Args()[0], false)
 	saveTo = l.expandArgs(saveTo, false)
 	saveAsLocalTo = l.expandArgs(saveAsLocalTo, false)
-	err = l.converter.SaveArtifact(l.ctx, saveFrom, saveTo, saveAsLocalTo, *keepTs, *keepOwn)
+	err = l.converter.SaveArtifact(l.ctx, saveFrom, saveTo, saveAsLocalTo, *keepTs, *keepOwn, *ifExists)
 	if err != nil {
 		l.err = errors.Wrap(err, "apply SAVE ARTIFACT")
 		return

--- a/earthfile2llb/listener.go
+++ b/earthfile2llb/listener.go
@@ -397,7 +397,7 @@ func (l *listener) ExitSaveArtifact(c *parser.SaveArtifactContext) {
 		l.err = fmt.Errorf("no arguments provided to the SAVE ARTIFACT command")
 		return
 	}
-	if fs.NArg() > 6 {
+	if fs.NArg() > 5 {
 		l.err = fmt.Errorf("too many arguments provided to the SAVE ARTIFACT command: %v", l.stmtWords)
 		return
 	}

--- a/examples/tests/Earthfile
+++ b/examples/tests/Earthfile
@@ -51,6 +51,7 @@ ga:
     BUILD +escape-dir-test
     BUILD +fail-invalid-artifact-test
     BUILD +target-first-line
+    BUILD +if-exists
     BUILD ./autocompletion+test-all
     BUILD ./with-docker+all
     BUILD ./with-docker-compose+all

--- a/examples/tests/Earthfile
+++ b/examples/tests/Earthfile
@@ -414,3 +414,20 @@ target-first-line:
         --entrypoint \
         --mount=type=tmpfs,target=/tmp/earthly \
         -- --no-output +test
+
+if-exists:
+    COPY if-exists.earth ./Earthfile
+    RUN --privileged \
+        --entrypoint \
+        --mount=type=tmpfs,target=/tmp/earthly \
+        -- +save-exist-local
+
+    # test that the 'failed with exit code' text is printed out
+    RUN --privileged \
+        --mount=type=tmpfs,target=/tmp/earthly \
+        /usr/bin/earthly-buildkitd-wrapper.sh +save-not-exist 2>&1 | perl -pe 'BEGIN {$status=1} END {exit $status} $status=0 if /save-not-exist/;'
+
+    # test that the 'failed with exit code' text is printed out
+    RUN --privileged \
+        --mount=type=tmpfs,target=/tmp/earthly \
+        /usr/bin/earthly-buildkitd-wrapper.sh +copy-not-exist 2>&1 | perl -pe 'BEGIN {$status=1} END {exit $status} $status=0 if /copy-not-exist/;'

--- a/examples/tests/Earthfile
+++ b/examples/tests/Earthfile
@@ -422,12 +422,18 @@ if-exists:
         --mount=type=tmpfs,target=/tmp/earthly \
         -- +save-exist-local
 
-    # test that the 'failed with exit code' text is printed out
     RUN --privileged \
         --mount=type=tmpfs,target=/tmp/earthly \
         /usr/bin/earthly-buildkitd-wrapper.sh +save-not-exist 2>&1 | perl -pe 'BEGIN {$status=1} END {exit $status} $status=0 if /save-not-exist/;'
 
-    # test that the 'failed with exit code' text is printed out
     RUN --privileged \
         --mount=type=tmpfs,target=/tmp/earthly \
         /usr/bin/earthly-buildkitd-wrapper.sh +copy-not-exist 2>&1 | perl -pe 'BEGIN {$status=1} END {exit $status} $status=0 if /copy-not-exist/;'
+
+    RUN --privileged \
+        --mount=type=tmpfs,target=/tmp/earthly \
+        /usr/bin/earthly-buildkitd-wrapper.sh +bad-wildcard-copy 2>&1 | perl -pe 'BEGIN {$status=1} END {exit $status} $status=0 if /bad-wildcard-copy/;'
+
+    RUN --privileged \
+        --mount=type=tmpfs,target=/tmp/earthly \
+        /usr/bin/earthly-buildkitd-wrapper.sh +bad-wildcard-save 2>&1 | perl -pe 'BEGIN {$status=1} END {exit $status} $status=0 if /bad-wildcard-save/;'

--- a/examples/tests/if-exists.earth
+++ b/examples/tests/if-exists.earth
@@ -1,0 +1,38 @@
+FROM alpine:3.11
+
+save:
+    RUN echo "aaa" > ok
+
+    RUN mkdir testdir
+    RUN echo "bbb" > testdir/1
+    RUN echo "ccc" > testdir/2
+
+    SAVE ARTIFACT ok
+    SAVE ARTIFACT --if-exists not_ok
+
+    SAVE ARTIFACT testdir/*
+
+save-exist-local:
+    FROM +save
+
+    COPY +save/ok ok
+    COPY --if-exists +save/not_ok not_ok
+
+    COPY +save/1 1
+    COPY +save/2 2
+    COPY --if-exists +save/3 3
+
+    SAVE ARTIFACT ok AS LOCAL ok
+    SAVE ARTIFACT --if-exists not_ok AS LOCAL not_ok
+
+    SAVE ARTIFACT 1 AS LOCAL 1
+    SAVE ARTIFACT 2 AS LOCAL 2
+    SAVE ARTIFACT --if-exists 3 AS LOCAL 3
+
+save-not-exist:
+    FROM +save
+    SAVE ARTIFACT not_ok AS LOCAL not_ok
+
+copy-not-exist:
+    FROM +save
+    COPY +save/not_ok not_ok

--- a/examples/tests/if-exists.earth
+++ b/examples/tests/if-exists.earth
@@ -36,3 +36,11 @@ save-not-exist:
 copy-not-exist:
     FROM +save
     COPY +save/not_ok not_ok
+
+bad-wildcard-copy:
+    FROM +save
+    COPY +save/baddir/* .
+
+bad-wildcard-save:
+    FROM +save
+    SAVE ARTIFACT baddir/* AS LOCAL baddir

--- a/states/states.go
+++ b/states/states.go
@@ -72,6 +72,8 @@ type SaveLocal struct {
 	ArtifactPath string
 	// Index is the index number of the "save as local" command encountered. Starts as 0.
 	Index int
+	// IfExists allows the artifact to be optional.
+	IfExists bool
 }
 
 // SaveImage is a docker image to be saved.


### PR DESCRIPTION
It was super easy to add it to `COPY`; and seemed applicable because you can COPY artifacts from upstream targets (see the `CopyArtifact` function...)

I chose to implement it by exploiting the "Allow Empty Wildcard" option for the LLB copy; as that logic is exactly the logic I also want to follow; just with an exact file name. This changes the filename into a wildcard-type string (that is sufficiently constrained enough to only match the file we want), and then enables the "Allow Empty Wildcard" behavior for the optional artifacts.

Admittedly a hack; but it was certainly less invasive than evaluating where we were at in a `WITH DOCKER` style setup for each artifact, and some `COPY`s. 

Resolves #588.
