### PR TITLE
Fix multiarch build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
       - name: Build latest earthly using released earthly
         run: earthly --use-inline-cache +for-linux
-      - name: Rebuild and push
+      - name: Build +all
         run: ./build/linux/amd64/earthly --ci +all
       - name: Buildkit logs (runs on failure)
         run: docker logs earthly-buildkitd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,44 @@ on:
     branches: [ main ]
 
 jobs:
+  build:
+    name: +all
+    runs-on: ubuntu-latest
+    env:
+      FORCE_COLOR: 1
+      EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"
+      EARTHLY_INSTALL_ID: "earthly-githubactions"
+    steps:
+      - uses: actions/checkout@v2
+      -
+        name: Set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@v1
+        with:
+          image: tonistiigi/binfmt:latest
+          platforms: all
+      - name: "Put back the git branch into git (Earthly uses it for tagging)"
+        run: |
+          branch=""
+          if [ -n "$GITHUB_HEAD_REF" ]; then
+            branch="$GITHUB_HEAD_REF"
+          else
+            branch="${GITHUB_REF##*/}"
+          fi
+          git checkout -b "$branch" || true
+      - name: Download released earthly
+        run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/latest/download/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly'"
+      - name: Docker Login (non fork only)
+        run: docker login --username "${{ secrets.DOCKERHUB_USERNAME }}" --password "${{ secrets.DOCKERHUB_TOKEN }}"
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+      - name: Build latest earthly using released earthly
+        run: earthly --use-inline-cache +for-linux
+      - name: Rebuild and push
+        run: ./build/linux/amd64/earthly --ci +all
+      - name: Buildkit logs (runs on failure)
+        run: docker logs earthly-buildkitd
+        if: ${{ failure() }}
+
   tests:
     name: +test +test-fail
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,44 +7,6 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
-    name: +all
-    runs-on: ubuntu-latest
-    env:
-      FORCE_COLOR: 1
-      EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"
-      EARTHLY_INSTALL_ID: "earthly-githubactions"
-    steps:
-      - uses: actions/checkout@v2
-      -
-        name: Set up QEMU
-        id: qemu
-        uses: docker/setup-qemu-action@v1
-        with:
-          image: tonistiigi/binfmt:latest
-          platforms: all
-      - name: "Put back the git branch into git (Earthly uses it for tagging)"
-        run: |
-          branch=""
-          if [ -n "$GITHUB_HEAD_REF" ]; then
-            branch="$GITHUB_HEAD_REF"
-          else
-            branch="${GITHUB_REF##*/}"
-          fi
-          git checkout -b "$branch" || true
-      - name: Download released earthly
-        run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/latest/download/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly'"
-      - name: Docker Login (non fork only)
-        run: docker login --username "${{ secrets.DOCKERHUB_USERNAME }}" --password "${{ secrets.DOCKERHUB_TOKEN }}"
-        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-      - name: Build latest earthly using released earthly
-        run: earthly --use-inline-cache +for-linux
-      - name: Build +all
-        run: ./build/linux/amd64/earthly --ci +all
-      - name: Buildkit logs (runs on failure)
-        run: docker logs earthly-buildkitd
-        if: ${{ failure() }}
-
   tests:
     name: +test +test-fail
     runs-on: ubuntu-latest

--- a/Earthfile
+++ b/Earthfile
@@ -131,22 +131,6 @@ earthly:
     SAVE ARTIFACT build/earthly AS LOCAL "build/$GOOS/$GOARCH$GOARM/earthly"
     SAVE IMAGE --cache-from=earthly/earthly:main
 
-earthly-arm5:
-    COPY \
-        --build-arg GOARCH=arm \
-        --build-arg GOARM=5 \
-        --build-arg GO_EXTRA_LDFLAGS= \
-        +earthly/* ./
-    SAVE ARTIFACT ./*
-
-earthly-arm6:
-    COPY \
-        --build-arg GOARCH=arm \
-        --build-arg GOARM=6 \
-        --build-arg GO_EXTRA_LDFLAGS= \
-        +earthly/* ./
-    SAVE ARTIFACT ./*
-
 earthly-arm7:
     COPY \
         --build-arg GOARCH=arm \
@@ -171,6 +155,7 @@ earthly-darwin-amd64:
     SAVE ARTIFACT ./*
 
 earthly-darwin-arm64:
+    # TODO: This doesn't work yet. https://github.com/golang/go/issues/40698#issuecomment-680134833
     COPY \
         --build-arg GOOS=darwin \
         --build-arg GOARCH=arm64 \
@@ -181,9 +166,7 @@ earthly-darwin-arm64:
 earthly-all:
     COPY +earthly/earthly ./earthly-linux-amd64
     COPY +earthly-darwin-amd64/earthly ./earthly-darwin-amd64
-    COPY +earthly-darwin-arm64/earthly ./earthly-darwin-arm64
-    COPY +earthly-arm5/earthly ./earthly-linux-arm5
-    COPY +earthly-arm6/earthly ./earthly-linux-arm6
+    #COPY +earthly-darwin-arm64/earthly ./earthly-darwin-arm64
     COPY +earthly-arm7/earthly ./earthly-linux-arm7
     COPY +earthly-arm64/earthly ./earthly-linux-arm64
     SAVE ARTIFACT ./*
@@ -203,6 +186,7 @@ prerelease:
     FROM alpine:3.11
     BUILD --build-arg TAG=prerelease \
         --platform=linux/amd64 \
+        --platform=linux/arm/v7 \
         --platform=linux/arm64 \
         ./buildkitd+buildkitd
     COPY --build-arg VERSION=prerelease +earthly-all/* ./
@@ -238,12 +222,14 @@ for-darwin:
 
 for-darwin-m1:
     BUILD ./buildkitd+buildkitd
-    COPY +earthly-darwin-arm64/earthly ./
+    # amd64 works on arm64 via rosetta 2.
+    COPY +earthly-darwin-amd64/earthly ./
     SAVE ARTIFACT ./earthly
 
 all:
     BUILD \
         --platform=linux/amd64 \
+        --platform=linux/arm/v7 \
         --platform=linux/arm64 \
         ./buildkitd+buildkitd
     BUILD +earthly-all

--- a/release/Earthfile
+++ b/release/Earthfile
@@ -19,12 +19,14 @@ release-dockerhub:
     BUILD --build-arg TAG="$RELEASE_TAG" ../+earthly-docker
     BUILD \
         --platform=linux/amd64 \
+        --platform=linux/arm/v7 \
         --platform=linux/arm64 \
         --build-arg TAG="$RELEASE_TAG" \
         ../buildkitd+buildkitd
     BUILD --build-arg TAG=latest ../+earthly-docker
     BUILD \
         --platform=linux/amd64 \
+        --platform=linux/arm/v7 \
         --platform=linux/arm64 \
         --build-arg TAG=latest \
         ../buildkitd+buildkitd
@@ -41,9 +43,6 @@ release-github:
     RUN ls ./release
     RUN test -f ./release/earthly-linux-amd64 && \
         test -f ./release/earthly-darwin-amd64 && \
-        test -f ./release/earthly-darwin-arm64 && \
-        test -f ./release/earthly-linux-arm5 && \
-        test -f ./release/earthly-linux-arm6 && \
         test -f ./release/earthly-linux-arm7 && \
         test -f ./release/earthly-linux-arm64
     ARG BODY="No details provided"


### PR DESCRIPTION
* Seems that darwin-arm64 binary cannot be built yet (https://github.com/golang/go/issues/40698#issuecomment-680134833). Though the amd64 one should work well enough via rosetta 2.
* We cannot support arm/v5 and arm/v6 as we cannot build buildkit images for them (No base images available). This should be fine generally, as these are older architectures superseded by arm/v7 and arm64.