### PR TITLE
Document the --secret-file and type=secret mount

### DIFF
--- a/docs/earthfile/earthfile.md
+++ b/docs/earthfile/earthfile.md
@@ -220,8 +220,9 @@ The `<mount-spec>` is defined as a series of comma-separated list of key-values.
 
 | Key | Description | Example |
 | --- | --- | --- |
-| `type` | The type of the mount. Currently only `cache` and `tmpfs` are allowed. | `type=cache` |
+| `type` | The type of the mount. Currently only `cache`, `tmpfs`, and `secret` are allowed. | `type=cache` |
 | `target` | The target path for the mount. | `target=/var/lib/data` |
+| `id` | The secret ID for the contents of the `target` file, only applicable for `type=secret`. | `id=+secrets/password` |
 
 Example:
 

--- a/docs/earthly-command/earthly-command.md
+++ b/docs/earthly-command/earthly-command.md
@@ -114,6 +114,14 @@ Passes a secret with ID `<secret-id>` to the build environments. If `<value>` is
 
 The secret can be referenced within Earthfile recipes as `RUN --secret <arbitrary-env-var-name>=+secrets/<secret-id>`. For more information see the [`RUN --secret` Earthfile command](../earthfile/earthfile.md#run).
 
+##### `--secret-file <secret-id>=<path>`
+
+Also available as an env var setting: `EARTHLY_SECRET_FILES="<secret-id>=<path>,<secret-id>=<path>,..."`.
+
+Loads the contents of a file located at `<path>` into a secret with ID `<secret-id>` for use within the build environments.
+
+The secret can be referenced within Earthfile recipes as `RUN --secret <arbitrary-env-var-name>=+secrets/<secret-id>`. For more information see the [`RUN --secret` Earthfile command](../earthfile/earthfile.md#run).
+
 ##### `--push`
 
 Also available as an env var setting: `EARTHLY_PUSH=true`.


### PR DESCRIPTION
- these features were released with earthly v0.4.4, but were never
documented.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>