### PR TITLE
A series of fixes to better support Apple M1

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -236,8 +236,7 @@ for-darwin:
 
 for-darwin-m1:
     BUILD ./buildkitd+buildkitd
-    # amd64 works on arm64 via rosetta 2.
-    COPY +earthly-darwin-amd64/earthly ./
+    COPY +earthly-darwin-arm64/earthly ./
     SAVE ARTIFACT ./earthly
 
 all:

--- a/Earthfile
+++ b/Earthfile
@@ -111,7 +111,7 @@ earthly:
     ARG VARIANT=$TARGETVARIANT
     ARG GO_EXTRA_LDFLAGS="-linkmode external -extldflags -static"
     RUN test -n "$GOOS" && test -n "$GOARCH"
-    RUN test "$GOARCH" != "ARM" || test -n "$GOARM"
+    RUN test "$GOARCH" != "arm" || test -n "$VARIANT"
     ARG EARTHLY_TARGET_TAG_DOCKER
     ARG VERSION=$EARTHLY_TARGET_TAG_DOCKER
     ARG EARTHLY_GIT_HASH
@@ -135,7 +135,7 @@ earthly:
             cmd/earthly/*.go
     SAVE ARTIFACT ./build/tags
     SAVE ARTIFACT ./build/ldflags
-    SAVE ARTIFACT build/earthly AS LOCAL "build/$GOOS/$GOARCH$GOARM/earthly"
+    SAVE ARTIFACT build/earthly AS LOCAL "build/$GOOS/$GOARCH$VARIANT/earthly"
     SAVE IMAGE --cache-from=earthly/earthly:main
 
 earthly-linux-amd64:

--- a/Earthfile
+++ b/Earthfile
@@ -41,7 +41,7 @@ code:
     COPY --dir earthfile2llb/antlrhandler earthfile2llb/*.go earthfile2llb/
 
 lint-scripts:
-    FROM alpine:3.13
+    FROM --platform=linux/amd64 alpine:3.13
     RUN apk add --update --no-cache shellcheck
     COPY ./earthly ./scripts/install-all-versions.sh ./buildkitd/entrypoint.sh ./earthly-buildkitd-wrapper.sh \
         ./buildkitd/dockerd-wrapper.sh ./buildkitd/docker-auto-install.sh \

--- a/Earthfile
+++ b/Earthfile
@@ -225,17 +225,17 @@ dind-ubuntu:
     SAVE IMAGE --push --cache-from=earthly/dind:ubuntu-main earthly/dind:$DIND_UBUNTU_TAG
 
 for-linux:
-    BUILD ./buildkitd+buildkitd
+    BUILD --platform=linux/amd64 ./buildkitd+buildkitd
     COPY +earthly-linux-amd64/earthly ./
     SAVE ARTIFACT ./earthly
 
 for-darwin:
-    BUILD ./buildkitd+buildkitd
+    BUILD --platform=linux/amd64 ./buildkitd+buildkitd
     COPY +earthly-darwin-amd64/earthly ./
     SAVE ARTIFACT ./earthly
 
 for-darwin-m1:
-    BUILD ./buildkitd+buildkitd
+    BUILD --platform=linux/arm64 ./buildkitd+buildkitd
     COPY +earthly-darwin-arm64/earthly ./
     SAVE ARTIFACT ./earthly
 

--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -25,8 +25,9 @@ buildkitd:
     COPY ./cni-conf.json /etc/cni/cni-conf.json
 
     # Scripts and binaries used for the builds.
-    COPY ../+shellrepeater/shellrepeater /usr/bin/shellrepeater
-    COPY ../+debugger/earth_debugger /usr/bin/earth_debugger
+    ARG TARGETPLATFORM
+    COPY --platform=$TARGETPLATFORM ../+shellrepeater/shellrepeater /usr/bin/shellrepeater
+    COPY --platform=$TARGETPLATFORM ../+debugger/earth_debugger /usr/bin/earth_debugger
     COPY ./dockerd-wrapper.sh /var/earthly/dockerd-wrapper.sh
     COPY ./docker-auto-install.sh /var/earthly/docker-auto-install.sh
 

--- a/earthly
+++ b/earthly
@@ -19,7 +19,11 @@ get_latest_binary() {
 
     earth_bin_path=/earthly-linux-amd64
     if [ "$(uname)" == "Darwin" ]; then
-        earth_bin_path=/earthly-darwin-amd64
+        if [ "$(uname -m)" == "arm64" ]; then
+            earth_bin_path=/earthly-darwin-arm64
+        else
+            earth_bin_path=/earthly-darwin-amd64
+        fi
     fi
 
     docker cp earthly_binary:"$earth_bin_path" "$bindir/earthly-prerelease"

--- a/release/Earthfile
+++ b/release/Earthfile
@@ -43,6 +43,7 @@ release-github:
     RUN ls ./release
     RUN test -f ./release/earthly-linux-amd64 && \
         test -f ./release/earthly-darwin-amd64 && \
+        test -f ./release/earthly-darwin-arm64 && \
         test -f ./release/earthly-linux-arm7 && \
         test -f ./release/earthly-linux-arm64
     ARG BODY="No details provided"


### PR DESCRIPTION
* Ability to compile for darwin arm64 (requires Go 1.16 beta; everything else will use Go 1.15)
* Add darwin arm64 to the release list
* Force `+lint-scripts` to run on amd64 since shellcheck is not available on arm
* `+earthly` attempts to autodetect your current platform