### PR TITLE
Print overrides on every command

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -156,6 +156,7 @@ earthly-linux-arm7:
 earthly-linux-arm64:
     COPY \
         --build-arg GOARCH=arm64 \
+        --build-arg VARIANT= \
         --build-arg GO_EXTRA_LDFLAGS= \
         +earthly/* ./
     SAVE ARTIFACT ./*
@@ -164,6 +165,7 @@ earthly-darwin-amd64:
     COPY \
         --build-arg GOOS=darwin \
         --build-arg GOARCH=amd64 \
+        --build-arg VARIANT= \
         --build-arg GO_EXTRA_LDFLAGS= \
         +earthly/* ./
     SAVE ARTIFACT ./*
@@ -173,6 +175,7 @@ earthly-darwin-arm64:
         --build-arg GO_VERSION=1.16beta1 \
         --build-arg GOOS=darwin \
         --build-arg GOARCH=arm64 \
+        --build-arg VARIANT= \
         --build-arg GO_EXTRA_LDFLAGS= \
         +earthly/* ./
     SAVE ARTIFACT ./*

--- a/builder/solver_monitor.go
+++ b/builder/solver_monitor.go
@@ -47,13 +47,13 @@ type vertexMonitor struct {
 	lastOpenLineSkipped bool
 }
 
-func (vm *vertexMonitor) printHeader(printMetadata bool) {
+func (vm *vertexMonitor) printHeader() {
 	vm.headerPrinted = true
 	if vm.operation == "" {
 		return
 	}
 	c := vm.console
-	if vm.targetBrackets != "" && printMetadata {
+	if vm.targetBrackets != "" {
 		c.WithMetadataMode(true).Printf("%s\n", vm.targetBrackets)
 	}
 	out := []string{}
@@ -350,7 +350,7 @@ func (sm *solverMonitor) printHeader(vm *vertexMonitor) {
 	if !seen {
 		sm.saltSeen[vm.salt] = true
 	}
-	vm.printHeader(!seen || sm.verbose)
+	vm.printHeader()
 }
 
 func (sm *solverMonitor) recordTiming(targetStr, targetBrackets, salt string, vertex *client.Vertex) {
@@ -423,7 +423,7 @@ func (sm *solverMonitor) reprintFailure(errVertex *vertexMonitor) {
 	sm.console.Warnf("Repeating the output of the command that caused the failure\n")
 	sm.console.PrintFailure()
 	errVertex.console = errVertex.console.WithFailed(true)
-	errVertex.printHeader(true)
+	errVertex.printHeader()
 	if errVertex.tailOutput != nil {
 		isTruncated := (errVertex.tailOutput.TotalWritten() > errVertex.tailOutput.Size())
 		if errVertex.tailOutput.TotalWritten() == 0 {

--- a/buildkitd/entrypoint.sh
+++ b/buildkitd/entrypoint.sh
@@ -78,6 +78,7 @@ echo "EARTHLY_ADDITIONAL_BUILDKIT_CONFIG=$EARTHLY_ADDITIONAL_BUILDKIT_CONFIG"
 echo "======== Buildkitd config =========="
 cat /etc/buildkitd.toml
 echo "======== End buildkitd config =========="
+echo "Detected container architecture is $(uname -m)"
 
 # start shell repeater server
 echo starting shellrepeater


### PR DESCRIPTION
Re #722 

* Print any build arg or platform overrides on every command
* Print detected architecture on buildkit startup
  ```
  Detected container architecture is x86_64
  ```
* Other minor adjustments

The output is now a bit more verbose when using `--platform` or `--build-arg`, however, this should improve readability when trying to follow the logs.

Random screenshot of a particularly verbose output:
![Screenshot from 2021-01-21 17-33-47](https://user-images.githubusercontent.com/446771/105433663-eb2fad80-5c0e-11eb-9fdb-c4a5d4e5c9d3.png)
