### PR TITLE
Fix build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         if: ${{ failure() }}
 
   misc-tests:
-    name: Misc tests
+    name: misc tests
     runs-on: ubuntu-latest
     env:
       FORCE_COLOR: 1
@@ -118,7 +118,7 @@ jobs:
         if: ${{ failure() }}
 
   cloud-integration:
-    name: Cloud Integration
+    name: cloud-integration
     runs-on: ubuntu-latest
     env:
       FORCE_COLOR: 1
@@ -169,8 +169,8 @@ jobs:
         run: docker logs earthly-buildkitd
         if: ${{ failure() }}
 
-  from-local-test:
-    name: FROM LOCAL test
+  test-local:
+    name: +test-local
     runs-on: ubuntu-latest
     env:
       FORCE_COLOR: 1
@@ -263,7 +263,16 @@ jobs:
   push:
     name: --push +all
     if: github.event_name == 'push'
-    needs: ["tests", "misc-tests", "examples", "cloud-integration"]
+    needs:
+      - tests
+      - misc-tests
+      - examples
+      - cloud-integration
+      - secrets-integration
+      - private-repo-test
+      - secrets
+      - test-local
+      - all
     runs-on: ubuntu-latest
     env:
       FORCE_COLOR: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,7 +266,6 @@ jobs:
       - cloud-integration
       - secrets-integration
       - private-repo-test
-      - secrets
       - test-local
       - all
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,7 @@ jobs:
         if: ${{ failure() }}
 
   cloud-integration:
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     env:
       FORCE_COLOR: 1
@@ -189,7 +190,7 @@ jobs:
         run: "! ls /tmp/earthly-test-local"
 
   private-repo-test:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     services:
       sshd:
         image: rastasheep/ubuntu-sshd:18.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,8 +219,8 @@ jobs:
         run: docker logs earthly-buildkitd
         if: ${{ failure() }}
 
-  all:
-    name: +all
+  all-buildkitd:
+    name: +all-buildkitd
     runs-on: ubuntu-latest
     env:
       FORCE_COLOR: 1
@@ -251,14 +251,130 @@ jobs:
         if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
       - name: Build latest earthly using released earthly
         run: earthly --use-inline-cache +for-linux
-      - name: Build +all
-        run: ./build/linux/amd64/earthly --ci +all
+      - name: Build +all-buildkitd
+        run: ./build/linux/amd64/earthly --ci +all-buildkitd
       - name: Buildkit logs (runs on failure)
         run: docker logs earthly-buildkitd
         if: ${{ failure() }}
 
-  push:
-    name: --push +all
+  all-dind:
+    name: +all-dind
+    runs-on: ubuntu-latest
+    env:
+      FORCE_COLOR: 1
+      EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"
+      EARTHLY_INSTALL_ID: "earthly-githubactions"
+    steps:
+      - uses: actions/checkout@v2
+      -
+        name: Set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@v1
+        with:
+          image: tonistiigi/binfmt:latest
+          platforms: all
+      - name: "Put back the git branch into git (Earthly uses it for tagging)"
+        run: |
+          branch=""
+          if [ -n "$GITHUB_HEAD_REF" ]; then
+            branch="$GITHUB_HEAD_REF"
+          else
+            branch="${GITHUB_REF##*/}"
+          fi
+          git checkout -b "$branch" || true
+      - name: Download released earthly
+        run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/latest/download/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly'"
+      - name: Docker Login (non fork only)
+        run: docker login --username "${{ secrets.DOCKERHUB_USERNAME }}" --password "${{ secrets.DOCKERHUB_TOKEN }}"
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+      - name: Build latest earthly using released earthly
+        run: earthly --use-inline-cache +for-linux
+      - name: Build +all-dind
+        run: ./build/linux/amd64/earthly --ci +all-dind
+      - name: Buildkit logs (runs on failure)
+        run: docker logs earthly-buildkitd
+        if: ${{ failure() }}
+  
+  earthly:
+    name: +earthly-all +earthly-docker
+    runs-on: ubuntu-latest
+    env:
+      FORCE_COLOR: 1
+      EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"
+      EARTHLY_INSTALL_ID: "earthly-githubactions"
+    steps:
+      - uses: actions/checkout@v2
+      -
+        name: Set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@v1
+        with:
+          image: tonistiigi/binfmt:latest
+          platforms: all
+      - name: "Put back the git branch into git (Earthly uses it for tagging)"
+        run: |
+          branch=""
+          if [ -n "$GITHUB_HEAD_REF" ]; then
+            branch="$GITHUB_HEAD_REF"
+          else
+            branch="${GITHUB_REF##*/}"
+          fi
+          git checkout -b "$branch" || true
+      - name: Download released earthly
+        run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/latest/download/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly'"
+      - name: Docker Login (non fork only)
+        run: docker login --username "${{ secrets.DOCKERHUB_USERNAME }}" --password "${{ secrets.DOCKERHUB_TOKEN }}"
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+      - name: Build latest earthly using released earthly
+        run: earthly --use-inline-cache +for-linux
+      - name: Build +earthly-all
+        run: ./build/linux/amd64/earthly --ci +earthly-all
+      - name: Build +earthly-docker
+        run: ./build/linux/amd64/earthly --ci +earthly-docker
+      - name: Buildkit logs (runs on failure)
+        run: docker logs earthly-buildkitd
+        if: ${{ failure() }}
+
+  prerelease:
+    name: +prerelease
+    runs-on: ubuntu-latest
+    env:
+      FORCE_COLOR: 1
+      EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"
+      EARTHLY_INSTALL_ID: "earthly-githubactions"
+    steps:
+      - uses: actions/checkout@v2
+      -
+        name: Set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@v1
+        with:
+          image: tonistiigi/binfmt:latest
+          platforms: all
+      - name: "Put back the git branch into git (Earthly uses it for tagging)"
+        run: |
+          branch=""
+          if [ -n "$GITHUB_HEAD_REF" ]; then
+            branch="$GITHUB_HEAD_REF"
+          else
+            branch="${GITHUB_REF##*/}"
+          fi
+          git checkout -b "$branch" || true
+      - name: Download released earthly
+        run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/latest/download/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly'"
+      - name: Docker Login (non fork only)
+        run: docker login --username "${{ secrets.DOCKERHUB_USERNAME }}" --password "${{ secrets.DOCKERHUB_TOKEN }}"
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+      - name: Build latest earthly using released earthly
+        run: earthly --use-inline-cache +for-linux
+      - name: Build +prerelease
+        run: ./build/linux/amd64/earthly --ci +prerelease
+      - name: Buildkit logs (runs on failure)
+        run: docker logs earthly-buildkitd
+        if: ${{ failure() }}
+
+  push-prerelease:
+    name: --push +prerelease
     if: github.event_name == 'push'
     needs:
       - tests
@@ -268,7 +384,10 @@ jobs:
       - secrets-integration
       - private-repo-test
       - test-local
-      - all
+      - all-buildkitd
+      - all-dind
+      - prerelease
+      - earthly
     runs-on: ubuntu-latest
     env:
       FORCE_COLOR: 1
@@ -298,8 +417,8 @@ jobs:
         run: docker login --username "${{ secrets.DOCKERHUB_USERNAME }}" --password "${{ secrets.DOCKERHUB_TOKEN }}"
       - name: Build latest earthly using released earthly
         run: earthly --use-inline-cache +for-linux
-      - name: Rebuild and push
-        run: ./build/linux/amd64/earthly --ci --push +all
+      - name: Build and push +prerelease
+        run: ./build/linux/amd64/earthly --ci --push +prerelease
       - name: Buildkit logs (runs on failure)
         run: docker logs earthly-buildkitd
         if: ${{ failure() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,6 @@ jobs:
         if: ${{ failure() }}
 
   misc-tests:
-    name: misc tests
     runs-on: ubuntu-latest
     env:
       FORCE_COLOR: 1
@@ -118,7 +117,6 @@ jobs:
         if: ${{ failure() }}
 
   cloud-integration:
-    name: cloud-integration
     runs-on: ubuntu-latest
     env:
       FORCE_COLOR: 1
@@ -145,8 +143,7 @@ jobs:
         run: docker logs earthly-buildkitd
         if: ${{ failure() }}
 
-  secrets:
-    name: secrets-integration
+  secrets-integration:
     runs-on: ubuntu-latest
     env:
       FORCE_COLOR: 1
@@ -192,7 +189,6 @@ jobs:
         run: "! ls /tmp/earthly-test-local"
 
   private-repo-test:
-    name: private repo test
     if: github.event_name == 'push'
     services:
       sshd:

--- a/Earthfile
+++ b/Earthfile
@@ -258,9 +258,11 @@ all:
     BUILD +prerelease
     BUILD \
         --platform=linux/amd64 \
-        --platform=linux/arm/v7 \
         --platform=linux/arm64 \
         +dind
+    BUILD \
+        --platform=linux/arm/v7 \
+        +dind-alpine
 
 test:
     BUILD +lint

--- a/Earthfile
+++ b/Earthfile
@@ -247,15 +247,14 @@ for-darwin-m1:
     COPY +earthly-darwin-arm64/earthly ./
     SAVE ARTIFACT ./earthly
 
-all:
+all-buildkitd:
     BUILD \
         --platform=linux/amd64 \
         --platform=linux/arm/v7 \
         --platform=linux/arm64 \
         ./buildkitd+buildkitd
-    BUILD +earthly-all
-    BUILD +earthly-docker
-    BUILD +prerelease
+
+all-dind:
     BUILD \
         --platform=linux/amd64 \
         --platform=linux/arm64 \
@@ -263,6 +262,13 @@ all:
     BUILD \
         --platform=linux/arm/v7 \
         +dind-alpine
+
+all:
+    BUILD +all-buildkitd
+    BUILD +earthly-all
+    BUILD +earthly-docker
+    BUILD +prerelease
+    BUILD +all-dind
 
 test:
     BUILD +lint

--- a/buildkitd/docker-auto-install.sh
+++ b/buildkitd/docker-auto-install.sh
@@ -33,9 +33,19 @@ install_docker_compose() {
         alpine)
             apk add --update --no-cache docker-compose
             ;;
-
         *)
-            curl -L "https://github.com/docker/compose/releases/download/1.27.4/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+            echo "Detected architecture is $(uname -m)"
+            case "$(uname -m)" in
+                armv7l|armhf)
+                    curl -L "https://github.com/linuxserver/docker-docker-compose/releases/download/1.27.4-ls27/docker-compose-armhf" -o /usr/local/bin/docker-compose
+                    ;;
+                arm64|aarch64)
+                    curl -L "https://github.com/linuxserver/docker-docker-compose/releases/download/1.27.4-ls27/docker-compose-arm64" -o /usr/local/bin/docker-compose
+                    ;;
+                *)
+                    curl -L "https://github.com/docker/compose/releases/download/1.27.4/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+                    ;;
+            esac
             chmod +x /usr/local/bin/docker-compose
             ;;
     esac


### PR DESCRIPTION
* fix dind build for arm
* arm/v7 dind on Ubuntu no longer supported. Seems that it cannot be installed via apt-get:
  ```
  +dind-ubuntu *failed* | Package docker-ce is not available, but is referred to by another package.
  +dind-ubuntu *failed* | This may mean that the package is missing, has been obsoleted, or
  +dind-ubuntu *failed* | is only available from another source

  +dind-ubuntu *failed* | E: Package 'docker-ce' has no installation candidate
  +dind-ubuntu *failed* | E: Unable to locate package docker-ce-cli
  +dind-ubuntu *failed* | E: Unable to locate package containerd.io
  +dind-ubuntu *failed* | E: Couldn't find any package by glob 'containerd.io'
  +dind-ubuntu *failed* | E: Couldn't find any package by regex 'containerd.io'
  ```
* reorganize GitHub actions: spread build of +all across multiple jobs
* don't push anything else other than +prerelease