### PR TITLE
Add test to make sure repo hash stays the same

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,8 @@ jobs:
         run: "./examples/tests/remote-cache/test.sh"
       - name: Execute registry-certs test
         run: "./examples/tests/registry-certs/test.sh"
+      - name: Execute tests requiring .git directory
+        run: go test ./analytics --tags=hasgitdirectory
       - name: Execute earthly docker command
         run: (cd examples/tests/docker && ../../.././build/linux/amd64/earthly docker --tag examples-test-docker:latest && diff <(docker run --rm examples-test-docker:latest) <(echo "hello dockerfile") )
       - name: Execute test similar to homebrew test in https://github.com/Homebrew/homebrew-core/blob/master/Formula/earthly.rb

--- a/analytics/analytics_test.go
+++ b/analytics/analytics_test.go
@@ -1,0 +1,16 @@
+// +build hasgitdirectory
+
+package analytics
+
+import (
+	"testing"
+
+	. "github.com/stretchr/testify/assert"
+)
+
+// TestGetRepoHash tests the git repo hashing never changes
+// in order to ensure our analytics stay consistent
+func TestGetRepoHash(t *testing.T) {
+	hash := getRepoHash()
+	Equal(t, hash, "5d892560f423223dec22b9b03e11d3aa3775871a80962326ac80543401843749")
+}


### PR DESCRIPTION
- this is to prevent us from changing the hashing function
which would make it impossible to track repos

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>