### PR TITLE
Turn non-constant build args into constant ones on the spot

### DIFF
--- a/earthfile2llb/earthfile2llb.go
+++ b/earthfile2llb/earthfile2llb.go
@@ -75,10 +75,6 @@ func Earthfile2LLB(ctx context.Context, target domain.Target, opt ConvertOpt) (m
 		same := (sts.TargetInput.Platform == llbutil.PlatformToString(opt.Platform))
 		if same {
 			for _, bai := range sts.TargetInput.BuildArgs {
-				if sts.Ongoing && !bai.IsConstant {
-					return nil, fmt.Errorf(
-						"Use of recursive targets with variable build args is not supported: %s", targetStr)
-				}
 				variable, _, found := opt.VarCollection.Get(bai.Name)
 				if found {
 					if !variable.BuildArgInput(bai.Name, bai.DefaultValue).Equals(bai) {

--- a/earthfile2llb/listener.go
+++ b/earthfile2llb/listener.go
@@ -698,7 +698,11 @@ func (l *listener) ExitArgStmt(c *parser.ArgStmtContext) {
 	value := l.expandArgs(l.envArgValue, true)
 	// Args declared in the base target are global.
 	global := (l.currentTarget == "base")
-	l.converter.Arg(l.ctx, key, value, global)
+	err := l.converter.Arg(l.ctx, key, value, global)
+	if err != nil {
+		l.err = errors.Wrapf(err, "apply ARG %s=%s", key, value)
+		return
+	}
 }
 
 func (l *listener) ExitLabelStmt(c *parser.LabelStmtContext) {

--- a/earthfile2llb/withdockerrun.go
+++ b/earthfile2llb/withdockerrun.go
@@ -165,7 +165,10 @@ func (wdr *withDockerRun) Run(ctx context.Context, args []string, opt WithDocker
 		return errors.Wrap(err, "compute dind id")
 	}
 	shellWrap := makeWithDockerdWrapFun(dindID, tarPaths, opt)
-	return wdr.c.internalRun(ctx, finalArgs, opt.Secrets, opt.WithShell, shellWrap, false, false, opt.NoCache, runStr, runOpts...)
+	_, err = wdr.c.internalRun(
+		ctx, finalArgs, opt.Secrets, opt.WithShell, shellWrap,
+		false, false, false, opt.NoCache, runStr, runOpts...)
+	return err
 }
 
 func (wdr *withDockerRun) installDeps(ctx context.Context, opt WithDockerOpt) error {

--- a/examples/tests/build-arg.earth
+++ b/examples/tests/build-arg.earth
@@ -46,7 +46,6 @@ test3:
     RUN test "$VAR1" == "test"
 
 test4:
-    RUN apk add tree
     RUN touch dummy
     ARG VAR1=$(ls)
     RUN touch should-not-be-seen

--- a/examples/tests/build-arg.earth
+++ b/examples/tests/build-arg.earth
@@ -8,6 +8,8 @@ all:
     BUILD +test1
     BUILD +test2
     BUILD +test3
+    BUILD +test4
+    BUILD +test5
     BUILD +test-global1
     BUILD +test-global2
     BUILD +test-global3
@@ -42,6 +44,18 @@ test3:
     ARG VAR1="test"
     FROM +dummy
     RUN test "$VAR1" == "test"
+
+test4:
+    RUN apk add tree
+    RUN touch dummy
+    ARG VAR1=$(ls)
+    RUN touch should-not-be-seen
+    RUN test "$VAR1" == "dummy"
+
+test5:
+    RUN printf '"text with quotes"' >./content
+    ARG VAR1=$(cat ./content)
+    RUN test "$VAR1" == '"text with quotes"'
 
 test-global1:
     RUN test "$global1" == "abc"

--- a/examples/tests/remote-cache/Earthfile
+++ b/examples/tests/remote-cache/Earthfile
@@ -3,7 +3,7 @@ WORKDIR /test
 ARG REGISTRY
 ARG EARTHLY_BUILD_ARGS="REGISTRY"
 ARG EARTHLY_ADDITIONAL_BUILDKIT_CONFIG="
-[registry.\\\"$REGISTRY\\\"]
+[registry.\"$REGISTRY\"]
   http = true
   insecure = true
 "

--- a/examples/tests/remote-cache/test.sh
+++ b/examples/tests/remote-cache/test.sh
@@ -23,6 +23,8 @@ export REGISTRY="$REGISTRY_IP:5000"
 # Test.
 set +e
 "$earthly" --allow-privileged \
+    \ # --build-arg DOCKERHUB_USER_SECRET=+secrets/earthly-technologies/dockerhub/user \
+    \ # --build-arg DOCKERHUB_TOKEN_SECRET=+secrets/earthly-technologies/dockerhub/token \
     --ci \
     --build-arg REGISTRY \
     +all

--- a/examples/tests/remote-cache/test.sh
+++ b/examples/tests/remote-cache/test.sh
@@ -23,8 +23,6 @@ export REGISTRY="$REGISTRY_IP:5000"
 # Test.
 set +e
 "$earthly" --allow-privileged \
-    \ # --build-arg DOCKERHUB_USER_SECRET=+secrets/earthly-technologies/dockerhub/user \
-    \ # --build-arg DOCKERHUB_TOKEN_SECRET=+secrets/earthly-technologies/dockerhub/token \
     --ci \
     --build-arg REGISTRY \
     +all

--- a/states/dedup/targetinput.go
+++ b/states/dedup/targetinput.go
@@ -60,8 +60,7 @@ func (ti TargetInput) clone() TargetInput {
 		Platform:        ti.Platform,
 	}
 	for _, bai := range ti.BuildArgs {
-		baiCopy := bai.clone()
-		tiCopy.BuildArgs = append(tiCopy.BuildArgs, baiCopy)
+		tiCopy.BuildArgs = append(tiCopy.BuildArgs, bai.clone())
 	}
 	return tiCopy
 }
@@ -82,11 +81,7 @@ func (ti TargetInput) cloneNoTag() (TargetInput, error) {
 		Platform:        ti.Platform,
 	}
 	for _, bai := range ti.BuildArgs {
-		baiCopy, err := bai.cloneNoTag()
-		if err != nil {
-			return TargetInput{}, err
-		}
-		tiCopy.BuildArgs = append(tiCopy.BuildArgs, baiCopy)
+		tiCopy.BuildArgs = append(tiCopy.BuildArgs, bai.clone())
 	}
 	return tiCopy, nil
 }
@@ -119,29 +114,21 @@ func (ti TargetInput) HashNoTag() (string, error) {
 type BuildArgInput struct {
 	// Name is the name of the build arg.
 	Name string `json:"name"`
-	// IsConstant represents whether the build arg has a constant value.
-	IsConstant bool `json:"isConstant"`
-	// ConstantValue is the constant value of this build arg. Only set if IsConstant is true.
+	// ConstantValue is the constant value of this build arg.
 	ConstantValue string `json:"constantValue"`
 	// DefaultValue represents the default value of the build arg.
 	DefaultValue string `json:"defaultConstant"`
-	// VariableFromInput is the definition of the conditions in which the build arg was formed.
-	// It is only set if IsConstant is false.
-	VariableFromInput VariableFromInput `json:"variableFromInput"`
 }
 
-// IsDefaultValue returns whether the BuildArgInput is constant and its value
+// IsDefaultValue returns whether the value of the BuildArgInput
 // is set as the same as the default.
 func (bai BuildArgInput) IsDefaultValue() bool {
-	return bai.IsConstant && bai.ConstantValue == bai.DefaultValue
+	return bai.ConstantValue == bai.DefaultValue
 }
 
 // Equals compares to another BuildArgInput for equality.
 func (bai BuildArgInput) Equals(other BuildArgInput) bool {
 	if bai.Name != other.Name {
-		return false
-	}
-	if bai.IsConstant != other.IsConstant {
 		return false
 	}
 	if bai.ConstantValue != other.ConstantValue {
@@ -150,71 +137,13 @@ func (bai BuildArgInput) Equals(other BuildArgInput) bool {
 	if bai.DefaultValue != other.DefaultValue {
 		return false
 	}
-	if !bai.VariableFromInput.Equals(other.VariableFromInput) {
-		return false
-	}
 	return true
 }
 
 func (bai BuildArgInput) clone() BuildArgInput {
-	vfiCopy := bai.VariableFromInput.clone()
 	return BuildArgInput{
-		Name:              bai.Name,
-		IsConstant:        bai.IsConstant,
-		ConstantValue:     bai.ConstantValue,
-		DefaultValue:      bai.DefaultValue,
-		VariableFromInput: vfiCopy,
+		Name:          bai.Name,
+		ConstantValue: bai.ConstantValue,
+		DefaultValue:  bai.DefaultValue,
 	}
-}
-
-func (bai BuildArgInput) cloneNoTag() (BuildArgInput, error) {
-	vfiCopy, err := bai.VariableFromInput.cloneNoTag()
-	if err != nil {
-		return BuildArgInput{}, err
-	}
-	return BuildArgInput{
-		Name:              bai.Name,
-		IsConstant:        bai.IsConstant,
-		ConstantValue:     bai.ConstantValue,
-		DefaultValue:      bai.DefaultValue,
-		VariableFromInput: vfiCopy,
-	}, nil
-}
-
-// VariableFromInput represents the conditions in which a variable build arg is passed.
-type VariableFromInput struct {
-	// TargetInput is the target where this variable's expression is executed.
-	TargetInput TargetInput `json:"targetInput"`
-	// Index is the order number of the expression for the build arg. Starts at 0 for each target.
-	Index int `json:"index"`
-}
-
-// Equals compares to another VariableFromInput for equality.
-func (vfi VariableFromInput) Equals(other VariableFromInput) bool {
-	if !vfi.TargetInput.Equals(other.TargetInput) {
-		return false
-	}
-	if vfi.Index != other.Index {
-		return false
-	}
-	return true
-}
-
-func (vfi VariableFromInput) clone() VariableFromInput {
-	tiCopy := vfi.TargetInput.clone()
-	return VariableFromInput{
-		TargetInput: tiCopy,
-		Index:       vfi.Index,
-	}
-}
-
-func (vfi VariableFromInput) cloneNoTag() (VariableFromInput, error) {
-	tiCopy, err := vfi.TargetInput.cloneNoTag()
-	if err != nil {
-		return VariableFromInput{}, err
-	}
-	return VariableFromInput{
-		TargetInput: tiCopy,
-		Index:       vfi.Index,
-	}, nil
 }

--- a/variables/collection.go
+++ b/variables/collection.go
@@ -338,7 +338,7 @@ func (c *Collection) parseBuildArg(arg string, pncvf ProcessNonConstantVariableF
 }
 
 func (c *Collection) parseBuildArgValue(name, value string, pncvf ProcessNonConstantVariableFunc) (Variable, error) {
-	if !strings.HasPrefix(value, "$") {
+	if !strings.HasPrefix(value, "$(") {
 		// Constant build arg.
 		return NewConstant(value), nil
 	}

--- a/variables/collection.go
+++ b/variables/collection.go
@@ -90,9 +90,6 @@ func (c *Collection) Expand(word string) string {
 	argsMap := make(map[string]string)
 	for varName := range c.activeVariables {
 		variable := c.variables[varName]
-		if !variable.IsConstant() {
-			continue
-		}
 		argsMap[varName] = variable.ConstantValue()
 	}
 	ret, err := shlex.ProcessWordWithMap(word, argsMap)
@@ -107,9 +104,6 @@ func (c *Collection) Expand(word string) string {
 func (c *Collection) AsMap() map[string]string {
 	ret := make(map[string]string)
 	for varName, variable := range c.variables {
-		if !variable.IsConstant() {
-			continue
-		}
 		ret[varName] = variable.ConstantValue()
 	}
 	return ret
@@ -301,7 +295,7 @@ func (c *Collection) WithParseBuildArgs(args []string, pncvf ProcessNonConstantV
 			continue
 		}
 		var finalValue Variable
-		if ba.IsConstant() && !haveValues[key] {
+		if !haveValues[key] {
 			existing, active, found := c.Get(key)
 			if found && active {
 				if existing.IsEnvVar() {
@@ -311,7 +305,7 @@ func (c *Collection) WithParseBuildArgs(args []string, pncvf ProcessNonConstantV
 				}
 			} else {
 				return nil, nil, fmt.Errorf(
-					"Value not specified for build arg %s and no value can be inferred", key)
+					"value not specified for build arg %s and no value can be inferred", key)
 			}
 		} else {
 			finalValue = ba

--- a/variables/variables.go
+++ b/variables/variables.go
@@ -2,50 +2,27 @@ package variables
 
 import (
 	"github.com/earthly/earthly/states/dedup"
-	"github.com/moby/buildkit/client/llb"
 )
 
 // Variable is an object representing a build arg or an env var.
 type Variable struct {
-	isConstant        bool
-	isEnvVar          bool
-	value             string
-	state             llb.State
-	variableFromInput dedup.VariableFromInput
+	isEnvVar bool
+	value    string
 }
 
 // NewConstant creates a new constant build arg.
 func NewConstant(value string) Variable {
 	return Variable{
-		isConstant: true,
-		value:      value,
+		value: value,
 	}
 }
 
 // NewConstantEnvVar cretes a new constant env var.
 func NewConstantEnvVar(value string) Variable {
 	return Variable{
-		isConstant: true,
-		isEnvVar:   true,
-		value:      value,
+		isEnvVar: true,
+		value:    value,
 	}
-}
-
-// NewVariable creates a new variable build arg.
-func NewVariable(state llb.State, targetInput dedup.TargetInput, argIndex int) Variable {
-	return Variable{
-		isConstant: false,
-		state:      state,
-		variableFromInput: dedup.VariableFromInput{
-			TargetInput: targetInput,
-			Index:       argIndex,
-		},
-	}
-}
-
-// IsConstant returns whether this build arg is constant.
-func (v Variable) IsConstant() bool {
-	return v.isConstant
 }
 
 // IsEnvVar returns whether the variable is an env var.
@@ -58,26 +35,11 @@ func (v Variable) ConstantValue() string {
 	return v.value
 }
 
-// VariableState returns the state that holds a file containing the expression
-// result of the build arg.
-func (v Variable) VariableState() llb.State {
-	return v.state
-}
-
 // BuildArgInput returns the BuildArgInput for this variable.
 func (v Variable) BuildArgInput(name string, defaultValue string) dedup.BuildArgInput {
-	if v.isConstant {
-		return dedup.BuildArgInput{
-			Name:          name,
-			IsConstant:    true,
-			ConstantValue: v.value,
-			DefaultValue:  defaultValue,
-		}
-	}
 	return dedup.BuildArgInput{
-		Name:              name,
-		IsConstant:        false,
-		VariableFromInput: v.variableFromInput,
-		DefaultValue:      defaultValue,
+		Name:          name,
+		ConstantValue: v.value,
+		DefaultValue:  defaultValue,
 	}
 }


### PR DESCRIPTION
Note to reviewer: it's easiest to review this commit-by-commit.

This enables the use of variable build args in non-RUN expressions. For example, something like the following is now possible:

```
ARG src=$(cat ./what-to-copy.txt)
COPY $src ./
```

It also simplifies the TargetInput-related logic as we don't have to account for the provenience tree of build args.