### PR TITLE
Support for build arg matrix

### DIFF
--- a/earthfile2llb/listener.go
+++ b/earthfile2llb/listener.go
@@ -1101,13 +1101,13 @@ func unescapeSlashPlus(str string) string {
 	return strings.ReplaceAll(str, "\\+", "+")
 }
 
-type matrixEntry struct {
+type argGroup struct {
 	key    string
 	values []*string
 }
 
 func buildArgMatrix(args []string) ([][]string, error) {
-	matrix := make([]matrixEntry, 0, len(args))
+	groupedArgs := make([]argGroup, 0, len(args))
 	for _, arg := range args {
 		k, v, err := parseKeyValue(arg)
 		if err != nil {
@@ -1115,39 +1115,39 @@ func buildArgMatrix(args []string) ([][]string, error) {
 		}
 
 		found := false
-		for i, e := range matrix {
-			if e.key == k {
-				matrix[i].values = append(matrix[i].values, v)
+		for i, g := range groupedArgs {
+			if g.key == k {
+				groupedArgs[i].values = append(groupedArgs[i].values, v)
 				found = true
 				break
 			}
 		}
 		if !found {
-			matrix = append(matrix, matrixEntry{
+			groupedArgs = append(groupedArgs, argGroup{
 				key:    k,
 				values: []*string{v},
 			})
 		}
 	}
-	return crossProduct(matrix, nil), nil
+	return crossProduct(groupedArgs, nil), nil
 }
 
-func crossProduct(m []matrixEntry, prefix []string) [][]string {
-	if len(m) == 0 {
+func crossProduct(ga []argGroup, prefix []string) [][]string {
+	if len(ga) == 0 {
 		return [][]string{prefix}
 	}
 	var ret [][]string
-	for _, v := range m[0].values {
+	for _, v := range ga[0].values {
 		newPrefix := prefix[:]
 		var kv string
 		if v == nil {
-			kv = m[0].key
+			kv = ga[0].key
 		} else {
-			kv = fmt.Sprintf("%s=%s", m[0].key, *v)
+			kv = fmt.Sprintf("%s=%s", ga[0].key, *v)
 		}
 		newPrefix = append(newPrefix, kv)
 
-		cp := crossProduct(m[1:], newPrefix)
+		cp := crossProduct(ga[1:], newPrefix)
 		ret = append(ret, cp...)
 	}
 	return ret

--- a/earthfile2llb/listener_test.go
+++ b/earthfile2llb/listener_test.go
@@ -1,0 +1,30 @@
+package earthfile2llb
+
+import (
+	"testing"
+
+	. "github.com/stretchr/testify/assert"
+)
+
+func TestBuildArgMatrix(t *testing.T) {
+	var tests = []struct {
+		in  []string
+		out [][]string
+	}{
+		{[]string{}, [][]string{nil}},
+		{[]string{"a=1"}, [][]string{{"a=1"}}},
+		{[]string{"a=1", "a=2", "a=3"}, [][]string{{"a=1"}, {"a=2"}, {"a=3"}}},
+		{[]string{"a=1", "b=2"}, [][]string{{"a=1", "b=2"}}},
+		{[]string{"a=1", "a=3", "b=2"}, [][]string{{"a=1", "b=2"}, {"a=3", "b=2"}}},
+		{[]string{"a=1", "a=3", "b=2", "b=4"}, [][]string{{"a=1", "b=2"}, {"a=1", "b=4"}, {"a=3", "b=2"}, {"a=3", "b=4"}}},
+		{[]string{"a=1", "b=2", "a=3", "b=4"}, [][]string{{"a=1", "b=2"}, {"a=1", "b=4"}, {"a=3", "b=2"}, {"a=3", "b=4"}}},
+		{[]string{"a=1", "b=2", "a=3", "b=4", "c=10"}, [][]string{{"a=1", "b=2", "c=10"}, {"a=1", "b=4", "c=10"}, {"a=3", "b=2", "c=10"}, {"a=3", "b=4", "c=10"}}},
+		{[]string{"a=1", "a=3", "a=7", "c=10"}, [][]string{{"a=1", "c=10"}, {"a=3", "c=10"}, {"a=7", "c=10"}}},
+	}
+
+	for _, tt := range tests {
+		ans, err := buildArgMatrix(tt.in)
+		NoError(t, err)
+		Equal(t, tt.out, ans)
+	}
+}

--- a/examples/tests/dind-auto-install/Earthfile
+++ b/examples/tests/dind-auto-install/Earthfile
@@ -1,14 +1,16 @@
 
 all:
-    BUILD --build-arg BASE_IMAGE=docker:dind +test
-    BUILD --build-arg BASE_IMAGE=alpine:latest +test
-    BUILD --build-arg BASE_IMAGE=debian:stable +test
-    BUILD --build-arg BASE_IMAGE=debian:stable-slim +test
-    BUILD --build-arg BASE_IMAGE=ubuntu:latest +test
-    BUILD --build-arg BASE_IMAGE=amazonlinux:1 +test
-    BUILD --build-arg BASE_IMAGE=amazonlinux:2 +test
-    BUILD --build-arg BASE_IMAGE=../../..+dind-alpine +test
-    BUILD --build-arg BASE_IMAGE=../../..+dind-ubuntu +test
+    BUILD \
+        --build-arg BASE_IMAGE=docker:dind \
+        --build-arg BASE_IMAGE=alpine:latest \
+        --build-arg BASE_IMAGE=debian:stable \
+        --build-arg BASE_IMAGE=debian:stable-slim \
+        --build-arg BASE_IMAGE=ubuntu:latest \
+        --build-arg BASE_IMAGE=amazonlinux:1 \
+        --build-arg BASE_IMAGE=amazonlinux:2 \
+        --build-arg BASE_IMAGE=../../..+dind-alpine \
+        --build-arg BASE_IMAGE=../../..+dind-ubuntu \
+        +test
 
 test:
     ARG BASE_IMAGE

--- a/examples/tests/with-docker-compose/Earthfile
+++ b/examples/tests/with-docker-compose/Earthfile
@@ -2,11 +2,13 @@ FROM earthly/dind
 WORKDIR /test
 
 all:
-    BUILD --build-arg INDEX=1 +test
-    BUILD --build-arg INDEX=2 +test
-    BUILD --build-arg INDEX=3 +test
-    BUILD --build-arg INDEX=4 +test
-    BUILD --build-arg INDEX=5 +test
+    BUILD \
+        --build-arg INDEX=1 \
+        --build-arg INDEX=2 \
+        --build-arg INDEX=3 \
+        --build-arg INDEX=4 \
+        --build-arg INDEX=5 \
+        +test
 
 print-countries:
     FROM jbergknoff/postgresql-client:latest

--- a/examples/tests/with-docker/Earthfile
+++ b/examples/tests/with-docker/Earthfile
@@ -43,12 +43,13 @@ docker-pull-test:
     END
 
 load-parallel-test:
-    BUILD --build-arg INDEX=1 +docker-load-test
-    BUILD --build-arg INDEX=2 +docker-load-test
-    BUILD --build-arg INDEX=3 +docker-load-test
-    BUILD --build-arg INDEX=4 +docker-load-test
-    BUILD --build-arg INDEX=5 +docker-load-test
-
+    BUILD \
+        --build-arg INDEX=1 \
+        --build-arg INDEX=2 \
+        --build-arg INDEX=3 \
+        --build-arg INDEX=4 \
+        --build-arg INDEX=5 \
+        +docker-load-test
 
 multi-from-one:
     FROM hello-world


### PR DESCRIPTION
Calls like these

```
BUILD --build-arg VAR=1 +target
BUILD --build-arg VAR=2 +target
```

can now be replaced with this

```
BUILD \
  --build-arg VAR=1 \
  --build-arg VAR=2 \
  +target
```

Or calls like these:

```
BUILD --build-arg BASE_IMAGE=ubuntu:16.04 --build-arg NODE_VERSION=14 +test
BUILD --build-arg BASE_IMAGE=ubuntu:16.04 --build-arg NODE_VERSION=15 +test
BUILD --build-arg BASE_IMAGE=ubuntu:16.04 --build-arg NODE_VERSION=16 +test
BUILD --build-arg BASE_IMAGE=ubuntu:18.04 --build-arg NODE_VERSION=14 +test
BUILD --build-arg BASE_IMAGE=ubuntu:18.04 --build-arg NODE_VERSION=15 +test
BUILD --build-arg BASE_IMAGE=ubuntu:18.04 --build-arg NODE_VERSION=16 +test
BUILD --build-arg BASE_IMAGE=ubuntu:20.04 --build-arg NODE_VERSION=14 +test
BUILD --build-arg BASE_IMAGE=ubuntu:20.04 --build-arg NODE_VERSION=15 +test
BUILD --build-arg BASE_IMAGE=ubuntu:20.04 --build-arg NODE_VERSION=16 +test
```

can be replaced with this:

```
BUILD \
  --build-arg BASE_IMAGE=ubuntu:16.04 \
  --build-arg BASE_IMAGE=ubuntu:18.04 \
  --build-arg BASE_IMAGE=ubuntu:20.04 \
  --build-arg NODE_VERSION=14 \
  --build-arg NODE_VERSION=15 \
  --build-arg NODE_VERSION=16 \
  +test
```

It performs the cross product under the hood.

This mirrors the behavior we already have for `BUILD --platform=...`.