### PR TITLE
Support for copying artifacts from LOCALLY target to containerized target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,6 +221,8 @@ jobs:
         run: "./build/linux/amd64/earthly --ci --push ./examples/tests/local+test-local"
       - name: Check --push cmd was run (and touched this file on the local disk)
         run: "ls /tmp/earthly-test-local"
+      - name: Run general local tests (TODO this is re-testing the +test-local target)
+        run: "./build/linux/amd64/earthly --ci ./examples/tests/local+all"
 
   private-repo-test:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository

--- a/examples/tests/local/Earthfile
+++ b/examples/tests/local/Earthfile
@@ -1,3 +1,5 @@
+FROM alpine:3.13
+
 test-local-with-arg:
     LOCALLY
     ARG pattern
@@ -10,4 +12,56 @@ test-local:
     RUN whoami
     RUN cat /proc/1/cgroup | grep '^[0-9]\+:cpuset:/$'
     RUN --push touch /tmp/earthly-test-local
+
+create-file:
+    LOCALLY
+    RUN echo hello > /tmp/earthly-test-a266bf52-f5ea-477c-9416-2931720d1826
+    SAVE ARTIFACT /tmp/earthly-test-a266bf52-f5ea-477c-9416-2931720d1826 data
+
+test-copy-file-from-local:
+    COPY +create-file/data actual
+    RUN echo hello > expected
+    RUN diff expected actual
+
+create-dir:
+    LOCALLY
+    RUN rm -rf /tmp/earthly-test-bfbe3177-8683-4f8f-8c42-75053dc0e807
+    RUN mkdir /tmp/earthly-test-bfbe3177-8683-4f8f-8c42-75053dc0e807
+    RUN echo aaa > /tmp/earthly-test-bfbe3177-8683-4f8f-8c42-75053dc0e807/a.txt
+    RUN echo bbb > /tmp/earthly-test-bfbe3177-8683-4f8f-8c42-75053dc0e807/b.txt
+    SAVE ARTIFACT /tmp/earthly-test-bfbe3177-8683-4f8f-8c42-75053dc0e807 datadir
+
+test-copy-dir-from-local:
+    COPY +create-dir/datadir the-data
+    RUN echo aaa > expected_a.txt
+    RUN echo bbb > expected_b.txt
+    RUN diff the-data/a.txt expected_a.txt
+    RUN diff the-data/b.txt expected_b.txt
+
+save-unnamed-artifact:
+    LOCALLY
+    RUN rm -rf /tmp/earthly-test-c5009c71-d573-4562-be15-2c28dae333fc
+    RUN mkdir /tmp/earthly-test-c5009c71-d573-4562-be15-2c28dae333fc
+    RUN echo ccc > /tmp/earthly-test-c5009c71-d573-4562-be15-2c28dae333fc/c.txt
+    SAVE ARTIFACT /tmp/earthly-test-c5009c71-d573-4562-be15-2c28dae333fc
+
+test-save-unnamed-artifact:
+    COPY +save-unnamed-artifact/earthly-test-c5009c71-d573-4562-be15-2c28dae333fc .
+    RUN cat c.txt | grep '^ccc$'
+
+test-save-unnamed-artifact-dir:
+    COPY --dir +save-unnamed-artifact/earthly-test-c5009c71-d573-4562-be15-2c28dae333fc .
+    RUN cat earthly-test-c5009c71-d573-4562-be15-2c28dae333fc/c.txt | grep '^ccc$'
+
+test-save-unnamed-artifact-dir2:
+    COPY --dir +save-unnamed-artifact/earthly-test-c5009c71-d573-4562-be15-2c28dae333fc /var/log/.
+    RUN cat /var/log/earthly-test-c5009c71-d573-4562-be15-2c28dae333fc/c.txt | grep '^ccc$'
+
+all:
+    BUILD +test-local
     BUILD --build-arg pattern=memory +test-local-with-arg
+    BUILD +test-copy-dir-from-local
+    BUILD +test-copy-file-from-local
+    BUILD +test-save-unnamed-artifact
+    BUILD +test-save-unnamed-artifact-dir
+    BUILD +test-save-unnamed-artifact-dir2

--- a/go.mod
+++ b/go.mod
@@ -39,5 +39,5 @@ replace (
 	github.com/docker/docker => github.com/docker/docker v17.12.0-ce-rc1.0.20200310163718-4634ce647cf2+incompatible
 	github.com/hashicorp/go-immutable-radix => github.com/tonistiigi/go-immutable-radix v0.0.0-20170803185627-826af9ccf0fe
 	github.com/jaguilar/vt100 => github.com/tonistiigi/vt100 v0.0.0-20190402012908-ad4c4a574305
-	github.com/moby/buildkit => github.com/earthly/buildkit v0.7.1-0.20210130000928-c2e9a46c8f51
+	github.com/moby/buildkit => github.com/alexcb/buildkit 0ae61da79f8edcfa1a2a230c722de3ad6df187e5
 )


### PR DESCRIPTION
This is still very much so a draft and is not ready for review.

This requires https://github.com/earthly/buildkit/pull/26 be merged first (then we can backout my buildkit/Earthfile change)