### PR TITLE
Improvements for Apple Silicon

### DIFF
--- a/analytics/analytics.go
+++ b/analytics/analytics.go
@@ -125,6 +125,7 @@ type EarthlyAnalytics struct {
 	Key              string  `json:"key"`
 	InstallID        string  `json:"install_id"`
 	Version          string  `json:"version"`
+	Platform         string  `json:"platform"`
 	GitSHA           string  `json:"git_sha"`
 	ExitCode         int     `json:"exit_code"`
 	CI               string  `json:"ci_name"`
@@ -159,7 +160,7 @@ func saveData(server string, data *EarthlyAnalytics) error {
 }
 
 // CollectAnalytics sends analytics to api.earthly.dev
-func CollectAnalytics(ctx context.Context, earthlyServer string, displayErrors bool, version, gitSha, commandName string, exitCode int, realtime time.Duration) {
+func CollectAnalytics(ctx context.Context, earthlyServer string, displayErrors bool, version, platform, gitSha, commandName string, exitCode int, realtime time.Duration) {
 	var err error
 	ciName, ci := detectCI()
 	repoHash := getRepoHash()
@@ -191,6 +192,7 @@ func CollectAnalytics(ctx context.Context, earthlyServer string, displayErrors b
 			Key:              key,
 			InstallID:        installID,
 			Version:          version,
+			Platform:         platform,
 			GitSHA:           gitSha,
 			ExitCode:         exitCode,
 			CI:               ciName,

--- a/buildkitd/buildkitd.go
+++ b/buildkitd/buildkitd.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -204,6 +205,7 @@ func Start(ctx context.Context, image string, settings Settings, reset bool) err
 	args := []string{
 		"run",
 		"-d",
+		platformFlag(),
 		"-v", fmt.Sprintf("%s:/tmp/earthly:rw", VolumeName),
 		"-v", runMount,
 		"-e", fmt.Sprintf("BUILDKIT_DEBUG=%t", settings.Debug),
@@ -402,4 +404,12 @@ func isRootlessDocker(ctx context.Context) (bool, error) {
 	}
 
 	return strings.Contains(string(output), "rootless"), nil
+}
+
+func platformFlag() string {
+	arch := runtime.GOARCH
+	if runtime.GOARCH == "arm" {
+		arch = "arm/v7"
+	}
+	return fmt.Sprintf("--platform=linux/%s", arch)
 }

--- a/buildkitd/buildkitd.go
+++ b/buildkitd/buildkitd.go
@@ -411,12 +411,11 @@ func isRootlessDocker(ctx context.Context) (bool, error) {
 
 func supportsPlatform(ctx context.Context) bool {
 	// We can't run scratch, but the error is different depending on whether
-	// platform is supported or not. This is faster than attempting to run
+	// --platform is supported or not. This is faster than attempting to run
 	// an actual image which may require downloading.
 	cmd := exec.CommandContext(ctx,
 		"docker", "run", "--rm", platformFlag(), "scratch")
 	output, _ := cmd.CombinedOutput()
-	fmt.Printf("@#@#@#@ output=%s\n", string(output))
 	return bytes.Contains(output, []byte("Unable to find image"))
 }
 

--- a/buildkitd/buildkitd.go
+++ b/buildkitd/buildkitd.go
@@ -410,10 +410,14 @@ func isRootlessDocker(ctx context.Context) (bool, error) {
 }
 
 func supportsPlatform(ctx context.Context) bool {
+	// We can't run scratch, but the error is different depending on whether
+	// platform is supported or not. This is faster than attempting to run
+	// an actual image which may require downloading.
 	cmd := exec.CommandContext(ctx,
-		"docker", "run", "--rm", platformFlag(), "busybox:latest")
-	err := cmd.Run()
-	return err == nil
+		"docker", "run", "--rm", platformFlag(), "scratch")
+	output, _ := cmd.CombinedOutput()
+	fmt.Printf("@#@#@#@ output=%s\n", string(output))
+	return bytes.Contains(output, []byte("Unable to find image"))
 }
 
 func platformFlag() string {

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -225,17 +225,22 @@ func main() {
 		ctxTimeout, cancel := context.WithTimeout(ctx, time.Millisecond*500)
 		defer cancel()
 		displayErrors := app.verbose
-		analytics.CollectAnalytics(ctxTimeout, app.apiServer, displayErrors, Version, GitSha, app.commandName, exitCode, time.Since(startTime))
+		analytics.CollectAnalytics(ctxTimeout, app.apiServer, displayErrors, Version, getPlatform(), GitSha, app.commandName, exitCode, time.Since(startTime))
 	}
 	os.Exit(exitCode)
 }
 
-func getVersion() string {
+func getVersionPlatform() string {
 	var isRelease = regexp.MustCompile(`^v[0-9]+\.[0-9]+\.[0-9]+$`)
-	if isRelease.MatchString(Version) {
-		return Version
+	v := Version
+	if !isRelease.MatchString(Version) {
+		v = fmt.Sprintf("%s-%s", Version, GitSha)
 	}
-	return fmt.Sprintf("%s-%s", Version, GitSha)
+	return fmt.Sprintf("%s %s", v, getPlatform())
+}
+
+func getPlatform() string {
+	return fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH)
 }
 
 func getBinaryName() string {
@@ -277,7 +282,7 @@ func newEarthlyApp(ctx context.Context, console conslogging.ConsoleLogger) *eart
 		"To get started with using Earthly, check out the getting started guide at https://docs.earthly.dev/guides/basics."
 	app.cliApp.UseShortOptionHandling = true
 	app.cliApp.Action = app.actionBuild
-	app.cliApp.Version = getVersion()
+	app.cliApp.Version = getVersionPlatform()
 	app.cliApp.Flags = []cli.Flag{
 		&cli.StringSliceFlag{
 			Name:    "platform",

--- a/earthly
+++ b/earthly
@@ -13,19 +13,21 @@ last_check_state_path=/tmp/last-earthly-prerelease-check
 get_latest_binary() {
     docker rm --force earthly_binary 2>/dev/null || true
 
-    docker pull earthly/buildkitd:prerelease
     docker pull earthly/earthlybinaries:prerelease
     docker create --name earthly_binary earthly/earthlybinaries:prerelease
 
     earth_bin_path=/earthly-linux-amd64
+    bk_platform=linux/amd64
     if [ "$(uname)" == "Darwin" ]; then
         if [ "$(uname -m)" == "arm64" ]; then
             earth_bin_path=/earthly-darwin-arm64
+            bk_platform=linux/arm64
         else
             earth_bin_path=/earthly-darwin-amd64
         fi
     fi
 
+    docker pull --platform="$bk_platform" earthly/buildkitd:prerelease
     docker cp earthly_binary:"$earth_bin_path" "$bindir/earthly-prerelease"
     docker rm earthly_binary
 }


### PR DESCRIPTION
* Make `./earthly` pull the right buildkit image
* `docker run` the right platform for buildkit
* Include platform in version output
* Track platform in analytics

With this, `earthly -P +test` works on arm64, including `WITH DOCKER`. However, `earthly -P --platform=linux/amd64 +test` does not work when ran on an M1 mac, because `WITH DOCKER` qemu emulation is not functional yet.