### PR TITLE
Fix ./earthly script for non-experimental mode

### DIFF
--- a/earthly
+++ b/earthly
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+DOCKER_EXPERIMENTAL=$(docker version --format '{{.Server.Experimental}}')
+
 bindir="$HOME/.earthly"
 if [ ! -d "$bindir" ]; then
   mkdir -p "$bindir"
@@ -27,7 +29,12 @@ get_latest_binary() {
         fi
     fi
 
-    docker pull --platform="$bk_platform" earthly/buildkitd:prerelease
+    PLATFORM_FLAG=""
+    if [ "$DOCKER_EXPERIMENTAL" == "true" ]; then
+        PLATFORM_FLAG="--platform=$bk_platform"
+    fi
+
+    docker pull $PLATFORM_FLAG earthly/buildkitd:prerelease
     docker cp earthly_binary:"$earth_bin_path" "$bindir/earthly-prerelease"
     docker rm earthly_binary
 }


### PR DESCRIPTION
- Platform flag can only be used when docker is in experimental mode;
otherwise if the --platform is given, one gets an error such as:

    $ ./earthly --help
    earthly_binary
    prerelease: Pulling from earthly/earthlybinaries
    Digest: sha256:c7b1e00253006411859ceaf3091a3069f1e92045e5e0b8af983bae0722459983
    Status: Image is up to date for earthly/earthlybinaries:prerelease
    docker.io/earthly/earthlybinaries:prerelease
    67931ddb4211edcf978b0960115648e9bb4563d7f6a3f1d051dd0eb278203f15
    "--platform" is only supported on a Docker daemon with experimental features enabled

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>