### PR TITLE
Display hint for platform related errors

### DIFF
--- a/builder/builder_error.go
+++ b/builder/builder_error.go
@@ -1,0 +1,36 @@
+package builder
+
+// BuildError contains an BuildError and log
+type BuildError struct {
+	err error
+	log string
+}
+
+// NewBuildError creates a new BuildError with the additional output log of the command that failed
+func NewBuildError(err error, vertexLog string) error {
+	if vertexLog == "" {
+		return err
+	}
+	return &BuildError{
+		err: err,
+		log: vertexLog,
+	}
+}
+
+// BuildError formats the BuildError as a string, ommitting the vertex log
+func (e *BuildError) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	return e.err.Error()
+}
+
+// Unwrap returns the wrapped error
+func (e *BuildError) Unwrap() error {
+	return e.err
+}
+
+// VertexLog returns the vertex log associated with the error
+func (e *BuildError) VertexLog() string {
+	return e.log
+}

--- a/builder/solver.go
+++ b/builder/solver.go
@@ -57,8 +57,11 @@ func (s *solver) solveDockerTar(ctx context.Context, state llb.State, platform s
 		}
 		return nil
 	})
+	var vertexFailureOutput string
 	eg.Go(func() error {
-		return s.sm.monitorProgress(ctx, ch, "")
+		var err error
+		vertexFailureOutput, err = s.sm.monitorProgress(ctx, ch, "")
+		return err
 	})
 	eg.Go(func() error {
 		file, err := os.Create(outFile)
@@ -93,7 +96,7 @@ func (s *solver) solveDockerTar(ctx context.Context, state llb.State, platform s
 	}()
 	err = eg.Wait()
 	if err != nil {
-		return err
+		return NewBuildError(err, vertexFailureOutput)
 	}
 	return nil
 }
@@ -115,12 +118,15 @@ func (s *solver) buildMainMulti(ctx context.Context, bf gwclient.BuildFunc, onIm
 		}
 		return nil
 	})
+	var vertexFailureOutput string
 	eg.Go(func() error {
-		return s.sm.monitorProgress(ctx, ch, phaseText)
+		var err error
+		vertexFailureOutput, err = s.sm.monitorProgress(ctx, ch, phaseText)
+		return err
 	})
 	err = eg.Wait()
 	if err != nil {
-		return err
+		return NewBuildError(err, vertexFailureOutput)
 	}
 	return nil
 }
@@ -146,12 +152,15 @@ func (s *solver) solveMain(ctx context.Context, state llb.State, platform specs.
 		}
 		return nil
 	})
+	var vertexFailureOutput string
 	eg.Go(func() error {
-		return s.sm.monitorProgress(ctx, ch, "")
+		var err error
+		vertexFailureOutput, err = s.sm.monitorProgress(ctx, ch, "")
+		return err
 	})
 	err = eg.Wait()
 	if err != nil {
-		return err
+		return NewBuildError(err, vertexFailureOutput)
 	}
 	return nil
 }

--- a/builder/solver_monitor.go
+++ b/builder/solver_monitor.go
@@ -234,7 +234,7 @@ func newSolverMonitor(console conslogging.ConsoleLogger, verbose bool) *solverMo
 	}
 }
 
-func (sm *solverMonitor) monitorProgress(ctx context.Context, ch chan *client.SolveStatus, phaseText string) error {
+func (sm *solverMonitor) monitorProgress(ctx context.Context, ch chan *client.SolveStatus, phaseText string) (string, error) {
 	sm.mu.Lock()
 	sm.ongoing = true
 	sm.mu.Unlock()
@@ -311,12 +311,14 @@ Loop:
 				}
 				err := sm.printOutput(vm, logLine.Data)
 				if err != nil {
-					return err
+					return "", err
 				}
 			}
 		}
 	}
+	failedVertexOutput := ""
 	if errVertex != nil {
+		failedVertexOutput = string(errVertex.tailOutput.Bytes())
 		sm.reprintFailure(errVertex, phaseText)
 	}
 	sm.mu.Lock()
@@ -328,7 +330,7 @@ Loop:
 	sm.ongoing = false
 	sm.mu.Unlock()
 	sm.PrintTiming()
-	return nil
+	return failedVertexOutput, nil
 }
 
 func (sm *solverMonitor) printOutput(vm *vertexMonitor, data []byte) error {


### PR DESCRIPTION
Here's an example of the error-fix hint:
```
$ ./build/linux/amd64/earthly -i --platform arm64 github.com/earthly/hello-world:main+hello
           buildkitd | Found buildkit daemon as docker container (earthly-buildkitd)
           buildkitd | Newer image available. Restarting buildkit daemon...
           buildkitd | ...Done
      busybox:1.32.0 | --> Load metadata linux/arm64
g/e/hello-world:main+base | platform=linux/arm64
g/e/hello-world:main+base | --> FROM busybox:1.32.0
g/e/hello-world:main+base | [██████████] resolve docker.io/library/busybox:1.32.0@sha256:bde48e1751173b709090c2539fdf12d6ba64e88ec7a4301591227ce925f3c678 ... 100%
g/e/hello-world:main+hello | platform=linux/arm64
g/e/hello-world:main+hello | --> RUN echo 'Hello, world!'
g/e/hello-world:main+hello | .buildkit_qemu_emulator: /usr/bin/earth_debugger: Invalid ELF image for this architecture
g/e/hello-world:main+hello | ERROR: Command exited with non-zero code: RUN echo 'Hello, world!'
Repeating the output of the command that caused the failure
================================ FAILURE [main] ================================
g/e/hello-world:main+hello *failed* | platform=linux/arm64
g/e/hello-world:main+hello *failed* | --> RUN echo 'Hello, world!'
g/e/hello-world:main+hello *failed* | .buildkit_qemu_emulator: /usr/bin/earth_debugger: Invalid ELF image for this architecture
g/e/hello-world:main+hello *failed* | ERROR: Command exited with non-zero code: RUN echo 'Hello, world!'
Error: build target: build main: bkClient.Build: failed to solve: rpc error: code = Unknown desc = executor failed running [/dev/.buildkit_qemu_emulator /bin/sh -c  /usr/bin/earth_debugger /bin/sh -c 'echo '"'"'Hello, world!'"'"'']: exit code: 255

[whitespace added to this PR comment to show the new addition to the warning message below]

Are you using --platform to target a different architecture? You may have to manually install Qemu.
For more information see https://docs.earthly.dev/guides/multi-platform
```