### PR TITLE
test earthly exports work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,6 +257,27 @@ jobs:
         run: docker logs earthly-buildkitd
         if: ${{ failure() }}
 
+  export-test:
+    runs-on: ubuntu-latest
+    env:
+      FORCE_COLOR: 1
+      EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"
+      EARTHLY_INSTALL_ID: "earthly-githubactions"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download released earthly
+        run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/latest/download/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly'"
+      - name: Docker Login (non fork only)
+        run: docker login --username "${{ secrets.DOCKERHUB_USERNAME }}" --password "${{ secrets.DOCKERHUB_TOKEN }}"
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+      - name: Build latest earthly using released earthly
+        run: earthly --use-inline-cache +for-linux
+      - name: run export tests
+        run: env earthly=./build/linux/amd64/earthly scripts/tests/export.sh
+      - name: Buildkit logs (runs on failure)
+        run: docker logs earthly-buildkitd
+        if: ${{ failure() }}
+
   all-buildkitd:
     name: +all-buildkitd
     runs-on: ubuntu-latest

--- a/Earthfile
+++ b/Earthfile
@@ -44,7 +44,7 @@ lint-scripts:
     COPY ./earthly ./scripts/install-all-versions.sh ./buildkitd/entrypoint.sh ./earthly-buildkitd-wrapper.sh \
         ./buildkitd/dockerd-wrapper.sh ./buildkitd/docker-auto-install.sh \
         ./release/envcredhelper.sh ./.buildkite/*.sh \
-        ./scripts/tests/private-repo.sh ./scripts/tests/self-hosted-private-repo.sh \
+        ./scripts/tests/*.sh \
         ./shell_scripts/
     RUN shellcheck shell_scripts/*
 

--- a/scripts/tests/export.sh
+++ b/scripts/tests/export.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -eu
+
+earthly=${earthly:=earthly}
+earthly=$(realpath "$earthly")
+echo "running tests with $earthly"
+
+# prevent the self-update of earthly from running (this ensures no bogus data is printed to stdout,
+# which would mess with the secrets data being fetched)
+date +%s > /tmp/last-earthly-prerelease-check
+
+# ensure earthly login works (and print out who gets logged in)
+"$earthly" account login
+
+# Test 1: export without anything
+echo ==== Running test 1 ====
+rm -rf /tmp/earthly-export-test-1
+docker rmi earthly-export-test-1:test || true
+
+mkdir /tmp/earthly-export-test-1
+cd /tmp/earthly-export-test-1
+cat >> Earthfile <<EOF
+test1:
+    FROM busybox:latest
+    SAVE IMAGE earthly-export-test-1:test
+EOF
+
+"$earthly" prune --reset
+"$earthly" +test1
+
+docker run --rm earthly-export-test-1:test
+
+# Test 2: export with only a CMD set
+echo ==== Running test 2 ====
+rm -rf /tmp/earthly-export-test-2
+docker rmi earthly-export-test-2:test || true
+
+mkdir /tmp/earthly-export-test-2
+cd /tmp/earthly-export-test-2
+cat >> Earthfile <<EOF
+test2:
+    FROM busybox:latest
+    CMD echo "running default cmd"
+    SAVE IMAGE earthly-export-test-2:test
+EOF
+
+"$earthly" prune --reset
+"$earthly" +test2
+
+docker run --rm earthly-export-test-2:test | grep "running default cmd"
+
+# Test 3: export with a single RUN
+echo ==== Running test 3 ====
+rm -rf /tmp/earthly-export-test-3
+docker rmi earthly-export-test-3:test || true
+
+mkdir /tmp/earthly-export-test-3
+cd /tmp/earthly-export-test-3
+cat >> Earthfile <<EOF
+test3:
+    FROM busybox:latest
+    RUN true # hack needed to make this work
+    SAVE IMAGE earthly-export-test-3:test
+EOF
+
+"$earthly" prune --reset
+"$earthly" +test3
+
+docker run --rm earthly-export-test-3:test | grep "running default cmd"

--- a/scripts/tests/private-repo.sh
+++ b/scripts/tests/private-repo.sh
@@ -2,6 +2,7 @@
 set -eu # don't use -x as it will leak the private key
 
 earthly=${earthly:=earthly}
+earthly=$(realpath "$earthly")
 echo "running tests with $earthly"
 
 # prevent the self-update of earthly from running (this ensures no bogus data is printed to stdout,
@@ -9,7 +10,7 @@ echo "running tests with $earthly"
 date +%s > /tmp/last-earthly-prerelease-check
 
 # ensure earthly login works (and print out who gets logged in)
-$earthly account login
+"$earthly" account login
 
 # fetch shared secret key (this step assumes your personal user has access to the /earthly-technologies/ secrets org
 ID_RSA=$($earthly secrets get -n /earthly-technologies/github/other-service+github-cinnamon@earthly.dev/id_rsa)
@@ -39,7 +40,7 @@ ssh git@github.com 2>&1 | perl -pe 'BEGIN {$status=1} END {exit $status} $status
 # Test a private repo can be cloned
 echo === Test 1 ===
 docker image rm -f test-private:latest
-$earthly -VD github.com/cinnamonthecat/test-private:main+docker
+"$earthly" -VD github.com/cinnamonthecat/test-private:main+docker
 docker run --rm test-private:latest | grep "Salut Lume"
 
 # Test public repo can be cloned without ssh, when GIT_URL_INSTEAD_OF is set as recommended by our CI docs

--- a/scripts/tests/secrets-integration.sh
+++ b/scripts/tests/secrets-integration.sh
@@ -2,6 +2,7 @@
 set -eu # don't use -x as it will leak the private key
 
 earthly=${earthly:=earthly}
+earthly=$(realpath "$earthly")
 echo "running tests with $earthly"
 
 # prevent the self-update of earthly from running (this ensures no bogus data is printed to stdout,
@@ -9,11 +10,10 @@ echo "running tests with $earthly"
 date +%s > /tmp/last-earthly-prerelease-check
 
 # ensure earthly login works (and print out who gets logged in)
-$earthly account login
+"$earthly" account login
 
 # fetch shared secret key (this step assumes your personal user has access to the /earthly-technologies/ secrets org
 ID_RSA=$($earthly secrets get -n /earthly-technologies/github/other-service+github-cinnamon@earthly.dev/id_rsa)
-GITHUB_PASSWORD=$($earthly secrets get -n /earthly-technologies/github/other-service+github-cinnamon@earthly.dev/password)
 
 # now that we grabbed the cinnamonthecat credentials, unset our token, to ensure that we're only testing using cinnamonthecat's credentials
 unset EARTHLY_TOKEN
@@ -34,7 +34,7 @@ echo testing that the ssh-agent only contains a single key
 test "$(ssh-add -l | wc -l)" = "1"
 
 echo "testing earthly account login works (and is using the earthly-cinnamon account)"
-$earthly account login | perl -pe 'BEGIN {$status=1} END {exit $status} $status=0 if /other-service\+earthly-cinnamon\@earthly.dev/;'
+"$earthly" account login | perl -pe 'BEGIN {$status=1} END {exit $status} $status=0 if /other-service\+earthly-cinnamon\@earthly.dev/;'
 
 mkdir -p /tmp/earthtest
 cat << EOF > /tmp/earthtest/Earthfile
@@ -48,16 +48,16 @@ test-server-secret:
 EOF
 
 # set and test get returns the correct value
-$earthly secrets set /user/earthly_integration_tests/my_test_file "secret-value"
-$earthly secrets get /user/earthly_integration_tests/my_test_file | perl -pe 'BEGIN {$status=1} END {exit $status} $status=0 if /secret-value/;'
+"$earthly" secrets set /user/earthly_integration_tests/my_test_file "secret-value"
+"$earthly" secrets get /user/earthly_integration_tests/my_test_file | perl -pe 'BEGIN {$status=1} END {exit $status} $status=0 if /secret-value/;'
 
 echo === test 1 ===
 # test RUN --mount can reference a secret from the command line
-$earthly --no-cache --secret my_secret=secret-value /tmp/earthtest+test-local-secret
+"$earthly" --no-cache --secret my_secret=secret-value /tmp/earthtest+test-local-secret
 
 echo === test 2 ===
 # test RUN --mount can reference a secret from the server that is only specified in the Earthfile
-$earthly --no-cache /tmp/earthtest+test-server-secret
+"$earthly" --no-cache /tmp/earthtest+test-server-secret
 
 echo === All tests have passed ===
 

--- a/scripts/tests/self-hosted-private-repo.sh
+++ b/scripts/tests/self-hosted-private-repo.sh
@@ -2,7 +2,7 @@
 set -eu
 
 earthly=${earthly:=earthly}
-earthly=$(realpath $earthly)
+earthly=$(realpath "$earthly")
 echo "running tests with $earthly"
 
 # use host IP, otherwise earthly-buildkit won't be able to connect to it
@@ -73,7 +73,7 @@ cd ~
 rm -rf odd-project
 
 # test that earthly has access to it
-$earthly config git "{myserver: {pattern: 'myserver/([^/]+)', substitute: 'ssh://root@$ip:2222/root/my/really/weird/path/\$1.git', auth: ssh}}"
+"$earthly" config git "{myserver: {pattern: 'myserver/([^/]+)', substitute: 'ssh://root@$ip:2222/root/my/really/weird/path/\$1.git', auth: ssh}}"
 
 if ! $earthly -V myserver/project:trunk+docker; then
     docker ps -a


### PR DESCRIPTION
This test is for validating the exporting from earthly to docker works.

It's written in a way that a user can run `./scripts/tests/export.sh` locally to run the test, or allow CI to invoke the script.