### PR TITLE
Fix for build arg issue when not overriding default value

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -178,10 +178,10 @@ earthly-darwin-arm64:
 
 earthly-all:
     COPY +earthly-linux-amd64/earthly ./earthly-linux-amd64
-    COPY +earthly-darwin-amd64/earthly ./earthly-darwin-amd64
-    COPY +earthly-darwin-arm64/earthly ./earthly-darwin-arm64
     COPY +earthly-linux-arm7/earthly ./earthly-linux-arm7
     COPY +earthly-linux-arm64/earthly ./earthly-linux-arm64
+    COPY +earthly-darwin-amd64/earthly ./earthly-darwin-amd64
+    COPY +earthly-darwin-arm64/earthly ./earthly-darwin-arm64
     SAVE ARTIFACT ./*
 
 earthly-docker:

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -622,7 +622,7 @@ func (c *Converter) Arg(ctx context.Context, argKey string, defaultArgValue stri
 		return err
 	}
 	c.mts.Final.TargetInput = c.mts.Final.TargetInput.WithBuildArgInput(
-		effective.BuildArgInput(argKey, effective.ConstantValue()))
+		effective.BuildArgInput(argKey, defaultArgValue))
 	return nil
 }
 

--- a/examples/tests/Earthfile
+++ b/examples/tests/Earthfile
@@ -58,6 +58,7 @@ ga:
     BUILD +run-no-cache
     BUILD +save-artifact-after-push
     BUILD +push-build
+    BUILD +build-arg-repeat
     BUILD ./autocompletion+test-all
     BUILD ./with-docker+all
     BUILD ./with-docker-compose+all
@@ -564,4 +565,26 @@ push-build:
     RUN cat output | perl -pe 'BEGIN {$status=1} END {exit $status} $status=0 if /\+test \| 0\n/;'
     RUN cat output | perl -pe 'BEGIN {$status=1} END {exit $status} $status=0 if /\+run1 \| 1\n/;'
     RUN cat output | perl -pe 'BEGIN {$status=1} END {exit $status} $status=0 if /\+run2 \| 2\n/;'
-    
+
+build-arg-repeat:
+    COPY build-arg-repeat.earth ./Earthfile
+    RUN --privileged \
+        --entrypoint \
+        --mount=type=tmpfs,target=/tmp/earthly \
+        -- +build-all-1
+    RUN test -f ./output/out-other-1
+    RUN test -f ./output/out-default-1
+    RUN cat ./output/out-other-1 | grep "A=other"
+    RUN cat ./output/out-other-1 | grep "B=1"
+    RUN cat ./output/out-default-1 | grep "A=default"
+    RUN cat ./output/out-default-1 | grep "B=1"
+    RUN --privileged \
+        --entrypoint \
+        --mount=type=tmpfs,target=/tmp/earthly \
+        -- +build-all-2
+    RUN test -f ./output/out-other-1
+    RUN test -f ./output/out-default-1
+    RUN cat ./output/out-other-1 | grep "A=other"
+    RUN cat ./output/out-other-1 | grep "B=1"
+    RUN cat ./output/out-default-1 | grep "A=default"
+    RUN cat ./output/out-default-1 | grep "B=1"

--- a/examples/tests/build-arg-repeat.earth
+++ b/examples/tests/build-arg-repeat.earth
@@ -1,0 +1,30 @@
+FROM alpine:3.13
+WORKDIR /test
+
+build:
+    ARG A=default
+    ARG B
+    RUN echo "A=$A" >./out
+    RUN echo "B=$B" >>./out
+    SAVE ARTIFACT ./out
+
+build-all-1:
+    COPY \
+        --build-arg A=other \
+        --build-arg B=1 \
+        +build/out ./out-other-1
+    COPY \
+        --build-arg B=1 \
+        +build/out ./out-default-1
+    SAVE ARTIFACT ./out-* AS LOCAL ./output/
+
+build-all-2:
+    # Same as above, but order of COPY's is reversed.
+    COPY \
+        --build-arg B=1 \
+        +build/out ./out-default-1
+    COPY \
+        --build-arg A=other \
+        --build-arg B=1 \
+        +build/out ./out-other-1
+    SAVE ARTIFACT ./out-* AS LOCAL ./output/

--- a/release/Earthfile
+++ b/release/Earthfile
@@ -39,6 +39,7 @@ release-dockerhub:
 
 release-github:
     FROM node:13.10.1-alpine3.11
+    RUN apk add file
     RUN npm install -g github-release-cli@v1.3.1
     WORKDIR /earthly
     ARG RELEASE_TAG
@@ -52,6 +53,14 @@ release-github:
         test -f ./release/earthly-darwin-arm64 && \
         test -f ./release/earthly-linux-arm7 && \
         test -f ./release/earthly-linux-arm64
+    RUN file ./release/earthly-linux-amd64 | grep "x86-64"
+    RUN file ./release/earthly-linux-amd64 | grep "ELF 64-bit"
+    RUN file ./release/earthly-darwin-amd64 | grep "Mach-O 64-bit x86_64"
+    RUN file ./release/earthly-darwin-arm64 | grep "Mach-O 64-bit arm64"
+    RUN file ./release/earthly-linux-arm7 | grep "ARM, EABI5 version 1"
+    RUN file ./release/earthly-linux-arm7 | grep "ELF 32-bit"
+    RUN file ./release/earthly-linux-arm64 | grep "aarch64"
+    RUN file ./release/earthly-linux-arm64 | grep "ELF 64-bit"
     ARG BODY="No details provided"
     RUN --secret GITHUB_TOKEN=+secrets/earthly-technologies/github/griswoldthecat/token test -n "$GITHUB_TOKEN"
     RUN --push \


### PR DESCRIPTION
This was causing our earthly-linux-arm64 binary to be the same as earthly-darwin-arm64.

Fixes https://github.com/earthly/earthly/issues/789