### PR TITLE
Get rid of old RunPath config and mount

### DIFF
--- a/buildkitd/buildkitd.go
+++ b/buildkitd/buildkitd.go
@@ -208,12 +208,10 @@ func Start(ctx context.Context, image string, settings Settings, reset bool) err
 		// Keep going - it might still work.
 	}
 	env := os.Environ()
-	runMount := fmt.Sprintf("%s:/run/earthly:consistent", settings.RunDir)
 	args := []string{
 		"run",
 		"-d",
 		"-v", fmt.Sprintf("%s:/tmp/earthly:rw", VolumeName),
-		"-v", runMount,
 		"-e", fmt.Sprintf("BUILDKIT_DEBUG=%t", settings.Debug),
 		"--label", fmt.Sprintf("dev.earthly.settingshash=%s", settingsHash),
 		"--name", ContainerName,

--- a/buildkitd/settings.go
+++ b/buildkitd/settings.go
@@ -13,7 +13,6 @@ import (
 type Settings struct {
 	CacheSizeMb     int      `json:"cacheSizeMb"`
 	GitURLInsteadOf string   `json:"gitUrlInsteadOf"`
-	RunDir          string   `json:"runDir"`
 	Debug           bool     `json:"debug"`
 	DebuggerPort    int      `json:"debuggerPort"`
 	AdditionalArgs  []string `json:"additionalArgs"`

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -854,15 +854,7 @@ func (app *earthlyApp) before(context *cli.Context) error {
 		app.buildkitdImage = app.cfg.Global.BuildkitImage
 	}
 
-	if !fileutil.DirExists(app.cfg.Global.RunPath) {
-		err := os.MkdirAll(app.cfg.Global.RunPath, 0755)
-		if err != nil {
-			return errors.Wrapf(err, "failed to create run directory %s", app.cfg.Global.RunPath)
-		}
-	}
-
 	app.buildkitdSettings.DebuggerPort = app.cfg.Global.DebuggerPort
-	app.buildkitdSettings.RunDir = app.cfg.Global.RunPath
 	app.buildkitdSettings.AdditionalArgs = app.cfg.Global.BuildkitAdditionalArgs
 
 	return nil

--- a/config/config.go
+++ b/config/config.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"reflect"
 	"regexp"
 	"sort"
@@ -24,7 +23,6 @@ var (
 
 // GlobalConfig contains global config values
 type GlobalConfig struct {
-	RunPath                 string   `yaml:"run_path"`
 	DisableAnalytics        bool     `yaml:"disable_analytics"`
 	BuildkitCacheSizeMb     int      `yaml:"cache_size_mb"`
 	BuildkitImage           string   `yaml:"buildkit_image"`
@@ -72,7 +70,6 @@ func ParseConfigFile(yamlData []byte) (*Config, error) {
 	// pre-populate defaults
 	config := Config{
 		Global: GlobalConfig{
-			RunPath:                 defaultRunPath(),
 			BuildkitCacheSizeMb:     0,
 			DebuggerPort:            8373,
 			BuildkitRestartTimeoutS: 60,
@@ -164,14 +161,6 @@ func CreateGitConfig(config *Config) (string, []string, error) {
 	gitConfig := strings.Join(lines, "\n")
 
 	return gitConfig, credentials, nil
-}
-
-func defaultRunPath() string {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		panic(err)
-	}
-	return filepath.Join(homeDir, ".earthly/run")
 }
 
 // UpsertConfig adds or modifies the key to be the specified value.

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -804,9 +804,7 @@ func (c *Converter) internalRun(ctx context.Context, args, secretKeyValues []str
 		fmt.Sprintf("/run/secrets/%s", common.DebuggerSettingsSecretsKey), secretOpts...)
 	debuggerMount := llb.AddMount(debuggerPath, llb.Scratch(),
 		llb.HostBind(), llb.SourcePath("/usr/bin/earth_debugger"))
-	runEarthlyMount := llb.AddMount("/run/earthly", llb.Scratch(),
-		llb.HostBind(), llb.SourcePath("/run/earthly"))
-	finalOpts = append(finalOpts, debuggerSecretMount, debuggerMount, runEarthlyMount)
+	finalOpts = append(finalOpts, debuggerSecretMount, debuggerMount)
 	if withSSH {
 		finalOpts = append(finalOpts, llb.AddSSHSocket())
 	}


### PR DESCRIPTION
This is no longer used AFAICT.

Fixes https://github.com/earthly/earthly/issues/791