### PR TITLE
Correctly detect when default platform matches specific platform for dedup reasons

### DIFF
--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -62,7 +62,7 @@ func NewConverter(ctx context.Context, target domain.Target, bc *buildcontext.Da
 		Platform: opt.Platform,
 		TargetInput: dedup.TargetInput{
 			TargetCanonical: target.StringCanonical(),
-			Platform:        llbutil.PlatformToString(opt.Platform),
+			Platform:        llbutil.PlatformWithDefaultToString(opt.Platform),
 		},
 		MainState:      llbutil.ScratchWithPlatform(),
 		MainImage:      image.NewImage(),
@@ -1147,6 +1147,7 @@ func (c *Converter) copyOwner(keepOwn bool, chown string) string {
 func (c *Converter) setPlatform(platform *specs.Platform) {
 	c.opt.Platform = platform
 	c.mts.Final.Platform = platform
+	c.mts.Final.TargetInput.Platform = llbutil.PlatformWithDefaultToString(platform)
 	c.varCollection.SetPlatformArgs(llbutil.PlatformWithDefault(platform))
 }
 

--- a/earthfile2llb/earthfile2llb.go
+++ b/earthfile2llb/earthfile2llb.go
@@ -18,7 +18,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// ConvertOpt holds conversion parameters needed for conversion.
+// ConvertOpt holds conversion parameters.
 type ConvertOpt struct {
 	// GwClient is the BuildKit gateway client.
 	GwClient gwclient.Client
@@ -69,7 +69,11 @@ func Earthfile2LLB(ctx context.Context, target domain.Target, opt ConvertOpt) (m
 	// Check if we have previously converted this target, with the same build args.
 	targetStr := target.String()
 	for _, sts := range opt.Visited.Visited[targetStr] {
-		same := (sts.TargetInput.Platform == llbutil.PlatformToString(opt.Platform))
+		stsPlat, err := llbutil.ParsePlatform(sts.TargetInput.Platform)
+		if err != nil {
+			return nil, err
+		}
+		same := llbutil.PlatformEquals(stsPlat, opt.Platform)
 		if same {
 			for _, bai := range sts.TargetInput.BuildArgs {
 				variable, _, found := opt.VarCollection.Get(bai.Name)

--- a/llbutil/platform.go
+++ b/llbutil/platform.go
@@ -37,6 +37,25 @@ func ScratchWithPlatform() llb.State {
 	return llb.Scratch().Platform(DefaultPlatform())
 }
 
+// PlatformEquals compares whether two platform pointers equate to the same platform.
+// If any of the pointers is nil, then the default platform is assumed for it.
+func PlatformEquals(p1 *specs.Platform, p2 *specs.Platform) bool {
+	if p1 == p2 {
+		// Quick way out.
+		return true
+	}
+	pp1 := PlatformWithDefault(p1)
+	pp2 := PlatformWithDefault(p2)
+	return pp1.OS == pp2.OS &&
+		pp1.Architecture == pp2.Architecture &&
+		pp1.Variant == pp2.Variant
+}
+
+// PlatformWithDefaultToString turns a platform pointer into a string representation.
+func PlatformWithDefaultToString(p *specs.Platform) string {
+	return platforms.Format(PlatformWithDefault(p))
+}
+
 // PlatformToString turns a platform pointer into a string representation.
 func PlatformToString(p *specs.Platform) string {
 	if p == nil {


### PR DESCRIPTION
* Don't use empty string for network in targetinput platform.