### PR TITLE
Correctly exclude .tmp-earthly-out

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -655,11 +655,11 @@ func (b *Builder) tempEarthlyOutDir() (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, "mk temp dir for artifacts")
 	}
-	// Note that because this removes the parent dir, it will cause the cleanup of any
-	// previous run tmp dir(s) as well. This is intentional so that there is GCing of any
-	// leftovers from ctrl+C'd runs.
 	b.opt.CleanCollection.Add(func() error {
-		return os.RemoveAll(tmpParentDir)
+		err := os.RemoveAll(outDir)
+		// Remove the parent dir only if it's empty.
+		_ = os.Remove(tmpParentDir)
+		return err
 	})
 	return outDir, nil
 }

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -646,7 +646,7 @@ func (b *Builder) saveArtifactLocally(ctx context.Context, artifact domain.Artif
 }
 
 func (b *Builder) tempEarthlyOutDir() (string, error) {
-	tmpParentDir := filepath.Join(".", ".tmp-earthly-out")
+	tmpParentDir := ".tmp-earthly-out"
 	err := os.MkdirAll(tmpParentDir, 0755)
 	if err != nil {
 		return "", errors.Wrapf(err, "unable to create dir %s", tmpParentDir)


### PR DESCRIPTION
The implicit exclude of `.tmp-earthly-out` was not working because the temp dir contained some numbers at the end and the exclude pattern was simply `.tmp-earthly-out/`. With this PR, the temp dirs are now stored under `./.tmp-earthly-out/tmpXXXXXX` instead of `./.tmp-earthly-outXXXXXX`.

The wrapping `.tmp-earthly-out` dir is removed only if it's empty.

It may be possible in the future to also remove any old leftover temp dirs within `.tmp-earthly-out` using some file lock-based logic to detect whether the temp dir is still being used by some process (a parallel earthly run).