### PR TITLE
Copy to localhost during solve

### DIFF
--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -1,6 +1,6 @@
 
 buildkitd:
-    ARG BUILDKIT_BASE_IMAGE=github.com/alexcb/buildkit:52f25d8929cd08b2858debb659f067089629e9f4+build
+    ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:earthly-main+build
     FROM $BUILDKIT_BASE_IMAGE
     RUN echo "@edge-community http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
     RUN apk add --update --no-cache \

--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -1,6 +1,6 @@
 
 buildkitd:
-    ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:earthly-main+build
+    ARG BUILDKIT_BASE_IMAGE=github.com/alexcb/buildkit:52f25d8929cd08b2858debb659f067089629e9f4+build
     FROM $BUILDKIT_BASE_IMAGE
     RUN echo "@edge-community http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
     RUN apk add --update --no-cache \

--- a/earthfile2llb/interpreter.go
+++ b/earthfile2llb/interpreter.go
@@ -268,6 +268,10 @@ func (i *Interpreter) handleRun(ctx context.Context, cmd spec.Command) error {
 			return Errorf(cmd.SourceLocation, "secrets need to be implemented for the LOCALLY directive")
 		}
 
+		if i.withDocker != nil {
+			return fmt.Errorf("WITH docker not currently supported under a LOCALLY target")
+		}
+
 		err = i.converter.RunLocal(ctx, fs.Args(), *pushFlag)
 		if err != nil {
 			return WrapError(err, cmd.SourceLocation, "apply RUN")

--- a/earthfile2llb/interpreter.go
+++ b/earthfile2llb/interpreter.go
@@ -269,7 +269,7 @@ func (i *Interpreter) handleRun(ctx context.Context, cmd spec.Command) error {
 		}
 
 		if i.withDocker != nil {
-			return fmt.Errorf("WITH docker not currently supported under a LOCALLY target")
+			return Errorf(cmd.SourceLocation, "the WITH DOCKER directive is not (yet) supported with the LOCALLY directive")
 		}
 
 		err = i.converter.RunLocal(ctx, fs.Args(), *pushFlag)
@@ -420,15 +420,26 @@ func (i *Interpreter) handleCopy(ctx context.Context, cmd spec.Command) error {
 			dest += string(filepath.Separator)
 		}
 		for _, src := range srcs {
-			err = i.converter.CopyArtifact(ctx, src, dest, platform, buildArgs.Args, *isDirCopy, *keepTs, *keepOwn, *chown, *ifExists)
-			if err != nil {
-				return WrapError(err, cmd.SourceLocation, "copy artifact")
+			if i.local {
+				err = i.converter.CopyArtifactLocal(ctx, src, dest, platform, buildArgs.Args, *isDirCopy)
+				if err != nil {
+					return WrapError(err, cmd.SourceLocation, "copy artifact locally")
+				}
+			} else {
+				err = i.converter.CopyArtifact(ctx, src, dest, platform, buildArgs.Args, *isDirCopy, *keepTs, *keepOwn, *chown, *ifExists)
+				if err != nil {
+					return WrapError(err, cmd.SourceLocation, "copy artifact")
+				}
 			}
 		}
 	} else {
 		if len(buildArgs.Args) != 0 {
 			return Errorf(cmd.SourceLocation, "build args not supported for non +artifact arguments case %v", cmd.Args)
 		}
+		if i.local {
+			return Errorf(cmd.SourceLocation, "unhandled locally artifact copy when allArtifacts is false")
+		}
+
 		i.converter.CopyClassical(ctx, srcs, dest, *isDirCopy, *keepTs, *keepOwn, *chown)
 	}
 	return nil

--- a/examples/tests/local/Earthfile
+++ b/examples/tests/local/Earthfile
@@ -1,5 +1,8 @@
 FROM alpine:3.13
 
+#################################################################################################################
+# tests for testing RUN commands are executed on the localhost
+
 test-local-with-arg:
     LOCALLY
     ARG pattern
@@ -7,23 +10,27 @@ test-local-with-arg:
 
 test-local:
     LOCALLY
-    # If run inside a container, one would expect something like 
+    # If run inside a container, one would expect something like
     # 12:cpuset:/docker/e4b6b1698e80c6a2d8ccdfcd689a1ce5828587ada1337ddcb0b9a80caf0087a4/buildkit/83zo724g6vr1ipssy0dic9kpa
     RUN whoami
     RUN cat /proc/1/cgroup | perl -pe 'BEGIN {$status=1} END {exit $status} $status=0 if /^[0-9]+:cpuset:\/$/;'
     RUN --push touch /tmp/earthly-test-local
 
-create-file:
+
+#################################################################################################################
+# tests for testing locally produced artifacts can be referenced by containerized targets
+
+create-local-file:
     LOCALLY
     RUN echo hello > /tmp/earthly-test-a266bf52-f5ea-477c-9416-2931720d1826
     SAVE ARTIFACT /tmp/earthly-test-a266bf52-f5ea-477c-9416-2931720d1826 data
 
 test-copy-file-from-local:
-    COPY +create-file/data actual
+    COPY +create-local-file/data actual
     RUN echo hello > expected
     RUN diff expected actual
 
-create-dir:
+create-local-dir:
     LOCALLY
     RUN rm -rf /tmp/earthly-test-bfbe3177-8683-4f8f-8c42-75053dc0e807
     RUN mkdir /tmp/earthly-test-bfbe3177-8683-4f8f-8c42-75053dc0e807
@@ -32,48 +39,103 @@ create-dir:
     SAVE ARTIFACT /tmp/earthly-test-bfbe3177-8683-4f8f-8c42-75053dc0e807 datadir
 
 test-copy-dir-from-local:
-    COPY +create-dir/datadir the-data
+    COPY +create-local-dir/datadir the-data
     RUN echo aaa > expected_a.txt
     RUN echo bbb > expected_b.txt
     RUN diff the-data/a.txt expected_a.txt
     RUN diff the-data/b.txt expected_b.txt
 
-save-unnamed-artifact:
+save-unnamed-local-artifact:
     LOCALLY
     RUN rm -rf /tmp/earthly-test-c5009c71-d573-4562-be15-2c28dae333fc
     RUN mkdir /tmp/earthly-test-c5009c71-d573-4562-be15-2c28dae333fc
     RUN echo ccc > /tmp/earthly-test-c5009c71-d573-4562-be15-2c28dae333fc/c.txt
     SAVE ARTIFACT /tmp/earthly-test-c5009c71-d573-4562-be15-2c28dae333fc
 
-test-save-unnamed-artifact:
-    COPY +save-unnamed-artifact/earthly-test-c5009c71-d573-4562-be15-2c28dae333fc .
+test-save-unnamed-local-artifact:
+    COPY +save-unnamed-local-artifact/earthly-test-c5009c71-d573-4562-be15-2c28dae333fc .
     RUN cat c.txt | grep '^ccc$'
 
-test-save-unnamed-artifact-dir:
-    COPY --dir +save-unnamed-artifact/earthly-test-c5009c71-d573-4562-be15-2c28dae333fc .
+test-save-unnamed-local-artifact-dir:
+    COPY --dir +save-unnamed-local-artifact/earthly-test-c5009c71-d573-4562-be15-2c28dae333fc .
     RUN cat earthly-test-c5009c71-d573-4562-be15-2c28dae333fc/c.txt | grep '^ccc$'
 
-test-save-unnamed-artifact-dir2:
-    COPY --dir +save-unnamed-artifact/earthly-test-c5009c71-d573-4562-be15-2c28dae333fc /var/log/.
+test-save-unnamed-local-artifact-dir2:
+    COPY --dir +save-unnamed-local-artifact/earthly-test-c5009c71-d573-4562-be15-2c28dae333fc /var/log/.
     RUN cat /var/log/earthly-test-c5009c71-d573-4562-be15-2c28dae333fc/c.txt | grep '^ccc$'
 
-mycontainer:
-    FROM busybox:latest
-    CMD echo hello world
 
-test-mycontainer-locally:
+#################################################################################################################
+# tests for testing containerized artifacts can be referenced by local targets
+
+busybox-artifact:
+    FROM busybox:1.32.1
+    RUN busybox > /data
+    SAVE ARTIFACT /data the-data
+
+test-copy-from-busybox-to-local:
     LOCALLY
-    RUN docker rm mycontainer-e3d32183-604d-4dc3-b519-f9af56ecb744 || true
-    WITH DOCKER \
-            --load mycontainer-e3d32183-604d-4dc3-b519-f9af56ecb744:latest=+mycontainer
-        RUN docker run --rm mycontainer-e3d32183-604d-4dc3-b519-f9af56ecb744 | grep "hello world"
-    END
+    RUN rm -rf /tmp/4eb5dcb7-2245-4f35-ab41-252f78e7a451
+    COPY +busybox-artifact/the-data /tmp/4eb5dcb7-2245-4f35-ab41-252f78e7a451
+    RUN cat /tmp/4eb5dcb7-2245-4f35-ab41-252f78e7a451 | grep "BusyBox v1.32.1"
+
+aline-artifacts:
+    FROM alpine:3.13
+    SAVE ARTIFACT /etc/alpine-release alpine-release
+    SAVE ARTIFACT /etc/motd alpine-motd
+    SAVE ARTIFACT /etc/os-release alpine-os-release
+
+test-multi-copy-from-alpine-to-local:
+    LOCALLY
+    RUN rm -rf /tmp/ac0887d7-fda7-4a1b-9873-054488c7e44d
+    COPY +aline-artifacts/alpine-release +aline-artifacts/alpine-motd +aline-artifacts/alpine-os-release /tmp/ac0887d7-fda7-4a1b-9873-054488c7e44d
+    RUN cat /tmp/ac0887d7-fda7-4a1b-9873-054488c7e44d/alpine-release | grep 3\\.13\\.2
+    RUN cat /tmp/ac0887d7-fda7-4a1b-9873-054488c7e44d/alpine-motd | grep alpinelinux.org
+    RUN cat /tmp/ac0887d7-fda7-4a1b-9873-054488c7e44d/alpine-os-release | grep "ID=alpine"
+
+busybox-dir-artifact:
+    FROM busybox:1.32.1
+    RUN mkdir /data-dir
+    RUN busybox > /data-dir/busybox
+    RUN hostname > /data-dir/hostname
+    SAVE ARTIFACT /data-dir the-data
+
+test-locally-can-copy-dir-contents:
+    LOCALLY
+    RUN rm -rf /tmp/f3fa2ae8-df5e-4b34-875d-c0919fae20d8
+    COPY +busybox-dir-artifact/the-data /tmp/f3fa2ae8-df5e-4b34-875d-c0919fae20d8
+    RUN cat /tmp/f3fa2ae8-df5e-4b34-875d-c0919fae20d8/busybox | grep "BusyBox v1.32.1"
+    RUN cat /tmp/f3fa2ae8-df5e-4b34-875d-c0919fae20d8/hostname | grep "buildkitsandbox"
+
+test-locally-can-copy-dir:
+    LOCALLY
+    RUN rm -rf /tmp/008f5069-567a-4aab-8024-1c974100a67f
+    COPY --dir +busybox-dir-artifact/the-data /tmp/008f5069-567a-4aab-8024-1c974100a67f
+    RUN cat /tmp/008f5069-567a-4aab-8024-1c974100a67f/the-data/busybox | grep "BusyBox v1.32.1"
+    RUN cat /tmp/008f5069-567a-4aab-8024-1c974100a67f/the-data/hostname | grep "buildkitsandbox"
+
+# TODO add support for copying container image into local docker
+#mycontainer:
+#    FROM busybox:latest
+#    CMD echo hello world
+#
+#test-mycontainer-locally:
+#    LOCALLY
+#    RUN docker rm mycontainer-e3d32183-604d-4dc3-b519-f9af56ecb744 || true
+#    WITH DOCKER \
+#            --load mycontainer-e3d32183-604d-4dc3-b519-f9af56ecb744:latest=+mycontainer
+#        RUN docker run --rm mycontainer-e3d32183-604d-4dc3-b519-f9af56ecb744:latest | grep "hello world"
+#    END
 
 all:
-    BUILD +test-local
     BUILD --build-arg pattern=memory +test-local-with-arg
-    BUILD +test-copy-dir-from-local
+    BUILD +test-local
     BUILD +test-copy-file-from-local
-    BUILD +test-save-unnamed-artifact
-    BUILD +test-save-unnamed-artifact-dir
-    BUILD +test-save-unnamed-artifact-dir2
+    BUILD +test-copy-dir-from-local
+    BUILD +test-save-unnamed-local-artifact
+    BUILD +test-save-unnamed-local-artifact-dir
+    BUILD +test-save-unnamed-local-artifact-dir2
+    BUILD +test-copy-from-busybox-to-local
+    BUILD +test-multi-copy-from-alpine-to-local
+    BUILD +test-locally-can-copy-dir-contents
+    BUILD +test-locally-can-copy-dir

--- a/examples/tests/local/Earthfile
+++ b/examples/tests/local/Earthfile
@@ -57,6 +57,18 @@ test-save-unnamed-artifact-dir2:
     COPY --dir +save-unnamed-artifact/earthly-test-c5009c71-d573-4562-be15-2c28dae333fc /var/log/.
     RUN cat /var/log/earthly-test-c5009c71-d573-4562-be15-2c28dae333fc/c.txt | grep '^ccc$'
 
+mycontainer:
+    FROM busybox:latest
+    CMD echo hello world
+
+test-mycontainer-locally:
+    LOCALLY
+    RUN docker rm mycontainer-e3d32183-604d-4dc3-b519-f9af56ecb744 || true
+    WITH DOCKER \
+            --load mycontainer-e3d32183-604d-4dc3-b519-f9af56ecb744:latest=+mycontainer
+        RUN docker run --rm mycontainer-e3d32183-604d-4dc3-b519-f9af56ecb744 | grep "hello world"
+    END
+
 all:
     BUILD +test-local
     BUILD --build-arg pattern=memory +test-local-with-arg

--- a/go.mod
+++ b/go.mod
@@ -39,5 +39,5 @@ replace (
 	github.com/docker/docker => github.com/docker/docker v17.12.0-ce-rc1.0.20200310163718-4634ce647cf2+incompatible
 	github.com/hashicorp/go-immutable-radix => github.com/tonistiigi/go-immutable-radix v0.0.0-20170803185627-826af9ccf0fe
 	github.com/jaguilar/vt100 => github.com/tonistiigi/vt100 v0.0.0-20190402012908-ad4c4a574305
-	github.com/moby/buildkit => github.com/earthly/buildkit v0.7.1-0.20210205234748-155288934f94
+	github.com/moby/buildkit => github.com/alexcb/buildkit v0.7.1-0.20210218020258-52f25d8929cd
 )

--- a/go.mod
+++ b/go.mod
@@ -39,5 +39,5 @@ replace (
 	github.com/docker/docker => github.com/docker/docker v17.12.0-ce-rc1.0.20200310163718-4634ce647cf2+incompatible
 	github.com/hashicorp/go-immutable-radix => github.com/tonistiigi/go-immutable-radix v0.0.0-20170803185627-826af9ccf0fe
 	github.com/jaguilar/vt100 => github.com/tonistiigi/vt100 v0.0.0-20190402012908-ad4c4a574305
-	github.com/moby/buildkit => github.com/alexcb/buildkit v0.7.1-0.20210218020258-52f25d8929cd
+	github.com/moby/buildkit => github.com/earthly/buildkit v0.7.1-0.20210223234127-dd44bfe50d68
 )

--- a/go.sum
+++ b/go.sum
@@ -166,6 +166,8 @@ github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d h1:UQZhZ2O0vMHr2c
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=
 github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
+github.com/alexcb/buildkit v0.7.1-0.20210218020258-52f25d8929cd h1:FE9rEZbH3Pi0hDIEgQPFnLdHDavkm1oe2PmWM7izKU8=
+github.com/alexcb/buildkit v0.7.1-0.20210218020258-52f25d8929cd/go.mod h1:Ch723AKY8/fNs7r8hqA5WOaptQo4T4zJaK2TbiAAMTI=
 github.com/alexflint/go-filemutex v0.0.0-20171022225611-72bdc8eae2ae h1:AMzIhMUqU3jMrZiTuW0zkYeKlKDAFD+DG20IoO421/Y=
 github.com/alexflint/go-filemutex v0.0.0-20171022225611-72bdc8eae2ae/go.mod h1:CgnQgUtFrFz9mxFNtED3jI5tLDjKlOM+oUF/sTk6ps0=
 github.com/antlr/antlr4 v0.0.0-20200225173536-225249fdaef5 h1:nkZ9axP+MvUFCu8JRN/MCY+DmTfs6lY7hE0QnJbxSdI=

--- a/go.sum
+++ b/go.sum
@@ -166,8 +166,6 @@ github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d h1:UQZhZ2O0vMHr2c
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=
 github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
-github.com/alexcb/buildkit v0.7.1-0.20210218020258-52f25d8929cd h1:FE9rEZbH3Pi0hDIEgQPFnLdHDavkm1oe2PmWM7izKU8=
-github.com/alexcb/buildkit v0.7.1-0.20210218020258-52f25d8929cd/go.mod h1:Ch723AKY8/fNs7r8hqA5WOaptQo4T4zJaK2TbiAAMTI=
 github.com/alexflint/go-filemutex v0.0.0-20171022225611-72bdc8eae2ae h1:AMzIhMUqU3jMrZiTuW0zkYeKlKDAFD+DG20IoO421/Y=
 github.com/alexflint/go-filemutex v0.0.0-20171022225611-72bdc8eae2ae/go.mod h1:CgnQgUtFrFz9mxFNtED3jI5tLDjKlOM+oUF/sTk6ps0=
 github.com/antlr/antlr4 v0.0.0-20200225173536-225249fdaef5 h1:nkZ9axP+MvUFCu8JRN/MCY+DmTfs6lY7hE0QnJbxSdI=
@@ -432,8 +430,8 @@ github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
-github.com/earthly/buildkit v0.7.1-0.20210205234748-155288934f94 h1:1zLX9HZZAS27k2TqC6aFPvFVSS73pThTZf+cApFFHNw=
-github.com/earthly/buildkit v0.7.1-0.20210205234748-155288934f94/go.mod h1:Ch723AKY8/fNs7r8hqA5WOaptQo4T4zJaK2TbiAAMTI=
+github.com/earthly/buildkit v0.7.1-0.20210223234127-dd44bfe50d68 h1:8THpVJRegekSK1PZIidgUHYctXIxPL43Q4kMTfQwjgM=
+github.com/earthly/buildkit v0.7.1-0.20210223234127-dd44bfe50d68/go.mod h1:Ch723AKY8/fNs7r8hqA5WOaptQo4T4zJaK2TbiAAMTI=
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153 h1:yUdfgN0XgIJw7foRItutHYUIhlcKzcSf5vDpdhQAKTc=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=


### PR DESCRIPTION
implements copying artifacts from containerized targets to `LOCALLY` targets. This functionality is different from `SAVE ARTIFACT AS LOCAL`, in that it is performed during the build rather than at the end of the build during the export stage.

This depends on https://github.com/earthly/buildkit/pull/30