### PR TITLE
Add early cutoff cache optimization example

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -308,6 +308,7 @@ examples1:
     BUILD ./examples/monorepo+all
     BUILD ./examples/multirepo+docker
     BUILD ./examples/python+docker
+    BUILD ./examples/cutoff-optimization+run
 
 examples2:
     BUILD ./examples/readme/go1+all

--- a/examples/cutoff-optimization/Earthfile
+++ b/examples/cutoff-optimization/Earthfile
@@ -1,0 +1,23 @@
+# This demostrates early cut off optimization from "Build Systems A la Carte"
+# 1) Run `earthly +run`
+# 2) Add or remove a comment to main.cpp
+# 3) ReRun `earthly +run`
+# Result: `build` will rerun, but `link` and `run` will be served from the cache as main.o is unchanged
+
+FROM alpine
+WORKDIR /code
+RUN apk add --update --no-cache build-base
+
+build:
+    COPY src .
+    RUN gcc -c main.cpp
+    SAVE ARTIFACT main.o
+
+link:
+    COPY +build/main.o .
+    RUN gcc -o main main.o
+    SAVE ARTIFACT main
+
+run:
+    COPY +link/main .
+    RUN ./main

--- a/examples/cutoff-optimization/src/main.cpp
+++ b/examples/cutoff-optimization/src/main.cpp
@@ -1,0 +1,7 @@
+#include <stdio.h>
+
+// comment
+int main() {
+   printf("Hello, World!");
+   return 0;
+}


### PR DESCRIPTION
This example demonstrates not repeating unnecessary subsequent steps after file changes.  This is called 'Early Cut Off Optimization' in the 'Build systems a la cart' paper.  

I also believe this is the behavior being referenced in #786 .