### PR TITLE
Allow platform contradictions

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -30,6 +30,7 @@ deps:
 
 code:
     FROM +deps
+    # TODO: --platform=linux/amd64 can be removed after the next prerelease.
     COPY --platform=linux/amd64 ./ast/parser+parser/*.go ./ast/parser/
     COPY --dir analytics autocomplete buildcontext builder cleanup cmd config conslogging debugger dockertar \
         docker2earthly domain fileutil gitutil llbutil logging secretsclient stringutil states syncutil termutil \

--- a/ast/parser/Earthfile
+++ b/ast/parser/Earthfile
@@ -1,4 +1,4 @@
-FROM golang:1.15-alpine3.13
+FROM --platform=linux/amd64 golang:1.15-alpine3.13
 
 RUN apk add --update --no-cache \
     openjdk11 \
@@ -8,7 +8,8 @@ RUN apk add --update --no-cache \
 
 # Install antlr.
 WORKDIR /usr/local/lib
-RUN curl -O https://www.antlr.org/download/antlr-4.8-complete.jar
+ARG ANTLR_VERSION=4.9.1
+RUN curl -O https://www.antlr.org/download/antlr-${ANTLR_VERSION}-complete.jar
 WORKDIR /earthly
 
 parser:
@@ -16,7 +17,7 @@ parser:
     COPY ./export.go ./ast/parser/
     RUN java \
         -Xmx500M \
-        -cp "/usr/local/lib/antlr-4.8-complete.jar:$CLASSPATH" \
+        -cp "/usr/local/lib/antlr-${ANTLR_VERSION}-complete.jar:$CLASSPATH" \
         org.antlr.v4.Tool \
         -Dlanguage=Go \
         -lib ast/parser/EarthLexer.g4 \

--- a/ast/parser/earth_lexer.go
+++ b/ast/parser/earth_lexer.go
@@ -1,4 +1,4 @@
-// Code generated from ast/parser/EarthLexer.g4 by ANTLR 4.8. DO NOT EDIT.
+// Code generated from ast/parser/EarthLexer.g4 by ANTLR 4.9.1. DO NOT EDIT.
 
 package parser
 
@@ -408,9 +408,6 @@ var serializedLexerAtn = []uint16{
 	4, 5, 2, 9, 37, 2, 9, 38, 2,
 }
 
-var lexerDeserializer = antlr.NewATNDeserializer(nil)
-var lexerAtn = lexerDeserializer.DeserializeFromUInt16(serializedLexerAtn)
-
 var lexerChannelNames = []string{
 	"DEFAULT_TOKEN_CHANNEL", "HIDDEN",
 }
@@ -462,18 +459,20 @@ type EarthLexer struct {
 	// TODO: EOF string
 }
 
-var lexerDecisionToDFA = make([]*antlr.DFA, len(lexerAtn.DecisionToState))
-
-func init() {
+// NewEarthLexer produces a new lexer instance for the optional input antlr.CharStream.
+//
+// The *EarthLexer instance produced may be reused by calling the SetInputStream method.
+// The initial lexer configuration is expensive to construct, and the object is not thread-safe;
+// however, if used within a Golang sync.Pool, the construction cost amortizes well and the
+// objects can be used in a thread-safe manner.
+func NewEarthLexer(input antlr.CharStream) *EarthLexer {
+	l := new(EarthLexer)
+	lexerDeserializer := antlr.NewATNDeserializer(nil)
+	lexerAtn := lexerDeserializer.DeserializeFromUInt16(serializedLexerAtn)
+	lexerDecisionToDFA := make([]*antlr.DFA, len(lexerAtn.DecisionToState))
 	for index, ds := range lexerAtn.DecisionToState {
 		lexerDecisionToDFA[index] = antlr.NewDFA(ds, index)
 	}
-}
-
-func NewEarthLexer(input antlr.CharStream) *EarthLexer {
-
-	l := new(EarthLexer)
-
 	l.BaseLexer = antlr.NewBaseLexer(input)
 	l.Interpreter = antlr.NewLexerATNSimulator(l, lexerAtn, lexerDecisionToDFA, antlr.NewPredictionContextCache())
 

--- a/ast/parser/earth_parser.go
+++ b/ast/parser/earth_parser.go
@@ -1,4 +1,4 @@
-// Code generated from ast/parser/EarthParser.g4 by ANTLR 4.8. DO NOT EDIT.
+// Code generated from ast/parser/EarthParser.g4 by ANTLR 4.9.1. DO NOT EDIT.
 
 package parser // EarthParser
 
@@ -262,9 +262,6 @@ var parserATN = []uint16{
 	409, 414, 419, 425, 428, 431, 434, 440, 445, 448, 450, 456, 461, 468, 472,
 	478, 488, 493, 498, 503, 508, 513, 521, 526,
 }
-var deserializer = antlr.NewATNDeserializer(nil)
-var deserializedATN = deserializer.DeserializeFromUInt16(parserATN)
-
 var literalNames = []string{
 	"", "", "", "", "'FROM'", "'FROM DOCKERFILE'", "'LOCALLY'", "'COPY'", "'SAVE ARTIFACT'",
 	"'SAVE IMAGE'", "'RUN'", "'EXPOSE'", "'VOLUME'", "'ENV'", "'ARG'", "'LABEL'",
@@ -292,21 +289,25 @@ var ruleNames = []string{
 	"healthcheckStmt", "shellStmt", "expr", "stmtWordsMaybeJSON", "stmtWords",
 	"stmtWord",
 }
-var decisionToDFA = make([]*antlr.DFA, len(deserializedATN.DecisionToState))
-
-func init() {
-	for index, ds := range deserializedATN.DecisionToState {
-		decisionToDFA[index] = antlr.NewDFA(ds, index)
-	}
-}
 
 type EarthParser struct {
 	*antlr.BaseParser
 }
 
+// NewEarthParser produces a new parser instance for the optional input antlr.TokenStream.
+//
+// The *EarthParser instance produced may be reused by calling the SetInputStream method.
+// The initial parser configuration is expensive to construct, and the object is not thread-safe;
+// however, if used within a Golang sync.Pool, the construction cost amortizes well and the
+// objects can be used in a thread-safe manner.
 func NewEarthParser(input antlr.TokenStream) *EarthParser {
 	this := new(EarthParser)
-
+	deserializer := antlr.NewATNDeserializer(nil)
+	deserializedATN := deserializer.DeserializeFromUInt16(parserATN)
+	decisionToDFA := make([]*antlr.DFA, len(deserializedATN.DecisionToState))
+	for index, ds := range deserializedATN.DecisionToState {
+		decisionToDFA[index] = antlr.NewDFA(ds, index)
+	}
 	this.BaseParser = antlr.NewBaseParser(input)
 
 	this.Interpreter = antlr.NewParserATNSimulator(this, deserializedATN, decisionToDFA, antlr.NewPredictionContextCache())

--- a/ast/parser/earthparser_base_listener.go
+++ b/ast/parser/earthparser_base_listener.go
@@ -1,4 +1,4 @@
-// Code generated from ast/parser/EarthParser.g4 by ANTLR 4.8. DO NOT EDIT.
+// Code generated from ast/parser/EarthParser.g4 by ANTLR 4.9.1. DO NOT EDIT.
 
 package parser // EarthParser
 

--- a/ast/parser/earthparser_listener.go
+++ b/ast/parser/earthparser_listener.go
@@ -1,4 +1,4 @@
-// Code generated from ast/parser/EarthParser.g4 by ANTLR 4.8. DO NOT EDIT.
+// Code generated from ast/parser/EarthParser.g4 by ANTLR 4.9.1. DO NOT EDIT.
 
 package parser // EarthParser
 

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -508,10 +508,7 @@ func (b *Builder) buildOnlyLastImageAsTar(ctx context.Context, mts *states.Multi
 		return err
 	}
 
-	platform, err := llbutil.ResolvePlatform(mts.Final.Platform, opt.Platform)
-	if err != nil {
-		platform = mts.Final.Platform
-	}
+	platform := llbutil.ResolvePlatform(opt.Platform, mts.Final.Platform)
 	plat := llbutil.PlatformWithDefault(platform)
 	err = b.outputImageTar(ctx, saveImage, plat, dockerTag, outFile)
 	if err != nil {
@@ -525,12 +522,9 @@ func (b *Builder) buildMain(ctx context.Context, mts *states.MultiTarget, opt Bu
 	if b.opt.NoCache {
 		state = state.SetMarshalDefaults(llb.IgnoreCache)
 	}
-	platform, err := llbutil.ResolvePlatform(mts.Final.Platform, opt.Platform)
-	if err != nil {
-		platform = mts.Final.Platform
-	}
+	platform := llbutil.ResolvePlatform(opt.Platform, mts.Final.Platform)
 	plat := llbutil.PlatformWithDefault(platform)
-	err = b.s.solveMain(ctx, state, plat)
+	err := b.s.solveMain(ctx, state, plat)
 	if err != nil {
 		return errors.Wrapf(err, "solve side effects")
 	}

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -140,6 +140,7 @@ func (c *Converter) fromTarget(ctx context.Context, targetName string, platform 
 	if err != nil {
 		return errors.Wrapf(err, "apply build %s", depTarget.String())
 	}
+	c.setPlatform(mts.Final.Platform)
 	if depTarget.IsLocalInternal() {
 		depTarget.LocalPath = c.mts.Final.Target.LocalPath
 	}
@@ -1116,7 +1117,7 @@ func (c *Converter) processNonConstantBuildArgFunc(ctx context.Context) variable
 func (c *Converter) vertexPrefix(local bool) string {
 	overriding := c.varCollection.SortedOverridingVariables()
 	varStrBuilder := make([]string, 0, len(overriding)+1)
-	if c.opt.Platform != nil {
+	if c.mts.Final.Platform != nil {
 		varStrBuilder = append(
 			varStrBuilder,
 			fmt.Sprintf("platform=%s", llbutil.PlatformToString(c.opt.Platform)))

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -95,10 +95,7 @@ func NewConverter(ctx context.Context, target domain.Target, bc *buildcontext.Da
 // From applies the earthly FROM command.
 func (c *Converter) From(ctx context.Context, imageName string, platform *specs.Platform, buildArgs []string) error {
 	c.nonSaveCommand()
-	platform, err := llbutil.ResolvePlatform(platform, c.opt.Platform)
-	if err != nil {
-		return err
-	}
+	platform = llbutil.ResolvePlatform(c.opt.Platform, platform)
 	c.setPlatform(platform)
 	if strings.Contains(imageName, "+") {
 		// Target-based FROM.
@@ -164,10 +161,7 @@ func (c *Converter) fromTarget(ctx context.Context, targetName string, platform 
 
 // FromDockerfile applies the earthly FROM DOCKERFILE command.
 func (c *Converter) FromDockerfile(ctx context.Context, contextPath string, dfPath string, dfTarget string, platform *specs.Platform, buildArgs []string) error {
-	platform, err := llbutil.ResolvePlatform(platform, c.opt.Platform)
-	if err != nil {
-		return err
-	}
+	platform = llbutil.ResolvePlatform(c.opt.Platform, platform)
 	c.setPlatform(platform)
 	plat := llbutil.PlatformWithDefault(platform)
 	c.nonSaveCommand()
@@ -871,11 +865,7 @@ func (c *Converter) buildTarget(ctx context.Context, fullTargetName string, plat
 	opt := c.opt
 	opt.Visited = c.mts.Visited
 	opt.VarCollection = newVarCollection
-	opt.Platform, err = llbutil.ResolvePlatform(platform, c.opt.Platform)
-	if err != nil {
-		// Contradiction allowed. You can BUILD another target with different platform.
-		opt.Platform = platform
-	}
+	opt.Platform = llbutil.ResolvePlatform(c.opt.Platform, platform)
 	mts, err := Earthfile2LLB(ctx, target, opt)
 	if err != nil {
 		return nil, errors.Wrapf(err, "earthfile2llb for %s", fullTargetName)

--- a/llbutil/platform.go
+++ b/llbutil/platform.go
@@ -6,7 +6,6 @@ import (
 	"github.com/containerd/containerd/platforms"
 	"github.com/moby/buildkit/client/llb"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 )
 
 // ParsePlatform parses a given platform string. Empty string is a valid selection:
@@ -65,33 +64,12 @@ func PlatformToString(p *specs.Platform) string {
 }
 
 // ResolvePlatform returns the non-nil platform provided. If both are nil, nil is returned.
-// If both are non-nil, they are compared to ensure they are identical. If they are not,
-// an error is returned.
-func ResolvePlatform(p1 *specs.Platform, p2 *specs.Platform) (*specs.Platform, error) {
-	if p1 == nil {
-		return p2, nil
+// If both are non-nil, override is returned.
+func ResolvePlatform(base *specs.Platform, override *specs.Platform) *specs.Platform {
+	if override == nil {
+		return base
 	}
-	if p2 == nil {
-		return p1, nil
-	}
-	plat1 := platforms.Normalize(*p1)
-	plat2 := platforms.Normalize(*p2)
-	if plat1.OS != plat2.OS {
-		return nil, errors.Errorf(
-			"platform contradiction %s vs %s",
-			platforms.Format(*p1), platforms.Format(*p2))
-	}
-	if plat1.Architecture != plat2.Architecture {
-		return nil, errors.Errorf(
-			"platform contradiction %s vs %s",
-			platforms.Format(*p1), platforms.Format(*p2))
-	}
-	if plat1.Variant != plat2.Variant {
-		return nil, errors.Errorf(
-			"platform contradiction %s vs %s",
-			platforms.Format(*p1), platforms.Format(*p2))
-	}
-	return p1, nil
+	return override
 }
 
 // PlatformWithDefault returns the same platform provided if not nil, or the default


### PR DESCRIPTION
Turns out detecting a contradiction isn't great in some specific situations. Like the following, which should be perfectly valid:

```
build:
  FROM --platform=platform1 ...
  COPY +other/... ./...

other:
  FROM --platform=platform2
  ...
```

Also, update antlr to `4.9.1`.