### PR TITLE
Example for creating rpm and yum repo

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -310,6 +310,7 @@ examples1:
     BUILD ./examples/multirepo+docker
     BUILD ./examples/python+docker
     BUILD ./examples/cutoff-optimization+run
+    BUILD ./examples/apt-repo+test
     BUILD ./examples/yum-repo+test
 
 examples2:

--- a/Earthfile
+++ b/Earthfile
@@ -310,6 +310,7 @@ examples1:
     BUILD ./examples/multirepo+docker
     BUILD ./examples/python+docker
     BUILD ./examples/cutoff-optimization+run
+    BUILD ./examples/yum-repo+test
 
 examples2:
     BUILD ./examples/readme/go1+all

--- a/examples/apt-repo/Earthfile
+++ b/examples/apt-repo/Earthfile
@@ -50,16 +50,16 @@ apt-repo:
     FROM +deps
     RUN mkdir -p /repo/dists/main/binary-amd64
     COPY --build-arg EARTHLY_VERSION +deb/*.deb /repo/pool/main/.
-    RUN ls /repo/pool/main/earthly_*.deb # ensure debs exist here
     WORKDIR /repo
     RUN mkdir -p dists/stable/main/binary-amd64
     RUN dpkg-scanpackages pool/ > dists/stable/main/binary-amd64/Packages
-    RUN ls /repo/dists/stable/main/binary-amd64/Packages && ( cat /repo/dists/stable/main/binary-amd64/Packages | gzip -c9 > /repo/dists/stable/main/binary-amd64/Packages.gz )
+    RUN gzip -c9 dists/stable/main/binary-amd64/Packages > dists/stable/main/binary-amd64/Packages.gz
     WORKDIR /repo/dists/stable
     COPY Release Release
-    RUN ls /repo/dists/stable/Release # ensure this exists here
     COPY generate-release.sh /
     RUN PACKAGES=main/binary-amd64/Packages /generate-release.sh >> Release
+    RUN ls /repo/pool/main/earthly_*.deb # ensure debs exist
+    RUN ls /repo/dists/stable/Release # ensure Release exists
     SAVE ARTIFACT /repo AS LOCAL repo
 
 signed-apt-repo:
@@ -75,8 +75,10 @@ apt-repo-server:
     FROM python:3
     RUN mkdir -p /repo-data/deb
     COPY +signed-apt-repo/repo /repo-data/deb
-    RUN ls -la /repo-data/deb/dists/stable/Release # ensure this exists
-    RUN ls -la /repo-data/deb/dists/stable/Release.gpg # ensure this exists
+    # First check these files exist
+    RUN ls -la /repo-data/deb/dists/stable/InRelease
+    RUN ls -la /repo-data/deb/dists/stable/Release
+    RUN ls -la /repo-data/deb/dists/stable/Release.gpg
     CMD python -m http.server --directory /repo-data 8000
 
 

--- a/examples/apt-repo/Earthfile
+++ b/examples/apt-repo/Earthfile
@@ -1,0 +1,113 @@
+deps:
+    FROM ubuntu:20.10
+    RUN apt-get update && apt-get install -y dpkg-dev wget dpkg-sig
+
+deb:
+    ARG EARTHLY_VERSION
+    ARG PKG_NAME=earthly_$EARTHLY_VERSION-1_amd64
+    FROM +deps
+    WORKDIR /work
+    RUN mkdir -p $PKG_NAME/DEBIAN
+    RUN mkdir -p $PKG_NAME/usr/bin/
+    RUN echo "$EARTHLY_VERSION" | grep '^[0-9]\+.[0-9]\+.[0-9]\+$' # ensure version is of the form 1.2.3
+    RUN wget -q "https://github.com/earthly/earthly/releases/download/v${EARTHLY_VERSION}/earthly-linux-amd64" -O $PKG_NAME/usr/bin/earthly && chmod +x $PKG_NAME/usr/bin/earthly
+    COPY earthly.control $PKG_NAME/DEBIAN/control
+    RUN sed -i "s/__earthly_version__/$EARTHLY_VERSION/" $PKG_NAME/DEBIAN/control
+    RUN dpkg -b $PKG_NAME
+    #RUN find / | grep deb$ && false
+    SAVE ARTIFACT $PKG_NAME.deb AS LOCAL $PKG_NAME.deb
+
+test-deb:
+    ARG EARTHLY_VERSION
+    FROM +deps
+    COPY --build-arg EARTHLY_VERSION +deb/earthly_*.deb .
+    RUN apt-get install ./earthly_*.deb
+    RUN earthly --version | grep "version v$EARTHLY_VERSION linux/amd64"
+
+gpg-key:
+    FROM +deps
+    WORKDIR /root/apt-key
+    RUN echo "%echo Generating a basic OpenPGP key
+Key-Type: RSA
+Key-Length: 4096
+Subkey-Type: RSA
+Subkey-Length: 4096
+Name-Real: earthly-apt
+Name-Email: example@earthly.dev
+Expire-Date: 0
+%no-ask-passphrase
+%no-protection
+%commit
+%echo done" > earthly-apt.batch
+    RUN rm -rf /root/gpupg && gpg --no-tty --batch --gen-key earthly-apt.batch
+    RUN gpg --output earthly-apt-public.pgp --armor --export example@earthly.dev
+    RUN gpg --output earthly-apt-private.pgp --armor --export-secret-key example@earthly.dev
+    SAVE ARTIFACT earthly-apt-public.pgp
+    SAVE ARTIFACT earthly-apt-private.pgp
+
+apt-repo:
+    ARG EARTHLY_VERSION
+    FROM +deps
+    RUN mkdir -p /repo/dists/main/binary-amd64
+    COPY --build-arg EARTHLY_VERSION +deb/*.deb /repo/pool/main/.
+    RUN ls /repo/pool/main/earthly_*.deb # ensure debs exist here
+    WORKDIR /repo
+    RUN mkdir -p dists/stable/main/binary-amd64
+    RUN dpkg-scanpackages pool/ > dists/stable/main/binary-amd64/Packages
+    RUN ls -la /repo/dists/stable/main/binary-amd64/Packages
+    RUN cat /repo/dists/stable/main/binary-amd64/Packages | gzip -c9 > /repo/dists/stable/main/binary-amd64/Packages.gz
+    WORKDIR /repo/dists/stable
+    COPY Release Release
+    RUN ls /repo/dists/stable/Release # ensure this exists here
+    COPY generate-release.sh /
+    RUN PACKAGES=main/binary-amd64/Packages /generate-release.sh >> Release
+    #RUN find . && false
+    SAVE ARTIFACT /repo AS LOCAL repo
+
+signed-apt-repo:
+    FROM +deps
+    COPY +apt-repo/repo /repo
+    COPY +gpg-key/earthly-apt-public.pgp +gpg-key/earthly-apt-private.pgp /apt-key/.
+    RUN gpg --import /apt-key/earthly-apt-private.pgp
+    RUN gpg --default-key earthly-apt -abs -o /repo/dists/stable/Release.gpg /repo/dists/stable/Release
+    RUN cat /repo/dists/stable/Release | gpg --default-key earthly-apt -abs --clearsign > /repo/dists/stable/InRelease
+    #RUN dpkg-sig -k earthly-apt --sign earthly.deb
+    SAVE ARTIFACT /repo AS LOCAL repo
+
+apt-repo-server:
+    FROM python:3
+    RUN mkdir -p /repo-data/deb
+    COPY +signed-apt-repo/repo /repo-data/deb
+    RUN ls -la /repo-data/deb/dists/stable/Release
+    RUN ls -la /repo-data/deb/dists/stable/Release.gpg
+    CMD python -m http.server --directory /repo-data 8000
+
+
+apt-repo-tester:
+    FROM +deps
+    COPY +gpg-key/earthly-apt-public.pgp /apt-key/.
+    # Most users will add the key via a command like:
+    #   curl http://127.0.0.1:8000/my-apt-repo/KEY.pgp | apt-key add -;
+    # However we can't do this here since that server isn't running during build time; so instead we used the key directly
+    RUN apt-key add /apt-key/earthly-apt-public.pgp
+    RUN apt-get update && apt-get install -y curl
+    RUN echo "deb [arch=amd64] http://127.0.0.1:8000/deb/ stable main" > /etc/apt/sources.list.d/earthly.list
+    # this means the following URLS must resolve:
+    #  - http://127.0.0.1:8000/deb/dists/stable/Release
+    #  - http://127.0.0.1:8000/deb/dists/stable/main/binary-amd64/Packages
+
+test-repo:
+    ARG EARTHLY_VERSION
+    FROM earthly/dind:alpine
+    RUN apk add curl
+    WITH DOCKER \
+        --load apt:server=+apt-repo-server \
+        --load apt:tester=+apt-repo-tester
+        RUN docker run -d --network=host --name=apt-server apt:server \
+            && sleep 1 \
+            && docker run --network=host --name=apt-tester apt:tester /bin/sh -c "which gpgv && apt-get update && apt-get install -y earthly && earthly --version | grep 'earthly version v$EARTHLY_VERSION linux/amd64'"
+    END
+
+test:
+    ARG EARTHLY_VERSION=0.5.3
+    BUILD --build-arg EARTHLY_VERSION +test-repo

--- a/examples/apt-repo/Earthfile
+++ b/examples/apt-repo/Earthfile
@@ -54,14 +54,12 @@ apt-repo:
     WORKDIR /repo
     RUN mkdir -p dists/stable/main/binary-amd64
     RUN dpkg-scanpackages pool/ > dists/stable/main/binary-amd64/Packages
-    RUN ls -la /repo/dists/stable/main/binary-amd64/Packages
-    RUN cat /repo/dists/stable/main/binary-amd64/Packages | gzip -c9 > /repo/dists/stable/main/binary-amd64/Packages.gz
+    RUN ls /repo/dists/stable/main/binary-amd64/Packages && ( cat /repo/dists/stable/main/binary-amd64/Packages | gzip -c9 > /repo/dists/stable/main/binary-amd64/Packages.gz )
     WORKDIR /repo/dists/stable
     COPY Release Release
     RUN ls /repo/dists/stable/Release # ensure this exists here
     COPY generate-release.sh /
     RUN PACKAGES=main/binary-amd64/Packages /generate-release.sh >> Release
-    #RUN find . && false
     SAVE ARTIFACT /repo AS LOCAL repo
 
 signed-apt-repo:
@@ -71,15 +69,14 @@ signed-apt-repo:
     RUN gpg --import /apt-key/earthly-apt-private.pgp
     RUN gpg --default-key earthly-apt -abs -o /repo/dists/stable/Release.gpg /repo/dists/stable/Release
     RUN cat /repo/dists/stable/Release | gpg --default-key earthly-apt -abs --clearsign > /repo/dists/stable/InRelease
-    #RUN dpkg-sig -k earthly-apt --sign earthly.deb
     SAVE ARTIFACT /repo AS LOCAL repo
 
 apt-repo-server:
     FROM python:3
     RUN mkdir -p /repo-data/deb
     COPY +signed-apt-repo/repo /repo-data/deb
-    RUN ls -la /repo-data/deb/dists/stable/Release
-    RUN ls -la /repo-data/deb/dists/stable/Release.gpg
+    RUN ls -la /repo-data/deb/dists/stable/Release # ensure this exists
+    RUN ls -la /repo-data/deb/dists/stable/Release.gpg # ensure this exists
     CMD python -m http.server --directory /repo-data 8000
 
 

--- a/examples/apt-repo/Release
+++ b/examples/apt-repo/Release
@@ -1,0 +1,8 @@
+Origin: Earthly Technologies
+Label: Earthly
+Suite: stable
+Codename: stable
+Version: 1.0
+Architectures: amd64
+Components: main
+Description: Earthly software repository

--- a/examples/apt-repo/earthly.control
+++ b/examples/apt-repo/earthly.control
@@ -1,0 +1,7 @@
+Package: earthly
+Version: __earthly_version__
+Architecture: all
+Maintainer: Alex <alex@earthly.dev>
+Depends: bash
+Homepage: http://earthly.dev
+Description: Build automation tool for the container era.

--- a/examples/apt-repo/generate-release.sh
+++ b/examples/apt-repo/generate-release.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+
+PKGS=$(wc -c ${PACKAGES})
+PKGS_GZ=$(wc -c ${PACKAGES}.gz)
+cat << EOF
+Date: $(date -R)
+MD5Sum:
+ $(md5sum ${PACKAGES}  | cut -d" " -f1) $PKGS
+ $(md5sum ${PACKAGES}.gz  | cut -d" " -f1) $PKGS_GZ
+SHA1:
+ $(sha1sum ${PACKAGES}  | cut -d" " -f1) $PKGS
+ $(sha1sum ${PACKAGES}.gz  | cut -d" " -f1) $PKGS_GZ
+SHA256:
+ $(sha256sum ${PACKAGES} | cut -d" " -f1) $PKGS
+ $(sha256sum ${PACKAGES}.gz | cut -d" " -f1) $PKGS_GZ
+EOF

--- a/examples/yum-repo/Earthfile
+++ b/examples/yum-repo/Earthfile
@@ -3,22 +3,28 @@ deps:
     RUN yum install -y createrepo rpm-build wget
 
 rpm:
+    ARG EARTHLY_VERSION
     FROM +deps
     WORKDIR /work
-    RUN wget -q https://github.com/earthly/earthly/releases/download/v0.5.3/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly
-    COPY buildrpm.sh .
-    RUN ./buildrpm.sh
-    SAVE ARTIFACT /root/rpmbuild/RPMS/x86_64/earthly-1.0.0-1.x86_64.rpm AS LOCAL earthly-1.0.0-1.x86_64.rpm
+    RUN echo "$EARTHLY_VERSION" | grep '^[0-9]\+.[0-9]\+.[0-9]\+$' # ensure version is of the form 1.2.3
+    RUN wget -q "https://github.com/earthly/earthly/releases/download/v${EARTHLY_VERSION}/earthly-linux-amd64" -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly
+    COPY earthly.spec .
+    RUN sed -i "s/__earthly_version__/$EARTHLY_VERSION/" earthly.spec
+    RUN cat earthly.spec
+    RUN rpmbuild --target x86_64 -bb earthly.spec
+    SAVE ARTIFACT "/root/rpmbuild/RPMS/x86_64/earthly-${EARTHLY_VERSION}-1.x86_64.rpm" AS LOCAL "earthly-${EARTHLY_VERSION}-1.x86_64.rpm"
 
 test-rpm:
+    ARG EARTHLY_VERSION
     FROM centos:8.3.2011
-    COPY +rpm/earthly-1.0.0-1.x86_64.rpm .
-    RUN yum localinstall -y earthly-1.0.0-1.x86_64.rpm && earthly --version
+    COPY +rpm/earthly-${EARTHLY_VERSION}-1.x86_64.rpm .
+    RUN yum localinstall -y earthly-${EARTHLY_VERSION}-1.x86_64.rpm && earthly --version
 
 yum-repo:
+    ARG EARTHLY_VERSION
     FROM +deps
     WORKDIR /repo
-    COPY +rpm/earthly-1.0.0-1.x86_64.rpm .
+    COPY --build-arg EARTHLY_VERSION +rpm/earthly-${EARTHLY_VERSION}-1.x86_64.rpm .
     RUN createrepo .
     SAVE ARTIFACT /repo AS LOCAL repo
 
@@ -37,6 +43,12 @@ yum-repo-tester:
     RUN echo "baseurl=http://127.0.0.1:8000/CentOS/8/os/x86_64/" >> /etc/yum.repos.d/earthly-test.repo
     RUN echo "enabled=1" >> /etc/yum.repos.d/earthly-test.repo
     RUN echo "gpgcheck=0" >> /etc/yum.repos.d/earthly-test.repo # TODO setup gpg signing
+
+    RUN echo "[earthly-test]
+name=Earthly Test Repository
+baseurl=http://127.0.0.1:8000/CentOS/8/os/x86_64/
+enabled=1
+gpgcheck=0" > /etc/yum.repos.d/earthly-test.repo # TODO setup gpg signing
 
 test-repo:
     ARG EARTHLY_VERSION

--- a/examples/yum-repo/Earthfile
+++ b/examples/yum-repo/Earthfile
@@ -1,0 +1,55 @@
+deps:
+    FROM centos:8.3.2011
+    RUN yum install -y createrepo rpm-build wget
+
+rpm:
+    FROM +deps
+    WORKDIR /work
+    RUN wget -q https://github.com/earthly/earthly/releases/download/v0.5.3/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly
+    COPY buildrpm.sh .
+    RUN ./buildrpm.sh
+    SAVE ARTIFACT /root/rpmbuild/RPMS/x86_64/earthly-1.0.0-1.x86_64.rpm AS LOCAL earthly-1.0.0-1.x86_64.rpm
+
+test-rpm:
+    FROM centos:8.3.2011
+    COPY +rpm/earthly-1.0.0-1.x86_64.rpm .
+    RUN yum localinstall -y earthly-1.0.0-1.x86_64.rpm && earthly --version
+
+yum-repo:
+    FROM +deps
+    WORKDIR /repo
+    COPY +rpm/earthly-1.0.0-1.x86_64.rpm .
+    RUN createrepo .
+    SAVE ARTIFACT /repo AS LOCAL repo
+
+yum-repo-server:
+    FROM python:3
+    RUN mkdir -p /repo-data/CentOS/8/os/x86_64
+    COPY +yum-repo/repo /repo-data/CentOS/8/os/x86_64
+    CMD python -m http.server --directory /repo-data 8000
+
+yum-repo-tester:
+    FROM +deps
+    RUN yum install -y curl
+
+    RUN echo "[earthly-test]" > /etc/yum.repos.d/earthly-test.repo
+    RUN echo "name=Earthly Test Repository" >> /etc/yum.repos.d/earthly-test.repo
+    RUN echo "baseurl=http://127.0.0.1:8000/CentOS/8/os/x86_64/" >> /etc/yum.repos.d/earthly-test.repo
+    RUN echo "enabled=1" >> /etc/yum.repos.d/earthly-test.repo
+    RUN echo "gpgcheck=0" >> /etc/yum.repos.d/earthly-test.repo # TODO setup gpg signing
+
+test-repo:
+    ARG EARTHLY_VERSION
+    FROM earthly/dind:alpine
+    RUN apk add curl
+    WITH DOCKER \
+        --load yum:server=+yum-repo-server \
+        --load yum:tester=+yum-repo-tester
+        RUN docker run -d --network=host yum:server \
+            && sleep 1 \
+            && docker run --network=host yum:tester /bin/sh -c "yum install -y earthly && earthly --version | grep 'earthly version v$EARTHLY_VERSION linux/amd64'"
+    END
+
+test:
+    ARG EARTHLY_VERSION=0.5.3
+    BUILD --build-arg EARTHLY_VERSION +test-repo

--- a/examples/yum-repo/buildrpm.sh
+++ b/examples/yum-repo/buildrpm.sh
@@ -1,0 +1,38 @@
+#/bin/sh
+set -e
+
+mkdir -p rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
+
+cat > earthly.spec << EOF
+Summary: Build automation tool for the container era
+Name: earthly
+Version: 1.0.0
+Release: 1
+License: Business Source License
+URL: http://earthly.dev
+Group: System
+Packager: Earthly team
+Requires: bash
+BuildRoot: /work/rpmbuild/
+
+%description
+Build automation tool for the container era
+
+%install
+mkdir -p %{buildroot}/usr/bin/
+cp /usr/local/bin/earthly %{buildroot}/usr/bin/earthly
+
+%files
+/usr/bin/earthly
+
+%changelog
+* Thu Feb 25 2021 alex <alex@earthly.dev>
+- initial poc
+
+%clean
+echo maybe-rm-rf $RPM_BUILD_ROOT
+
+EOF
+
+rpmbuild --target x86_64 -bb earthly.spec
+find / | grep -w .rpm$

--- a/examples/yum-repo/earthly.spec
+++ b/examples/yum-repo/earthly.spec
@@ -1,12 +1,6 @@
-#/bin/sh
-set -e
-
-mkdir -p rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
-
-cat > earthly.spec << EOF
 Summary: Build automation tool for the container era
 Name: earthly
-Version: 1.0.0
+Version: __earthly_version__
 Release: 1
 License: Business Source License
 URL: http://earthly.dev
@@ -28,11 +22,3 @@ cp /usr/local/bin/earthly %{buildroot}/usr/bin/earthly
 %changelog
 * Thu Feb 25 2021 alex <alex@earthly.dev>
 - initial poc
-
-%clean
-echo maybe-rm-rf $RPM_BUILD_ROOT
-
-EOF
-
-rpmbuild --target x86_64 -bb earthly.spec
-find / | grep -w .rpm$


### PR DESCRIPTION
- an example for generating a rpm from scratch
- testing the rpm can be installed
- an example for creating a yum repo
- testing the yum repo can be served over http and a centos client can
install the earthly rpm via yum

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>