### PR TITLE
Analytics improvements

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -189,12 +189,17 @@ earthly-docker:
     FROM ./buildkitd+buildkitd
     RUN apk add --update --no-cache docker-cli
     ENV NETWORK_MODE=host
+    ENV EARTHLY_IMAGE=true
     COPY earthly-buildkitd-wrapper.sh /usr/bin/earthly-buildkitd-wrapper.sh
     ENTRYPOINT ["/usr/bin/earthly-buildkitd-wrapper.sh"]
     ARG EARTHLY_TARGET_TAG_DOCKER
     ARG TAG=$EARTHLY_TARGET_TAG_DOCKER
     COPY --build-arg VERSION=$TAG +earthly/earthly /usr/bin/earthly
     SAVE IMAGE --push --cache-from=earthly/earthly:main earthly/earthly:$TAG
+
+earthly-integration-test-base:
+    FROM +earthly-docker
+    RUN earthly config global.disable_analytics true
 
 prerelease:
     FROM alpine:3.13

--- a/analytics/analytics.go
+++ b/analytics/analytics.go
@@ -31,6 +31,8 @@ func detectCI() (string, bool) {
 		"BUILDKITE":       "buildkite",
 		"DRONE_BRANCH":    "drone",
 		"TRAVIS":          "travis",
+		"GITLAB_CI":       "gitlab",
+		"EARTHLY_IMAGE":   "earthly-image",
 	} {
 		if _, ok := os.LookupEnv(k); ok {
 			return v, true
@@ -63,6 +65,7 @@ func getRepo() string {
 		"DRONE_REPO",
 		"TRAVIS_REPO_SLUG",
 		"EARTHLY_GIT_ORIGIN_URL",
+		"CI_REPOSITORY_URL",
 	} {
 		if v, ok := os.LookupEnv(k); ok {
 			return strings.TrimSpace(v)

--- a/examples/tests/Earthfile
+++ b/examples/tests/Earthfile
@@ -1,4 +1,4 @@
-FROM ../..+earthly-docker
+FROM ../..+earthly-integration-test-base
 
 RUN apk add --update --no-cache \
     perl findutils

--- a/examples/tests/autocompletion/Earthfile
+++ b/examples/tests/autocompletion/Earthfile
@@ -1,4 +1,4 @@
-FROM ../../..+earthly-docker
+FROM ../../..+earthly-integration-test-base
 
 test-root-commands:
     RUN echo "./

--- a/examples/tests/cloud-push-pull/Earthfile
+++ b/examples/tests/cloud-push-pull/Earthfile
@@ -1,4 +1,4 @@
-FROM ../../..+earthly-docker
+FROM ../../..+earthly-integration-test-base
 WORKDIR /test
 
 RUN apk update && \

--- a/examples/tests/registry-certs/Earthfile
+++ b/examples/tests/registry-certs/Earthfile
@@ -24,7 +24,7 @@ certs:
     SAVE ARTIFACT certs AS LOCAL certs
 
 test-base:
-    FROM ../../..+earthly-docker
+    FROM ../../..+earthly-integration-test-base
     WORKDIR /test
     COPY ./certs/domain.crt /etc/config/test.ca
 

--- a/examples/tests/remote-cache/Earthfile
+++ b/examples/tests/remote-cache/Earthfile
@@ -1,4 +1,4 @@
-FROM ../../..+earthly-docker
+FROM ../../..+earthly-integration-test-base
 WORKDIR /test
 ARG REGISTRY
 ARG EARTHLY_BUILD_ARGS="REGISTRY"


### PR DESCRIPTION
* Disable analytics for our earthly image-based integration tests. This is not strictly necessary as we anyway perform filtering on the other side. This data is never useful, however, and it's better if it's not there so that we don't accidentally forget to filter it out.
* Treat the earthly docker image as CI for analytics purposes, just in case anyone is using the image extensively. It's not well supported - we should have some way to know if it has wide use.
* Add detection for GitLab CI.