### PR TITLE
Provide updates about what is ongoing if there is no output

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -336,3 +336,15 @@ examples2:
     BUILD ./examples/multiplatform+all
     BUILD ./examples/multiplatform-cross-compile+build-all-platforms
     BUILD github.com/earthly/hello-world:main+hello
+
+# @#
+a-target:
+    BUILD +another-target
+    RUN echo aaaaaaa
+    RUN sleep 20
+    RUN sleep 5
+
+another-target:
+    RUN echo baaaaa
+    RUN sleep 10
+    RUN sleep 10

--- a/Earthfile
+++ b/Earthfile
@@ -336,15 +336,3 @@ examples2:
     BUILD ./examples/multiplatform+all
     BUILD ./examples/multiplatform-cross-compile+build-all-platforms
     BUILD github.com/earthly/hello-world:main+hello
-
-# @#
-a-target:
-    BUILD +another-target
-    RUN echo aaaaaaa
-    RUN sleep 20
-    RUN sleep 5
-
-another-target:
-    RUN echo baaaaa
-    RUN sleep 10
-    RUN sleep 10

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -691,7 +691,7 @@ func (b *Builder) saveArtifactLocally(ctx context.Context, artifact domain.Artif
 			destPath2 = filepath.Join(destPath2, filepath.Base(artifactPath))
 		}
 		if opt.PrintSuccess {
-			artifactStr := console.PrefixColor().Sprintf(artifact2.StringCanonical())
+			artifactStr := console.PrefixColor().Sprintf("%s", artifact2.StringCanonical())
 			console.Printf("Artifact %s as local %s\n", artifactStr, destPath2)
 		}
 	}

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -433,7 +433,8 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 			if shouldPush {
 				pushStr = " (pushed)"
 			}
-			console.Printf("Image %s as %s%s\n", mts.Final.Target.StringCanonical(), saveImage.DockerTag, pushStr)
+			targetStr := console.PrefixColor().Sprintf("%s", mts.Final.Target.StringCanonical())
+			console.Printf("Image %s as %s%s\n", targetStr, saveImage.DockerTag, pushStr)
 			if saveImage.Push && !opt.Push {
 				console.Printf("Did not push %s. Use earthly --push to enable pushing\n", saveImage.DockerTag)
 			}
@@ -455,7 +456,8 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 				if shouldPush {
 					pushStr = " (pushed)"
 				}
-				console.Printf("Image %s as %s%s\n", sts.Target.StringCanonical(), saveImage.DockerTag, pushStr)
+				targetStr := console.PrefixColor().Sprintf("%s", sts.Target.StringCanonical())
+				console.Printf("Image %s as %s%s\n", targetStr, saveImage.DockerTag, pushStr)
 				if saveImage.Push && !opt.Push && !sts.Target.IsRemote() {
 					console.Printf("Did not push %s. Use earthly --push to enable pushing\n", saveImage.DockerTag)
 				}
@@ -633,7 +635,7 @@ func (b *Builder) saveArtifactLocally(ctx context.Context, artifact domain.Artif
 			// Ignore err. Likely dest path does not exist.
 			if isWildcard && !destIsDir {
 				return errors.New(
-					"Artifact is a wildcard, but AS LOCAL destination does not end with /")
+					"artifact is a wildcard, but AS LOCAL destination does not end with /")
 			}
 			destIsDir = fiSrc.IsDir()
 		} else {
@@ -642,7 +644,7 @@ func (b *Builder) saveArtifactLocally(ctx context.Context, artifact domain.Artif
 		}
 		if srcIsDir && !destIsDir {
 			return errors.New(
-				"Artifact is a directory, but existing AS LOCAL destination is a file")
+				"artifact is a directory, but existing AS LOCAL destination is a file")
 		}
 		if destExists {
 			if !srcIsDir {
@@ -689,7 +691,8 @@ func (b *Builder) saveArtifactLocally(ctx context.Context, artifact domain.Artif
 			destPath2 = filepath.Join(destPath2, filepath.Base(artifactPath))
 		}
 		if opt.PrintSuccess {
-			console.Printf("Artifact %s as local %s\n", artifact2.StringCanonical(), destPath2)
+			artifactStr := console.PrefixColor().Sprintf(artifact2.StringCanonical())
+			console.Printf("Artifact %s as local %s\n", artifactStr, destPath2)
 		}
 	}
 	return nil

--- a/builder/solver_monitor.go
+++ b/builder/solver_monitor.go
@@ -22,13 +22,13 @@ import (
 )
 
 const (
-	durationBetweenSha256ProgressUpdate = 5 * time.Second
-	durationBetweenProgressUpdate       = 3 * time.Second
-	durationBetweenProgressUpdateIfSame = 5 * time.Millisecond
-	durationBetweenOpenLineUpdate       = time.Second
-	durationBetweenAnyOutput            = 5 * time.Second
-	durationBetweenAnyOutputNoAnsi      = 20 * time.Second
-	tailErrorBufferSizeBytes            = 80 * 1024 // About as much as 1024 lines of 80 chars each.
+	durationBetweenSha256ProgressUpdate  = 5 * time.Second
+	durationBetweenProgressUpdate        = 3 * time.Second
+	durationBetweenProgressUpdateIfSame  = 5 * time.Millisecond
+	durationBetweenOpenLineUpdate        = time.Second
+	durationBetweenNoOutputUpdates       = 5 * time.Second
+	durationBetweenNoOutputUpdatesNoAnsi = 20 * time.Second
+	tailErrorBufferSizeBytes             = 80 * 1024 // About as much as 1024 lines of 80 chars each.
 )
 
 type vertexMonitor struct {
@@ -247,9 +247,9 @@ func (sm *solverMonitor) monitorProgress(ctx context.Context, ch chan *client.So
 	sm.ongoing = true
 	sm.mu.Unlock()
 	var errVertex *vertexMonitor
-	noOutputTick := durationBetweenAnyOutputNoAnsi
+	noOutputTick := durationBetweenNoOutputUpdatesNoAnsi
 	if ansiSupported {
-		noOutputTick = durationBetweenAnyOutput
+		noOutputTick = durationBetweenNoOutputUpdates
 	}
 	noOutputTicker := time.NewTicker(noOutputTick)
 	defer noOutputTicker.Stop()

--- a/builder/solver_monitor.go
+++ b/builder/solver_monitor.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/armon/circbuf"
+	"github.com/dustin/go-humanize"
 	"github.com/earthly/earthly/conslogging"
 	"github.com/mattn/go-isatty"
 	"github.com/moby/buildkit/client"
@@ -25,6 +26,8 @@ const (
 	durationBetweenProgressUpdate       = 3 * time.Second
 	durationBetweenProgressUpdateIfSame = 5 * time.Millisecond
 	durationBetweenOpenLineUpdate       = time.Second
+	durationBetweenAnyOutput            = 5 * time.Second
+	durationBetweenAnyOutputNoAnsi      = 20 * time.Second
 	tailErrorBufferSizeBytes            = 80 * 1024 // About as much as 1024 lines of 80 chars each.
 )
 
@@ -201,15 +204,20 @@ func (vm *vertexMonitor) printTimingInfo() {
 		Printf("Completed in %s\n", vm.vertex.Completed.Sub(*vm.vertex.Started))
 }
 
+func (vm *vertexMonitor) isOngoing() bool {
+	return vm.vertex.Started != nil && vm.vertex.Completed == nil && !vm.isError
+}
+
 type solverMonitor struct {
-	console                      conslogging.ConsoleLogger
-	verbose                      bool
-	vertices                     map[digest.Digest]*vertexMonitor
-	saltSeen                     map[string]bool
-	lastVertexOutput             *vertexMonitor
-	lastOutputWasOngoingProgress bool
-	timingTable                  map[timingKey]time.Duration
-	startTime                    time.Time
+	console                     conslogging.ConsoleLogger
+	verbose                     bool
+	vertices                    map[digest.Digest]*vertexMonitor
+	saltSeen                    map[string]bool
+	lastVertexOutput            *vertexMonitor
+	lastOutputWasProgress       bool
+	lastOutputWasNoOutputUpdate bool
+	timingTable                 map[timingKey]time.Duration
+	startTime                   time.Time
 
 	mu             sync.Mutex
 	success        bool
@@ -239,6 +247,12 @@ func (sm *solverMonitor) monitorProgress(ctx context.Context, ch chan *client.So
 	sm.ongoing = true
 	sm.mu.Unlock()
 	var errVertex *vertexMonitor
+	noOutputTick := durationBetweenAnyOutputNoAnsi
+	if ansiSupported {
+		noOutputTick = durationBetweenAnyOutput
+	}
+	noOutputTicker := time.NewTicker(noOutputTick)
+	defer noOutputTicker.Stop()
 Loop:
 	for {
 		select {
@@ -267,22 +281,26 @@ Loop:
 				if !vm.headerPrinted &&
 					((!vm.isInternal && (vertex.Cached || vertex.Started != nil)) || vertex.Error != "") {
 					sm.printHeader(vm)
+					noOutputTicker.Reset(noOutputTick)
 				}
 				if vertex.Error != "" {
 					if strings.Contains(vertex.Error, "context canceled") {
 						if !vm.isInternal {
 							vm.console.Printf("WARN: Canceled\n")
+							noOutputTicker.Reset(noOutputTick)
 						}
 					} else {
 						vm.isError = vm.printError()
 						if errVertex == nil && vm.isError {
 							errVertex = vm
 						}
+						noOutputTicker.Reset(noOutputTick)
 					}
 				}
 				if sm.verbose {
 					vm.printTimingInfo()
 					sm.recordTiming(vm.targetStr, vm.targetBrackets, vm.salt, vertex)
+					noOutputTicker.Reset(noOutputTick)
 				}
 			}
 			for _, vs := range ss.Statuses {
@@ -299,6 +317,7 @@ Loop:
 					progress = 100
 				}
 				sm.printProgress(vm, vs.ID, progress)
+				noOutputTicker.Reset(noOutputTick)
 			}
 			for _, logLine := range ss.Logs {
 				vm, ok := sm.vertices[logLine.Vertex]
@@ -313,7 +332,29 @@ Loop:
 				if err != nil {
 					return "", err
 				}
+				noOutputTicker.Reset(noOutputTick)
 			}
+		case <-noOutputTicker.C:
+			ongoingBuilder := []string{}
+			if sm.lastOutputWasNoOutputUpdate {
+				// Overwrite previous line if the previous update was also a no-output update.
+				ongoingBuilder = append(ongoingBuilder, string(ansiUp))
+			}
+			ongoing := []string{}
+			now := time.Now()
+			for _, vm := range sm.vertices {
+				if vm.isOngoing() {
+					col := vm.console.PrefixColor()
+					relTime := humanize.RelTime(*vm.vertex.Started, now, "ago", "from now")
+					ongoing = append(ongoing, fmt.Sprintf("%s (a step started %s)", col.Sprintf("%s", vm.targetStr), relTime))
+				}
+			}
+			sort.Strings(ongoing) // not entirely correct, but makes the ordering consistent
+			ongoingBuilder = append(ongoingBuilder,
+				strings.Join(ongoing, ", "), string(ansiEraseRestLine))
+			sm.console.WithPrefix("ongoing").Printf("%s\n", strings.Join(ongoingBuilder, ""))
+			sm.lastOutputWasProgress = false
+			sm.lastOutputWasNoOutputUpdate = true
 		}
 	}
 	failedVertexOutput := ""
@@ -325,7 +366,8 @@ Loop:
 	}
 	sm.mu.Lock()
 	if sm.success && !sm.printedSuccess {
-		sm.lastOutputWasOngoingProgress = false
+		sm.lastOutputWasProgress = false
+		sm.lastOutputWasNoOutputUpdate = false
 		sm.console.PrintSuccess(phaseText)
 		sm.printedSuccess = true
 	}
@@ -336,19 +378,21 @@ Loop:
 }
 
 func (sm *solverMonitor) printOutput(vm *vertexMonitor, data []byte) error {
-	sameAsLast := (sm.lastVertexOutput == vm && !sm.lastOutputWasOngoingProgress)
+	sameAsLast := (sm.lastVertexOutput == vm && !sm.lastOutputWasProgress)
 	sm.lastVertexOutput = vm
-	sm.lastOutputWasOngoingProgress = false
+	sm.lastOutputWasProgress = false
+	sm.lastOutputWasNoOutputUpdate = false
 	return vm.printOutput(data, sameAsLast)
 }
 
 func (sm *solverMonitor) printProgress(vm *vertexMonitor, id string, progress int) {
-	if vm.shouldPrintProgress(id, progress, sm.verbose, sm.lastOutputWasOngoingProgress) {
+	if vm.shouldPrintProgress(id, progress, sm.verbose, sm.lastOutputWasProgress) {
 		if !vm.headerPrinted {
 			sm.printHeader(vm)
 		}
-		vm.printProgress(id, progress, sm.verbose, sm.lastOutputWasOngoingProgress)
-		sm.lastOutputWasOngoingProgress = (progress != 100)
+		vm.printProgress(id, progress, sm.verbose, sm.lastOutputWasProgress)
+		sm.lastOutputWasProgress = (progress != 100)
+		sm.lastOutputWasNoOutputUpdate = false
 	}
 }
 
@@ -358,6 +402,8 @@ func (sm *solverMonitor) printHeader(vm *vertexMonitor) {
 		sm.saltSeen[vm.salt] = true
 	}
 	vm.printHeader()
+	sm.lastOutputWasProgress = false
+	sm.lastOutputWasNoOutputUpdate = false
 }
 
 func (sm *solverMonitor) recordTiming(targetStr, targetBrackets, salt string, vertex *client.Vertex) {
@@ -381,7 +427,8 @@ func (sm *solverMonitor) SetSuccess(msg string) {
 	defer sm.mu.Unlock()
 	sm.success = true
 	if !sm.ongoing {
-		sm.lastOutputWasOngoingProgress = false
+		sm.lastOutputWasProgress = false
+		sm.lastOutputWasNoOutputUpdate = false
 		sm.console.PrintSuccess(msg)
 		sm.printedSuccess = true
 	}
@@ -429,7 +476,8 @@ func (sm *solverMonitor) PrintTiming() {
 }
 
 func (sm *solverMonitor) reprintFailure(errVertex *vertexMonitor, phaseText string) {
-	sm.lastOutputWasOngoingProgress = false
+	sm.lastOutputWasProgress = false
+	sm.lastOutputWasNoOutputUpdate = false
 	sm.console.Warnf("Repeating the output of the command that caused the failure\n")
 	sm.console.PrintFailure(phaseText)
 	errVertex.console = errVertex.console.WithFailed(true)

--- a/conslogging/conslogging.go
+++ b/conslogging/conslogging.go
@@ -144,6 +144,17 @@ func (cl ConsoleLogger) PrintFailure(msg string) {
 	cl.PrintBar(warnColor, " FAILURE ", msg)
 }
 
+// PrefixColor returns the color used for the prefix.
+func (cl ConsoleLogger) PrefixColor() *color.Color {
+	c, found := cl.saltColors[cl.salt]
+	if !found {
+		c = availablePrefixColors[*cl.nextColorIndex]
+		cl.saltColors[cl.salt] = c
+		*cl.nextColorIndex = (*cl.nextColorIndex + 1) % len(availablePrefixColors)
+	}
+	return cl.color(c)
+}
+
 // PrintBar prints an earthly message bar
 func (cl ConsoleLogger) PrintBar(c *color.Color, center, msg string) {
 	if msg != "" {
@@ -251,13 +262,7 @@ func (cl ConsoleLogger) printPrefix(useErrWriter bool) {
 	if cl.prefix == "" {
 		return
 	}
-	c, found := cl.saltColors[cl.salt]
-	if !found {
-		c = availablePrefixColors[*cl.nextColorIndex]
-		cl.saltColors[cl.salt] = c
-		*cl.nextColorIndex = (*cl.nextColorIndex + 1) % len(availablePrefixColors)
-	}
-	c = cl.color(c)
+	c := cl.PrefixColor()
 	c.Fprintf(w, cl.prettyPrefix())
 	if cl.isFailed {
 		w.Write([]byte(" *"))


### PR DESCRIPTION
Here's what this looks like in practice (note the `ongoing | ... ` lines)

![Screenshot from 2021-03-04 17-08-31](https://user-images.githubusercontent.com/446771/110052331-4e335a80-7d0c-11eb-8a98-ba5a644b53ce.png)

These get updated as time passes, if the terminal supports ansi. If not (usually in CI), the updates happen more rarely and are printed on new lines.

#### Other

Also in this PR, a somewhat unrelated change: the artifacts and image targets are colored with the same color used for the target:

![Screenshot from 2021-03-04 17-06-48](https://user-images.githubusercontent.com/446771/110052564-a0747b80-7d0c-11eb-8b32-97a4c244f08b.png)

