### PR TITLE
Fix leaking index-X dir names in artifact printout

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -683,11 +683,7 @@ func (b *Builder) saveArtifactLocally(ctx context.Context, artifact domain.Artif
 		}
 
 		// Write to console about this artifact.
-		parts := strings.Split(filepath.ToSlash(from), "/")
-		artifactPath := artifact.Artifact
-		if len(parts) >= 2 {
-			artifactPath = filepath.FromSlash(strings.Join(parts[2:], "/"))
-		}
+		artifactPath := trimFilePathPrefix(indexOutDir, from)
 		artifact2 := domain.Artifact{
 			Target:   artifact.Target,
 			Artifact: artifactPath,
@@ -726,4 +722,13 @@ func (b *Builder) tempEarthlyOutDir() (string, error) {
 		})
 	})
 	return b.outDir, err
+}
+
+func trimFilePathPrefix(prefix string, thePath string) string {
+	ret, err := filepath.Rel(prefix, thePath)
+	if err != nil {
+		fmt.Printf("Warning: Could not compute relative path for %s as being relative to %s: %s\n", thePath, prefix, err.Error())
+		return thePath
+	}
+	return ret
 }


### PR DESCRIPTION
Before:

![Screenshot from 2021-03-08 19-04-26](https://user-images.githubusercontent.com/446771/110412685-6fb08100-8041-11eb-84de-99fe924ab7cd.png)

(Notice the `index-0` `index-1` in the artifact path)

After:

![Screenshot from 2021-03-08 19-02-05](https://user-images.githubusercontent.com/446771/110412693-73440800-8041-11eb-9863-4cae9017813f.png)
