### PR TITLE
Syntax highlighting for command references and command definitions

### DIFF
--- a/contrib/earthfile-syntax-highlighting/README.md
+++ b/contrib/earthfile-syntax-highlighting/README.md
@@ -11,6 +11,8 @@ For an introduction of Earthly see the [Earthly GitHub repository](https://githu
 ### 0.0.10
 
 * Add highlighting for `DO`, `COMMAND`, `IMPORT` and `LOCALLY`.
+* Add highlighting for command definition and references.
+* Change the semantic type of targets to "class".
 
 ### 0.0.9
 

--- a/contrib/earthfile-syntax-highlighting/syntaxes/earthfile.tmLanguage.json
+++ b/contrib/earthfile-syntax-highlighting/syntaxes/earthfile.tmLanguage.json
@@ -106,7 +106,7 @@
 				{
 					"captures": {
 						"1": {
-							"name": "entity.name.function.target.earthfile"
+							"name": "entity.name.class.target.earthfile"
 						}
 					},
 					"match": "^\\s*([a-z]([a-zA-Z0-9.]|-)*):"
@@ -248,7 +248,7 @@
 				},
 				{
 					"match": "([a-zA-Z0-9._\\-/:]*\\+[A-Z][a-zA-Z0-9._]*)",
-					"name": "entity.name.type.user-command.earthfile"
+					"name": "entity.name.function.user-command.earthfile"
 				}
 			]
 		}

--- a/contrib/earthfile-syntax-highlighting/syntaxes/earthfile.tmLanguage.json
+++ b/contrib/earthfile-syntax-highlighting/syntaxes/earthfile.tmLanguage.json
@@ -22,6 +22,9 @@
 		},
 		{
 			"include": "#target"
+		},
+		{
+			"include": "#user-command"
 		}
 	],
 	"scopeName": "source.earthfile",
@@ -92,6 +95,9 @@
 				},
 				{
 					"include": "#target"
+				},
+				{
+					"include": "#user-command"
 				}
 			]
 		},
@@ -103,7 +109,19 @@
 							"name": "entity.name.function.target.earthfile"
 						}
 					},
-					"match": "^\\s*(([a-zA-Z0-9.]|-)+):"
+					"match": "^\\s*([a-z]([a-zA-Z0-9.]|-)*):"
+				}
+			]
+		},
+		"user-command": {
+			"patterns": [
+				{
+					"captures": {
+						"1": {
+							"name": "entity.name.function.user-command.earthfile"
+						}
+					},
+					"match": "^\\s*([A-Z][a-zA-Z0-9._]*):"
 				}
 			]
 		},
@@ -221,12 +239,16 @@
 		"entity": {
 			"patterns": [
 				{
-					"match": "([a-zA-Z0-9._\\-/:]*\\+[a-zA-Z0-9.\\-]+(/\\S*)+)",
-					"name": "entity.name.variable.target.earthfile"
+					"match": "([a-zA-Z0-9._\\-/:]*\\+[a-z][a-zA-Z0-9.\\-]*(/\\S*)+)",
+					"name": "entity.name.variable.artifact.earthfile"
 				},
 				{
-					"match": "([a-zA-Z0-9._\\-/:]*\\+[a-zA-Z0-9.\\-]+)",
+					"match": "([a-zA-Z0-9._\\-/:]*\\+[a-z][a-zA-Z0-9.\\-]*)",
 					"name": "entity.name.type.target.earthfile"
+				},
+				{
+					"match": "([a-zA-Z0-9._\\-/:]*\\+[A-Z][a-zA-Z0-9._]*)",
+					"name": "entity.name.type.user-command.earthfile"
 				}
 			]
 		}


### PR DESCRIPTION
Some screenshots

![Screenshot from 2021-03-09 17-14-51](https://user-images.githubusercontent.com/446771/110560980-c11d4680-80fb-11eb-8a54-2eca26ccb93b.png)

Semantic type of target declarations has also been updated - so it has a different color now (matches the target references):

![Screenshot from 2021-03-09 17-14-43](https://user-images.githubusercontent.com/446771/110561035-d4c8ad00-80fb-11eb-8cfc-043b9ff903e1.png)
