### PR TITLE
disable all locally tests

### DIFF
--- a/examples/tests/local/Earthfile
+++ b/examples/tests/local/Earthfile
@@ -133,18 +133,21 @@ test-locally-workdir:
 #    END
 
 all:
-    BUILD --build-arg pattern=memory +test-local-with-arg
-    BUILD +test-local
-    BUILD +test-copy-file-from-local
-    BUILD +test-copy-dir-from-local
-    BUILD +test-save-unnamed-local-artifact
-    BUILD +test-save-unnamed-local-artifact-dir
-    BUILD +test-save-unnamed-local-artifact-dir2
-    BUILD +test-multi-copy-from-alpine-to-local
-    BUILD +test-locally-can-copy-dir-contents
-    BUILD +test-locally-can-copy-dir
+    # need at least one command here for the target to be considered valid
+    RUN echo "all local tests are dissabled until flakyness is resolved"
 
     # these tests is flaky on GHA, but passes locally.
     # lets disable it until we figure it out.
     #BUILD +test-locally-workdir
     #BUILD +test-copy-from-busybox-to-local
+    #BUILD --build-arg pattern=memory +test-local-with-arg
+    #BUILD +test-local
+    #BUILD +test-copy-file-from-local
+    #BUILD +test-copy-dir-from-local
+    #BUILD +test-save-unnamed-local-artifact
+    #BUILD +test-save-unnamed-local-artifact-dir
+    #BUILD +test-save-unnamed-local-artifact-dir2
+    #BUILD +test-multi-copy-from-alpine-to-local
+    #BUILD +test-locally-can-copy-dir-contents
+    #BUILD +test-locally-can-copy-dir
+


### PR DESCRIPTION
some of these tests are still flaky; let's disable them all and then I will work on re-enabling them once we sort out the underlying issue.