### PR TITLE
generate railroad diagrams for lexer and parser

### DIFF
--- a/ast/parser/Earthfile
+++ b/ast/parser/Earthfile
@@ -29,3 +29,29 @@ parser:
     RUN sed -i.bak 's/(1<</(int64(1)<</g' ./ast/parser/*.go
     RUN diff ./ast/parser/earth_parser.go.bak ./ast/parser/earth_parser.go || true
     SAVE ARTIFACT ./ast/parser/*.go / AS LOCAL ./
+
+rrd-antlr4:
+    FROM maven:3.6.3-jdk-11
+    WORKDIR /rrd-antlr4
+    ENV RRD_SHA 4cedafca603f64ae1e26b597444a7bfd33d0f37e
+    RUN curl -L https://github.com/bkiers/rrd-antlr4/archive/$RRD_SHA.zip > rrdantlr4.zip
+    RUN unzip rrdantlr4.zip
+    WORKDIR rrd-antlr4-$RRD_SHA
+    RUN mvn package
+    SAVE ARTIFACT target/rrd-antlr4-0.1.2.jar rrd-antlr4.jar
+
+generate-railroad-diagrams:
+    COPY +rrd-antlr4/rrd-antlr4.jar .
+    COPY ./*.g4 ./ast/parser/
+    RUN java \
+        -Xmx500M \
+        -cp "/usr/local/lib/antlr-${ANTLR_VERSION}-complete.jar:$CLASSPATH" \
+        -jar rrd-antlr4.jar \
+        ast/parser/EarthLexer.g4
+    RUN java \
+        -Xmx500M \
+        -cp "/usr/local/lib/antlr-${ANTLR_VERSION}-complete.jar:$CLASSPATH" \
+        -jar rrd-antlr4.jar \
+        ast/parser/EarthParser.g4
+    SAVE ARTIFACT output/EarthLexer/index.html AS LOCAL lexer-railroad-diagram.html
+    SAVE ARTIFACT output/EarthParser/index.html AS LOCAL parser-railroad-diagram.html


### PR DESCRIPTION
- the generate-railroad-diagrams target will save two html files locally
which can be used to visualize the lexer and parser antlr code.

here's an example of a screenshot of a generated html page containing the railroad diagram.

![image](https://user-images.githubusercontent.com/1806823/111711026-1f3adf80-8808-11eb-85fc-2533a38d92fe.png)


Signed-off-by: Alex Couture-Beil <alex@earthly.dev>