### PR TITLE
re-enable locally-tests

### DIFF
--- a/examples/tests/local/Earthfile
+++ b/examples/tests/local/Earthfile
@@ -138,16 +138,16 @@ all:
 
     # these tests is flaky on GHA, but passes locally.
     # lets disable it until we figure it out.
-    #BUILD +test-locally-workdir
-    #BUILD +test-copy-from-busybox-to-local
-    #BUILD --build-arg pattern=memory +test-local-with-arg
-    #BUILD +test-local
-    #BUILD +test-copy-file-from-local
-    #BUILD +test-copy-dir-from-local
-    #BUILD +test-save-unnamed-local-artifact
-    #BUILD +test-save-unnamed-local-artifact-dir
-    #BUILD +test-save-unnamed-local-artifact-dir2
-    #BUILD +test-multi-copy-from-alpine-to-local
-    #BUILD +test-locally-can-copy-dir-contents
-    #BUILD +test-locally-can-copy-dir
+    BUILD +test-locally-workdir
+    BUILD +test-copy-from-busybox-to-local
+    BUILD --build-arg pattern=memory +test-local-with-arg
+    BUILD +test-local
+    BUILD +test-copy-file-from-local
+    BUILD +test-copy-dir-from-local
+    BUILD +test-save-unnamed-local-artifact
+    BUILD +test-save-unnamed-local-artifact-dir
+    BUILD +test-save-unnamed-local-artifact-dir2
+    BUILD +test-multi-copy-from-alpine-to-local
+    BUILD +test-locally-can-copy-dir-contents
+    BUILD +test-locally-can-copy-dir
 


### PR DESCRIPTION
    - the dockerhub cache was in a bad state due to a locally-specific
      snapshotting bug that didn't correctly walk the snapshot files which
      produced conflicting hashes; the buggy code was never merged into
      main; however the cache persisted. To rebuild the cache, I
      1) added a `--no-cache` option to the earthly calls under the CI,
      2) triggered a new PR build, then 3) removed the --no-cache option.
    
    Signed-off-by: Alex Couture-Beil <alex@earthly.dev>
