### PR TITLE
Do not run examples builds on the M1

### DIFF
--- a/.buildkite/blog-examples.yml
+++ b/.buildkite/blog-examples.yml
@@ -7,4 +7,5 @@ steps:
       EARTHLY_INSTALL_ID: "earthly-buildkite-macos"
     agents:
       os: macOS
+      arch: amd64
     timeout_in_minutes: 55


### PR DESCRIPTION
It fails on JVM stuff, see more recent builds segfaulting on `sbt`.