### PR TITLE
Refs in UDCs should be relative to where the UDC is defined

### DIFF
--- a/earthfile2llb/interpreter.go
+++ b/earthfile2llb/interpreter.go
@@ -1193,7 +1193,7 @@ func (i *Interpreter) handleDoUserCommand(ctx context.Context, command domain.Co
 	scopeName := fmt.Sprintf(
 		"%s (%s line %d:%d)",
 		command.StringCanonical(), do.SourceLocation.File, do.SourceLocation.StartLine, do.SourceLocation.StartColumn)
-	err := i.converter.EnterScope(ctx, baseTarget(relCommand), scopeName, buildArgs)
+	err := i.converter.EnterScope(ctx, command, baseTarget(relCommand), scopeName, buildArgs)
 	if err != nil {
 		return i.wrapError(err, uc.SourceLocation, "enter scope")
 	}


### PR DESCRIPTION
This is s.t. stuff like this doesn't happen: https://github.com/earthly/lib/blob/main/Earthfile#L4 (we can instead just say `+install-dind-script`).