### PR TITLE
fix mapping of custom projects to self-hosted git repos

### DIFF
--- a/buildcontext/gitlookup.go
+++ b/buildcontext/gitlookup.go
@@ -161,10 +161,11 @@ func (gl *GitLookup) GetCloneURL(path string) (string, string, string, error) {
 		return "", "", "", err
 	}
 
-	n := len(match) + 1
+	n := len(match)
 	subPath := ""
 	if len(path) > n {
-		subPath = path[n:]
+		subPath = path[n+1:]
+		path = path[:n]
 	}
 
 	var gitURL, keyScan string
@@ -183,6 +184,9 @@ func (gl *GitLookup) GetCloneURL(path string) (string, string, string, error) {
 	}
 
 	if m.sub != "" {
+		if !m.re.MatchString(path) {
+			return "", "", "", errors.Errorf("failed to determine git path to clone for %q", path)
+		}
 		gitURL = m.re.ReplaceAllString(path, m.sub)
 	}
 

--- a/scripts/tests/self-hosted-private-repo.sh
+++ b/scripts/tests/self-hosted-private-repo.sh
@@ -1,6 +1,20 @@
 #!/usr/bin/env bash
 set -eu
 
+if [ -z ${GITHUB_ACTIONS+x} ]; then
+    echo "this script should only be run from GHA; if run locally it will modify your ssh settings"
+    exit 1
+fi
+
+# setup a trap to display logs on errors
+function displaylogsonexit {
+    echo "-- error detected; dumping logs ---"
+    docker ps -a
+    docker logs earthly-buildkitd
+    exit 1
+}
+trap displaylogsonexit ERR
+
 earthly=${earthly:=earthly}
 earthly=$(realpath "$earthly")
 echo "running tests with $earthly"
@@ -68,6 +82,22 @@ git branch -M trunk
 git remote add origin ssh://root@$sshhost:2222/root/my/really/weird/path/project.git
 git push -u origin trunk
 
+# Create a second Earthfile in a subdirectory which will contain a Command:
+mkdir -p weirdcommands
+cat <<EOF >> weirdcommands/Earthfile
+TOUCH:
+  COMMAND
+  ARG file=touched
+  RUN touch weird-\$file
+
+target:
+  FROM alpine:latest
+  RUN echo hello
+EOF
+git add weirdcommands/Earthfile
+git commit -m 'here are my weird commands'
+git push -u origin trunk
+
 # delete the repo now that we've pushed it
 cd ~
 rm -rf odd-project
@@ -75,11 +105,27 @@ rm -rf odd-project
 # test that earthly has access to it
 "$earthly" config git "{myserver: {pattern: 'myserver/([^/]+)', substitute: 'ssh://root@$ip:2222/root/my/really/weird/path/\$1.git', auth: ssh}}"
 
-if ! $earthly -V myserver/project:trunk+docker; then
-    docker ps -a
-    docker logs earthly-buildkitd
-    exit 1
-fi
+echo === Test remote build under repo root ===
+$earthly -V myserver/project:trunk+docker
 
-# finally test that the container was built and runs
+echo === Test remote build under repo subdir ===
+$earthly -V myserver/project/weirdcommands:trunk+target
+
+# test that the container was built and runs
 docker run --rm weirdrepo:latest | grep "hello weird world"
+
+# next test that we can reference commands in the weird repo;
+# create a local Earthfile (that wont be saved to git)
+cat <<EOF > Earthfile
+
+IMPORT myserver/project/weirdcommands:trunk
+
+FROM alpine:latest
+
+testweirdtouch:
+  DO weirdcommands+TOUCH --file=foo
+  RUN ls weird-foo
+EOF
+
+echo === Test local build referencing remote commands ===
+$earthly -V +testweirdtouch


### PR DESCRIPTION
- fix our handling of non-standard (e.g. self-hosted) git repos; this bug only affected accessing subdirectories of self-hosted git repos.
- extend our self hosted private repo test to reference commands that are stored remotely but from a local Earthfile
    
Signed-off-by: Alex Couture-Beil <alex@earthly.dev>