### PR TITLE
Check for reserved target names (e.g. base)

### DIFF
--- a/ast/validator.go
+++ b/ast/validator.go
@@ -11,6 +11,7 @@ type astValidator func(spec.Earthfile) []error
 
 var astValidations = []astValidator{
 	noTargetsWithSameName,
+	noTargetsWithKeywords,
 	// TODO other checks go here
 }
 
@@ -45,6 +46,22 @@ func noTargetsWithSameName(ef spec.Earthfile) []error {
 		}
 
 		seenTargets[t.Name] = struct{}{}
+	}
+
+	if len(errs) > 0 {
+		return errs
+	}
+
+	return nil
+}
+
+func noTargetsWithKeywords(ef spec.Earthfile) []error {
+	var errs []error
+
+	for _, t := range ef.Targets {
+		if t.Name == "base" {
+			errs = append(errs, errors.Errorf("%s line %v:%v invalid target \"%s\": %s is a reserved target name", t.SourceLocation.File, t.SourceLocation.StartLine, t.SourceLocation.StartColumn, t.Name, t.Name))
+		}
 	}
 
 	if len(errs) > 0 {

--- a/examples/tests/Earthfile
+++ b/examples/tests/Earthfile
@@ -59,6 +59,7 @@ ga:
     BUILD +platform-output
     BUILD +command
     BUILD +duplicate
+    BUILD +reserved
     BUILD +quotes-test
     BUILD +new-args
     BUILD +import
@@ -431,6 +432,9 @@ command:
 
 duplicate:
     DO +RUN_EARTHLY --earthfile=duplicate-target-names.earth --should_fail=true --target=+duplicate
+
+reserved:
+    DO +RUN_EARTHLY --earthfile=reserved-target-names.earth --should_fail=true --target=+reserved
 
 quotes-test:
     DO +RUN_EARTHLY --earthfile=quotes.earth

--- a/examples/tests/reserved-target-names.earth
+++ b/examples/tests/reserved-target-names.earth
@@ -1,0 +1,12 @@
+FROM alpine:3.13
+
+reserved:
+    FROM +base
+    # this should be running alpine; however, this earthfile should fail to parse
+    # since it contains an invalid base target.
+    RUN ls /etc/alpine-release
+
+base:
+    FROM fedora:latest
+    RUN echo this target is invalid and should produce a parsing error
+


### PR DESCRIPTION
- adds a check for invalid target names that conflict with reserved
target names

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>

```
FROM alpine:latest


base:
    RUN echo foo > /data

foo:
    FROM +base
    RUN ls /data
```

will now produce the following error:

```
$ ./build/linux/amd64/earthly ~/broken/base+foo
           buildkitd | Starting buildkit daemon as a docker container (earthly-buildkitd)...
           buildkitd | ...Done
Error: resolve build context for target /home/alex/broken/base+foo: 1 validation issues.
- /home/alex/broken/base/Earthfile line 4:0 invalid target "base": base is a reserved target name
```