### PR TITLE
Add `earthly bootstrap --ci` flag

### DIFF
--- a/analytics/analytics.go
+++ b/analytics/analytics.go
@@ -23,7 +23,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func detectCI() (string, bool) {
+func detectCI(isCI bool) (string, bool) {
 	for k, v := range map[string]string{
 		"GITHUB_WORKFLOW": "github-actions",
 		"CIRCLECI":        "circle-ci",
@@ -53,6 +53,10 @@ func detectCI() (string, bool) {
 			return "ci-env-var-set", true
 		}
 		return v, true
+	}
+
+	if isCI {
+		return "config-ci-installation", true
 	}
 
 	return "false", false
@@ -171,9 +175,9 @@ func saveData(server string, data *EarthlyAnalytics) error {
 }
 
 // CollectAnalytics sends analytics to api.earthly.dev
-func CollectAnalytics(ctx context.Context, earthlyServer string, displayErrors bool, version, platform, gitSha, commandName string, exitCode int, realtime time.Duration) {
+func CollectAnalytics(ctx context.Context, isCI bool, earthlyServer string, displayErrors bool, version, platform, gitSha, commandName string, exitCode int, realtime time.Duration) {
 	var err error
-	ciName, ci := detectCI()
+	ciName, ci := detectCI(isCI)
 	repoHash := getRepoHash()
 	installID, overrideInstallID := os.LookupEnv("EARTHLY_INSTALL_ID")
 	if !overrideInstallID {

--- a/config/config.go
+++ b/config/config.go
@@ -31,6 +31,7 @@ type GlobalConfig struct {
 	BuildkitAdditionalArgs   []string `yaml:"buildkit_additional_args"   help:"Additional args to pass to buildkit when it starts. Useful for custom/self-signed certs, or user namespace complications."`
 	BuildkitAdditionalConfig string   `yaml:"buildkit_additional_config" help:"Additional config to use when starting the buildkit container; like using custom/self-signed certificates."`
 	CniMtu                   uint16   `yaml:"cni_mtu"                    help:"Override auto-detection of the default interface MTU, for all containers within buildkit"`
+	CiInstallation           bool     `yaml:"ci_installation"            help:"Mark the Earthly installation as a CI installation for analytics purposes"`
 
 	// Obsolete.
 	CachePath string `yaml:"cache_path"`


### PR DESCRIPTION
* Marks the installation as a CI installation via the Earthly config
* Skips bash/zsh autocompletion installation as part of bootstrap