### PR TITLE
Write to ash_history too

### DIFF
--- a/cmd/debugger/main.go
+++ b/cmd/debugger/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/alessio/shellescape"
 	"github.com/creack/pty"
 	"github.com/fatih/color"
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -66,6 +67,7 @@ func handleWinChangeData(ptmx *os.File, data []byte) error {
 }
 
 func populateShellHistory(cmd string) error {
+	var result error
 	for _, f := range []string{
 		"/root/.ash_history",
 		"/root/.bash_history",
@@ -73,12 +75,12 @@ func populateShellHistory(cmd string) error {
 
 		f, err := os.Create(f)
 		if err != nil {
-			return err
+			result = multierror.Append(result, err)
 		}
 		defer f.Close()
 		f.Write([]byte(cmd + "\n"))
 	}
-	return nil
+	return result
 }
 
 func interactiveMode(ctx context.Context, remoteConsoleAddr string, cmdBuilder func() (*exec.Cmd, error)) error {

--- a/cmd/debugger/main.go
+++ b/cmd/debugger/main.go
@@ -66,12 +66,18 @@ func handleWinChangeData(ptmx *os.File, data []byte) error {
 }
 
 func populateShellHistory(cmd string) error {
-	f, err := os.Create("/root/.bash_history")
-	if err != nil {
-		return err
+	for _, f := range []string{
+		"/root/.ash_history",
+		"/root/.bash_history",
+	} {
+
+		f, err := os.Create(f)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		f.Write([]byte(cmd + "\n"))
 	}
-	defer f.Close()
-	f.Write([]byte(cmd + "\n"))
 	return nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/fatih/color v1.9.0
 	github.com/golang/protobuf v1.4.3
 	github.com/google/uuid v1.2.0
+	github.com/hashicorp/go-multierror v1.1.0
 	github.com/joho/godotenv v1.3.0
 	github.com/mattn/go-isatty v0.0.12
 	github.com/moby/buildkit v0.8.2-0.20210129065303-6b9ea0c202cf


### PR DESCRIPTION
- the debugger should produce an .ash_history file incase the user
enters ash instead of bash.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>