### PR TITLE
log interactive shell repeater messages

### DIFF
--- a/debugger/terminal/terminal_other.go
+++ b/debugger/terminal/terminal_other.go
@@ -5,7 +5,6 @@ package terminal
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net"
 	"os"
 	"os/signal"
@@ -148,7 +147,8 @@ func ConnectTerm(ctx context.Context, addr string) error {
 	}()
 
 	<-ctx.Done()
-	fmt.Fprintf(os.Stderr, "exiting interactive debugger shell\n")
+
+	log.Debug("exiting interactive debugger shell")
 	err = ts.restore()
 	if err != nil {
 		return err

--- a/go.mod
+++ b/go.mod
@@ -40,5 +40,5 @@ replace (
 	github.com/docker/docker => github.com/docker/docker v17.12.0-ce-rc1.0.20200310163718-4634ce647cf2+incompatible
 	github.com/hashicorp/go-immutable-radix => github.com/tonistiigi/go-immutable-radix v0.0.0-20170803185627-826af9ccf0fe
 	github.com/jaguilar/vt100 => github.com/tonistiigi/vt100 v0.0.0-20190402012908-ad4c4a574305
-	github.com/moby/buildkit => github.com/earthly/buildkit v0.7.1-0.20210401230601-d20d543fc6a5
+	github.com/moby/buildkit => github.com/earthly/buildkit v0.7.1-0.20210408235408-008b1ea46de8
 )

--- a/go.sum
+++ b/go.sum
@@ -290,8 +290,8 @@ github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
-github.com/earthly/buildkit v0.7.1-0.20210401230601-d20d543fc6a5 h1:LC1kQvc7Jxq9nzY+7rFIgpy7bv/QBb1fGzCHt3BgN7Q=
-github.com/earthly/buildkit v0.7.1-0.20210401230601-d20d543fc6a5/go.mod h1:DIx5g9IZJWZCOtqtSzrHxanBPR2JClX4zo8/TSr7dis=
+github.com/earthly/buildkit v0.7.1-0.20210408235408-008b1ea46de8 h1:kg/Q8YBs/gKw1atGVDnXi6FTcPE+wYcxAxGNuKL4M9I=
+github.com/earthly/buildkit v0.7.1-0.20210408235408-008b1ea46de8/go.mod h1:DIx5g9IZJWZCOtqtSzrHxanBPR2JClX4zo8/TSr7dis=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153 h1:yUdfgN0XgIJw7foRItutHYUIhlcKzcSf5vDpdhQAKTc=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=


### PR DESCRIPTION
- rather than print to stderr when the shell repeater exits, use log
instead.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>