### PR TITLE
Disallow privileged and local execution from remote Earthfiles

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -64,6 +64,7 @@ type Opt struct {
 // BuildOpt is a collection of build options.
 type BuildOpt struct {
 	Platform              *specs.Platform
+	AllowPrivileged       bool
 	PrintSuccess          bool
 	Push                  bool
 	NoOutput              bool
@@ -175,8 +176,10 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 				UseFakeDep:           b.opt.UseFakeDep,
 				AllowLocally:         !b.opt.Strict,
 				AllowInteractive:     !b.opt.Strict,
+				AllowPrivileged:      opt.AllowPrivileged,
 				ParallelConversion:   b.opt.ParallelConversion,
 				Parallelism:          b.opt.Parallelism,
+				Console:              b.opt.Console,
 			})
 			if err != nil {
 				return nil, err

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -2473,6 +2473,10 @@ func (app *earthlyApp) actionBuildImp(c *cli.Context, flagArgs, nonFlagArgs []st
 		NoOutput:              app.noOutput,
 		OnlyFinalTargetImages: app.imageMode,
 		Platform:              platformsSlice[0],
+
+		// explicitly set this to true at the top level (without granting the entitlements.EntitlementSecurityInsecure buildkit option),
+		// to differentiate between a user forgetting to run earthly -P, versus a remotely referening an earthfile that requires privileged.
+		AllowPrivileged: true,
 	}
 	if app.artifactMode {
 		buildOpts.OnlyArtifact = &artifact

--- a/earthfile2llb/earthfile2llb.go
+++ b/earthfile2llb/earthfile2llb.go
@@ -66,7 +66,8 @@ type ConvertOpt struct {
 	HasDangling bool
 	// Console is for logging
 	Console conslogging.ConsoleLogger
-
+	// AllowPrivileged is used to allow (or prevent) any "RUN --privileged" or RUNs under a LOCALLY target to be executed,
+	// when set to false, it prevents other referenced remote targets from requesting elevated privileges
 	AllowPrivileged bool
 
 	// ParallelConversion is a feature flag enabling the parallel conversion algorithm.

--- a/earthfile2llb/earthfile2llb.go
+++ b/earthfile2llb/earthfile2llb.go
@@ -13,6 +13,7 @@ import (
 	"github.com/earthly/earthly/buildcontext"
 	"github.com/earthly/earthly/buildcontext/provider"
 	"github.com/earthly/earthly/cleanup"
+	"github.com/earthly/earthly/conslogging"
 	"github.com/earthly/earthly/domain"
 	"github.com/earthly/earthly/states"
 	"github.com/earthly/earthly/variables"
@@ -63,6 +64,10 @@ type ConvertOpt struct {
 	// ie if there are any non-SAVE commands after the first SAVE command,
 	// or if the target is invoked via BUILD command (not COPY nor FROM).
 	HasDangling bool
+	// Console is for logging
+	Console conslogging.ConsoleLogger
+
+	AllowPrivileged bool
 
 	// ParallelConversion is a feature flag enabling the parallel conversion algorithm.
 	ParallelConversion bool
@@ -90,7 +95,7 @@ func Earthfile2LLB(ctx context.Context, target domain.Target, opt ConvertOpt) (m
 		return nil, errors.Wrapf(err, "resolve build context for target %s", target.String())
 	}
 	targetWithMetadata := bc.Ref.(domain.Target)
-	sts, found, err := opt.Visited.Add(ctx, targetWithMetadata, opt.Platform, opt.OverridingVars, opt.parentDepSub)
+	sts, found, err := opt.Visited.Add(ctx, targetWithMetadata, opt.Platform, opt.AllowPrivileged, opt.OverridingVars, opt.parentDepSub)
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +110,7 @@ func Earthfile2LLB(ctx context.Context, target domain.Target, opt ConvertOpt) (m
 	if err != nil {
 		return nil, err
 	}
-	interpreter := newInterpreter(converter, targetWithMetadata, opt.ParallelConversion, opt.Parallelism)
+	interpreter := newInterpreter(converter, targetWithMetadata, opt.AllowPrivileged, opt.ParallelConversion, opt.Parallelism, opt.Console)
 	err = interpreter.Run(ctx, bc.Earthfile)
 	if err != nil {
 		return nil, err

--- a/earthfile2llb/interpreter.go
+++ b/earthfile2llb/interpreter.go
@@ -650,7 +650,7 @@ func (i *Interpreter) handleCopy(ctx context.Context, cmd spec.Command) error {
 	keepTs := fs.Bool("keep-ts", false, "Keep created time file timestamps")
 	keepOwn := fs.Bool("keep-own", false, "Keep owner info")
 	ifExists := fs.Bool("if-exists", false, "Do not fail if the artifact does not exist")
-	allowPrivilegedFlag := fs.Bool("allow-privileged", false, "allow targets to assume privileged mode")
+	allowPrivilegedFlag := fs.Bool("allow-privileged", false, "Allow targets to assume privileged mode")
 	platformStr := fs.String("platform", "", "The platform to use")
 	buildArgs := new(StringSliceFlag)
 	fs.Var(buildArgs, "build-arg", "A build arg override passed on to a referenced Earthly target")

--- a/earthfile2llb/interpreter.go
+++ b/earthfile2llb/interpreter.go
@@ -445,6 +445,10 @@ func (i *Interpreter) handleRun(ctx context.Context, cmd spec.Command) error {
 	// Note: Not expanding args for the run itself, as that will be take care of by the shell.
 
 	if i.local {
+		if i.target.IsRemote() {
+			return i.errorf(cmd.SourceLocation, "Permission denied: unwilling to run locally command from remote Earthfile")
+		}
+
 		if len(mounts.Args) > 0 {
 			return i.errorf(cmd.SourceLocation, "mounts are not supported in combination with the LOCALLY directive")
 		}
@@ -491,6 +495,10 @@ func (i *Interpreter) handleRun(ctx context.Context, cmd spec.Command) error {
 			return i.wrapError(err, cmd.SourceLocation, "apply RUN")
 		}
 		return nil
+	}
+
+	if i.target.IsRemote() && *privileged {
+		return i.errorf(cmd.SourceLocation, "Permission denied: unwilling to run privileged command from remote Earthfile")
 	}
 
 	if i.withDocker == nil {

--- a/earthfile2llb/interpreter.go
+++ b/earthfile2llb/interpreter.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/earthly/earthly/ast/spec"
+	"github.com/earthly/earthly/conslogging"
 	"github.com/earthly/earthly/domain"
 	"github.com/earthly/earthly/llbutil"
 	"github.com/earthly/earthly/variables"
@@ -31,6 +32,7 @@ type Interpreter struct {
 	isWith          bool
 	pushOnlyAllowed bool
 	local           bool
+	allowPrivileged bool
 
 	stack string
 
@@ -40,16 +42,19 @@ type Interpreter struct {
 	parallelConversion bool
 	parallelism        *semaphore.Weighted
 	parallelErrChan    chan error
+	console            conslogging.ConsoleLogger
 }
 
-func newInterpreter(c *Converter, t domain.Target, parallelConversion bool, parallelism *semaphore.Weighted) *Interpreter {
+func newInterpreter(c *Converter, t domain.Target, allowPrivileged, parallelConversion bool, parallelism *semaphore.Weighted, console conslogging.ConsoleLogger) *Interpreter {
 	return &Interpreter{
 		converter:          c,
 		target:             t,
 		stack:              c.StackString(),
+		allowPrivileged:    allowPrivileged,
 		parallelism:        parallelism,
 		parallelConversion: parallelConversion,
 		parallelErrChan:    make(chan error),
+		console:            console,
 	}
 }
 
@@ -87,7 +92,7 @@ func (i *Interpreter) Run(ctx context.Context, ef spec.Earthfile) (err error) {
 
 func (i *Interpreter) handleTarget(ctx context.Context, t spec.Target) error {
 	// Apply implicit FROM +base
-	err := i.converter.From(ctx, "+base", nil, nil)
+	err := i.converter.From(ctx, "+base", nil, i.allowPrivileged, nil)
 	if err != nil {
 		return i.wrapError(err, t.SourceLocation, "apply FROM")
 	}
@@ -364,6 +369,7 @@ func (i *Interpreter) handleFrom(ctx context.Context, cmd spec.Command) error {
 		return i.pushOnlyErr(cmd.SourceLocation)
 	}
 	fs := flag.NewFlagSet("FROM", flag.ContinueOnError)
+	allowPrivilegedFlag := fs.Bool("allow-privileged", false, "Enable privileged mode")
 	buildArgs := new(StringSliceFlag)
 	fs.Var(buildArgs, "build-arg", "A build arg override passed on to a referenced Earthly target")
 	platformStr := fs.String("platform", "", "The platform to use")
@@ -393,12 +399,48 @@ func (i *Interpreter) handleFrom(ctx context.Context, cmd spec.Command) error {
 	}
 	expandedBuildArgs = append(parsedFlagArgs, expandedBuildArgs...)
 
+	allowPrivileged, err := i.getAllowPrivilegedTarget(imageName, *allowPrivilegedFlag)
+	if err != nil {
+		return err
+	}
+
 	i.local = false
-	err = i.converter.From(ctx, imageName, platform, expandedBuildArgs)
+	err = i.converter.From(ctx, imageName, platform, allowPrivileged, expandedBuildArgs)
 	if err != nil {
 		return i.wrapError(err, cmd.SourceLocation, "apply FROM %s", imageName)
 	}
 	return nil
+}
+
+func (i *Interpreter) getAllowPrivilegedTarget(targetName string, allowPrivileged bool) (bool, error) {
+	if !strings.Contains(targetName, "+") {
+		return false, nil
+	}
+	depTarget, err := domain.ParseTarget(targetName)
+	if err != nil {
+		return false, errors.Wrapf(err, "parse target name %s", targetName)
+	}
+
+	return i.getAllowPrivileged(depTarget, allowPrivileged)
+}
+
+func (i *Interpreter) getAllowPrivileged(depTarget domain.Target, allowPrivileged bool) (bool, error) {
+	if depTarget.IsRemote() {
+		return i.allowPrivileged && allowPrivileged, nil
+	}
+	if allowPrivileged {
+		i.console.Printf("the --allow-privileged flag has no effect when referencing a local or relative target\n")
+	}
+	return i.allowPrivileged, nil
+}
+
+func (i *Interpreter) getAllowPrivilegedArtifact(artifactName string, allowPrivileged bool) (bool, error) {
+	artifact, err := domain.ParseArtifact(artifactName)
+	if err != nil {
+		return false, errors.Wrapf(err, "parse artifact name %s", artifactName)
+	}
+
+	return i.getAllowPrivileged(artifact.Target, allowPrivileged)
 }
 
 func (i *Interpreter) handleRun(ctx context.Context, cmd spec.Command) error {
@@ -445,10 +487,6 @@ func (i *Interpreter) handleRun(ctx context.Context, cmd spec.Command) error {
 	// Note: Not expanding args for the run itself, as that will be take care of by the shell.
 
 	if i.local {
-		if i.target.IsRemote() {
-			return i.errorf(cmd.SourceLocation, "Permission denied: unwilling to run locally command from remote Earthfile")
-		}
-
 		if len(mounts.Args) > 0 {
 			return i.errorf(cmd.SourceLocation, "mounts are not supported in combination with the LOCALLY directive")
 		}
@@ -497,8 +535,8 @@ func (i *Interpreter) handleRun(ctx context.Context, cmd spec.Command) error {
 		return nil
 	}
 
-	if i.target.IsRemote() && *privileged {
-		return i.errorf(cmd.SourceLocation, "Permission denied: unwilling to run privileged command from remote Earthfile")
+	if *privileged && !i.allowPrivileged {
+		return i.errorf(cmd.SourceLocation, "Permission denied: unwilling to run privileged command; did you reference a remote Earthfile without the --allow-privileged flag?")
 	}
 
 	if i.withDocker == nil {
@@ -580,6 +618,10 @@ func (i *Interpreter) handleFromDockerfile(ctx context.Context, cmd spec.Command
 }
 
 func (i *Interpreter) handleLocally(ctx context.Context, cmd spec.Command) error {
+	if !i.allowPrivileged {
+		return i.errorf(cmd.SourceLocation, "Permission denied: unwilling to allow locally directive from remote Earthfile; did you reference a remote Earthfile without the --allow-privileged flag?")
+	}
+
 	if i.pushOnlyAllowed {
 		return i.pushOnlyErr(cmd.SourceLocation)
 	}
@@ -608,6 +650,7 @@ func (i *Interpreter) handleCopy(ctx context.Context, cmd spec.Command) error {
 	keepTs := fs.Bool("keep-ts", false, "Keep created time file timestamps")
 	keepOwn := fs.Bool("keep-own", false, "Keep owner info")
 	ifExists := fs.Bool("if-exists", false, "Do not fail if the artifact does not exist")
+	allowPrivilegedFlag := fs.Bool("allow-privileged", false, "allow targets to assume privileged mode")
 	platformStr := fs.String("platform", "", "The platform to use")
 	buildArgs := new(StringSliceFlag)
 	fs.Var(buildArgs, "build-arg", "A build arg override passed on to a referenced Earthly target")
@@ -631,6 +674,7 @@ func (i *Interpreter) handleCopy(ctx context.Context, cmd spec.Command) error {
 	if err != nil {
 		return i.wrapError(err, cmd.SourceLocation, "parse platform %s", *platformStr)
 	}
+
 	allClassical := true
 	allArtifacts := true
 	for index, src := range srcs {
@@ -668,6 +712,11 @@ func (i *Interpreter) handleCopy(ctx context.Context, cmd spec.Command) error {
 			dest += string(filepath.Separator)
 		}
 		for index, src := range srcs {
+			allowPrivileged, err := i.getAllowPrivilegedArtifact(src, *allowPrivilegedFlag)
+			if err != nil {
+				return err
+			}
+
 			expandedFlagArgs := i.expandArgsSlice(srcFlagArgs[index], true)
 			parsedFlagArgs, err := variables.ParseFlagArgs(expandedFlagArgs)
 			if err != nil {
@@ -676,12 +725,12 @@ func (i *Interpreter) handleCopy(ctx context.Context, cmd spec.Command) error {
 			srcBuildArgs := append(parsedFlagArgs, expandedBuildArgs...)
 
 			if i.local {
-				err = i.converter.CopyArtifactLocal(ctx, src, dest, platform, srcBuildArgs, *isDirCopy)
+				err = i.converter.CopyArtifactLocal(ctx, src, dest, platform, allowPrivileged, srcBuildArgs, *isDirCopy)
 				if err != nil {
 					return i.wrapError(err, cmd.SourceLocation, "copy artifact locally")
 				}
 			} else {
-				err = i.converter.CopyArtifact(ctx, src, dest, platform, srcBuildArgs, *isDirCopy, *keepTs, *keepOwn, *chown, *ifExists)
+				err = i.converter.CopyArtifact(ctx, src, dest, platform, allowPrivileged, srcBuildArgs, *isDirCopy, *keepTs, *keepOwn, *chown, *ifExists)
 				if err != nil {
 					return i.wrapError(err, cmd.SourceLocation, "copy artifact")
 				}
@@ -809,6 +858,7 @@ func (i *Interpreter) handleBuild(ctx context.Context, cmd spec.Command, async b
 	fs.Var(platformsStr, "platform", "The platform to build")
 	buildArgs := new(StringSliceFlag)
 	fs.Var(buildArgs, "build-arg", "A build arg override passed on to a referenced Earthly target")
+	allowPrivilegedFlag := fs.Bool("allow-privileged", false, "allow targets to assume privileged mode")
 	err := fs.Parse(getArgsCopy(cmd))
 	if err != nil {
 		return i.wrapError(err, cmd.SourceLocation, "invalid BUILD arguments %v", cmd.Args)
@@ -845,13 +895,18 @@ func (i *Interpreter) handleBuild(ctx context.Context, cmd spec.Command, async b
 		return i.wrapError(err, cmd.SourceLocation, "build arg matrix")
 	}
 
+	allowPrivileged, err := i.getAllowPrivilegedTarget(fullTargetName, *allowPrivilegedFlag)
+	if err != nil {
+		return err
+	}
+
 	for _, bas := range crossProductBuildArgs {
 		for _, platform := range platformsSlice {
 			if async {
-				errChan := i.converter.BuildAsync(ctx, fullTargetName, platform, bas)
+				errChan := i.converter.BuildAsync(ctx, fullTargetName, platform, allowPrivileged, bas)
 				i.monitorErrChan(ctx, errChan)
 			} else {
-				err = i.converter.Build(ctx, fullTargetName, platform, bas)
+				err = i.converter.Build(ctx, fullTargetName, platform, allowPrivileged, bas)
 				if err != nil {
 					return i.wrapError(err, cmd.SourceLocation, "apply BUILD %s", fullTargetName)
 				}
@@ -1290,7 +1345,7 @@ func (i *Interpreter) handleDoUserCommand(ctx context.Context, command domain.Co
 	scopeName := fmt.Sprintf(
 		"%s (%s line %d:%d)",
 		command.StringCanonical(), do.SourceLocation.File, do.SourceLocation.StartLine, do.SourceLocation.StartColumn)
-	err := i.converter.EnterScope(ctx, command, baseTarget(relCommand), scopeName, buildArgs)
+	err := i.converter.EnterScope(ctx, command, baseTarget(relCommand), i.allowPrivileged, scopeName, buildArgs)
 	if err != nil {
 		return i.wrapError(err, uc.SourceLocation, "enter scope")
 	}

--- a/earthfile2llb/withdockerrun.go
+++ b/earthfile2llb/withdockerrun.go
@@ -32,10 +32,11 @@ const (
 
 // DockerLoadOpt holds parameters for WITH DOCKER --load parameter.
 type DockerLoadOpt struct {
-	Target    string
-	ImageName string
-	Platform  *specs.Platform
-	BuildArgs []string
+	Target          string
+	ImageName       string
+	Platform        *specs.Platform
+	BuildArgs       []string
+	AllowPrivileged bool
 }
 
 // DockerPullOpt holds parameters for the WITH DOCKER --pull parameter.
@@ -287,7 +288,7 @@ func (wdr *withDockerRun) load(ctx context.Context, opt DockerLoadOpt) error {
 	if err != nil {
 		return errors.Wrapf(err, "parse target %s", opt.Target)
 	}
-	mts, err := wdr.c.buildTarget(ctx, depTarget.String(), opt.Platform, true, opt.BuildArgs, false, false)
+	mts, err := wdr.c.buildTarget(ctx, depTarget.String(), opt.Platform, opt.AllowPrivileged, opt.BuildArgs, false, false)
 	if err != nil {
 		return err
 	}

--- a/earthfile2llb/withdockerrun.go
+++ b/earthfile2llb/withdockerrun.go
@@ -287,7 +287,7 @@ func (wdr *withDockerRun) load(ctx context.Context, opt DockerLoadOpt) error {
 	if err != nil {
 		return errors.Wrapf(err, "parse target %s", opt.Target)
 	}
-	mts, err := wdr.c.buildTarget(ctx, depTarget.String(), opt.Platform, opt.BuildArgs, false, false)
+	mts, err := wdr.c.buildTarget(ctx, depTarget.String(), opt.Platform, true, opt.BuildArgs, false, false)
 	if err != nil {
 		return err
 	}

--- a/earthfile2llb/withdockerrunlocal.go
+++ b/earthfile2llb/withdockerrunlocal.go
@@ -43,7 +43,7 @@ func (wdrl *withDockerRunLocal) load(ctx context.Context, opt DockerLoadOpt) (st
 	if err != nil {
 		return "", errors.Wrapf(err, "parse target %s", opt.Target)
 	}
-	mts, err := wdrl.c.buildTarget(ctx, depTarget.String(), opt.Platform, true, opt.BuildArgs, false, false)
+	mts, err := wdrl.c.buildTarget(ctx, depTarget.String(), opt.Platform, opt.AllowPrivileged, opt.BuildArgs, false, false)
 	if err != nil {
 		return "", err
 	}

--- a/earthfile2llb/withdockerrunlocal.go
+++ b/earthfile2llb/withdockerrunlocal.go
@@ -43,7 +43,7 @@ func (wdrl *withDockerRunLocal) load(ctx context.Context, opt DockerLoadOpt) (st
 	if err != nil {
 		return "", errors.Wrapf(err, "parse target %s", opt.Target)
 	}
-	mts, err := wdrl.c.buildTarget(ctx, depTarget.String(), opt.Platform, opt.BuildArgs, false, false)
+	mts, err := wdrl.c.buildTarget(ctx, depTarget.String(), opt.Platform, true, opt.BuildArgs, false, false)
 	if err != nil {
 		return "", err
 	}

--- a/examples/tests/Earthfile
+++ b/examples/tests/Earthfile
@@ -36,6 +36,7 @@ ga:
     BUILD +dockerfile-test
     BUILD +fail-test
     BUILD +fail-push-test
+    BUILD +allow-privileged-test
     BUILD +push-test
     BUILD +gen-dockerfile-test
     BUILD +chown-test
@@ -147,6 +148,11 @@ remote-test:
         --entrypoint \
         --mount=type=tmpfs,target=/tmp/earthly \
         -- --no-output github.com/earthly/hello-world:main+hello
+    RUN --privileged \
+        --entrypoint \
+        --mount=type=tmpfs,target=/tmp/earthly \
+        -- --no-output github.com/earthly/test-privileged:main+locally && \
+        ls /tmp/hostname.3d4b1831-c07e-4b2d-805e-2b8ce578bb50
 
 transitive-args-test:
     DO +RUN_EARTHLY --earthfile=transitive-args.earth --extra_args="--build-arg SOMEARG=xyz" --target=+test
@@ -219,6 +225,19 @@ fail-test:
     # test that the 'failed with exit code' text is printed out
     DO +RUN_EARTHLY --earthfile=fail.earth --target=+test \
         --post_command="2>&1 | perl -pe 'BEGIN {\\\$status=1} END {exit \\\$status} \\\$status=0 if /this-will-fail/;'"
+
+allow-privileged-test:
+    # test that privileged-tasks in remote repos dont run
+    DO +RUN_EARTHLY --earthfile=allow-privileged.earth --should_fail=true --extra_args="--allow-privileged" -target=+reject-privileged-in-remote-repo-triggered-by-from-locally
+    DO +RUN_EARTHLY --earthfile=allow-privileged.earth --should_fail=true --extra_args="--allow-privileged" -target=+reject-privileged-in-remote-repo-triggered-by-from-privileged
+    DO +RUN_EARTHLY --earthfile=allow-privileged.earth --should_fail=true --extra_args="--allow-privileged" -target=+reject-privileged-in-remote-repo-triggered-by-copy-locally
+    DO +RUN_EARTHLY --earthfile=allow-privileged.earth --should_fail=true --extra_args="--allow-privileged" -target=+reject-privileged-in-remote-repo-triggered-by-copy-privileged
+    DO +RUN_EARTHLY --earthfile=allow-privileged.earth --should_fail=true --extra_args="--allow-privileged" -target=+reject-privileged-in-remote-repo-triggered-by-build-locally
+    DO +RUN_EARTHLY --earthfile=allow-privileged.earth --should_fail=true --extra_args="--allow-privileged" -target=+reject-privileged-in-remote-repo-triggered-by-build-privileged
+    DO +RUN_EARTHLY --earthfile=allow-privileged.earth --should_fail=true --extra_args="--allow-privileged" -target=+reject-dedup
+    # test allowed-privileged tasks in remote repos work
+    DO +RUN_EARTHLY --earthfile=allow-privileged.earth --extra_args="--allow-privileged" --target=+allow-all
+
 
 fail-push-test:
     # test that an error code is correctly returned
@@ -472,10 +491,12 @@ RUN_EARTHLY:
         if $use_tmpfs; then
             export EARTHLY_TMP_DIR=/tmp/earthly-tmpfs
         fi
+        echo running earthly with $target
         eval \"/usr/bin/earthly-buildkitd-wrapper.sh $extra_args $target $post_command\"
         exit_code=\$?
         if $should_fail; then
             if [ \$exit_code -eq 0 ]; then
+                echo ERROR: earthly should have failed but didn\'t.
                 exit 1
             else
                 exit 0

--- a/examples/tests/allow-privileged.earth
+++ b/examples/tests/allow-privileged.earth
@@ -5,7 +5,7 @@ reject-privileged-in-remote-repo-triggered-by-from-locally:
     RUN echo this should never run because the above FROM should fail
 
 reject-privileged-in-remote-repo-triggered-by-from-privileged:
-    FROM github.com/earthly/test-privileged:main+locally
+    FROM github.com/earthly/test-privileged:main+privileged
     RUN echo this should never run because the above FROM should fail
 
 reject-privileged-in-remote-repo-triggered-by-copy-locally:
@@ -13,7 +13,7 @@ reject-privileged-in-remote-repo-triggered-by-copy-locally:
     RUN echo this should never run because the above COPY should fail
 
 reject-privileged-in-remote-repo-triggered-by-copy-privileged:
-    COPY github.com/earthly/test-privileged:main+locally/hostname .
+    COPY github.com/earthly/test-privileged:main+privileged/hostname .
     RUN echo this should never run because the above COPY should fail
 
 reject-privileged-in-remote-repo-triggered-by-build-locally:
@@ -21,7 +21,7 @@ reject-privileged-in-remote-repo-triggered-by-build-locally:
     RUN echo this should never run because the above BUILD should fail
 
 reject-privileged-in-remote-repo-triggered-by-build-privileged:
-    BUILD github.com/earthly/test-privileged:main+locally
+    BUILD github.com/earthly/test-privileged:main+privileged
     RUN echo this should never run because the above BUILD should fail
 
 reject-dedup:
@@ -31,6 +31,11 @@ reject-dedup:
     # but without an --allow-privileged, this should fail even though it was
     # successfuly run (and cached) in the first step.
     BUILD +reject-privileged-in-remote-repo-triggered-by-copy
+
+reject-privileged-in-remote-repo-triggered-by-docker-load-privileged:
+    WITH DOCKER --load shouldfail:latest=github.com/earthly/test-privileged:main+privileged
+        RUN echo this should never run because the above --load should fail
+    END
 
 allow-privileged-in-remote-repo-triggered-by-from-locally:
     FROM --allow-privileged github.com/earthly/test-privileged:main+locally
@@ -53,6 +58,7 @@ allow-privileged-in-remote-repo-triggered-by-copy-privileged:
 
 allow-privileged-in-remote-repo-triggered-by-build-privileged:
     BUILD --allow-privileged github.com/earthly/test-privileged:main+privileged
+
 
 allow-all:
     # TODO there's a bug that's preventing using FROM in combination with locally

--- a/examples/tests/allow-privileged.earth
+++ b/examples/tests/allow-privileged.earth
@@ -1,0 +1,64 @@
+FROM alpine:3.13
+
+reject-privileged-in-remote-repo-triggered-by-from-locally:
+    FROM github.com/earthly/test-privileged:main+locally
+    RUN echo this should never run because the above FROM should fail
+
+reject-privileged-in-remote-repo-triggered-by-from-privileged:
+    FROM github.com/earthly/test-privileged:main+locally
+    RUN echo this should never run because the above FROM should fail
+
+reject-privileged-in-remote-repo-triggered-by-copy-locally:
+    COPY github.com/earthly/test-privileged:main+locally/hostname .
+    RUN echo this should never run because the above COPY should fail
+
+reject-privileged-in-remote-repo-triggered-by-copy-privileged:
+    COPY github.com/earthly/test-privileged:main+locally/hostname .
+    RUN echo this should never run because the above COPY should fail
+
+reject-privileged-in-remote-repo-triggered-by-build-locally:
+    BUILD github.com/earthly/test-privileged:main+locally
+    RUN echo this should never run because the above BUILD should fail
+
+reject-privileged-in-remote-repo-triggered-by-build-privileged:
+    BUILD github.com/earthly/test-privileged:main+locally
+    RUN echo this should never run because the above BUILD should fail
+
+reject-dedup:
+    # the first build will succeed
+    BUILD +allow-privileged-in-remote-repo-triggered-by-copy
+    # the second build then references the same repo that the first test referenced
+    # but without an --allow-privileged, this should fail even though it was
+    # successfuly run (and cached) in the first step.
+    BUILD +reject-privileged-in-remote-repo-triggered-by-copy
+
+allow-privileged-in-remote-repo-triggered-by-from-locally:
+    FROM --allow-privileged github.com/earthly/test-privileged:main+locally
+    RUN echo this command should work
+
+allow-privileged-in-remote-repo-triggered-by-copy-locally:
+    COPY --allow-privileged github.com/earthly/test-privileged:main+locally/hostname .
+    RUN ls hostname
+
+allow-privileged-in-remote-repo-triggered-by-build-locally:
+    BUILD --allow-privileged github.com/earthly/test-privileged:main+locally
+
+allow-privileged-in-remote-repo-triggered-by-from-privileged:
+    FROM --allow-privileged github.com/earthly/test-privileged:main+privileged
+    RUN echo this command should work
+
+allow-privileged-in-remote-repo-triggered-by-copy-privileged:
+    COPY --allow-privileged github.com/earthly/test-privileged:main+privileged/proc-status .
+    RUN cat proc-status | grep CapEff | grep 0000003fffffffff
+
+allow-privileged-in-remote-repo-triggered-by-build-privileged:
+    BUILD --allow-privileged github.com/earthly/test-privileged:main+privileged
+
+allow-all:
+    # TODO there's a bug that's preventing using FROM in combination with locally
+    # BUILD +allow-privileged-in-remote-repo-triggered-by-from-locally
+    BUILD +allow-privileged-in-remote-repo-triggered-by-copy-locally
+    BUILD +allow-privileged-in-remote-repo-triggered-by-build-locally
+    BUILD +allow-privileged-in-remote-repo-triggered-by-from-privileged
+    BUILD +allow-privileged-in-remote-repo-triggered-by-copy-privileged
+    BUILD +allow-privileged-in-remote-repo-triggered-by-build-privileged

--- a/states/dedup/targetinput.go
+++ b/states/dedup/targetinput.go
@@ -17,6 +17,8 @@ type TargetInput struct {
 	BuildArgs []BuildArgInput `json:"buildArgs"`
 	// Platform is the target platform of the target.
 	Platform string `json:"platform"`
+	// AllowPrivileged is true if the target will allow priviledged access
+	AllowPrivileged bool `json:"allowPrivileged"`
 }
 
 // WithBuildArgInput returns a clone of the current target input, with a
@@ -42,6 +44,9 @@ func (ti TargetInput) Equals(other TargetInput) bool {
 	if ti.Platform != other.Platform {
 		return false
 	}
+	if ti.AllowPrivileged != other.AllowPrivileged {
+		return false
+	}
 	if len(ti.BuildArgs) != len(other.BuildArgs) {
 		return false
 	}
@@ -58,6 +63,7 @@ func (ti TargetInput) clone() TargetInput {
 		TargetCanonical: ti.TargetCanonical,
 		BuildArgs:       make([]BuildArgInput, 0, len(ti.BuildArgs)),
 		Platform:        ti.Platform,
+		AllowPrivileged: ti.AllowPrivileged,
 	}
 	for _, bai := range ti.BuildArgs {
 		tiCopy.BuildArgs = append(tiCopy.BuildArgs, bai.clone())
@@ -79,6 +85,7 @@ func (ti TargetInput) cloneNoTag() (TargetInput, error) {
 		TargetCanonical: targetStr,
 		BuildArgs:       make([]BuildArgInput, 0, len(ti.BuildArgs)),
 		Platform:        ti.Platform,
+		AllowPrivileged: ti.AllowPrivileged,
 	}
 	for _, bai := range ti.BuildArgs {
 		tiCopy.BuildArgs = append(tiCopy.BuildArgs, bai.clone())

--- a/states/states.go
+++ b/states/states.go
@@ -76,7 +76,7 @@ type SingleTarget struct {
 	incomingNewSubscriptions chan string
 }
 
-func newSingleTarget(ctx context.Context, target domain.Target, platform *specs.Platform, overridingVars *variables.Scope, parentDepSub chan string) (*SingleTarget, error) {
+func newSingleTarget(ctx context.Context, target domain.Target, platform *specs.Platform, allowPrivileged bool, overridingVars *variables.Scope, parentDepSub chan string) (*SingleTarget, error) {
 	targetStr := target.StringCanonical()
 	sts := &SingleTarget{
 		ID:       uuid.New().String(),
@@ -85,6 +85,7 @@ func newSingleTarget(ctx context.Context, target domain.Target, platform *specs.
 		targetInput: dedup.TargetInput{
 			TargetCanonical: targetStr,
 			Platform:        llbutil.PlatformWithDefaultToString(platform),
+			AllowPrivileged: allowPrivileged,
 		},
 		MainState:                llbutil.ScratchWithPlatform(),
 		MainImage:                image.NewImage(),


### PR DESCRIPTION
- We should avoid running local and priviledged commands that are
referenced from remote Earthfiles.
- We will design a way to configure trusted repos in a follow up PR.