### PR TITLE
move interpreter flags to separate file

### DIFF
--- a/earthfile2llb/flags.go
+++ b/earthfile2llb/flags.go
@@ -1,0 +1,120 @@
+package earthfile2llb
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/pkg/errors"
+
+	flags "github.com/jessevdk/go-flags"
+)
+
+type ifOpts struct {
+	Privileged bool     `long:"privileged" description:"Enable privileged mode"`
+	WithSSH    bool     `long:"ssh" description:"Make available the SSH agent of the host"`
+	NoCache    bool     `long:"no-cache" description:"Always run this specific item, ignoring cache"`
+	Secrets    []string `long:"secret" description:"Make available a secret"`
+	Mounts     []string `long:"mount" description:"Mount a file or directory"`
+}
+
+type runOpts struct {
+	Push            bool     `long:"push" description:"Execute this command only if the build succeeds and also if earthly is invoked in push mode"`
+	Privileged      bool     `long:"privileged" description:"Enable privileged mode"`
+	WithEntrypoint  bool     `long:"entrypoint" description:"Include the entrypoint of the image when running the command"`
+	WithDocker      bool     `long:"with-docker" description:"Deprecated"`
+	WithSSH         bool     `long:"ssh" description:"Make available the SSH agent of the host"`
+	NoCache         bool     `long:"no-cache" description:"Always run this specific item, ignoring cache"`
+	Interactive     bool     `long:"interactive" description:"Run this command with an interactive session, without saving changes"`
+	InteractiveKeep bool     `long:"interactive-keep" description:"Run this command with an interactive session, saving changes"`
+	Secrets         []string `long:"secret" description:"Make available a secret"`
+	Mounts          []string `long:"mount" description:"Mount a file or directory"`
+}
+
+type fromOpts struct {
+	AllowPrivileged bool     `long:"allow-privileged" description:"Allow commands under remote targets to enable privileged mode"`
+	BuildArgs       []string `long:"build-arg" description:"A build arg override passed on to a referenced Earthly target"`
+	Platform        string   `long:"platform" description:"The platform to use"`
+}
+
+type fromDockerfileOpts struct {
+	BuildArgs []string `long:"build-arg" description:"A build arg override passed on to a referenced Earthly target and also to the Dockerfile build"`
+	Platform  string   `long:"platform" description:"The platform to use"`
+	Target    string   `long:"target" description:"The Dockerfile target to inherit from"`
+	Path      string   `short:"f" description:"Not supported"`
+}
+
+type copyOpts struct {
+	From            string   `long:"from" description:"Not supported"`
+	IsDirCopy       bool     `long:"dir" description:"Copy entire directories, not just the contents"`
+	Chown           string   `long:"chown" description:"Apply a specific group and/or owner to the copied files and directories"`
+	KeepTs          bool     `long:"keep-ts" description:"Keep created time file timestamps"`
+	KeepOwn         bool     `long:"keep-own" description:"Keep owner info"`
+	IfExists        bool     `long:"if-exists" description:"Do not fail if the artifact does not exist"`
+	AllowPrivileged bool     `long:"allow-privileged" description:"Allow targets to assume privileged mode"`
+	Platform        string   `long:"platform" description:"The platform to use"`
+	BuildArgs       []string `long:"build-arg" description:"A build arg override passed on to a referenced Earthly target"`
+}
+
+type saveArtifactOpts struct {
+	KeepTs   bool `long:"keep-ts" description:"Keep created time file timestamps"`
+	KeepOwn  bool `long:"keep-own" description:"Keep owner info"`
+	IfExists bool `long:"if-exists" description:"Do not fail if the artifact does not exist"`
+}
+
+type saveImageOpts struct {
+	Push      bool     `long:"push" description:"Push the image to the remote registry provided that the build succeeds and also that earthly is invoked in push mode"`
+	CacheHint bool     `long:"cache-hint" description:"Instruct Earthly that the current target shuold be saved entirely as part of the remote cache"`
+	Insecure  bool     `long:"insecure" description:"Use unencrypted connection for the push"`
+	CacheFrom []string `long:"cache-from" description:"Declare additional cache import as a Docker tag"`
+}
+
+type buildOpts struct {
+	Platforms       []string `long:"platform" description:"The platform to use"`
+	BuildArgs       []string `long:"build-arg" description:"A build arg override passed on to a referenced Earthly target"`
+	AllowPrivileged bool     `long:"allow-privileged" description:"Allow targets to assume privileged mode"`
+}
+
+type gitCloneOpts struct {
+	Branch string `long:"branch" description:"The git ref to use when cloning"`
+	KeepTs bool   `long:"keep-ts" description:"Keep created time file timestamps"`
+}
+
+type healthCheckOpts struct {
+	Interval    time.Duration `long:"interval" description:"The interval between healthchecks" default:"30s"`
+	Timeout     time.Duration `long:"timeout" description:"The timeout before the command is considered failed" default:"30s"`
+	StartPeriod time.Duration `long:"start-period" description:"An initialization time period in which failures are not counted towards the maximum number of retries"`
+	Retries     int           `long:"retries" description:"The number of retries before a container is considered unhealthy" default:"3"`
+}
+
+type withDockerOpts struct {
+	ComposeFiles    []string `long:"compose" description:"A compose file used to bring up services from"`
+	ComposeServices []string `long:"service" description:"A compose service to bring up"`
+	Loads           []string `long:"load" description:"An image produced by Earthly which is loaded as a Docker image"`
+	Platform        string   `long:"platform" description:"The platform to use"`
+	BuildArgs       []string `long:"build-arg" description:"A build arg override passed on to a referenced Earthly target"`
+	Pulls           []string `long:"pull" description:"An image which is pulled and made available in the docker cache"`
+	AllowPrivileged bool     `long:"allow-privileged" description:"Allow targets referenced by load to assume privileged mode"`
+}
+
+type doOpts struct {
+	AllowPrivileged bool `long:"allow-privileged" description:"Allow targets to assume privileged mode"`
+}
+
+type importOpts struct {
+	AllowPrivileged bool `long:"allow-privileged" description:"Allow targets to assume privileged mode"`
+}
+
+func parseArgs(command string, data interface{}, args []string) ([]string, error) {
+	p := flags.NewNamedParser("", flags.PrintErrors|flags.PassDoubleDash|flags.PassAfterNonOption)
+	_, err := p.AddGroup(fmt.Sprintf("%s [options] args", command), "", data)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to initiate parser.AddGroup for %s", command)
+	}
+	res, err := p.ParseArgs(args)
+	if err != nil {
+		p.WriteHelp(os.Stderr)
+		return nil, err
+	}
+	return res, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/golang/protobuf v1.4.3
 	github.com/google/uuid v1.2.0
 	github.com/hashicorp/go-multierror v1.1.0
+	github.com/jessevdk/go-flags v1.5.0
 	github.com/joho/godotenv v1.3.0
 	github.com/mattn/go-isatty v0.0.12
 	github.com/moby/buildkit v0.8.2-0.20210129065303-6b9ea0c202cf

--- a/go.sum
+++ b/go.sum
@@ -506,6 +506,8 @@ github.com/ishidawataru/sctp v0.0.0-20191218070446-00ab2ac2db07 h1:rw3IAne6CDuVF
 github.com/ishidawataru/sctp v0.0.0-20191218070446-00ab2ac2db07/go.mod h1:co9pwDoBCm1kGxawmb4sPq0cSIOOWNPT4KnHotMP1Zg=
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56 h1:742eGXur0715JMq73aD95/FU0XpVKXqNuTnEfXsLOYQ=
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
+github.com/jessevdk/go-flags v1.5.0 h1:1jKYvbxEjfUl0fmqTCOfonvskHHXMjBySTLW4y9LFvc=
+github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7 h1:SMvOWPJCES2GdFracYbBQh93GXac8fq7HeN6JnpduB8=
 github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=


### PR DESCRIPTION
- move interpreter flags to separate file for clearer visibility of flags
- switch from go's flag library to go-flags which supports both short and long names

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>