### PR TITLE
`sudo earthly bootstrap` should use the same `install_id` as the calling user

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -31,7 +31,7 @@ deps:
 code:
     FROM +deps
     COPY --platform=linux/amd64 ./ast/parser+parser/*.go ./ast/parser/
-    COPY --dir analytics autocomplete buildcontext builder cleanup cmd config conslogging debugger dockertar \
+    COPY --dir analytics autocomplete buildcontext builder cleanup cliutil cmd config conslogging debugger dockertar \
         docker2earthly domain fileutil gitutil llbutil logging secretsclient stringutil states syncutil termutil \
         variables ./
     COPY --dir buildkitd/buildkitd.go buildkitd/settings.go buildkitd/

--- a/analytics/analytics.go
+++ b/analytics/analytics.go
@@ -11,12 +11,12 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/earthly/earthly/cliutil"
 	"github.com/earthly/earthly/fileutil"
 	"github.com/earthly/earthly/gitutil"
 	"github.com/earthly/earthly/syncutil"
@@ -125,18 +125,13 @@ func getRepoHash() string {
 }
 
 func getInstallID() (string, error) {
-	homeDir, err := detectHomeDir()
+	earthlyDir, err := cliutil.GetEarthlyDir()
 	if err != nil {
-		return "", errors.Wrap(err, "failed to get user home dir")
+		return "", err
 	}
 
-	parent := filepath.Join(homeDir, ".earthly")
-	path := filepath.Join(parent, "install_id")
+	path := filepath.Join(earthlyDir, "install_id")
 	if !fileutil.FileExists(path) {
-		err := os.MkdirAll(parent, 0755)
-		if err != nil {
-			return "", errors.Wrapf(err, "failed to create dir %s", parent)
-		}
 		u, err := uuid.NewUUID()
 		if err != nil {
 			u, err = uuid.NewRandom()
@@ -157,35 +152,6 @@ func getInstallID() (string, error) {
 		return "", errors.Wrapf(err, "failed to read %q", path)
 	}
 	return string(s), nil
-}
-
-func detectHomeDir() (string, error) {
-	if runtime.GOOS == "windows" {
-		return os.UserHomeDir()
-	}
-	// See if SUDO_USER exists. Use that user's home dir.
-	sudoUser, ok := os.LookupEnv("SUDO_USER")
-	if ok {
-		bashFormHomeDir := fmt.Sprintf("~%s", sudoUser)
-		cmd := exec.Command("/bin/sh", "-c", fmt.Sprintf("eval echo \"%s\"", bashFormHomeDir))
-		homeDirDt, err := cmd.CombinedOutput()
-		homeDir := string(bytes.TrimSpace(homeDirDt))
-		if err == nil && homeDir != "" && homeDir != "/" && homeDir != bashFormHomeDir {
-			return homeDir, nil
-		}
-	}
-	// Try to use current user's home dir.
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		// Try $HOME.
-		homeDir, ok := os.LookupEnv("HOME")
-		if ok {
-			return homeDir, nil
-		}
-		// No home dir available - use /etc instead.
-		return "/etc", nil
-	}
-	return homeDir, nil
 }
 
 func isTerminal() bool {

--- a/cliutil/earthlydir.go
+++ b/cliutil/earthlydir.go
@@ -1,0 +1,84 @@
+package cliutil
+
+import (
+	"os"
+	"os/user"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"sync"
+
+	"github.com/earthly/earthly/fileutil"
+	"github.com/pkg/errors"
+)
+
+var earthlyDir string
+var earthlyDirErr error
+var earthlyDirOnce sync.Once
+
+func GetEarthlyDir() (string, error) {
+	earthlyDirOnce.Do(func() {
+		earthlyDir, earthlyDirErr = makeEarthlyDir()
+	})
+	return earthlyDir, earthlyDirErr
+}
+
+func makeEarthlyDir() (string, error) {
+	homeDir, sudoUser, err := detectHomeDir()
+	if err != nil {
+		return "", err
+	}
+	earthlyDir := filepath.Join(homeDir, ".earthly")
+	if !fileutil.DirExists(earthlyDir) {
+		err := os.MkdirAll(earthlyDir, 0755)
+		if err != nil {
+			return "", errors.Wrapf(err, "unable to create dir %s", earthlyDir)
+		}
+		if sudoUser != nil {
+			// Attempt to chown the created dir to belong to the sudo user.
+			uid, err := strconv.Atoi(sudoUser.Uid)
+			if err != nil {
+				// Swallow error.
+				return earthlyDir, nil
+			}
+			gid := 0
+			if sudoUser.Gid != "" {
+				// If cannot convert will use gid 0.
+				gid, _ = strconv.Atoi(sudoUser.Gid)
+			}
+			err = os.Chown(earthlyDir, uid, gid)
+			if err != nil {
+				// Swallow error.
+				return earthlyDir, nil
+			}
+		}
+	}
+	return earthlyDir, nil
+}
+
+func detectHomeDir() (homeDir string, sudoUser *user.User, err error) {
+	if runtime.GOOS == "windows" {
+		homeDir, err := os.UserHomeDir()
+		return homeDir, nil, err
+	}
+	// See if SUDO_USER exists. Use that user's home dir.
+	sudoUserName, ok := os.LookupEnv("SUDO_USER")
+	if ok {
+		sudoUser, err := user.Lookup(sudoUserName)
+		if err == nil && sudoUser.HomeDir != "" {
+			return sudoUser.HomeDir, sudoUser, nil
+		}
+	}
+	// Try to use current user's home dir.
+	homeDir, err = os.UserHomeDir()
+	if err != nil {
+		// Try $HOME.
+		homeDir, ok := os.LookupEnv("HOME")
+		if ok {
+			return homeDir, nil, nil
+		}
+		// No home dir available - use /etc instead.
+		return "/etc", nil, nil
+	}
+	return homeDir, nil, nil
+}

--- a/cliutil/earthlydir.go
+++ b/cliutil/earthlydir.go
@@ -16,6 +16,7 @@ var earthlyDir string
 var earthlyDirErr error
 var earthlyDirOnce sync.Once
 
+// GetEarthlyDir returns the .earthly dir. (Usually ~/.earthly).
 func GetEarthlyDir() (string, error) {
 	earthlyDirOnce.Do(func() {
 		earthlyDir, earthlyDirErr = makeEarthlyDir()

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -55,6 +55,7 @@ import (
 	"github.com/earthly/earthly/builder"
 	"github.com/earthly/earthly/buildkitd"
 	"github.com/earthly/earthly/cleanup"
+	"github.com/earthly/earthly/cliutil"
 	"github.com/earthly/earthly/config"
 	"github.com/earthly/earthly/conslogging"
 	debuggercommon "github.com/earthly/earthly/debugger/common"
@@ -1019,11 +1020,10 @@ func (app *earthlyApp) autoComplete() {
 	err := app.autoCompleteImp()
 	if err != nil {
 		errToLog := err
-		homeDir, err := os.UserHomeDir()
+		logDir, err := cliutil.GetEarthlyDir()
 		if err != nil {
 			os.Exit(1)
 		}
-		logDir := filepath.Join(homeDir, ".earthly")
 		logFile := filepath.Join(logDir, "autocomplete.log")
 		err = os.MkdirAll(logDir, 0755)
 		if err != nil {
@@ -2618,13 +2618,13 @@ func processSecrets(secrets, secretFiles []string, dotEnvMap map[string]string) 
 }
 
 func defaultConfigPath() string {
-	homeDir, err := os.UserHomeDir()
+	earthlyDir, err := cliutil.GetEarthlyDir()
 	if err != nil {
 		panic(err)
 	}
 
-	oldConfig := filepath.Join(homeDir, ".earthly", "config.yaml")
-	newConfig := filepath.Join(homeDir, ".earthly", "config.yml")
+	oldConfig := filepath.Join(earthlyDir, "config.yaml")
+	newConfig := filepath.Join(earthlyDir, "config.yml")
 	if fileutil.FileExists(oldConfig) && !fileutil.FileExists(newConfig) {
 		return oldConfig
 	}

--- a/secretsclient/client.go
+++ b/secretsclient/client.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/earthly/earthly/cliutil"
 	"github.com/earthly/earthly/fileutil"
 	"github.com/earthly/earthly/secretsclient/api"
 
@@ -870,16 +871,10 @@ func (c *client) WhoAmI() (string, string, bool, error) {
 func (c *client) getAuthTokenPath(create bool) (string, error) {
 	confDirPath := c.authTokenDir
 	if confDirPath == "" {
-		homeDir, err := os.UserHomeDir()
+		var err error
+		confDirPath, err = cliutil.GetEarthlyDir()
 		if err != nil {
-			return "", errors.Wrapf(err, "failed to get home dir")
-		}
-		confDirPath = filepath.Join(homeDir, ".earthly")
-		if !fileutil.DirExists(confDirPath) && create {
-			err := os.MkdirAll(confDirPath, 0755)
-			if err != nil {
-				return "", errors.Wrapf(err, "failed to create run directory %s", confDirPath)
-			}
+			return "", errors.Wrap(err, "cannot get .earthly dir")
 		}
 	}
 	tokenPath := filepath.Join(confDirPath, "auth.token")


### PR DESCRIPTION
~Uses the magical incantation `eval echo ~$SUDO_USER` to figure out the sudo user's home dir and use that dir for `install_id`.~

TIL https://golang.org/pkg/os/user/#Lookup