### PR TITLE
More Buildkit Cleaning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Execute earthly docker command
         run: (cd examples/tests/docker && ../../.././build/linux/amd64/earthly docker --tag examples-test-docker:latest && diff <(docker run --rm examples-test-docker:latest) <(echo "hello dockerfile") )
       - name: Execute test similar to homebrew test in https://github.com/Homebrew/homebrew-core/blob/master/Formula/earthly.rb
-        run: "./build/linux/amd64/earthly --buildkit-host 127.0.0.1 ./examples/tests/with-docker+all 2>&1 | grep 'connect provided buildkit: timeout'"
+        run: "./build/linux/amd64/earthly --buildkit-host 127.0.0.1 ./examples/tests/with-docker+all 2>&1 | grep 'buildkitd failed to start'"
       - name: Execute private image test (non fork only)
         run: ./build/linux/amd64/earthly --ci ./examples/tests+private-image-test
         if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Execute earthly docker command
         run: (cd examples/tests/docker && ../../.././build/linux/amd64/earthly docker --tag examples-test-docker:latest && diff <(docker run --rm examples-test-docker:latest) <(echo "hello dockerfile") )
       - name: Execute test similar to homebrew test in https://github.com/Homebrew/homebrew-core/blob/master/Formula/earthly.rb
-        run: ./build/linux/amd64/earthly --buildkit-host 127.0.0.1 ./examples/tests/with-docker+all 2>&1 | grep 'Error while dialing invalid address 127.0.0.1'
+        run: "./build/linux/amd64/earthly --buildkit-host 127.0.0.1 ./examples/tests/with-docker+all 2>&1 | grep 'connect provided buildkit: timeout'"
       - name: Execute private image test (non fork only)
         run: ./build/linux/amd64/earthly --ci ./examples/tests+private-image-test
         if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@
 .antlr/
 .env
 .vscode
+.idea
 .tmp-earthly-out*

--- a/buildkitd/buildkitd.go
+++ b/buildkitd/buildkitd.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/earthly/earthly/conslogging"
+	"github.com/fatih/color"
 	"github.com/moby/buildkit/client"
 	_ "github.com/moby/buildkit/client/connhelper/dockercontainer" // Load "docker-container://" helper.
 	"github.com/pkg/errors"
@@ -473,7 +474,13 @@ func MaybePull(ctx context.Context, console conslogging.ConsoleLogger, image str
 }
 
 // PrintLogs prints the buildkitd logs to stderr.
-func PrintLogs(ctx context.Context) error {
+func PrintLogs(ctx context.Context, settings Settings, console conslogging.ConsoleLogger) error {
+	if settings.BuildkitHost != "" {
+		return nil
+	}
+
+	console.PrintBar(color.New(color.FgHiRed), "Buildkit Logs", "")
+
 	cmd := exec.CommandContext(ctx, "docker", "logs", ContainerName)
 	cmd.Stdout = os.Stderr
 	cmd.Stderr = os.Stderr

--- a/buildkitd/buildkitd.go
+++ b/buildkitd/buildkitd.go
@@ -74,7 +74,7 @@ func NewClient(ctx context.Context, console conslogging.ConsoleLogger, image str
 func ResetCache(ctx context.Context, console conslogging.ConsoleLogger, image string, settings Settings) error {
 	// Prune by resetting container.
 	if settings.BuildkitHost != "" {
-		return errors.New("Cannot reset cache of a provided buildkit-host setting")
+		return errors.New("cannot reset cache of a provided buildkit-host setting")
 	}
 
 	console.

--- a/buildkitd/settings.go
+++ b/buildkitd/settings.go
@@ -15,6 +15,7 @@ type Settings struct {
 	GitURLInsteadOf  string
 	Debug            bool
 	DebuggerPort     int
+	BuildkitHost     string `hash:"ignore"`
 	AdditionalArgs   []string
 	AdditionalConfig string
 	CniMtu           uint16

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -1251,26 +1251,23 @@ func (app *earthlyApp) run(ctx context.Context, args []string) int {
 			if bytes.Contains(baseErrMsg, []byte("transport is closing")) {
 				app.console.Warnf(
 					"It seems that buildkitd is shutting down or it has crashed. " +
-						"You can report crashes at https://github.com/earthly/earthly/issues/new. " +
-						"Buildkitd logs follow...")
-				buildkitd.PrintLogs(ctx)
+						"You can report crashes at https://github.com/earthly/earthly/issues/new.")
+				buildkitd.PrintLogs(ctx, app.buildkitdSettings, app.console)
 				return 7
 			}
 		} else if errors.Is(err, buildkitd.ErrBuildkitCrashed) {
 			app.console.Warnf("Error: %v\n", err)
 			app.console.Warnf(
 				"It seems that buildkitd is shutting down or it has crashed. " +
-					"You can report crashes at https://github.com/earthly/earthly/issues/new. " +
-					"Buildkitd logs follow...")
-			buildkitd.PrintLogs(ctx)
+					"You can report crashes at https://github.com/earthly/earthly/issues/new.")
+			buildkitd.PrintLogs(ctx, app.buildkitdSettings, app.console)
 			return 7
 		} else if errors.Is(err, buildkitd.ErrBuildkitStartFailure) {
 			app.console.Warnf("Error: %v\n", err)
 			app.console.Warnf(
 				"It seems that buildkitd had an issue. " +
-					"You can report crashes at https://github.com/earthly/earthly/issues/new. " +
-					"Buildkitd logs follow...")
-			buildkitd.PrintLogs(ctx)
+					"You can report crashes at https://github.com/earthly/earthly/issues/new.")
+			buildkitd.PrintLogs(ctx, app.buildkitdSettings, app.console)
 			return 6
 		} else if isInterpereterError {
 			app.console.Warnf("Error: %s\n", ie.Error())

--- a/release/README.md
+++ b/release/README.md
@@ -34,6 +34,8 @@
   ./earthly --build-arg RELEASE_TAG --push ./release+release-homebrew
   ```
 * Important: Subscribe to the PR that griswoldthecat created in homebrew-core, so that you can address any review comments that may come up.
+* *One-Time:* Update the homebrew formula to change the test. It should now check for "`buildkitd failed to start`" as the sentinel error string.
+  * Remove this (and the above) line once release process is complete.
 * Merge branch `main` into `next`, then merge branch `next` into `main`.
 * Update the version for the installation command in the following places:
   * [ci-integration.md](../docs/ci-integration.md)


### PR DESCRIPTION
Pull in more details that have leaked into the main `earthly` command. Additionally, use the same retry logic when a provided buildkit address is used.