### PR TITLE
Include GHA workflow generation script for auth tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,7 +316,7 @@ jobs:
         if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
       - name: Build latest earthly using released earthly
         run: earthly --use-inline-cache +for-linux
-# to regenerate the entries below; run earthly ./scripts/tests/refactor+generate-github-task
+# to regenerate the entries below; run earthly ./scripts/tests/auth+generate-github-tasks
 # auto-generated-entries start;
       - name: run test-hello-world-no-ssh-agent.sh
         run: env earthly=./build/linux/amd64/earthly scripts/tests/auth/test-hello-world-no-ssh-agent.sh

--- a/scripts/tests/auth/Earthfile
+++ b/scripts/tests/auth/Earthfile
@@ -1,0 +1,19 @@
+FROM alpine:latest
+
+generate-github-tasks:
+    LOCALLY # this was used since COPY ../../../.github/workflows/ci.yml didn't work (perhaps because it matches ".git")
+    RUN set -e; \
+        > /tmp/earthly-6b4acf13-2ef9-4008-9e64-a369b0eedc4a.steps; \
+        for f in $(ls -1 test-*.sh | sort -n); do \
+            echo "      - name: run $f" >> /tmp/earthly-6b4acf13-2ef9-4008-9e64-a369b0eedc4a.steps; \
+            echo "        run: env earthly=./build/linux/amd64/earthly scripts/tests/auth/$f" >> /tmp/earthly-6b4acf13-2ef9-4008-9e64-a369b0eedc4a.steps; \
+        done; \
+        ls -lah ../../../.github/workflows/ci.yml; \ 
+        START=$(grep -n '# auto-generated-entries start' ../../../.github/workflows/ci.yml | awk -F ':' '{print $1}'); \
+        END=$(grep -n '# auto-generated-entries end' ../../../.github/workflows/ci.yml | awk -F ':' '{print $1}'); \
+        test -n "$START"; \
+        test -n "$END"; \
+        head -n "$START" ../../../.github/workflows/ci.yml > /tmp/earthly-6b4acf13-2ef9-4008-9e64-a369b0eedc4a.ci; \
+        cat /tmp/earthly-6b4acf13-2ef9-4008-9e64-a369b0eedc4a.steps >> /tmp/earthly-6b4acf13-2ef9-4008-9e64-a369b0eedc4a.ci; \
+        tail -n "+$END" ../../../.github/workflows/ci.yml >> /tmp/earthly-6b4acf13-2ef9-4008-9e64-a369b0eedc4a.ci; \
+        mv /tmp/earthly-6b4acf13-2ef9-4008-9e64-a369b0eedc4a.ci ../../../.github/workflows/ci.yml

--- a/scripts/tests/auth/README.md
+++ b/scripts/tests/auth/README.md
@@ -1,0 +1,6 @@
+These tests are for tests that can not run via earthly-in-earthly.
+
+If you add or remote any tests from this directory, the corresponding entry in .github/workflows/ci.yml
+must also be updated by running:
+
+    earthly +generate-github-tasks


### PR DESCRIPTION
- includes a script that regenerates github action integration tests
for auth related tests that can't run via earthly in earthly.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>