### PR TITLE
Display which secret was not found in error message

### DIFF
--- a/examples/tests/Earthfile
+++ b/examples/tests/Earthfile
@@ -119,6 +119,11 @@ secrets-test:
         --earthfile=secrets.earth \
         --extra_args="--secret SECRET1 --secret SECRET2=bar --secret-file SECRET3=/my-secret-file" \
         --target=+test
+    DO +RUN_EARTHLY \
+        --earthfile=secrets.earth \
+        --extra_args="--secret SECRET1 --secret SECRET2=bar" \
+        --target=+test \
+        --post_command="2>&1 | perl -pe 'BEGIN {\\\$status=1} END {exit \\\$status} \\\$status=0 if /unable to lookup secret SECRET3: not found/;'"
 
 build-arg-test:
     DO +RUN_EARTHLY --earthfile=build-arg.earth

--- a/util/llbutil/secrets.go
+++ b/util/llbutil/secrets.go
@@ -83,7 +83,7 @@ type mapStore map[string][]byte
 func (m mapStore) GetSecret(ctx context.Context, id string) ([]byte, error) {
 	v, ok := m[id]
 	if !ok {
-		return nil, errors.WithStack(secrets.ErrNotFound)
+		return nil, errors.WithStack(errors.Wrapf(secrets.ErrNotFound, "unable to lookup secret %s", id))
 	}
 	return v, nil
 }


### PR DESCRIPTION
Previously if one referenced a secret which was not available, earthly
would fail and simply return "Error: not found"; this changes the
behavious to display which secret was not found.

For example, consider an Earthfile like:

    foo:
        FROM alpine:latest
        RUN --secret password=+secrets/password env

If you invoke earthly +foo (without passing a value for the password secret), now it will display
an error such as:

    Error: unable to lookup secret password: not found

Where as previously it just displayed:

    Error: not found

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>