### PR TITLE
expand secret-file path

### DIFF
--- a/autocomplete/complete.go
+++ b/autocomplete/complete.go
@@ -1,20 +1,16 @@
 package autocomplete
 
 import (
-	"bufio"
-	"io"
 	"io/ioutil"
 	"os"
 	"os/user"
 	"path"
-	"path/filepath"
 	"reflect"
-	"runtime"
 	"strings"
 
 	"github.com/earthly/earthly/earthfile2llb"
+	"github.com/earthly/earthly/util/fileutil"
 
-	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"
 )
 
@@ -37,57 +33,6 @@ func isLocalPath(path string) bool {
 	return false
 }
 
-func getUsers() (map[string]string, error) {
-	users := map[string]string{}
-	if runtime.GOOS == "darwin" {
-		currentUser, err := user.Current()
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to get current user")
-		}
-		home := filepath.Dir(currentUser.HomeDir)
-		directoryList, err := ioutil.ReadDir(home)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to read dir")
-		}
-		for _, s := range directoryList {
-			if !s.IsDir() {
-				continue
-			}
-			u, err := user.Lookup(s.Name())
-			if err != nil {
-				continue
-			}
-			users[u.Username] = path.Join(home, u.Username)
-		}
-	} else {
-		fp, err := os.Open("/etc/passwd")
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to open /etc/passwd")
-		}
-		reader := bufio.NewReader(fp)
-		for {
-			line, err := reader.ReadString('\n')
-			if err != nil {
-				if err == io.EOF {
-					break
-				}
-				return nil, errors.Wrap(err, "failed to read line")
-			}
-			line = strings.TrimSpace(line)
-			if strings.HasPrefix(line, "#") {
-				continue
-			}
-			parts := strings.Split(line, ":")
-			if len(parts) >= 6 {
-				user := parts[0]
-				home := parts[5]
-				users[user] = home
-			}
-		}
-	}
-	return users, nil
-}
-
 func getPotentialPaths(prefix string) ([]string, error) {
 	if prefix == "." {
 		return []string{"./", "../"}, nil
@@ -100,7 +45,7 @@ func getPotentialPaths(prefix string) ([]string, error) {
 	var user string
 	expandedHomeLen := 0
 	if strings.HasPrefix(prefix, "~") {
-		users, err := getUsers()
+		users, err := fileutil.GetUserHomeDirs()
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -2573,7 +2573,7 @@ func processSecrets(secrets, secretFiles []string, dotEnvMap map[string]string) 
 			return nil, errors.Errorf("unable to parse --secret-file argument: %q", secret)
 		}
 		k := parts[0]
-		path := parts[1]
+		path := fileutil.ExpandPath(parts[1])
 		data, err := ioutil.ReadFile(path)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to open %q", path)

--- a/examples/tests/Earthfile
+++ b/examples/tests/Earthfile
@@ -114,10 +114,10 @@ excludes-test:
 secrets-test:
     ENV SECRET1=foo
     ENV SECRET2=wrong
-    RUN echo -n "secretfilecontents" > /my-secret-file
+    RUN echo -n "secretfilecontents" > /root/my-secret-file
     DO +RUN_EARTHLY \
         --earthfile=secrets.earth \
-        --extra_args="--secret SECRET1 --secret SECRET2=bar --secret-file SECRET3=/my-secret-file" \
+        --extra_args="--secret SECRET1 --secret SECRET2=bar --secret-file SECRET3=~/my-secret-file" \
         --target=+test
     DO +RUN_EARTHLY \
         --earthfile=secrets.earth \

--- a/util/cliutil/earthlydir.go
+++ b/util/cliutil/earthlydir.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"sync"
 
@@ -60,28 +59,12 @@ func makeEarthlyDir() (string, error) {
 // DetectHomeDir returns the home directory of the current user, an additional sudoUser
 // is returned if the user is currently running as root
 func DetectHomeDir() (homeDir string, sudoUser *user.User, err error) {
-	if runtime.GOOS == "windows" {
-		homeDir, err := os.UserHomeDir()
-		return homeDir, nil, err
-	}
-	// See if SUDO_USER exists. Use that user's home dir.
-	sudoUserName, ok := os.LookupEnv("SUDO_USER")
-	if ok {
-		sudoUser, err := user.Lookup(sudoUserName)
-		if err == nil && sudoUser.HomeDir != "" {
-			return sudoUser.HomeDir, sudoUser, nil
-		}
-	}
-	// Try to use current user's home dir.
-	homeDir, err = os.UserHomeDir()
+	homeDir, sudoUser, err = fileutil.HomeDir()
 	if err != nil {
-		// Try $HOME.
-		homeDir, ok := os.LookupEnv("HOME")
-		if ok {
-			return homeDir, nil, nil
-		}
-		// No home dir available - use /etc instead.
-		return "/etc", nil, nil
+		return
 	}
-	return homeDir, nil, nil
+	if homeDir == "" {
+		homeDir = "/etc" // No home dir available - use /etc instead.
+	}
+	return
 }

--- a/util/fileutil/expand.go
+++ b/util/fileutil/expand.go
@@ -1,0 +1,36 @@
+package fileutil
+
+import (
+	"strings"
+)
+
+// ExpandPath expands the tilde in the path
+func ExpandPath(s string) string {
+	if !strings.HasPrefix(s, "~") {
+		return s
+	}
+	homeDir, _, err := HomeDir()
+	if err != nil || homeDir == "" {
+		return s // best effort
+	}
+
+	if s == "~" {
+		return homeDir
+	}
+	parts := strings.SplitN(s, "/", 2)
+	if parts[0] != "~" {
+		user := parts[0][1:]
+		users, err := GetUserHomeDirs()
+		if err != nil {
+			return s // best effort
+		}
+		homeDir, _ = users[user]
+		if homeDir == "" {
+			return s // best effort
+		}
+	}
+	if len(parts) == 1 {
+		return homeDir
+	}
+	return homeDir + "/" + parts[1]
+}

--- a/util/fileutil/homedir.go
+++ b/util/fileutil/homedir.go
@@ -1,0 +1,36 @@
+package fileutil
+
+import (
+	"os"
+	"os/user"
+	"runtime"
+)
+
+// HomeDir returns the home directory of the current user, an additional sudoUser
+// is returned if the user is currently running as root
+func HomeDir() (homeDir string, sudoUser *user.User, err error) {
+	if runtime.GOOS == "windows" {
+		homeDir, err := os.UserHomeDir()
+		return homeDir, nil, err
+	}
+	// See if SUDO_USER exists. Use that user's home dir.
+	sudoUserName, ok := os.LookupEnv("SUDO_USER")
+	if ok {
+		sudoUser, err := user.Lookup(sudoUserName)
+		if err == nil && sudoUser.HomeDir != "" {
+			return sudoUser.HomeDir, sudoUser, nil
+		}
+	}
+	// Try to use current user's home dir.
+	homeDir, err = os.UserHomeDir()
+	if err != nil {
+		// Try $HOME.
+		homeDir, ok := os.LookupEnv("HOME")
+		if ok {
+			return homeDir, nil, nil
+		}
+		// No home dir available - use /etc instead.
+		return "", nil, nil
+	}
+	return homeDir, nil, nil
+}

--- a/util/fileutil/homedirs.go
+++ b/util/fileutil/homedirs.go
@@ -1,0 +1,67 @@
+package fileutil
+
+import (
+	"bufio"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/user"
+	"path"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// GetUserHomeDirs returns a map of all users and their homedirs
+func GetUserHomeDirs() (map[string]string, error) {
+	users := map[string]string{}
+	if runtime.GOOS == "darwin" {
+		currentUser, err := user.Current()
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to get current user")
+		}
+		home := filepath.Dir(currentUser.HomeDir)
+		directoryList, err := ioutil.ReadDir(home)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to read dir")
+		}
+		for _, s := range directoryList {
+			if !s.IsDir() {
+				continue
+			}
+			u, err := user.Lookup(s.Name())
+			if err != nil {
+				continue
+			}
+			users[u.Username] = path.Join(home, u.Username)
+		}
+	} else {
+		fp, err := os.Open("/etc/passwd")
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to open /etc/passwd")
+		}
+		reader := bufio.NewReader(fp)
+		for {
+			line, err := reader.ReadString('\n')
+			if err != nil {
+				if err == io.EOF {
+					break
+				}
+				return nil, errors.Wrap(err, "failed to read line")
+			}
+			line = strings.TrimSpace(line)
+			if strings.HasPrefix(line, "#") {
+				continue
+			}
+			parts := strings.Split(line, ":")
+			if len(parts) >= 6 {
+				user := parts[0]
+				home := parts[5]
+				users[user] = home
+			}
+		}
+	}
+	return users, nil
+}


### PR DESCRIPTION
Typically the shell will expand paths such as `~/foo`; however when given
as an argument to `--secret-file secret=~/foo`, the shell did not expand
this path. This addresses this issue.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>