### PR TITLE
fix panic when netrc file exists but doesnt contain host

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,6 +322,8 @@ jobs:
         run: env earthly=./build/linux/amd64/earthly scripts/tests/auth/test-earthfile-can-clone-private-repo-with-earthly-config.sh
       - name: run test-earthfile-can-clone-private-repo-with-netrc.sh
         run: env earthly=./build/linux/amd64/earthly scripts/tests/auth/test-earthfile-can-clone-private-repo-with-netrc.sh
+      - name: run test-hello-world-empty-netrc.sh
+        run: env earthly=./build/linux/amd64/earthly scripts/tests/auth/test-hello-world-empty-netrc.sh
       - name: run test-hello-world-no-ssh-agent.sh
         run: env earthly=./build/linux/amd64/earthly scripts/tests/auth/test-hello-world-no-ssh-agent.sh
       - name: run test-hello-world-no-ssh-keys.sh

--- a/buildcontext/gitlookup.go
+++ b/buildcontext/gitlookup.go
@@ -237,6 +237,8 @@ func (gl *GitLookup) detectProtocol(host string) (protocol string, err error) {
 	return
 }
 
+var errNoRCHostEntry = fmt.Errorf("no netrc host entry")
+
 func (gl *GitLookup) lookupNetRCCredential(host string) (login, password string, err error) {
 	homeDir, _, err := cliutil.DetectHomeDir()
 	if err != nil {
@@ -245,6 +247,10 @@ func (gl *GitLookup) lookupNetRCCredential(host string) (login, password string,
 	n, err := netrc.Parse(filepath.Join(homeDir, ".netrc"))
 	if err != nil {
 		return "", "", errors.Wrap(err, "failed to parse .netrc")
+	}
+	machine := n.Machine(host)
+	if machine == nil {
+		return "", "", errors.Wrapf(errNoRCHostEntry, "failed to lookup netrc entry for %s", host)
 	}
 	login = n.Machine(host).Get("login")
 	password = n.Machine(host).Get("password")

--- a/scripts/tests/auth/test-hello-world-empty-netrc.sh
+++ b/scripts/tests/auth/test-hello-world-empty-netrc.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -eu # don't use -x as it will leak the private key
+# shellcheck source=./setup.sh
+source "$(dirname "$0")/setup.sh"
+
+# create an empty netrc file, to validate earthly can handle fetching from github.com when
+# no entry exists in the netrc file.
+touch ~/.netrc
+
+# test earthly can access a public repo
+"$earthly" github.com/earthly/hello-world:main+hello


### PR DESCRIPTION
- fixes a panic that occurs when a ~/.netrc file exists but is either
empty, invalid, or doesn't contain login information for the host that
is being looked up.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>