### PR TITLE
add apt and yum repo release to main release process

### DIFF
--- a/release/Earthfile
+++ b/release/Earthfile
@@ -200,3 +200,9 @@ release-homebrew:
 release-vscode-syntax-highlighting:
     ARG VSCODE_RELEASE_TAG
     BUILD --build-arg VSCODE_RELEASE_TAG="$VSCODE_RELEASE_TAG" ../contrib/earthfile-syntax-highlighting+release
+
+release-repo:
+    ARG RELEASE_TAG
+    RUN test -n "$RELEASE_TAG"
+    BUILD --build-arg RELEASE_TAG="$RELEASE_TAG" ./apt-repo+build-and-release
+    BUILD --build-arg RELEASE_TAG="$RELEASE_TAG" ./yum-repo+build-and-release

--- a/release/README.md
+++ b/release/README.md
@@ -5,6 +5,10 @@
   ```bash
   ./earthly secrets ls /earthly-technologies
   ```
+* Make sure you have uploaded your aws credentials to your user secrets.
+  ```bash
+  ./earthly secrets ls /user/earthly-technologies/aws/credentials
+  ```
 * Choose the next [release tag](https://github.com/earthly/earthly/releases).
   ```bash
   export RELEASE_TAG="v..."
@@ -34,6 +38,10 @@
   ./earthly --build-arg RELEASE_TAG --push ./release+release-homebrew
   ```
 * Important: Subscribe to the PR that griswoldthecat created in homebrew-core, so that you can address any review comments that may come up.
+* Run
+  ```bash
+  ./earthly --build-arg RELEASE_TAG --push ./release+release-repo
+  ```
 * Merge branch `main` into `next`, then merge branch `next` into `main`.
 * Update the version for the installation command in the following places:
   * [ci-integration.md](../docs/ci-integration.md)

--- a/release/apt-repo/Earthfile
+++ b/release/apt-repo/Earthfile
@@ -8,7 +8,7 @@ deb:
     ARG RELEASE_TAG
     ARG EARTHLY_PLATFORM
     ARG EARTHLY_VERSION=$(echo "$RELEASE_TAG" | cut -c 2-)
-    ARG PKG_NAME=earthly_${VERSION}-1_${EARTHLY_PLATFORM}
+    ARG PKG_NAME=earthly_${EARTHLY_VERSION}-1_${EARTHLY_PLATFORM}
     FROM +deps
     WORKDIR /work
     RUN mkdir -p $PKG_NAME/DEBIAN
@@ -46,27 +46,25 @@ deb-all:
 
 # If for any reason you need to generate a new PGP key, it can be done with
 # this target; however this has already been done once, and our official key has
-# been saved under +secrets/earthly-technologies/apt/keys/earthly-apt-private.pgp (and earthly-apt-public.pgp)
+# been saved under +secrets/earthly-technologies/release/keys/earthly-private.pgp (and earthly-public.pgp)
 generate-new-gpg-key:
     FROM +deps
-    WORKDIR /root/apt-key
+    WORKDIR /root/pgp-key
     RUN echo "%echo Generating a basic OpenPGP key
 Key-Type: RSA
 Key-Length: 4096
-Subkey-Type: RSA
-Subkey-Length: 4096
-Name-Real: earthly-apt
+Name-Real: earthly
 Name-Email: support@earthly.dev
 Expire-Date: 0
 %no-ask-passphrase
 %no-protection
 %commit
-%echo done" > earthly-apt.batch
-    RUN gpg --no-tty --batch --gen-key earthly-apt.batch
-    RUN gpg --output earthly-apt-public.pgp --armor --export support@earthly.dev
-    RUN gpg --output earthly-apt-private.pgp --armor --export-secret-key support@earthly.dev
-    SAVE ARTIFACT earthly-apt-public.pgp AS LOCAL earthly-apt-public.pgp
-    SAVE ARTIFACT earthly-apt-private.pgp AS LOCAL earthly-apt-private.pgp
+%echo done" > earthly-pgp.batch
+    RUN rm -rf /root/gpupg && gpg --no-tty --batch --gen-key earthly-pgp.batch
+    RUN gpg --output earthly-pgp-public.pgp --armor --export support@earthly.dev
+    RUN gpg --output earthly-pgp-private.pgp --armor --export-secret-key support@earthly.dev
+    SAVE ARTIFACT earthly-pgp-public.pgp AS LOCAL earthly-pgp-public.pgp
+    SAVE ARTIFACT earthly-pgp-private.pgp AS LOCAL earthly-pgp-private.pgp
 
 
 aws-base:
@@ -88,7 +86,7 @@ download:
     FROM +aws
     RUN env | grep dev
     RUN --no-cache \
-        --mount type=secret,id=+secrets/aws-credentials,target=/root/.aws/credentials \
+        --mount type=secret,id=+secrets/user/earthly-technologies/aws/credentials,target=/root/.aws/credentials \
         aws s3 cp --recursive s3://staging-pkg/deb/ repo
     SAVE ARTIFACT repo AS LOCAL output/repo
 
@@ -138,8 +136,9 @@ index-and-sign:
         ls /repo/dists/stable/Release;
 
     # Next move on to signing it
-    RUN --mount type=secret,id=+secrets/earthly-technologies/apt/keys/earthly-apt-private.pgp,target=/apt-key/earthly-apt-private.pgp \
-        gpg --import /apt-key/earthly-apt-private.pgp
+    RUN \
+        --mount type=secret,id=+secrets/earthly-technologies/release/keys/earthly-private.pgp,target=/release-key/earthly-private.pgp \
+        gpg --import /release-key/earthly-private.pgp
     RUN gpg --default-key earthly-apt -abs -o /repo/dists/stable/Release.gpg /repo/dists/stable/Release
     RUN cat /repo/dists/stable/Release | gpg --default-key earthly-apt -abs --clearsign --no-emit-version > /repo/dists/stable/InRelease
 
@@ -162,13 +161,14 @@ upload:
             exit 1; \
         fi
     # upload public key
-    RUN --no-cache \
-        --mount type=secret,id=+secrets/earthly-technologies/apt/keys/earthly-apt-public.pgp,target=/apt-key/earthly-apt-public.pgp \
-        --mount type=secret,id=+secrets/aws-credentials,target=/root/.aws/credentials \
-        aws s3 cp --acl public-read /apt-key/earthly-apt-public.pgp s3://staging-pkg/earthly-apt.pgp
+    RUN --push \
+        --mount type=secret,id=+secrets/earthly-technologies/release/keys/earthly-public.pgp,target=/release-key/earthly-public.pgp \
+        --mount type=secret,id=+secrets/user/earthly-technologies/aws/credentials,target=/root/.aws/credentials \
+        grep PUBLIC /release-key/earthly-public.pgp >/dev/null && \
+        aws s3 cp --acl public-read /release-key/earthly-public.pgp s3://staging-pkg/earthly.pgp
     # upload signed repo
-    RUN --no-cache \
-        --mount type=secret,id=+secrets/aws-credentials,target=/root/.aws/credentials \
+    RUN --push \
+        --mount type=secret,id=+secrets/user/earthly-technologies/aws/credentials,target=/root/.aws/credentials \
         aws s3 cp --recursive --acl public-read /repo s3://staging-pkg/deb/
 
 build-and-release:

--- a/release/apt-repo/README.md
+++ b/release/apt-repo/README.md
@@ -34,7 +34,10 @@ Finally, setup the stable repository:
 
 To package a new version of earthly, ensure the following requirements are met:
 
-1. you have aws credentials configured in `~/.aws/credentials`, and have access to the developer role
+1. you have aws credentials configured in the earthly secret store under `/user/earthly-technologies/aws/credentials`, and have access to the developer role
+
+    # you can upload them via
+    earthly secrets set --file ~/.aws/credentials /user/earthly-technologies/aws/credentials
 
 2. you have access to the earthly-technologies secrets; specifically the following two commands should work:
 
@@ -49,7 +52,7 @@ Once earthly has been released to github, visit https://github.com/earthly/earth
 
 Then run
 
-    earthly --secret-file aws-credentials=/home/alex/.aws/credentials --build-arg RELEASE_TAG +build-and-release
+    earthly --build-arg RELEASE_TAG +build-and-release
 
 ### Running steps independently
 
@@ -67,12 +70,12 @@ To package a specific platform
 
 #### Cloning the s3 repo to your local disk
 
-    earthly --secret-file aws-credentials=/home/alex/.aws/credentials +download
+    earthly +download
 
 #### Indexing and signing the repo
 
-    earthly --secret-file aws-credentials=/home/alex/.aws/credentials +index-and-sign
+    earthly +index-and-sign
 
 #### Uploading the repo to s3
 
-    earthly --secret-file aws-credentials=/home/alex/.aws/credentials +upload
+    earthly +upload

--- a/release/apt-repo/test/Earthfile
+++ b/release/apt-repo/test/Earthfile
@@ -2,7 +2,7 @@ test-ubuntu:
     ARG version=20.10
     FROM ubuntu:$version
     RUN apt-get update && apt-get install -y dpkg-dev wget dpkg-sig curl
-    RUN --no-cache curl https://pkg.earthly.dev/earthly-apt.pgp | apt-key add -
+    RUN --no-cache curl https://pkg.earthly.dev/earthly.pgp | apt-key add -
     RUN --no-cache echo "deb [arch=amd64] https://pkg.earthly.dev/deb/ stable main" > /etc/apt/sources.list.d/earthly.list
     RUN --no-cache apt-get update && apt-get install -y earthly
     RUN --no-cache earthly --version
@@ -17,7 +17,7 @@ test-debian:
         gnupg \
         lsb-release
 
-    RUN --no-cache curl -fsSL https://pkg.earthly.dev/earthly-apt.pgp | gpg --dearmor -o /usr/share/keyrings/earthly-archive-keyring.gpg
+    RUN --no-cache curl -fsSL https://pkg.earthly.dev/earthly.pgp | gpg --dearmor -o /usr/share/keyrings/earthly-archive-keyring.gpg
     RUN --no-cache echo "deb [arch=amd64 signed-by=/usr/share/keyrings/earthly-archive-keyring.gpg] https://pkg.earthly.dev/deb/ stable main" > /etc/apt/sources.list.d/earthly.list
     RUN --no-cache apt-get update && apt-get install -y earthly
     RUN --no-cache earthly --version

--- a/release/yum-repo/Earthfile
+++ b/release/yum-repo/Earthfile
@@ -72,7 +72,7 @@ download:
     FROM +aws
     RUN env | grep dev
     RUN --no-cache \
-        --mount type=secret,id=+secrets/aws-credentials,target=/root/.aws/credentials \
+        --mount type=secret,id=+secrets/user/earthly-technologies/aws/credentials,target=/root/.aws/credentials \
         aws s3 cp --recursive s3://staging-pkg/rpm/stable repo
     SAVE ARTIFACT repo AS LOCAL output/repo
 
@@ -98,13 +98,16 @@ index-and-sign:
 
     WORKDIR /repo
     # Next move on to signing it (we sign the rpm repo with the same key we use for signing our apt repo)
-    RUN --mount type=secret,id=+secrets/earthly-technologies/apt/keys/earthly-apt-private.pgp,target=/apt-key/earthly-apt-private.pgp \
-        gpg --import /apt-key/earthly-apt-private.pgp
+    RUN --no-cache \
+        --mount type=secret,id=+secrets/earthly-technologies/release/keys/earthly-private.pgp,target=/release-key/earthly-private.pgp \
+        gpg --import /release-key/earthly-private.pgp
 
     RUN echo "%_signature gpg
-%_gpg_name earthly-apt" > /root/.rpmmacros
+%_gpg_name B1185ECA33F8EB64" > /root/.rpmmacros
 
-    RUN rpm --resign packages/*.rpm
+    RUN rpm --addsign packages/*.rpm
+    # validate all packages are signed with our key
+    RUN cd packages; for p in *.rpm; do rpm -qpi "$p" | grep Signature | grep -i B1185ECA33F8EB64; done
     RUN rm -rf repodata && createrepo .
     RUN gpg --detach-sign --armor repodata/repomd.xml
     SAVE ARTIFACT /repo AS LOCAL output/signed-repo
@@ -126,13 +129,14 @@ upload:
             exit 1; \
         fi
     # upload public key
-    RUN --no-cache \
-        --mount type=secret,id=+secrets/earthly-technologies/apt/keys/earthly-apt-public.pgp,target=/apt-key/earthly-apt-public.pgp \
-        --mount type=secret,id=+secrets/aws-credentials,target=/root/.aws/credentials \
-        aws s3 cp --acl public-read /apt-key/earthly-apt-public.pgp s3://staging-pkg/earthly.pgp
+    RUN --push \
+        --mount type=secret,id=+secrets/earthly-technologies/release/keys/earthly-public.pgp,target=/release-key/earthly-public.pgp \
+        --mount type=secret,id=+secrets/user/earthly-technologies/aws/credentials,target=/root/.aws/credentials \
+        grep PUBLIC /release-key/earthly-public.pgp >/dev/null && \
+        aws s3 cp --acl public-read /release-key/earthly-public.pgp s3://staging-pkg/earthly.pgp
     # upload signed repo
-    RUN --no-cache \
-        --mount type=secret,id=+secrets/aws-credentials,target=/root/.aws/credentials \
+    RUN --push \
+        --mount type=secret,id=+secrets/user/earthly-technologies/aws/credentials,target=/root/.aws/credentials \
         aws s3 cp --recursive --acl public-read /repo s3://staging-pkg/rpm/stable
 
 build-and-release:

--- a/release/yum-repo/README.md
+++ b/release/yum-repo/README.md
@@ -29,7 +29,10 @@ Finally, install earthly:
 
 To package a new version of earthly, ensure the following requirements are met:
 
-1. you have aws credentials configured in `~/.aws/credentials`, and have access to the developer role
+1. you have aws credentials configured in the earthly secret store under `/user/earthly-technologies/aws/credentials`, and have access to the developer role
+
+    # you can upload them via
+    earthly secrets set --file ~/.aws/credentials /user/earthly-technologies/aws/credentials
 
 2. you have access to the earthly-technologies secrets; specifically the following two commands should work:
 
@@ -44,7 +47,7 @@ Once earthly has been released to github, visit https://github.com/earthly/earth
 
 Then run
 
-    earthly --secret-file aws-credentials=/home/alex/.aws/credentials --build-arg RELEASE_TAG +build-and-release
+    earthly --build-arg RELEASE_TAG --push +build-and-release
 
 ### Running steps independently
 
@@ -62,12 +65,12 @@ To package a specific platform
 
 #### Cloning the s3 repo to your local disk
 
-    earthly --secret-file aws-credentials=/home/alex/.aws/credentials +download
+    earthly +download
 
 #### Indexing and signing the repo
 
-    earthly --secret-file aws-credentials=/home/alex/.aws/credentials +index-and-sign
+    earthly +index-and-sign
 
 #### Uploading the repo to s3
 
-    earthly --secret-file aws-credentials=/home/alex/.aws/credentials +upload
+    earthly --push +upload

--- a/release/yum-repo/test/Earthfile
+++ b/release/yum-repo/test/Earthfile
@@ -8,9 +8,22 @@ test-fedora:
     RUN --no-cache dnf -y install earthly
     RUN --no-cache earthly --version
 
+test-centos:
+    ARG version=7
+    FROM centos:$version
+    RUN yum install -y yum-utils
+    RUN --no-cache yum-config-manager \
+        --add-repo \
+        https://pkg.earthly.dev/earthly.repo
+    RUN --no-cache yum -y install earthly
+    RUN --no-cache earthly --version
+
 test-all:
     BUILD \
         --build-arg version=34 \
         --build-arg version=33 \
         --build-arg version=32 \
         +test-fedora
+    BUILD \
+        --build-arg version=7 \
+        +test-centos


### PR DESCRIPTION
- expand the release process to release apt and yum repos.
- move the location to search for aws credentials to the user-namespace
of earthly secrets store.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>