### PR TITLE
Only save artifacts when they are directly referenced

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,9 @@ jobs:
       - name: Execute private image test (non fork only)
         run: ./build/linux/amd64/earthly --ci ./examples/tests+private-image-test
         if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+      - name: Execute save images test
+        run: ./examples/tests/save-images/test.sh
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
       - name: "Experimental tests (not a fork)"
         run: ./build/linux/amd64/earthly --ci -P ./examples/tests+experimental
         if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -159,6 +159,8 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 
 	sharedLocalStateCache := earthfile2llb.NewSharedLocalStateCache()
 
+	featureFlagOverrides := b.opt.FeatureFlagOverrides
+
 	destPathWhitelist := make(map[string]bool)
 	manifestLists := make(map[string][]manifest) // parent image -> child images
 	var mts *states.MultiTarget
@@ -191,9 +193,9 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 				Parallelism:          b.opt.Parallelism,
 				Console:              b.opt.Console,
 				GitLookup:            b.opt.GitLookup,
-				FeatureFlagOverrides: b.opt.FeatureFlagOverrides,
+				FeatureFlagOverrides: featureFlagOverrides,
 				LocalStateCache:      sharedLocalStateCache,
-			})
+			}, true)
 			if err != nil {
 				return nil, err
 			}
@@ -339,10 +341,10 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 					}
 				}
 			}
-			performSaveLocals := (!sts.Target.IsRemote() &&
-				!opt.NoOutput &&
+			performSaveLocals := (!opt.NoOutput &&
 				!opt.OnlyFinalTargetImages &&
 				opt.OnlyArtifact == nil)
+
 			if performSaveLocals {
 				for _, saveLocal := range b.targetPhaseArtifacts(sts) {
 					ref, err := b.artifactStateToRef(childCtx, gwClient, sts.SeparateArtifactsState[saveLocal.Index], sts.Platform)
@@ -499,7 +501,6 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 		dirIndex := 0
 		for _, sts := range mts.All() {
 			console := b.opt.Console.WithPrefixAndSalt(sts.Target.String(), sts.ID)
-
 			for _, saveImage := range sts.SaveImages {
 				shouldPush := opt.Push && saveImage.Push && !sts.Target.IsRemote() && saveImage.DockerTag != ""
 				shouldExport := !opt.NoOutput && saveImage.DockerTag != ""
@@ -516,46 +517,44 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 					console.Printf("Did not push %s. Use earthly --push to enable pushing\n", saveImage.DockerTag)
 				}
 			}
-			if !sts.Target.IsRemote() {
-				for _, saveLocal := range sts.SaveLocals {
-					artifactDir := filepath.Join(outDir, fmt.Sprintf("index-%d", dirIndex))
-					artifact := domain.Artifact{
-						Target:   sts.Target,
-						Artifact: saveLocal.ArtifactPath,
-					}
-					err := b.saveArtifactLocally(ctx, artifact, artifactDir, saveLocal.DestPath, sts.ID, opt, saveLocal.IfExists)
-					if err != nil {
-						return nil, err
-					}
-					dirIndex++
+			for _, saveLocal := range sts.SaveLocals {
+				artifactDir := filepath.Join(outDir, fmt.Sprintf("index-%d", dirIndex))
+				artifact := domain.Artifact{
+					Target:   sts.Target,
+					Artifact: saveLocal.ArtifactPath,
 				}
+				err := b.saveArtifactLocally(ctx, artifact, artifactDir, saveLocal.DestPath, sts.ID, opt, saveLocal.IfExists)
+				if err != nil {
+					return nil, err
+				}
+				dirIndex++
+			}
 
-				if sts.RunPush.HasState {
-					if opt.Push {
-						for _, saveLocal := range sts.RunPush.SaveLocals {
-							artifactDir := filepath.Join(outDir, fmt.Sprintf("index-%d", dirIndex))
-							artifact := domain.Artifact{
-								Target:   sts.Target,
-								Artifact: saveLocal.ArtifactPath,
-							}
-							err := b.saveArtifactLocally(ctx, artifact, artifactDir, saveLocal.DestPath, sts.ID, opt, saveLocal.IfExists)
-							if err != nil {
-								return nil, err
-							}
-							dirIndex++
+			if sts.RunPush.HasState {
+				if opt.Push {
+					for _, saveLocal := range sts.RunPush.SaveLocals {
+						artifactDir := filepath.Join(outDir, fmt.Sprintf("index-%d", dirIndex))
+						artifact := domain.Artifact{
+							Target:   sts.Target,
+							Artifact: saveLocal.ArtifactPath,
 						}
-					} else {
-						for _, commandStr := range sts.RunPush.CommandStrs {
-							console.Printf("Did not execute push command %s. Use earthly --push to enable pushing\n", commandStr)
+						err := b.saveArtifactLocally(ctx, artifact, artifactDir, saveLocal.DestPath, sts.ID, opt, saveLocal.IfExists)
+						if err != nil {
+							return nil, err
 						}
+						dirIndex++
+					}
+				} else {
+					for _, commandStr := range sts.RunPush.CommandStrs {
+						console.Printf("Did not execute push command %s. Use earthly --push to enable pushing\n", commandStr)
+					}
 
-						for _, saveImage := range sts.RunPush.SaveImages {
-							console.Printf("Did not push, OR save %s locally, as evaluating the image would have caused a RUN --push to execute", saveImage.DockerTag)
-						}
+					for _, saveImage := range sts.RunPush.SaveImages {
+						console.Printf("Did not push, OR save %s locally, as evaluating the image would have caused a RUN --push to execute", saveImage.DockerTag)
+					}
 
-						if sts.RunPush.InteractiveSession.Initialized {
-							console.Printf("Did not start an %s interactive session with command %s. Use earthly --push to start the session\n", sts.RunPush.InteractiveSession.Kind, sts.RunPush.InteractiveSession.CommandStr)
-						}
+					if sts.RunPush.InteractiveSession.Initialized {
+						console.Printf("Did not start an %s interactive session with command %s. Use earthly --push to start the session\n", sts.RunPush.InteractiveSession.Kind, sts.RunPush.InteractiveSession.CommandStr)
 					}
 				}
 			}

--- a/examples/tests/Earthfile
+++ b/examples/tests/Earthfile
@@ -60,6 +60,11 @@ ga:
     BUILD +file-copying
     BUILD +run-no-cache
     BUILD +save-artifact-after-push
+    BUILD +save-artifact-selective
+    BUILD +save-artifact-selective-legacy
+    BUILD +save-artifact-selective-referencing-remote
+    BUILD +save-remote-artifact-selective-legacy
+    BUILD +save-remote-artifact-selective
     BUILD +push-build
     BUILD +build-arg-repeat
     BUILD +if
@@ -76,6 +81,7 @@ ga:
     BUILD +cache-mount-arg
     BUILD +true-false-flag
     BUILD +true-false-flag-invalid
+    BUILD +dont-save-indirect-remote-artifact
 
 experimental:
     BUILD ./dind-auto-install+all
@@ -490,6 +496,119 @@ save-artifact-after-push:
     DO +RUN_EARTHLY --earthfile=save-artifact-after-push.earth --target=+copy-test \
         --post_command="2>&1 | perl -pe 'BEGIN {\\\$status=1} END {exit \\\$status} \\\$status=0 if /not found/;'"
 
+save-artifact-selective-test1:
+    DO +RUN_EARTHLY --earthfile=save-artifact-selective.earth --target=+test1
+    RUN test   -f a && \
+        test   -f b && \
+        test ! -f c && \
+        test ! -f d && \
+        test ! -f e
+
+save-artifact-selective-test2:
+    DO +RUN_EARTHLY --earthfile=save-artifact-selective.earth --target=+test2
+    RUN test ! -f a && \
+        test ! -f b && \
+        test   -f c && \
+        test ! -f d && \
+        test ! -f e
+
+save-artifact-selective-test3:
+    DO +RUN_EARTHLY --earthfile=save-artifact-selective.earth --target=+test3
+    RUN test ! -f a && \
+        test ! -f b && \
+        test ! -f c && \
+        test   -f d && \
+        test ! -f e
+
+save-artifact-selective-test4:
+    DO +RUN_EARTHLY --earthfile=save-artifact-selective.earth --target=+test4
+    RUN test ! -f a && \
+        test ! -f b && \
+        test ! -f c && \
+        test ! -f d && \
+        test   -f e
+
+save-artifact-selective-test5:
+    DO +RUN_EARTHLY --earthfile=save-artifact-selective.earth --target=+test5
+    RUN test ! -f a && \
+        test ! -f b && \
+        test ! -f c && \
+        test ! -f d && \
+        test ! -f e && \
+        test ! -f test5sub && \
+        test   -f test5
+
+save-artifact-selective:
+    # test that the `--referenced-save-only` feature only saves referenced artifacts
+    BUILD +save-artifact-selective-test1
+    BUILD +save-artifact-selective-test2
+    BUILD +save-artifact-selective-test3
+    BUILD +save-artifact-selective-test4
+    BUILD +save-artifact-selective-test5
+
+save-artifact-selective-legacy:
+    RUN env | grep EARTHLY
+    DO +RUN_EARTHLY --earthfile=save-artifact-legacy.earth --target=+all
+    RUN test ! -f a && \
+        test   -f b && \
+        test   -f c && \
+        test   -f d && \
+        test   -f e && \
+        test   -f f && \
+        test ! -d output && \
+        test ! -f output/testfile && \    # THIS FAILED
+        test ! -f testfile
+
+save-artifact-selective-referencing-remote-test1:
+    DO +RUN_EARTHLY --earthfile=save-artifact-selective-remote.earth --target=+test1
+    RUN test   -f a && \
+        test ! -f b && \
+        test ! -f c && \
+        test ! -d output && \
+        test ! -f output/testfile && \
+        test ! -f testfile
+
+save-artifact-selective-referencing-remote-test2:
+    DO +RUN_EARTHLY --earthfile=save-artifact-selective-remote.earth --target=+test2
+    RUN test ! -f a && \
+        test   -f b && \
+        test ! -f c && \
+        test ! -d output && \
+        test ! -f output/testfile && \
+        test ! -f testfile
+
+save-artifact-selective-referencing-remote-test3:
+    DO +RUN_EARTHLY --earthfile=save-artifact-selective-remote.earth --target=+test3
+    RUN test ! -f a && \
+        test ! -f b && \
+        test   -f c && \
+        test   -d output && \
+        test   -f output/testfile && \
+        test ! -f testfile
+
+save-artifact-selective-referencing-remote:
+    BUILD +save-artifact-selective-referencing-remote-test1
+    BUILD +save-artifact-selective-referencing-remote-test2
+    BUILD +save-artifact-selective-referencing-remote-test3
+
+save-remote-artifact-selective-legacy:
+    DO +RUN_EARTHLY --target=github.com/earthly/test-remote/output/no-version:main+savelocal
+    # if it were to be saved, it should show up under output/testfile; but we're going to check for
+    # a) no output directory (which also means output/testfile doesn't exist), and
+    # b) that ./testfile wasn't accidentally created.
+    RUN test ! -d output && \
+        test ! -f testfile
+
+save-remote-artifact-selective:
+    DO +RUN_EARTHLY --target=github.com/earthly/test-remote/output/versioned:main+savelocal
+    RUN test -f ./output/testfile
+
+dont-save-indirect-remote-artifact:
+    DO +RUN_EARTHLY --target=github.com/earthly/test-remote/output/no-version:main+copy-from-savelocal
+    RUN test ! -f ./output/testfile
+    DO +RUN_EARTHLY --target=github.com/earthly/test-remote/output/versioned:main+copy-from-savelocal
+    RUN test ! -f ./output/testfile
+
 push-build:
     DO +RUN_EARTHLY --earthfile=push-build.earth --target=+test --extra_args="--push" --post_command="> output 2>&1"
     RUN cat output
@@ -606,7 +725,9 @@ RUN_EARTHLY:
     ARG post_command
     ARG should_fail=false
     ARG use_tmpfs=true
-    COPY "$earthfile" "$earthfile_dest"
+    IF [ ! -z "$earthfile" ]
+        COPY "$earthfile" "$earthfile_dest"
+    END
     RUN echo "
         set -x
         if $use_tmpfs; then

--- a/examples/tests/save-artifact-legacy.earth
+++ b/examples/tests/save-artifact-legacy.earth
@@ -1,0 +1,50 @@
+VERSION 0.5 # this should save all direct AND indirect artifacts
+
+# first test: savea is never referenced anywhere
+# and should never be executed (or produce file a)
+savea:
+    FROM alpine:latest
+    RUN echo apple > a
+    SAVE ARTIFACT a AS LOCAL a
+
+# second test: saveb is triggered by
+# a BUILD in savec, and savec is inherrited by
+# saved. when +saved is run, we should
+# produce files b, c, and d.
+
+saveb:
+    FROM alpine:latest
+    RUN echo bannana > b
+    SAVE ARTIFACT b AS LOCAL b
+
+savec:
+    BUILD +saveb
+    FROM alpine:latest
+    RUN echo cherry > c
+    SAVE ARTIFACT c AS LOCAL c
+
+saved:
+    FROM +savec
+    RUN echo durian > d
+    SAVE ARTIFACT d AS LOCAL d
+
+# third test: github.com/earthly/test-remote/output+savelocal
+# will save a file under ./output/testfile; this should NOT be saved
+# when referenced by savee.
+savee:
+    FROM github.com/earthly/test-remote/output/no-version:main+savelocal
+    RUN echo elderberry > e
+    SAVE ARTIFACT e AS LOCAL e
+
+# fourth test: github.com/earthly/test-remote/output+copy-from-savelocal
+# references github.com/earthly/test-remote/output+savelocal via a COPY
+# this also should not produce the ./output/testfile
+savef:
+    FROM github.com/earthly/test-remote/output/no-version:main+copy-from-savelocal
+    RUN echo fig > f
+    SAVE ARTIFACT f AS LOCAL f
+
+all:
+    BUILD +saved
+    BUILD +savee
+    BUILD +savef

--- a/examples/tests/save-artifact-selective-remote.earth
+++ b/examples/tests/save-artifact-selective-remote.earth
@@ -1,0 +1,32 @@
+VERSION --referenced-save-only 0.5
+
+savea:
+    FROM github.com/earthly/test-remote/output/versioned:main+savelocal
+    RUN echo apple > a
+    SAVE ARTIFACT a AS LOCAL a
+
+saveb:
+    FROM alpine:3.13
+    COPY github.com/earthly/test-remote/output/versioned:main+savelocal/data .
+    RUN echo bannan > b
+    SAVE ARTIFACT b AS LOCAL b
+
+savec:
+    FROM alpine:3.13
+    BUILD github.com/earthly/test-remote/output/versioned:main+savelocal
+    RUN echo cherry > c
+    SAVE ARTIFACT c AS LOCAL c
+
+test1:
+    BUILD +savea
+
+test2:
+    BUILD +saveb
+
+test3:
+    BUILD +savec
+
+all:
+    BUILD +test1
+    BUILD +test2
+    BUILD +test3

--- a/examples/tests/save-artifact-selective.earth
+++ b/examples/tests/save-artifact-selective.earth
@@ -1,0 +1,64 @@
+VERSION --referenced-save-only 0.5
+
+savea:
+    FROM alpine:3.13
+    RUN echo apple > a
+    SAVE ARTIFACT a AS LOCAL a
+
+saveb:
+    FROM alpine:3.13
+    RUN echo bannana > b
+    SAVE ARTIFACT b AS LOCAL b
+
+savec:
+    FROM alpine:3.13
+    RUN echo cherry > c
+    SAVE ARTIFACT c AS LOCAL c
+
+saved:
+    FROM +savec
+    RUN echo durian > d
+    SAVE ARTIFACT d AS LOCAL d
+
+savee:
+    FROM +saved
+    RUN echo elderberry > e
+    SAVE ARTIFACT e AS LOCAL e
+
+test1:
+    BUILD +savea
+    BUILD +saveb
+
+test2:
+    BUILD +savec
+
+test3:
+    BUILD +saved
+
+test4sub:
+    BUILD +savee
+
+test4:
+    BUILD +test4sub
+
+test5sub:
+    FROM alpine:3.13
+    DO +SAVE_CMD --name test5sub
+
+test5:
+    FROM alpine:3.13
+    COPY +test5sub/data .
+    DO +SAVE_CMD --name test5
+
+SAVE_CMD:
+    COMMAND
+    ARG name
+    RUN echo $name > data
+    SAVE ARTIFACT data AS LOCAL "$name"
+
+all:
+    BUILD +test1
+    BUILD +test2
+    BUILD +test3
+    BUILD +test4
+    BUILD +test5

--- a/examples/tests/save-images/new-behaviour-remote/Earthfile
+++ b/examples/tests/save-images/new-behaviour-remote/Earthfile
@@ -1,0 +1,17 @@
+VERSION  --referenced-save-only 0.5
+FROM alpine:3.13
+
+myimage-fromtest:
+    FROM github.com/earthly/test-remote/save-image:main+saveimage
+    RUN echo "a639c7fe-9981-4a14-baa0-319c6b0ee49b" > myimage
+    SAVE IMAGE myimage:fromtest
+
+myimage-copytest:
+    COPY github.com/earthly/test-remote/save-image-with-artifact:main+saveimageandartifact/saveimageandartifact-data .
+    RUN echo "740d027d-06f6-4dc8-a659-2cfa6e782edd" > myimage
+    SAVE IMAGE myimage:copytest
+
+myimage-buildtest:
+    BUILD github.com/earthly/test-remote/save-image:main+saveimage
+    RUN echo "0a59f9f3-8dc9-461b-971d-16800ba4884f" > myimage
+    SAVE IMAGE myimage:buildtest

--- a/examples/tests/save-images/new-behaviour/Earthfile
+++ b/examples/tests/save-images/new-behaviour/Earthfile
@@ -1,0 +1,12 @@
+VERSION  --referenced-save-only 0.5
+FROM alpine:3.13
+
+mysubimage:
+    WORKDIR /data
+    RUN echo mysubimage > mysubimage
+    SAVE IMAGE mysubimage:test
+
+myimage:
+    FROM +mysubimage
+    RUN echo myimage > myimage
+    SAVE IMAGE myimage:test

--- a/examples/tests/save-images/old-behaviour-build/Earthfile
+++ b/examples/tests/save-images/old-behaviour-build/Earthfile
@@ -1,0 +1,11 @@
+FROM alpine:3.13
+
+mysubimage:
+    WORKDIR /data
+    RUN echo f0b94bbc-0451-4edb-b141-8829bfda076d > mysubimage
+    SAVE IMAGE mysubimage:buildtest
+
+myimage:
+    FROM +mysubimage
+    RUN echo 4a62afce-daf7-489b-918e-fdf08f95c8f6 > myimage
+    SAVE IMAGE myimage:buildtest

--- a/examples/tests/save-images/old-behaviour-copy/Earthfile
+++ b/examples/tests/save-images/old-behaviour-copy/Earthfile
@@ -1,0 +1,12 @@
+FROM alpine:3.13
+
+mysubimage:
+    WORKDIR /data
+    RUN echo 88b383e9-4222-4a82-b767-79229a35aa21 > mysubimage-data
+    SAVE ARTIFACT mysubimage-data
+    SAVE IMAGE mysubimage:copytest
+
+myimage:
+    COPY +mysubimage/mysubimage-data .
+    RUN echo b3a2dfc1-e4fb-4904-bfb0-15bdce9fe2db > myimage
+    SAVE IMAGE myimage:copytest

--- a/examples/tests/save-images/old-behaviour-from/Earthfile
+++ b/examples/tests/save-images/old-behaviour-from/Earthfile
@@ -1,0 +1,11 @@
+FROM alpine:3.13
+
+mysubimage:
+    WORKDIR /data
+    RUN echo a532d715-bd5a-448a-917f-b5ec4996b22c > mysubimage
+    SAVE IMAGE mysubimage:fromtest
+
+myimage:
+    FROM +mysubimage
+    RUN echo 1222dca7-f95d-4854-89c5-d4762e372c59 > myimage
+    SAVE IMAGE myimage:fromtest

--- a/examples/tests/save-images/old-behaviour-remote/Earthfile
+++ b/examples/tests/save-images/old-behaviour-remote/Earthfile
@@ -1,0 +1,17 @@
+FROM alpine:3.13
+
+myimage-fromtest:
+    FROM github.com/earthly/test-remote/save-image:main+saveimage
+    RUN echo "358718f8-ff97-45b0-8670-3edd69b335ba" > myimage
+    SAVE IMAGE myimage:old-remote-from-test
+
+myimage-copytest:
+    COPY github.com/earthly/test-remote/save-image-with-artifact:main+saveimageandartifact/saveimageandartifact-data .
+    RUN test "$(cat saveimageandartifact-data)" = "a119f6a9-9749-4035-8647-48d48bb6a361"
+    RUN echo "3debd2b7-bc2c-4167-9e05-c6d628e8a13a" > myimage
+    SAVE IMAGE myimage:old-remote-copy-test
+
+myimage-buildtest:
+    BUILD github.com/earthly/test-remote/save-image:main+saveimage
+    RUN echo "dfb4215f-989e-41d1-84b8-3080e84783d3" > myimage
+    SAVE IMAGE myimage:old-remote-build-test

--- a/examples/tests/save-images/test.sh
+++ b/examples/tests/save-images/test.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -uex
+set -o pipefail
+
+cd "$(dirname "$0")"
+
+earthly=${earthly-"../../../build/linux/amd64/earthly"}
+"$earthly" --version
+
+echo "=== ($LINENO): Test Old Copy Behaviour ==="
+
+docker rmi -f myimage:copytest
+docker rmi -f mysubimage:copytest
+"$earthly" ./old-behaviour-copy+myimage
+echo done
+docker inspect myimage:copytest >/dev/null
+docker inspect mysubimage:copytest >/dev/null
+
+echo "=== ($LINENO): Test Old build Behaviour ==="
+docker rmi -f myimage:buildtest
+docker rmi -f mysubimage:buildtest
+"$earthly" ./old-behaviour-build+myimage
+docker inspect myimage:buildtest >/dev/null
+docker inspect mysubimage:buildtest >/dev/null
+
+echo "=== ($LINENO): Test Old from Behaviour ==="
+docker rmi -f myimage:fromtest
+docker rmi -f mysubimage:fromtest
+"$earthly" ./old-behaviour-from+myimage
+docker inspect myimage:fromtest >/dev/null
+docker inspect mysubimage:fromtest >/dev/null
+
+echo "=== ($LINENO): Test Old Behaviour with remote target referenced by from ==="
+docker rmi -f myimage:old-remote-from-test
+docker rmi -f earthly-test-saveimage:test
+"$earthly" ./old-behaviour-remote+myimage-fromtest
+docker inspect myimage:old-remote-from-test >/dev/null
+docker inspect earthly-test-saveimage:test >/dev/null
+
+echo "=== ($LINENO): Test Old Behaviour with remote target referenced by build ==="
+docker rmi -f myimage:old-remote-build-test
+docker rmi -f earthly-test-saveimage:test
+"$earthly" ./old-behaviour-remote+myimage-buildtest
+docker inspect myimage:old-remote-build-test >/dev/null
+docker inspect earthly-test-saveimage:test >/dev/null
+
+echo "=== ($LINENO): Test Old Behaviour with remote target referenced by copy ==="
+docker rmi -f myimage:old-remote-copy-test
+docker rmi -f earthly-test-saveimage-and-artifact:test
+"$earthly" ./old-behaviour-remote+myimage-copytest
+docker inspect myimage:old-remote-copy-test >/dev/null
+docker inspect earthly-test-saveimage-and-artifact:test >/dev/null
+
+echo "=== ($LINENO): Test Old Behaviour on directly referenced remote target ==="
+docker rmi -f earthly-test-saveimage:test
+"$earthly" github.com/earthly/test-remote/save-image:main+saveimage
+docker inspect earthly-test-saveimage:test >/dev/null
+
+
+echo "=== ($LINENO): Test New Behaviour ==="
+
+docker rmi -f myimage:test
+docker rmi -f mysubimage:test
+docker rmi -f earthly-test-saveimage:test
+"$earthly" ./new-behaviour+myimage
+
+docker inspect myimage:test >/dev/null
+
+if docker inspect mysubimage:latest; then
+	echo "ERROR ($LINENO): mysubimage should not have been saved1."
+    exit 1
+fi
+
+echo "=== ($LINENO): Test New Behaviour referencing remote via from ==="
+
+docker rmi -f myimage:fromtest
+docker rmi -f earthly-test-saveimage:test
+
+"$earthly" -V ./new-behaviour-remote+myimage-fromtest
+docker inspect myimage:fromtest >/dev/null
+if docker inspect earthly-test-saveimage:test >/dev/null; then
+    echo "ERROR ($LINENO): earthly-test-saveimage:test should not have been saved."   # THIS IS LEGIT BROKEN
+    exit 1
+fi
+
+echo "=== ($LINENO): Test New Behaviour referencing remote via copy ==="
+
+docker rmi -f myimage:copytest
+docker rmi -f earthly-test-saveimage:test
+
+"$earthly" ./new-behaviour-remote+myimage-copytest
+docker inspect myimage:copytest >/dev/null
+if docker inspect earthly-test-saveimage:test >/dev/null; then
+	echo "ERROR ($LINENO) : earthly-test-saveimage:test should not have been save3."
+    exit 1
+fi
+
+echo "=== ($LINENO): Test New Behaviour referencing remote via build ==="
+
+docker rmi -f myimage:buildtest
+docker rmi -f earthly-test-saveimage:test
+
+"$earthly" ./new-behaviour-remote+myimage-buildtest
+docker inspect myimage:buildtest >/dev/null
+docker inspect earthly-test-saveimage:test >/dev/null
+
+echo "save-images test passed"


### PR DESCRIPTION
Re https://github.com/earthly/earthly/issues/896

Artifacts will only be saved locally when their target is directly
referenced, or referenced by a BUILD.

This will cause targets that are referenced from a FROM, or COPY from
*not* saving artifacts as a side-effect.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>