### PR TITLE
One-time section, include docs update.

### DIFF
--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -1381,6 +1381,8 @@ func (app *earthlyApp) actionBootstrap(c *cli.Context) error {
 			}
 			fmt.Print(compEntry)
 			return nil
+		case "":
+			break
 		default:
 			return errors.Errorf("unhandled source %q", app.homebrewSource)
 		}

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -1359,34 +1359,35 @@ func symlinkEarthlyToEarth() error {
 
 func (app *earthlyApp) actionBootstrap(c *cli.Context) error {
 	app.commandName = "bootstrap"
+	defer cliutil.EnsurePermissions()
 
 	var err error
 	console := app.console.WithPrefix("bootstrap")
 
-	if app.bootstrapWithAutocomplete || app.homebrewSource != "" {
-		switch app.homebrewSource {
-		case "bash":
-			compEntry, err := bashCompleteEntry()
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Warning: failed to enable bash-completion: %s\n", err)
-				return nil // zsh-completion isn't available, silently fail.
-			}
-			fmt.Print(compEntry)
-			return nil
-		case "zsh":
-			compEntry, err := zshCompleteEntry()
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Warning: failed to bootstrap zsh-completion: %s\n", err)
-				return nil // zsh-completion isn't available, silently fail.
-			}
-			fmt.Print(compEntry)
-			return nil
-		case "":
-			break
-		default:
-			return errors.Errorf("unhandled source %q", app.homebrewSource)
+	switch app.homebrewSource {
+	case "bash":
+		compEntry, err := bashCompleteEntry()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to enable bash-completion: %s\n", err)
+			return nil // zsh-completion isn't available, silently fail.
 		}
+		fmt.Print(compEntry)
+		return nil
+	case "zsh":
+		compEntry, err := zshCompleteEntry()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to bootstrap zsh-completion: %s\n", err)
+			return nil // zsh-completion isn't available, silently fail.
+		}
+		fmt.Print(compEntry)
+		return nil
+	case "":
+		break
+	default:
+		return errors.Errorf("unhandled source %q", app.homebrewSource)
+	}
 
+	if app.bootstrapWithAutocomplete {
 		// Because this requires sudo, it should warn and not fail the rest of it.
 		err = app.insertBashCompleteEntry()
 		if err != nil {
@@ -1415,11 +1416,6 @@ func (app *earthlyApp) actionBootstrap(c *cli.Context) error {
 			return errors.Wrap(err, "bootstrap new buildkitd client")
 		}
 		defer bkClient.Close()
-	}
-
-	err = cliutil.EnsurePermissions()
-	if err != nil {
-		return errors.Wrap(err, "configure earthly directory permissions")
 	}
 
 	console.Printf("Bootstrapping successful.\n")

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -1363,7 +1363,7 @@ func (app *earthlyApp) actionBootstrap(c *cli.Context) error {
 	var err error
 	console := app.console.WithPrefix("bootstrap")
 
-	if app.bootstrapWithAutocomplete {
+	if app.bootstrapWithAutocomplete || app.homebrewSource != "" {
 		switch app.homebrewSource {
 		case "bash":
 			compEntry, err := bashCompleteEntry()
@@ -1381,8 +1381,6 @@ func (app *earthlyApp) actionBootstrap(c *cli.Context) error {
 			}
 			fmt.Print(compEntry)
 			return nil
-		case "":
-			break
 		default:
 			return errors.Errorf("unhandled source %q", app.homebrewSource)
 		}

--- a/examples/tests/bootstrap/test-bootstrap.sh
+++ b/examples/tests/bootstrap/test-bootstrap.sh
@@ -142,17 +142,45 @@ echo "=== Test 6: Homebrew Source ==="
 
 bash=$("$earthly" bootstrap --source bash)
 if [[ "$bash" != *"complete -o nospace"* ]]; then
-  echo "bash autocompletion appeared to be incorrect."
+  echo "bash autocompletion appeared to be incorrect"
   echo "$bash"
   exit 1
 fi
 
 zsh=$("$earthly" bootstrap --source zsh)
 if [[ "$zsh" != *"complete -o nospace"* ]]; then
-  echo "zsh autocompletion appeared to be incorrect."
+  echo "zsh autocompletion appeared to be incorrect"
   echo "$zsh"
   exit 1
 fi
 
+if docker container ls | grep earthly-buildkitd; then
+  echo "--source created a docker container"
+  exit 1
+fi
+
+if [[ -f ../../../build/linux/amd64/earth ]]; then
+  echo "--source symlinked earthly to earth"
+fi
+
+if ! DOCKER_HOST="docker is missing" "$earthly" bootstrap --source zsh > /dev/null 2>&1; then
+  echo "--source failed when docker was missing"
+  exit 1
+fi
+
+rm -rf "$HOME/.earthly/"
+
+echo "=== Test 7: No Buildkit ==="
+
+"$earthly" bootstrap --no-buildkit
+if docker container ls | grep earthly-buildkitd; then
+  echo "--no-buildkit created a docker container"
+  exit 1
+fi
+
+if ! DOCKER_HOST="docker is missing" "$earthly" bootstrap --no-buildkit; then
+  echo "--no-buildkit fails when docker is missing"
+  exit 1
+fi
 
 rm -rf "$HOME/.earthly/"

--- a/examples/tests/bootstrap/test-bootstrap.sh
+++ b/examples/tests/bootstrap/test-bootstrap.sh
@@ -137,3 +137,22 @@ if [[ $(stat --format '%G' "$HOME/.earthly/config.yml") != "$GRP" ]]; then
   stat "$HOME/.earthly/config.yml"
   exit 1
 fi
+
+echo "=== Test 6: Homebrew Source ==="
+
+bash=$("$earthly" bootstrap --source bash)
+if [[ "$bash" != *"complete -o nospace"* ]]; then
+  echo "bash autocompletion appeared to be incorrect."
+  echo "$bash"
+  exit 1
+fi
+
+zsh=$("$earthly" bootstrap --source zsh)
+if [[ "$zsh" != *"complete -o nospace"* ]]; then
+  echo "zsh autocompletion appeared to be incorrect."
+  echo "$zsh"
+  exit 1
+fi
+
+
+rm -rf "$HOME/.earthly/"

--- a/examples/tests/bootstrap/test-bootstrap.sh
+++ b/examples/tests/bootstrap/test-bootstrap.sh
@@ -140,6 +140,10 @@ fi
 
 echo "=== Test 6: Homebrew Source ==="
 
+if which docker > /dev/null; then
+  docker rm -f earthly-buildkitd
+fi
+
 bash=$("$earthly" bootstrap --source bash)
 if [[ "$bash" != *"complete -o nospace"* ]]; then
   echo "bash autocompletion appeared to be incorrect"

--- a/release/README.md
+++ b/release/README.md
@@ -59,6 +59,7 @@
 ### One-Time (clear this section when done during release)
 
 * Update the website with the documentation for bootstrap, include `--with-autocomplete` as part of the installation.
+  * On macOS, remove `sudo`; the `--with-autocomplete` will be handled by `brew`'s installation.
 
 #### Troubleshooting
 

--- a/release/README.md
+++ b/release/README.md
@@ -56,6 +56,10 @@
 * Copy the release notes you have written before and paste them in the Earthly Community slack channel `#announcements`, together with a link to the release's GitHub page. If you have Slack markdown editing activated, you can copy the markdown version of the text.
 * Ask Adam to tweet about the release.
 
+### One-Time (clear this section when done during release)
+
+* Update the website with the documentation for bootstrap, include `--with-autocomplete` as part of the installation.
+
 #### Troubleshooting
 
 If the release-homebrew fails with a rejected git push, you may have to delete the remote branch by running the following under the interactive debugger:


### PR DESCRIPTION
Add a section to hold all the one-time release items I am generating, and include a one-time item for updating `bootstrap` invocations on the website.