### PR TITLE
Fix cache mount depending on inactive args

### DIFF
--- a/examples/tests/Earthfile
+++ b/examples/tests/Earthfile
@@ -70,6 +70,7 @@ ga:
     BUILD +import
     BUILD +infinite-recursion
     BUILD +from-dockerfile-arg
+    BUILD +cache-mount-arg
 
 experimental:
     BUILD ./dind-auto-install+all
@@ -503,6 +504,23 @@ from-dockerfile-arg:
     RUN test "$(cat ./arg-value-default)" = "default"
     RUN test "$(cat ./arg-value-foo)" = "foo"
     RUN test "$(cat ./arg-value-bar)" = "bar"
+
+cache-mount-arg:
+    DO +RUN_EARTHLY --earthfile=cache-mount-arg.earth --use_tmpfs=false --target="+b-nomount --MYARG=123"
+    DO +RUN_EARTHLY --earthfile=cache-mount-arg.earth --use_tmpfs=false --target="+b-nomount --MYARG=1234" --post_command="2>output-nomount.txt"
+    RUN cat output-nomount.txt
+    RUN cat output-nomount.txt | grep '\*cached\* --> RUN echo Doing something 1'
+    RUN cat output-nomount.txt | grep '\*cached\* --> RUN echo Doing something 2'; test "$?" != 0
+    DO +RUN_EARTHLY --earthfile=cache-mount-arg.earth --use_tmpfs=false --target="+b --MYARG=abc"
+    DO +RUN_EARTHLY --earthfile=cache-mount-arg.earth --use_tmpfs=false --target="+b --MYARG=abcd" --post_command="2>output.txt"
+    RUN cat output.txt
+    RUN cat output.txt | grep '\*cached\* --> RUN echo Doing something 1'
+    RUN cat output.txt | grep '\*cached\* --> RUN echo Doing something 2'; test "$?" != 0
+    DO +RUN_EARTHLY --earthfile=cache-mount-arg.earth --use_tmpfs=false --target="+b-with-arg --MYARG=def"
+    DO +RUN_EARTHLY --earthfile=cache-mount-arg.earth --use_tmpfs=false --target="+b-with-arg --MYARG=defg" --post_command="2>output.txt"
+    RUN cat output.txt
+    RUN cat output.txt | grep '\*cached\* --> RUN echo Doing something 1'; test "$?" != 0
+    RUN cat output.txt | grep '\*cached\* --> RUN echo Doing something 2'; test "$?" != 0
 
 RUN_EARTHLY:
     COMMAND

--- a/examples/tests/cache-mount-arg.earth
+++ b/examples/tests/cache-mount-arg.earth
@@ -1,0 +1,27 @@
+a-nomount:
+    FROM alpine:3.13
+    RUN echo Doing something 1
+
+b-nomount:
+    FROM +a-nomount
+    ARG MYARG
+    RUN echo Doing something 2
+
+a:
+    FROM alpine:3.13
+    RUN --mount=type=cache,target=/cache echo Doing something 1
+
+b:
+    FROM +a
+    ARG MYARG
+    RUN echo Doing something 2
+
+a-with-arg:
+    FROM alpine:3.13
+    ARG MYARG
+    RUN --mount=type=cache,target=/cache echo Doing something 1
+
+b-with-arg:
+    FROM +a-with-arg
+    ARG MYARG
+    RUN echo Doing something 2

--- a/states/dedup/targetinput.go
+++ b/states/dedup/targetinput.go
@@ -36,6 +36,19 @@ func (ti TargetInput) WithBuildArgInput(bai BuildArgInput) TargetInput {
 	return tiClone
 }
 
+// WithFilterBuildArgs returns a clone of the current target input, with filtered
+// build args, based on an include-list of names.
+func (ti TargetInput) WithFilterBuildArgs(buildArgNames map[string]bool) TargetInput {
+	tiClone := ti.clone()
+	tiClone.BuildArgs = make([]BuildArgInput, 0, len(buildArgNames))
+	for _, bai := range ti.BuildArgs {
+		if buildArgNames[bai.Name] {
+			tiClone.BuildArgs = append(tiClone.BuildArgs, bai)
+		}
+	}
+	return tiClone
+}
+
 // Equals compares to another TargetInput for equality.
 func (ti TargetInput) Equals(other TargetInput) bool {
 	if ti.TargetCanonical != other.TargetCanonical {


### PR DESCRIPTION
* Cache mount ID now depends on a target input hash which does not include inactive variables
* Cache mount base image is now simply scratch (previously it was an empty host dir, but this seems unnecessary now)

Fixes https://github.com/earthly/earthly/issues/996