### PR TITLE
Try using direct aarch64 shellcheck download?

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -48,8 +48,20 @@ update-buildkit:
 
 
 lint-scripts-base:
-    FROM --platform=linux/amd64 alpine:3.13
-    RUN apk add --update --no-cache shellcheck
+    FROM alpine:3.13
+
+    ARG TARGETARCH
+
+    IF [ $TARGETARCH == "arm64" ]
+        RUN echo "Downloading, and manually installing shellcheck for ARM" && \
+            wget https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.aarch64.tar.xz && \
+            tar -xf shellcheck-stable.linux.aarch64.tar.xz && \
+            mv shellcheck-stable/shellcheck /usr/bin/shellcheck
+    ELSE
+        RUN echo "Installing shellcheck from Alpine repos" && \
+            apk add --update --no-cache shellcheck
+    END
+
     WORKDIR /shell_scripts
 
 lint-scripts-misc:

--- a/scripts/tests/auth/test-self-hosted.sh
+++ b/scripts/tests/auth/test-self-hosted.sh
@@ -110,10 +110,10 @@ rm -rf odd-project
 # test that earthly has access to it
 "$earthly" config git "{myserver: {pattern: 'myserver/([^/]+)', substitute: 'ssh://root@$ip:2222/root/my/really/weird/path/\$1.git', auth: ssh}}"
 
-echo === Test remote build under repo root ===
+echo "=== Test remote build under repo root ==="
 $earthly -V myserver/project:trunk+docker
 
-echo === Test remote build under repo subdir ===
+echo "=== Test remote build under repo subdir ==="
 $earthly -V myserver/project/weirdcommands:trunk+target
 
 # test that the container was built and runs
@@ -132,5 +132,5 @@ testweirdtouch:
   RUN ls weird-foo
 EOF
 
-echo === Test local build referencing remote commands ===
+echo "=== Test local build referencing remote commands ==="
 $earthly -V +testweirdtouch

--- a/scripts/tests/secrets-integration.sh
+++ b/scripts/tests/secrets-integration.sh
@@ -51,13 +51,13 @@ EOF
 "$earthly" secrets set /user/earthly_integration_tests/my_test_file "secret-value"
 "$earthly" secrets get /user/earthly_integration_tests/my_test_file | perl -pe 'BEGIN {$status=1} END {exit $status} $status=0 if /secret-value/;'
 
-echo === test 1 ===
+echo "=== test 1 ==="
 # test RUN --mount can reference a secret from the command line
 "$earthly" --no-cache --secret my_secret=secret-value /tmp/earthtest+test-local-secret
 
-echo === test 2 ===
+echo "=== test 2 ==="
 # test RUN --mount can reference a secret from the server that is only specified in the Earthfile
 "$earthly" --no-cache /tmp/earthtest+test-server-secret
 
-echo === All tests have passed ===
+echo "=== All tests have passed ==="
 


### PR DESCRIPTION
Th M1 continues to fail in CI when it comes to Shellcheck. This should enable Shellcheck natively on the M1, eliminating the emulation layer as a source of problems.

This is finding some lint issues, but appears to make it further more consistently than before.