### PR TITLE
Fix VERSION parser handling of comments

### DIFF
--- a/ast/version.go
+++ b/ast/version.go
@@ -72,6 +72,7 @@ outer:
 			}
 
 			if strings.HasPrefix(f, "#") {
+				foundComment = true
 				continue
 			}
 

--- a/examples/tests/version/Earthfile
+++ b/examples/tests/version/Earthfile
@@ -9,6 +9,9 @@ test-single-line:
 test-single-line-with-args:
     DO tests+RUN_EARTHLY --earthfile=single-line-with-args.earth --target=+test
 
+test-single-line-with-comment:
+    DO tests+RUN_EARTHLY --earthfile=single-line-with-comment.earth --target=+test
+
 test-multi-line:
     DO tests+RUN_EARTHLY --earthfile=multi-line.earth --target=+test
 
@@ -51,6 +54,7 @@ test-whitespace-then-version:
 test-all:
     BUILD +test-single-line
     BUILD +test-single-line-with-args
+    BUILD +test-single-line-with-comment
     BUILD +test-multi-line
     BUILD +test-multi-line-with-comment
     BUILD +test-multi-line-with-comment2

--- a/examples/tests/version/single-line-with-comment.earth
+++ b/examples/tests/version/single-line-with-comment.earth
@@ -1,0 +1,5 @@
+VERSION 0.5 # make sure a comment here works
+
+FROM alpine:3.13
+test:
+    RUN echo "pass"


### PR DESCRIPTION
fixes handling of comments directly after a VERSION without any line
continuations.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>