### PR TITLE
Add a variant for the Earthly target project without the tag

### DIFF
--- a/examples/tests/Earthfile
+++ b/examples/tests/Earthfile
@@ -165,6 +165,10 @@ remote-test:
         --mount=type=tmpfs,target=/tmp/earthly \
         -- --no-output github.com/earthly/test-privileged:main+locally && \
         ls /tmp/hostname.3d4b1831-c07e-4b2d-805e-2b8ce578bb50
+    RUN --privileged \
+        --entrypoint \
+        --mount=type=tmpfs,target=/tmp/earthly \
+        -- --no-output github.com/earthly/test-builtin-args/subdir:main+test
 
 transitive-args-test:
     DO +RUN_EARTHLY --earthfile=transitive-args.earth --extra_args="--build-arg SOMEARG=xyz" --target=+test

--- a/states/dedup/targetinput.go
+++ b/states/dedup/targetinput.go
@@ -144,6 +144,7 @@ type BuildArgInput struct {
 var BuiltinVariables = map[string]bool{
 	"EARTHLY_TARGET":                  true,
 	"EARTHLY_TARGET_PROJECT":          true,
+	"EARTHLY_TARGET_PROJECT_NO_TAG":   true,
 	"EARTHLY_TARGET_NAME":             true,
 	"EARTHLY_TARGET_TAG":              true,
 	"EARTHLY_TARGET_TAG_DOCKER":       true,

--- a/variables/builtin.go
+++ b/variables/builtin.go
@@ -18,6 +18,9 @@ func BuiltinArgs(target domain.Target, platform specs.Platform, gitMeta *gitutil
 	ret := NewScope()
 	ret.AddInactive("EARTHLY_TARGET", target.StringCanonical())
 	ret.AddInactive("EARTHLY_TARGET_PROJECT", target.ProjectCanonical())
+	targetNoTag := target
+	targetNoTag.Tag = ""
+	ret.AddInactive("EARTHLY_TARGET_PROJECT_NO_TAG", targetNoTag.ProjectCanonical())
 	ret.AddInactive("EARTHLY_TARGET_NAME", target.Target)
 	ret.AddInactive("EARTHLY_TARGET_TAG", target.Tag)
 	ret.AddInactive("EARTHLY_TARGET_TAG_DOCKER", llbutil.DockerTagSafe(target.Tag))

--- a/variables/builtin_test.go
+++ b/variables/builtin_test.go
@@ -20,6 +20,15 @@ func TestGetProjectName(t *testing.T) {
 		{"git@bitbucket.com:earthly/earthly", "earthly/earthly"},
 		{"ssh://git@github.com/earthly/earthly", "earthly/earthly"},
 		{"ssh://git@github.com:22/earthly/earthly", "earthly/earthly"},
+		{"http://github.com/earthly/earthly/subdir/anothersubdir", "earthly/earthly/subdir/anothersubdir"},
+		{"http://gitlab.com/earthly/earthly/subdir/anothersubdir", "earthly/earthly/subdir/anothersubdir"},
+		{"https://github.com/earthly/earthly/subdir/anothersubdir", "earthly/earthly/subdir/anothersubdir"},
+		{"https://user@github.com/earthly/earthly/subdir/anothersubdir", "earthly/earthly/subdir/anothersubdir"},
+		{"https://user:password@github.com/earthly/earthly/subdir/anothersubdir", "earthly/earthly/subdir/anothersubdir"},
+		{"git@github.com:earthly/earthly/subdir/anothersubdir", "earthly/earthly/subdir/anothersubdir"},
+		{"git@bitbucket.com:earthly/earthly/subdir/anothersubdir", "earthly/earthly/subdir/anothersubdir"},
+		{"ssh://git@github.com/earthly/earthly/subdir/anothersubdir", "earthly/earthly/subdir/anothersubdir"},
+		{"ssh://git@github.com:22/earthly/earthly/subdir/anothersubdir", "earthly/earthly/subdir/anothersubdir"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Adds `EARTHLY_TARGET_PROJECT_NO_TAG` builtin arg, which is the canonical Earthly project ref minus the tag.

I've created a test in this repository: https://github.com/earthly/test-builtin-args/blob/main/subdir/Earthfile

Fixes https://github.com/earthly/earthly/issues/1005