### PR TITLE
Auto install bash completion file on debian

### DIFF
--- a/release/apt-repo/Earthfile
+++ b/release/apt-repo/Earthfile
@@ -7,6 +7,7 @@ deps:
 deb:
     ARG RELEASE_TAG
     ARG EARTHLY_PLATFORM
+    RUN test ! -z "$EARTHLY_PLATFORM" || (echo "EARTHLY_PLATFORM is required" && exit 1)
     ARG EARTHLY_VERSION=$(echo "$RELEASE_TAG" | cut -c 2-)
     ARG PKG_NAME=earthly_${EARTHLY_VERSION}-1_${EARTHLY_PLATFORM}
     FROM +deps
@@ -16,6 +17,9 @@ deb:
     RUN (echo "$RELEASE_TAG" | grep '^v[0-9]\+.[0-9]\+.[0-9]\+$' > /dev/null) || (echo "RELEASE_TAG must be formatted as v1.2.3; instead got \"$RELEASE_TAG\""; exit 1)
     RUN wget -q "https://github.com/earthly/earthly/releases/download/v${EARTHLY_VERSION}/earthly-linux-$EARTHLY_PLATFORM" -O $PKG_NAME/usr/bin/earthly && chmod +x $PKG_NAME/usr/bin/earthly
     COPY earthly.control $PKG_NAME/DEBIAN/control
+    COPY postinst $PKG_NAME/DEBIAN/postinst
+    COPY postrm $PKG_NAME/DEBIAN/postrm
+    RUN chmod 0555 $PKG_NAME/DEBIAN/postinst $PKG_NAME/DEBIAN/postrm
     RUN sed -i "s/__earthly_version__/$EARTHLY_VERSION/" $PKG_NAME/DEBIAN/control
     RUN dpkg -b $PKG_NAME
     SAVE ARTIFACT $PKG_NAME.deb AS LOCAL output/debs/$PKG_NAME.deb

--- a/release/apt-repo/earthly.control
+++ b/release/apt-repo/earthly.control
@@ -2,6 +2,6 @@ Package: earthly
 Version: __earthly_version__
 Architecture: all
 Maintainer: Earthly Technologies <support@earthly.dev>
-Depends: bash
+Depends: bash, bash-completion
 Homepage: https://earthly.dev
 Description: Build automation tool for the container era.

--- a/release/apt-repo/postinst
+++ b/release/apt-repo/postinst
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -e
+
+# install bash auto completion
+BASH_COMPLETION_DIR="/usr/share/bash-completion/completions"
+if [ -d "$BASH_COMPLETION_DIR" ]
+then
+    earthly bootstrap --source bash > "$BASH_COMPLETION_DIR/earthly"
+fi
+
+# install zsh auto completion
+ZSH_COMPLETION_DIR="/usr/local/share/zsh/site-functions"
+if [ -d "$ZSH_COMPLETION_DIR" ]
+then
+    earthly bootstrap --source zsh > "$ZSH_COMPLETION_DIR/_earthly"
+fi
+
+# skip bootstraping if docker isn't installed or running
+if ! command -v docker &> /dev/null
+then
+    echo "docker was not found; skipping earthly bootstrap"
+    exit
+fi
+if ! docker info 2>/dev/null >/dev/null
+then
+    echo "unable to query docker daemon; skipping earthly bootstrap"
+    exit
+fi
+
+echo "bootstrapping earthly"
+earthly bootstrap
+echo "bootstrapping earthly done"

--- a/release/apt-repo/postrm
+++ b/release/apt-repo/postrm
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -e
+
+UNABLE_TO_REMOVE="unable to remove earthly-related docker resources"
+
+rm -f /usr/share/bash-completion/completions/earthly
+rm -f /usr/local/share/zsh/site-functions/_earthly
+
+if ! command -v docker &> /dev/null
+then
+    echo "docker was not found; $UNABLE_TO_REMOVE"
+    exit
+fi
+
+if ! docker info 2>/dev/null >/dev/null
+then
+    echo "unable to query docker daemon; $UNABLE_TO_REMOVE"
+    exit
+fi
+
+echo "removing earthly-buildkitd docker container"
+docker rm --force earthly-buildkitd
+
+echo "removing earthly-cache docker volume"
+docker volume rm --force earthly-cache


### PR DESCRIPTION
I tried to make use of `dh $@ --with bash-completion` in a rules file however I just couldn't get auto-completion to persist when I logged out and back in. Ultimately I figured we could stick with the approach that homebrew uses to have the earthly binary output the auto-completion contents.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>