### PR TITLE
Reference renamed remote repo for tests

### DIFF
--- a/examples/tests/Earthfile
+++ b/examples/tests/Earthfile
@@ -163,12 +163,12 @@ remote-test:
     RUN --privileged \
         --entrypoint \
         --mount=type=tmpfs,target=/tmp/earthly \
-        -- --no-output github.com/earthly/test-privileged:main+locally && \
+        -- --no-output github.com/earthly/test-remote/privileged:main+locally && \
         ls /tmp/hostname.3d4b1831-c07e-4b2d-805e-2b8ce578bb50
     RUN --privileged \
         --entrypoint \
         --mount=type=tmpfs,target=/tmp/earthly \
-        -- --no-output github.com/earthly/test-builtin-args/subdir:main+test
+        -- --no-output github.com/earthly/test-remote/builtin-args:main+test
 
 transitive-args-test:
     DO +RUN_EARTHLY --earthfile=transitive-args.earth --extra_args="--build-arg SOMEARG=xyz" --target=+test

--- a/examples/tests/allow-privileged-import.earth
+++ b/examples/tests/allow-privileged-import.earth
@@ -1,10 +1,10 @@
 FROM alpine:3.13
 
-IMPORT --allow-privileged github.com/earthly/test-privileged:main
+IMPORT --allow-privileged github.com/earthly/test-remote/privileged:main
 IMPORT ./a/really/deep/subdir
 
 test-remote-import:
-    COPY test-privileged+privileged/proc-status .
+    COPY privileged+privileged/proc-status .
     RUN cat proc-status | grep CapEff | grep 0000003fffffffff
 
 test-relative-import:
@@ -12,7 +12,7 @@ test-relative-import:
     RUN cat proc-status | grep CapEff | grep 0000003fffffffff
 
 test-remote-cmd:
-    DO test-privileged+PRIV
+    DO privileged+PRIV
 
 test:
     BUILD +test-remote-import

--- a/examples/tests/allow-privileged.earth
+++ b/examples/tests/allow-privileged.earth
@@ -1,27 +1,27 @@
 FROM alpine:3.13
 
 reject-privileged-in-remote-repo-triggered-by-from-locally:
-    FROM github.com/earthly/test-privileged:main+locally
+    FROM github.com/earthly/test-remote/privileged:main+locally
     RUN echo this should never run because the above FROM should fail
 
 reject-privileged-in-remote-repo-triggered-by-from-privileged:
-    FROM github.com/earthly/test-privileged:main+privileged
+    FROM github.com/earthly/test-remote/privileged:main+privileged
     RUN echo this should never run because the above FROM should fail
 
 reject-privileged-in-remote-repo-triggered-by-copy-locally:
-    COPY github.com/earthly/test-privileged:main+locally/hostname .
+    COPY github.com/earthly/test-remote/privileged:main+locally/hostname .
     RUN echo this should never run because the above COPY should fail
 
 reject-privileged-in-remote-repo-triggered-by-copy-privileged:
-    COPY github.com/earthly/test-privileged:main+privileged/hostname .
+    COPY github.com/earthly/test-remote/privileged:main+privileged/hostname .
     RUN echo this should never run because the above COPY should fail
 
 reject-privileged-in-remote-repo-triggered-by-build-locally:
-    BUILD github.com/earthly/test-privileged:main+locally
+    BUILD github.com/earthly/test-remote/privileged:main+locally
     RUN echo this should never run because the above BUILD should fail
 
 reject-privileged-in-remote-repo-triggered-by-build-privileged:
-    BUILD github.com/earthly/test-privileged:main+privileged
+    BUILD github.com/earthly/test-remote/privileged:main+privileged
     RUN echo this should never run because the above BUILD should fail
 
 reject-dedup:
@@ -33,34 +33,34 @@ reject-dedup:
     BUILD +reject-privileged-in-remote-repo-triggered-by-copy
 
 reject-privileged-in-remote-repo-triggered-by-docker-load-privileged:
-    WITH DOCKER --load shouldfail:latest=github.com/earthly/test-privileged:main+privileged
+    WITH DOCKER --load shouldfail:latest=github.com/earthly/test-remote/privileged:main+privileged
         RUN echo this should never run because the above --load should fail
     END
 
 allow-privileged-in-remote-repo-triggered-by-from-locally:
-    FROM --allow-privileged github.com/earthly/test-privileged:main+locally
+    FROM --allow-privileged github.com/earthly/test-remote/privileged:main+locally
     RUN echo this command should work
 
 allow-privileged-in-remote-repo-triggered-by-copy-locally:
-    COPY --allow-privileged github.com/earthly/test-privileged:main+locally/hostname .
+    COPY --allow-privileged github.com/earthly/test-remote/privileged:main+locally/hostname .
     RUN ls hostname
 
 allow-privileged-in-remote-repo-triggered-by-build-locally:
-    BUILD --allow-privileged github.com/earthly/test-privileged:main+locally
+    BUILD --allow-privileged github.com/earthly/test-remote/privileged:main+locally
 
 allow-privileged-in-remote-repo-triggered-by-from-privileged:
-    FROM --allow-privileged github.com/earthly/test-privileged:main+privileged
+    FROM --allow-privileged github.com/earthly/test-remote/privileged:main+privileged
     RUN echo this command should work
 
 allow-privileged-in-remote-repo-triggered-by-copy-privileged:
-    COPY --allow-privileged github.com/earthly/test-privileged:main+privileged/proc-status .
+    COPY --allow-privileged github.com/earthly/test-remote/privileged:main+privileged/proc-status .
     RUN cat proc-status | grep CapEff | grep 0000003fffffffff
 
 allow-privileged-in-remote-repo-triggered-by-build-privileged:
-    BUILD --allow-privileged github.com/earthly/test-privileged:main+privileged
+    BUILD --allow-privileged github.com/earthly/test-remote/privileged:main+privileged
 
 allow-privileged-in-remote-repo-triggered-by-cmd-privileged:
-    DO --allow-privileged github.com/earthly/test-privileged:main+PRIV
+    DO --allow-privileged github.com/earthly/test-remote/privileged:main+PRIV
 
 
 allow-all:

--- a/examples/tests/reject-privileged-import.earth
+++ b/examples/tests/reject-privileged-import.earth
@@ -1,11 +1,11 @@
 FROM alpine:3.13
 
-IMPORT github.com/earthly/test-privileged:main
+IMPORT github.com/earthly/test-remote/privileged:main
 
 test-reject-copy:
-    COPY test-privileged+privileged/proc-status .
+    COPY test-remote/privileged+privileged/proc-status .
     RUN echo the above COPY should fail since it was not imported with the --allow-privileged flag.
 
 test-reject-cmd:
-    DO test-privileged+PRIV
+    DO test-remote/privileged+PRIV
     RUN echo the above DO should fail since it was not imported with the --allow-privileged flag.


### PR DESCRIPTION
The remote repo used for testing has grown beyond priviledged tests,
The Earthfile from github.com/earthly/test-privileged has been copied to
github.com/earthly/test-remote/privileged. Once merged, we can remove
the old github.com/earthly/test-privileged repo.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>