### PR TITLE
Ignore errors while detecting earthly home dir

### DIFF
--- a/analytics/analytics.go
+++ b/analytics/analytics.go
@@ -129,7 +129,7 @@ func RepoHashFromCloneURL(repo string) string {
 }
 
 func getInstallID() (string, error) {
-	earthlyDir, err := cliutil.GetEarthlyDir()
+	earthlyDir, err := cliutil.GetOrCreateEarthlyDir()
 	if err != nil {
 		return "", err
 	}

--- a/buildcontext/gitlookup.go
+++ b/buildcontext/gitlookup.go
@@ -240,10 +240,7 @@ func (gl *GitLookup) detectProtocol(host string) (protocol string, err error) {
 var errNoRCHostEntry = fmt.Errorf("no netrc host entry")
 
 func (gl *GitLookup) lookupNetRCCredential(host string) (login, password string, err error) {
-	homeDir, _, err := cliutil.DetectHomeDir()
-	if err != nil {
-		return "", "", errors.Wrap(err, "failed to detect home dir")
-	}
+	homeDir, _ := cliutil.DetectHomeDir()
 	n, err := netrc.Parse(filepath.Join(homeDir, ".netrc"))
 	if err != nil {
 		return "", "", errors.Wrap(err, "failed to parse .netrc")

--- a/buildkitd/buildkitd.go
+++ b/buildkitd/buildkitd.go
@@ -754,7 +754,7 @@ func makeTLSPath(path string) (string, error) {
 	fullPath := path
 
 	if !filepath.IsAbs(path) {
-		earthlyDir, err := cliutil.GetEarthlyDir()
+		earthlyDir, err := cliutil.GetOrCreateEarthlyDir()
 		if err != nil {
 			return "", err
 		}

--- a/secretsclient/client.go
+++ b/secretsclient/client.go
@@ -871,10 +871,14 @@ func (c *client) WhoAmI() (string, string, bool, error) {
 func (c *client) getAuthTokenPath(create bool) (string, error) {
 	confDirPath := c.authTokenDir
 	if confDirPath == "" {
-		var err error
-		confDirPath, err = cliutil.GetEarthlyDir()
-		if err != nil {
-			return "", errors.Wrap(err, "cannot get .earthly dir")
+		if create {
+			var err error
+			confDirPath, err = cliutil.GetOrCreateEarthlyDir()
+			if err != nil {
+				return "", errors.Wrap(err, "cannot get .earthly dir")
+			}
+		} else {
+			confDirPath = cliutil.GetEarthlyDir()
 		}
 	}
 	tokenPath := filepath.Join(confDirPath, "auth.token")

--- a/util/cliutil/earthlydir.go
+++ b/util/cliutil/earthlydir.go
@@ -84,7 +84,11 @@ func getHomeFromUserCurrent() (string, *user.User, bool) {
 	if u.HomeDir == "" {
 		return "", nil, false
 	}
-	return u.HomeDir, u, true
+
+	// do NOT return the user here, because the user is only
+	// required during the SUDO_USER case; where as this case
+	// the permissions will belong to the current user and won't need changing.
+	return u.HomeDir, nil, true
 }
 
 // DetectHomeDir returns the home directory of the current user, together with


### PR DESCRIPTION
Earthly attempts to find the config path under the $SUDO_USER's ~/.earthly path, otherwise if $SUDO_USER isn't set, then under $HOME/.earthly, then the users' home directory (for cases where the HOME env isn't set), then if all of those fail, "/etc". If any of these heuristics fail, errors will be silently ignored.

`GetEarthlyDir()` has been changed to always return a string, without any error as the heuristic will always fallback to `/etc`.

A new function: `GetOrCreateEarthlyDir()` has been created which will call `GetEarthlyDir()` and additionally create the path if it does not exist. This function will continue to return errors which occur during directory creation.

This PR additionally deduplicates some of the path look up code to ensure there's only one mechanism that constructs the ".earthly" path, and also prevents the `before` handler from calling the homebrew specific `--source` handler code which should only ever be executed via `earthly bootstrap --source "bash|zsh"`.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>