### PR TITLE
Add verbose calls to conslogging

### DIFF
--- a/cmd/debugger/main.go
+++ b/cmd/debugger/main.go
@@ -198,7 +198,7 @@ func main() {
 		forceInteractive = true
 	}
 
-	conslogger := conslogging.Current(conslogging.ForceColor, conslogging.NoPadding)
+	conslogger := conslogging.Current(conslogging.ForceColor, conslogging.NoPadding, false)
 	color.NoColor = false
 
 	debuggerSettings, err := getSettings(fmt.Sprintf("/run/secrets/%s", common.DebuggerSettingsSecretsKey))
@@ -209,6 +209,7 @@ func main() {
 
 	if debuggerSettings.DebugLevelLogging {
 		logrus.SetLevel(logrus.DebugLevel)
+		conslogger.SetVerbose(true)
 	}
 
 	ctx := context.Background()

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -226,7 +226,7 @@ func main() {
 		padding = conslogging.NoPadding
 	}
 
-	app := newEarthlyApp(ctx, conslogging.Current(colorMode, padding))
+	app := newEarthlyApp(ctx, conslogging.Current(colorMode, padding, false))
 	app.autoComplete()
 
 	exitCode := app.run(ctx, os.Args)
@@ -931,6 +931,8 @@ func (app *earthlyApp) before(context *cli.Context) error {
 	if app.enableProfiler {
 		go profhandler()
 	}
+
+	app.console.SetVerbose(app.verbose)
 
 	if context.IsSet("config") {
 		app.console.Printf("loading config values from %q\n", app.configPath)

--- a/conslogging/conslogging.go
+++ b/conslogging/conslogging.go
@@ -46,6 +46,7 @@ type ConsoleLogger struct {
 	colorMode ColorMode
 	isCached  bool
 	isFailed  bool
+	verbose   bool
 
 	// The following are shared between instances and are protected by the mutex.
 	mu             *sync.Mutex
@@ -64,6 +65,7 @@ func (cl ConsoleLogger) clone() ConsoleLogger {
 		prefix:         cl.prefix,
 		metadataMode:   cl.metadataMode,
 		isLocal:        cl.isLocal,
+		verbose:        cl.verbose,
 		salt:           cl.salt,
 		isCached:       cl.isCached,
 		isFailed:       cl.isFailed,
@@ -245,6 +247,20 @@ func (cl ConsoleLogger) PrintBytes(data []byte) {
 	}
 }
 
+// VerbosePrintf prints formatted text to the console when verbose flag is set.
+func (cl ConsoleLogger) VerbosePrintf(format string, args ...interface{}) {
+	if cl.verbose {
+		cl.Printf(format, args...)
+	}
+}
+
+// VerboseBytes prints bytes directly to the console when verbose flag is set.
+func (cl ConsoleLogger) VerboseBytes(data []byte) {
+	if cl.verbose {
+		cl.PrintBytes(data)
+	}
+}
+
 func (cl ConsoleLogger) printPrefix(useErrWriter bool) {
 	var w io.Writer
 	if useErrWriter {
@@ -322,4 +338,9 @@ func (cl ConsoleLogger) prettyPrefix() string {
 
 	formatString := fmt.Sprintf("%%%vv", cl.prefixPadding)
 	return fmt.Sprintf(formatString, fmt.Sprintf("%s%s", prettyPrefix, brackets))
+}
+
+// SetVerbose toggles the verbose level
+func (cl *ConsoleLogger) SetVerbose(verbose bool) {
+	cl.verbose = verbose
 }

--- a/conslogging/conslogging_others.go
+++ b/conslogging/conslogging_others.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Current returns the current console.
-func Current(colorMode ColorMode, prefixPadding int) ConsoleLogger {
+func Current(colorMode ColorMode, prefixPadding int, verbose bool) ConsoleLogger {
 	return ConsoleLogger{
 		outW:           os.Stderr, // So logs dont sully any intended outputs of commands.
 		errW:           os.Stderr,
@@ -18,5 +18,6 @@ func Current(colorMode ColorMode, prefixPadding int) ConsoleLogger {
 		nextColorIndex: new(int),
 		prefixPadding:  prefixPadding,
 		mu:             &currentConsoleMutex,
+		verbose:        verbose,
 	}
 }

--- a/conslogging/conslogging_windows.go
+++ b/conslogging/conslogging_windows.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Current returns the current console.
-func Current(colorMode ColorMode, prefixPadding int) ConsoleLogger {
+func Current(colorMode ColorMode, prefixPadding int, verbose bool) ConsoleLogger {
 	return ConsoleLogger{
 		outW:           colorable.NewColorable(os.Stderr), // So logs dont sully any intended outputs of commands.
 		errW:           colorable.NewColorable(os.Stderr),
@@ -19,5 +19,6 @@ func Current(colorMode ColorMode, prefixPadding int) ConsoleLogger {
 		nextColorIndex: new(int),
 		prefixPadding:  prefixPadding,
 		mu:             &currentConsoleMutex,
+		verbose:        verbose,
 	}
 }


### PR DESCRIPTION
New Debugf and DebugBytes will print their messages only when
conslogging is running under verbose mode.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>