### PR TITLE
Add debug logs to shell repeater

### DIFF
--- a/cmd/shellrepeater/main.go
+++ b/cmd/shellrepeater/main.go
@@ -1,12 +1,21 @@
 package main
 
 import (
+	"context"
+
 	"github.com/earthly/earthly/debugger/server"
+	"github.com/earthly/earthly/logging"
+
+	"github.com/sirupsen/logrus"
 )
 
 const addr = "0.0.0.0:8373"
 
 func main() {
-	x := server.NewServer(addr)
+	logrus.SetLevel(logrus.DebugLevel)
+	ctx := context.Background()
+	log := logging.GetLogger(ctx).With("app", "shellrepeater")
+
+	x := server.NewServer(addr, log)
 	x.Start()
 }

--- a/debugger/server/server_test.go
+++ b/debugger/server/server_test.go
@@ -1,17 +1,25 @@
 package server
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"testing"
 	"time"
 
 	"github.com/earthly/earthly/debugger/common"
+	"github.com/earthly/earthly/logging"
+
+	"github.com/sirupsen/logrus"
 )
 
 func TestServer(t *testing.T) {
+	logrus.SetLevel(logrus.DebugLevel)
+	ctx := context.TODO()
+	log := logging.GetLogger(ctx).With("test.name", t.Name())
+
 	addr := "127.0.0.1:9834"
-	s := NewServer(addr)
+	s := NewServer(addr, log)
 	go s.Start()
 
 	time.Sleep(10 * time.Millisecond)


### PR DESCRIPTION
This creates a logger for the shell repeater with the app label set to
"shellrepeater" to make it easier to view shellrepeater logs vs buildkit
logs via:

    docker logs earthly-buildkitd 2>&1 | grep shellrepeater

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>