### PR TITLE
Use conslogging for logging debug term messages

### DIFF
--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -2640,9 +2640,10 @@ func (app *earthlyApp) actionBuildImp(c *cli.Context, flagArgs, nonFlagArgs []st
 			panic("debugger host was not a URL")
 		}
 
-		err = terminal.ConnectTerm(c.Context, u.Host)
+		debugTermConsole := app.console.WithPrefix("internal-term")
+		err = terminal.ConnectTerm(c.Context, u.Host, debugTermConsole)
 		if err != nil {
-			app.console.Warnf("Failed to connect to terminal: %s", err.Error())
+			debugTermConsole.Warnf("Failed to connect to terminal: %s", err.Error())
 		}
 	}()
 

--- a/debugger/terminal/terminal_windows.go
+++ b/debugger/terminal/terminal_windows.go
@@ -5,9 +5,11 @@ package terminal
 import (
 	"context"
 
+	"github.com/earthly/earthly/conslogging"
+
 	"github.com/pkg/errors"
 )
 
-func ConnectTerm(ctx context.Context, addr string) error {
+func ConnectTerm(ctx context.Context, addr string, console conslogging.ConsoleLogger) error {
 	return errors.New("debugger not supported on Windows yet")
 }


### PR DESCRIPTION
Since the debug terminal is called within earthly, it should use the
conslogger along with an "internal-term" prefix. The previous logrus
logger was no correctly logging debug messages due to

    logrus.StandardLogger().Out = ioutil.Discard

being set (to prevent other imported libraries from logging).