### PR TITLE
rename logging to slog (structured log)

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -40,7 +40,7 @@ code:
     END
     COPY --platform=linux/amd64 ./ast/parser+parser/*.go ./ast/parser/
     COPY --dir analytics autocomplete buildcontext builder cleanup cmd config conslogging debugger dockertar \
-        docker2earthly domain features logging secretsclient states util variables ./
+        docker2earthly domain features slog secretsclient states util variables ./
     COPY --dir buildkitd/buildkitd.go buildkitd/settings.go buildkitd/certificates.go buildkitd/
     COPY --dir earthfile2llb/*.go earthfile2llb/
     COPY --dir ast/antlrhandler ast/spec ast/*.go ast/

--- a/cmd/debugger/main.go
+++ b/cmd/debugger/main.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/earthly/earthly/conslogging"
 	"github.com/earthly/earthly/debugger/common"
-	"github.com/earthly/earthly/logging"
+	"github.com/earthly/earthly/slog"
 
 	"github.com/alessio/shellescape"
 	"github.com/creack/pty"
@@ -84,7 +84,7 @@ func populateShellHistory(cmd string) error {
 }
 
 func interactiveMode(ctx context.Context, remoteConsoleAddr string, cmdBuilder func() (*exec.Cmd, error)) error {
-	log := logging.GetLogger(ctx)
+	log := slog.GetLogger(ctx)
 
 	conn, err := net.Dial("tcp", remoteConsoleAddr)
 	if err != nil {
@@ -214,7 +214,7 @@ func main() {
 
 	ctx := context.Background()
 
-	log := logging.GetLogger(ctx)
+	log := slog.GetLogger(ctx)
 
 	if forceInteractive {
 		quotedCmd := shellescape.QuoteCommand(args)

--- a/cmd/shellrepeater/main.go
+++ b/cmd/shellrepeater/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/earthly/earthly/debugger/server"
-	"github.com/earthly/earthly/logging"
+	"github.com/earthly/earthly/slog"
 
 	"github.com/sirupsen/logrus"
 )
@@ -14,7 +14,7 @@ const addr = "0.0.0.0:8373"
 func main() {
 	logrus.SetLevel(logrus.DebugLevel)
 	ctx := context.Background()
-	log := logging.GetLogger(ctx).With("app", "shellrepeater")
+	log := slog.GetLogger(ctx).With("app", "shellrepeater")
 
 	x := server.NewServer(addr, log)
 	x.Start()

--- a/debugger/server/server.go
+++ b/debugger/server/server.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"sync"
 
-	"github.com/earthly/earthly/logging"
+	"github.com/earthly/earthly/slog"
 
 	"github.com/pkg/errors"
 )
@@ -22,7 +22,7 @@ type Server struct {
 	dataForTerminal chan []byte
 
 	addr string
-	log  logging.Logger
+	log  slog.Logger
 }
 
 func (s *Server) handleConn(conn net.Conn, readFrom, writeTo chan []byte) {
@@ -143,7 +143,7 @@ func (s *Server) Start() error {
 }
 
 // NewServer returns a new server
-func NewServer(addr string, log logging.Logger) *Server {
+func NewServer(addr string, log slog.Logger) *Server {
 	return &Server{
 		addr:            addr,
 		dataForShell:    make(chan []byte, 100),

--- a/debugger/server/server_test.go
+++ b/debugger/server/server_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/earthly/earthly/debugger/common"
-	"github.com/earthly/earthly/logging"
+	"github.com/earthly/earthly/slog"
 
 	"github.com/sirupsen/logrus"
 )
@@ -16,7 +16,7 @@ import (
 func TestServer(t *testing.T) {
 	logrus.SetLevel(logrus.DebugLevel)
 	ctx := context.TODO()
-	log := logging.GetLogger(ctx).With("test.name", t.Name())
+	log := slog.GetLogger(ctx).With("test.name", t.Name())
 
 	addr := "127.0.0.1:9834"
 	s := NewServer(addr, log)

--- a/slog/context.go
+++ b/slog/context.go
@@ -1,4 +1,4 @@
-package logging
+package slog
 
 import "context"
 

--- a/slog/logging.go
+++ b/slog/logging.go
@@ -1,4 +1,7 @@
-package logging
+// Package slog is a structured logging library which is for use by shellrepeater
+// or any other servers, it should not be used by commands that are run directly
+// by users (e.g. the earthly binary)
+package slog
 
 import (
 	"fmt"


### PR DESCRIPTION
Structured logging should only be used by servers (e.g. shellrepeater),
and should not be used by the earthly command. This renames logging to
slog and gives a comment describing when to use slog.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>