### PR TITLE
Humanize bytes in verbose logging

### DIFF
--- a/buildcontext/provider/provider.go
+++ b/buildcontext/provider/provider.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/earthly/earthly/conslogging"
 
+	"github.com/dustin/go-humanize"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/filesync"
 	"github.com/pkg/errors"
@@ -148,7 +149,7 @@ func (bcp *BuildContextProvider) handle(method string, stream grpc.ServerStream)
 			numStats++
 			//console.VerbosePrintf("sent file stat for %s\n", fullPath) ignored as it is too verbose. TODO add different verbose levels to support ExtraVerbosePrintf
 		case fsutil.StatusSent:
-			console.VerbosePrintf("sent data for %s (%d bytes)\n", fullPath, numBytes)
+			console.VerbosePrintf("sent data for %s (%s)\n", fullPath, humanize.Bytes(uint64(numBytes)))
 			numSends++
 		case fsutil.StatusFailed:
 			console.VerbosePrintf("sent data for %s failed\n", fullPath)
@@ -163,7 +164,7 @@ func (bcp *BuildContextProvider) handle(method string, stream grpc.ServerStream)
 		mutex.Lock()
 		defer mutex.Unlock()
 		if last {
-			console.Printf("transferred %d file(s) for context %s (%d bytes, %d file/dir stats)", numSends, dir.Dir, numBytes, numStats)
+			console.Printf("transferred %d file(s) for context %s (%s, %d file/dir stats)", numSends, dir.Dir, humanize.Bytes(uint64(numBytes)), numStats)
 		}
 	}
 

--- a/examples/tests/Earthfile
+++ b/examples/tests/Earthfile
@@ -97,8 +97,8 @@ copy-test:
     RUN echo "output.txt" > .earthignore
     DO +RUN_EARTHLY --earthfile=copy.earth --extra_args="--verbose"  --post_command="2>output.txt"
     RUN cat output.txt
-    RUN cat output.txt | grep 'sent data for in/root (5 bytes)'
-    RUN cat output.txt | grep 'transferred 4 file(s) for context . (261 bytes, 8 file/dir stats)'
+    RUN cat output.txt | grep 'sent data for in/root (5 B)'
+    RUN cat output.txt | grep 'transferred 4 file(s) for context . (261 B, 8 file/dir stats)'
 
 cache-test:
     # Test that a file can be passed between runs through the mounted cache.


### PR DESCRIPTION
display bytes as MB, kB, or B rather than just bytes.

![image](https://user-images.githubusercontent.com/1806823/121758219-61a54d00-cad5-11eb-85a7-08ee568d060e.png)


Signed-off-by: Alex Couture-Beil <alex@earthly.dev>