### PR TITLE
post install script for rpms

### DIFF
--- a/release/yum-repo/Earthfile
+++ b/release/yum-repo/Earthfile
@@ -10,6 +10,7 @@ rpm:
     ARG EARTHLY_VERSION=$(echo "$RELEASE_TAG" | cut -c 2-)
     FROM +deps
     WORKDIR /work
+    RUN test ! -z "$EARTHLY_PLATFORM" || (echo "EARTHLY_PLATFORM is required" && exit 1)
     RUN (echo "$RELEASE_TAG" | grep '^v[0-9]\+.[0-9]\+.[0-9]\+$' > /dev/null) || (echo "RELEASE_TAG must be formatted as v1.2.3; instead got \"$RELEASE_TAG\""; exit 1)
     RUN wget -q "https://github.com/earthly/earthly/releases/download/v${EARTHLY_VERSION}/earthly-linux-$EARTHLY_PLATFORM" -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly
 

--- a/release/yum-repo/earthly.spec
+++ b/release/yum-repo/earthly.spec
@@ -19,6 +19,56 @@ cp /usr/local/bin/earthly %{buildroot}/usr/bin/earthly
 %files
 /usr/bin/earthly
 
+%post
+set -e
+# install bash auto completion
+BASH_COMPLETION_DIR="/usr/share/bash-completion/completions"
+if [ -d "$BASH_COMPLETION_DIR" ]
+then
+    earthly bootstrap --source bash > "$BASH_COMPLETION_DIR/earthly"
+fi
+
+# install zsh auto completion
+ZSH_COMPLETION_DIR="/usr/local/share/zsh/site-functions"
+if [ -d "$ZSH_COMPLETION_DIR" ]
+then
+    earthly bootstrap --source zsh > "$ZSH_COMPLETION_DIR/_earthly"
+fi
+
+# skip bootstraping if docker isn't installed or running
+if ! command -v docker &> /dev/null
+then
+    echo "docker was not found; skipping earthly bootstrap"
+    exit
+fi
+if ! docker info 2>/dev/null >/dev/null
+
+%postun
+set -e
+
+UNABLE_TO_REMOVE="unable to remove earthly-related docker resources"
+
+rm -f /usr/share/bash-completion/completions/earthly
+rm -f /usr/local/share/zsh/site-functions/_earthly
+
+if ! command -v docker &> /dev/null
+then
+    echo "docker was not found; $UNABLE_TO_REMOVE"
+    exit
+fi
+
+if ! docker info 2>/dev/null >/dev/null
+then
+    echo "unable to query docker daemon; $UNABLE_TO_REMOVE"
+    exit
+fi
+
+echo "removing earthly-buildkitd docker container"
+docker rm --force earthly-buildkitd
+
+echo "removing earthly-cache docker volume"
+docker volume rm --force earthly-cache
+
 %changelog
 * Thu Feb 25 2021 alex <alex@earthly.dev>
 - initial poc


### PR DESCRIPTION
Post install script to enable bash completion and earthly bootstrapping.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>