### PR TITLE
Re-add DockerHub docs to the CI process.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -649,7 +649,7 @@ jobs:
       - name: Build and push +prerelease
         run: ./build/linux/amd64/earthly --ci --push +prerelease
       - name: Update DockerHub description for earthly/earthly
-        uses: peter-evans/dockerhub-description@v2
+        uses: peter-evans/dockerhub-description@616d1b63e806b630b975af3b4fe3304307b20f40
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -657,7 +657,7 @@ jobs:
           readme-filepath: ./docs/docker-images/all-in-one.md
           short-description: ${{ github.event.repository.description }}
       - name: Update DockerHub description for earthly/buildkitd
-        uses: peter-evans/dockerhub-description@v2
+        uses: peter-evans/dockerhub-description@616d1b63e806b630b975af3b4fe3304307b20f40
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -648,6 +648,22 @@ jobs:
         run: ./build/linux/amd64/earthly config global.local_registry_host 'tcp://127.0.0.1:8371'
       - name: Build and push +prerelease
         run: ./build/linux/amd64/earthly --ci --push +prerelease
+      - name: Update DockerHub description for earthly/earthly
+        uses: peter-evans/dockerhub-description@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          repository: earthly/earthly
+          readme-filepath: ./docs/docker-images/all-in-one.md
+          short-description: ${{ github.event.repository.description }}
+      - name: Update DockerHub description for earthly/buildkitd
+        uses: peter-evans/dockerhub-description@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          repository: earthly/buildkitd
+          readme-filepath: ./docs/docker-images/buildkit-standalone.md
+          short-description: Standalone Earthly buildkitd image
       - name: Buildkit logs (runs on failure)
         run: docker logs earthly-buildkitd
         if: ${{ failure() }}


### PR DESCRIPTION
Now that permissions have been sorted, we can re-add this. I have tested the action locally and successfully updated the descriptions.