### PR TITLE
Include version and help flags in autocomplete

### DIFF
--- a/autocomplete/complete.go
+++ b/autocomplete/complete.go
@@ -208,6 +208,8 @@ func GetPotentials(compLine string, compPoint int, app *cli.App) ([]string, erro
 		flags = getVisibleFlags(cmd.Flags)
 	} else {
 		flags = getVisibleFlags(app.Flags)
+		// append flags that urfav/cli automatically include
+		flags = append(flags, "version", "help")
 	}
 
 	var commands []string


### PR DESCRIPTION
The --help and --version flags are added automatically to urfav, and aren't
included in the flags we define for earthly; therefore we must
explicitly add them.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>