### PR TITLE
perform LOCALLY RUNs sequentially

### DIFF
--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -11,7 +11,7 @@ buildkitd:
             ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:00025901bf6b30a374e68eecf9fab9c28554bd25+build
         END
     ELSE
-        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:00025901bf6b30a374e68eecf9fab9c28554bd25+build
+        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:a261c5b2b4f0ec7ba98cb0d2fb88999ae6efd22d+build
     END
     FROM $BUILDKIT_BASE_IMAGE
     RUN echo "@edge-community http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories

--- a/earthfile2llb/withdockerrunlocal.go
+++ b/earthfile2llb/withdockerrunlocal.go
@@ -17,6 +17,7 @@ import (
 type withDockerRunLocal struct {
 	c        *Converter
 	tarLoads []llb.State
+	local    string
 }
 
 func (wdrl *withDockerRunLocal) Run(ctx context.Context, args []string, opt WithDockerOpt) error {
@@ -35,7 +36,7 @@ func (wdrl *withDockerRunLocal) Run(ctx context.Context, args []string, opt With
 	}
 
 	// then finally run the command
-	return wdrl.c.RunLocal(ctx, args, false)
+	return wdrl.c.RunLocal(ctx, wdrl.local, args, false)
 }
 
 func (wdrl *withDockerRunLocal) load(ctx context.Context, opt DockerLoadOpt) (string, error) {

--- a/examples/tests/Earthfile
+++ b/examples/tests/Earthfile
@@ -72,6 +72,7 @@ ga:
     BUILD +infinite-recursion
     BUILD +from-dockerfile-arg
     BUILD +cache-mount-arg
+    BUILD +sequential-locally-test
 
 experimental:
     BUILD ./dind-auto-install+all
@@ -540,6 +541,43 @@ cache-mount-arg:
     RUN cat output.txt
     RUN cat output.txt | grep '\*cached\* --> RUN echo Doing something 1'; test "$?" != 0
     RUN cat output.txt | grep '\*cached\* --> RUN echo Doing something 2'; test "$?" != 0
+
+sequential-locally-test:
+    DO +RUN_EARTHLY --earthfile=sequential-locally.earth --use_tmpfs=false --target="+run-lots" --extra_args="--no-cache" --post_command="2>output.txt"
+    RUN cat output.txt | grep -vw RUN | grep -vw char | grep -o '\(start\|mid\|end\).*' > output-filtered.txt
+    RUN echo "set -e
+expectedmode=\"start\"
+expectedchar=\"?\"
+while read line; do
+    mode=\$(echo \"\$line\" | cut -d \" \" -f1)
+    char=\$(echo \"\$line\" | cut -d \" \" -f2)
+    echo \"mode=\$mode char=\$char\"
+    case \"\$mode\" in
+        start)
+            test \"\$expectedmode\" = \"start\" || (echo \"expected \$expectedmode; got \$mode\" && exit 1)
+            expectedmode=\"mid\"
+            expectedchar=\"$char\"
+            ;;
+        mid)
+            test \"\$expectedmode\" = \"mid\" || (echo \"expected \$expectedmode; got \$mode\" && exit 1)
+            test \"\$expectedchar\" = \"$char\" || (echo \"expected \$expectedchar; got \$char\" && exit 1)
+            # we don't change expectedmode to end, because we can have multiple 'mid's
+            ;;
+        end)
+            test \"\$expectedmode\" = \"mid\" || (echo \"expected \$expectedmode; got \$mode\" && exit 1)
+            test \"\$expectedchar\" = \"$char\" || (echo \"expected \$expectedchar; got \$char\" && exit 1)
+            expectedmode=\"start\"
+            expectedchar=\"?\"
+            ;;
+        *)
+            echo unhandled mode: $mode
+            exit 1
+    esac
+done
+echo RUNs were sequentially grouped; hooray!
+" > test-output.sh && chmod +x test-output.sh
+    RUN cat output-filtered.txt | ./test-output.sh
+
 
 RUN_EARTHLY:
     COMMAND

--- a/examples/tests/sequential-locally.earth
+++ b/examples/tests/sequential-locally.earth
@@ -1,0 +1,33 @@
+lots:
+    LOCALLY
+    ARG char
+    RUN echo "start $char"
+    RUN echo "mid $char"
+    RUN echo "mid $char"
+    RUN echo "mid $char"
+    RUN echo "mid $char"
+    RUN echo "mid $char"
+    RUN echo "mid $char"
+    RUN echo "mid $char"
+    RUN echo "mid $char"
+    RUN echo "mid $char"
+    RUN echo "mid $char"
+    RUN echo "mid $char"
+    RUN echo "mid $char"
+    RUN echo "mid $char"
+    RUN echo "mid $char"
+    RUN echo "mid $char"
+    RUN echo "mid $char"
+    RUN echo "mid $char"
+    RUN echo "mid $char"
+    RUN echo "mid $char"
+    RUN echo "mid $char"
+    RUN echo "end $char"
+
+run-lots:
+    BUILD \
+        --build-arg char=a \
+        --build-arg char=b \
+        --build-arg char=c \
+        --build-arg char=d \
+       +lots

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,6 @@ replace (
 	github.com/docker/docker => github.com/docker/docker v17.12.0-ce-rc1.0.20200310163718-4634ce647cf2+incompatible
 	github.com/hashicorp/go-immutable-radix => github.com/tonistiigi/go-immutable-radix v0.0.0-20170803185627-826af9ccf0fe
 	github.com/jaguilar/vt100 => github.com/tonistiigi/vt100 v0.0.0-20190402012908-ad4c4a574305
-	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.0-20210609215831-00025901bf6b
+	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.0-20210616225716-a261c5b2b4f0
 	github.com/tonistiigi/fsutil => github.com/earthly/fsutil v0.0.0-20210609160335-a94814c540b2
 )

--- a/go.sum
+++ b/go.sum
@@ -262,8 +262,8 @@ github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
-github.com/earthly/buildkit v0.0.0-20210609215831-00025901bf6b h1:E3zi1q9bIwdEDK3BqyEPCzVAGApzFvrhPbpVxcsq+sk=
-github.com/earthly/buildkit v0.0.0-20210609215831-00025901bf6b/go.mod h1:Egi9MpHewQKej77rEOHuHITF6WTAOLBOPXaWY9SGyFw=
+github.com/earthly/buildkit v0.0.0-20210616225716-a261c5b2b4f0 h1:HoGvgiP/2LqTylTH3aBIUWUN6VEb/ZrGCEGwj1uNxpE=
+github.com/earthly/buildkit v0.0.0-20210616225716-a261c5b2b4f0/go.mod h1:Egi9MpHewQKej77rEOHuHITF6WTAOLBOPXaWY9SGyFw=
 github.com/earthly/fsutil v0.0.0-20210609160335-a94814c540b2 h1:prCu8h270ALmF4U16kSBIJow23/w6NYFeQlr6A1NCbw=
 github.com/earthly/fsutil v0.0.0-20210609160335-a94814c540b2/go.mod h1:4Bcxev2PKmz1bFF6Mg3opy8w4kYQVvEXQGKVkQkP2Ac=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=


### PR DESCRIPTION
This ensures that all locally targets will run sequentially one at a
time across all earthly instances.

this requires https://github.com/earthly/buildkit/pull/45/commits/a261c5b2b4f0ec7ba98cb0d2fb88999ae6efd22d

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>