### PR TITLE
Introduce a --no-follow option for copying

### DIFF
--- a/buildcontext/git.go
+++ b/buildcontext/git.go
@@ -64,7 +64,7 @@ func (gr *gitResolver) resolveEarthProject(ctx context.Context, gwClient gwclien
 		} else {
 			buildContext = llbutil.ScratchWithPlatform()
 			buildContext = llbutil.CopyOp(
-				rgp.state, []string{subDir}, buildContext, "./", false, false, false, "root:root", false,
+				rgp.state, []string{subDir}, buildContext, "./", false, false, false, "root:root", false, false,
 				llb.WithCustomNamef("[internal] COPY git context %s", ref.String()))
 		}
 	} else {

--- a/earthfile2llb/flags.go
+++ b/earthfile2llb/flags.go
@@ -45,6 +45,7 @@ type copyOpts struct {
 	KeepTs          bool     `long:"keep-ts" description:"Keep created time file timestamps"`
 	KeepOwn         bool     `long:"keep-own" description:"Keep owner info"`
 	IfExists        bool     `long:"if-exists" description:"Do not fail if the artifact does not exist"`
+	NoFollow        bool     `long:"no-follow" description:"Do not follow symlinks"`
 	AllowPrivileged bool     `long:"allow-privileged" description:"Allow targets to assume privileged mode"`
 	Platform        string   `long:"platform" description:"The platform to use"`
 	BuildArgs       []string `long:"build-arg" description:"A build arg override passed on to a referenced Earthly target"`

--- a/earthfile2llb/interpreter.go
+++ b/earthfile2llb/interpreter.go
@@ -692,7 +692,7 @@ func (i *Interpreter) handleCopy(ctx context.Context, cmd spec.Command) error {
 					return i.wrapError(err, cmd.SourceLocation, "copy artifact locally")
 				}
 			} else {
-				err = i.converter.CopyArtifact(ctx, src, dest, platform, allowPrivileged, srcBuildArgs, opts.IsDirCopy, opts.KeepTs, opts.KeepOwn, opts.Chown, opts.IfExists)
+				err = i.converter.CopyArtifact(ctx, src, dest, platform, allowPrivileged, srcBuildArgs, opts.IsDirCopy, opts.KeepTs, opts.KeepOwn, opts.Chown, opts.IfExists, opts.NoFollow)
 				if err != nil {
 					return i.wrapError(err, cmd.SourceLocation, "copy artifact")
 				}

--- a/examples/tests/copy.earth
+++ b/examples/tests/copy.earth
@@ -15,6 +15,7 @@ all:
     BUILD +copy-art-multi-no-exist
     BUILD +copy-art-multi-trailing-slash
     BUILD +copy-art-multi-existing
+    BUILD +copy-invalid-symlink
 
 artifact:
     COPY --dir in in
@@ -165,3 +166,11 @@ copied/1/file
 copied/2
 copied/2/file" >./expected
     RUN diff -b ./actual ./expected
+
+copy-invalid-symlink-base:
+    RUN ln -s nonexistant symlink
+    SAVE ARTIFACT symlink
+
+copy-invalid-symlink:
+    COPY --no-follow +copy-invalid-symlink-base/symlink .
+    RUN ls -la symlink | grep nonexistant

--- a/util/llbutil/copyop.go
+++ b/util/llbutil/copyop.go
@@ -13,7 +13,7 @@ import (
 )
 
 // CopyOp is a simplified llb copy operation.
-func CopyOp(srcState pllb.State, srcs []string, destState pllb.State, dest string, allowWildcard bool, isDir bool, keepTs bool, chown string, ifExists bool, opts ...llb.ConstraintsOpt) pllb.State {
+func CopyOp(srcState pllb.State, srcs []string, destState pllb.State, dest string, allowWildcard bool, isDir bool, keepTs bool, chown string, ifExists, noFollow bool, opts ...llb.ConstraintsOpt) pllb.State {
 	destAdjusted := dest
 	if dest == "." || dest == "" || len(srcs) > 1 {
 		destAdjusted += string("/") // TODO: needs to be the containers platform, not the earthly hosts platform. For now, this is always Linux.
@@ -37,7 +37,7 @@ func CopyOp(srcState pllb.State, srcs []string, destState pllb.State, dest strin
 		}
 		copyOpts := append([]llb.CopyOption{
 			&llb.CopyInfo{
-				FollowSymlinks:      true,
+				FollowSymlinks:      !noFollow,
 				CopyDirContentsOnly: !isDir,
 				AttemptUnpack:       false,
 				CreateDestPath:      true,


### PR DESCRIPTION
The --no-follow option will instruct buildkit not to follow symlinks.
This is helpful for cases where one wishes to copy an invalid symlink.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>