### PR TITLE
No follow

### DIFF
--- a/ast/tests/copy.ast.json
+++ b/ast/tests/copy.ast.json
@@ -116,6 +116,22 @@
             ],
             "name": "BUILD"
           }
+        },
+        {
+          "command": {
+            "args": [
+              "+copy-invalid-symlink"
+            ],
+            "name": "BUILD"
+          }
+        },
+        {
+          "command": {
+            "args": [
+              "+copy-dir-containing-invalid-symlink"
+            ],
+            "name": "BUILD"
+          }
         }
       ]
     },
@@ -778,6 +794,210 @@
               "-b",
               "./actual",
               "./expected"
+            ],
+            "name": "RUN"
+          }
+        }
+      ]
+    },
+    {
+      "name": "copy-invalid-symlink-base",
+      "recipe": [
+        {
+          "command": {
+            "args": [
+              "ln",
+              "-s",
+              "nonexistanttarget",
+              "symlink"
+            ],
+            "name": "RUN"
+          }
+        },
+        {
+          "command": {
+            "args": [
+              "--no-follow",
+              "symlink"
+            ],
+            "name": "SAVE ARTIFACT"
+          }
+        }
+      ]
+    },
+    {
+      "name": "copy-invalid-symlink",
+      "recipe": [
+        {
+          "command": {
+            "args": [
+              "--no-follow",
+              "+copy-invalid-symlink-base/symlink",
+              "."
+            ],
+            "name": "COPY"
+          }
+        },
+        {
+          "command": {
+            "args": [
+              "ls",
+              "-la",
+              "symlink",
+              "|",
+              "grep",
+              "nonexistanttarget"
+            ],
+            "name": "RUN"
+          }
+        },
+        {
+          "command": {
+            "args": [
+              "ls",
+              "symlink",
+              "2>&1",
+              "|",
+              "grep",
+              "'No",
+              "such",
+              "file",
+              "or",
+              "directory'"
+            ],
+            "name": "RUN"
+          }
+        }
+      ]
+    },
+    {
+      "name": "copy-dir-containing-invalid-symlink-base",
+      "recipe": [
+        {
+          "command": {
+            "args": [
+              "mkdir",
+              "-p",
+              "/symlinks"
+            ],
+            "name": "RUN"
+          }
+        },
+        {
+          "command": {
+            "args": [
+              "mkdir",
+              "-p",
+              "/data"
+            ],
+            "name": "RUN"
+          }
+        },
+        {
+          "command": {
+            "args": [
+              "echo",
+              "hello",
+              ">",
+              "/data/hello.txt"
+            ],
+            "name": "RUN"
+          }
+        },
+        {
+          "command": {
+            "args": [
+              "ln",
+              "-s",
+              "/data/hello.txt",
+              "/symlinks/symlink"
+            ],
+            "name": "RUN"
+          }
+        },
+        {
+          "command": {
+            "args": [
+              "/symlinks/",
+              "/symlinks/"
+            ],
+            "name": "SAVE ARTIFACT"
+          }
+        }
+      ]
+    },
+    {
+      "name": "copy-dir-containing-invalid-symlink",
+      "recipe": [
+        {
+          "command": {
+            "args": [
+              "--no-follow",
+              "+copy-dir-containing-invalid-symlink-base/*",
+              "/"
+            ],
+            "name": "COPY"
+          }
+        },
+        {
+          "command": {
+            "args": [
+              "ls",
+              "-la",
+              "/symlinks/symlink",
+              "|",
+              "grep",
+              "hello.txt"
+            ],
+            "name": "RUN"
+          }
+        },
+        {
+          "command": {
+            "args": [
+              "ls",
+              "/symlinks/symlink",
+              "2>&1",
+              "|",
+              "grep",
+              "'No",
+              "such",
+              "file",
+              "or",
+              "directory'"
+            ],
+            "name": "RUN"
+          }
+        },
+        {
+          "command": {
+            "args": [
+              "mkdir",
+              "/data"
+            ],
+            "name": "RUN"
+          }
+        },
+        {
+          "command": {
+            "args": [
+              "echo",
+              "hi",
+              ">",
+              "/data/hello.txt"
+            ],
+            "name": "RUN"
+          }
+        },
+        {
+          "command": {
+            "args": [
+              "cat",
+              "/symlinks/symlink",
+              "|",
+              "grep",
+              "-w",
+              "hi"
             ],
             "name": "RUN"
           }

--- a/ast/tests/copy.ast.json
+++ b/ast/tests/copy.ast.json
@@ -817,7 +817,7 @@
         {
           "command": {
             "args": [
-              "--no-follow",
+              "--symlink-no-follow",
               "symlink"
             ],
             "name": "SAVE ARTIFACT"
@@ -831,7 +831,7 @@
         {
           "command": {
             "args": [
-              "--no-follow",
+              "--symlink-no-follow",
               "+copy-invalid-symlink-base/symlink",
               "."
             ],
@@ -932,7 +932,7 @@
         {
           "command": {
             "args": [
-              "--no-follow",
+              "--symlink-no-follow",
               "+copy-dir-containing-invalid-symlink-base/*",
               "/"
             ],

--- a/buildcontext/git.go
+++ b/buildcontext/git.go
@@ -64,7 +64,7 @@ func (gr *gitResolver) resolveEarthProject(ctx context.Context, gwClient gwclien
 		} else {
 			buildContext = llbutil.ScratchWithPlatform()
 			buildContext = llbutil.CopyOp(
-				rgp.state, []string{subDir}, buildContext, "./", false, false, false, "root:root", false,
+				rgp.state, []string{subDir}, buildContext, "./", false, false, false, "root:root", false, false,
 				llb.WithCustomNamef("[internal] COPY git context %s", ref.String()))
 		}
 	} else {

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -373,7 +373,7 @@ func (c *Converter) CopyArtifactLocal(ctx context.Context, artifactName string, 
 }
 
 // CopyArtifact applies the earthly COPY artifact command.
-func (c *Converter) CopyArtifact(ctx context.Context, artifactName string, dest string, platform *specs.Platform, allowPrivileged bool, buildArgs []string, isDir bool, keepTs bool, keepOwn bool, chown string, ifExists, noFollow bool) error {
+func (c *Converter) CopyArtifact(ctx context.Context, artifactName string, dest string, platform *specs.Platform, allowPrivileged bool, buildArgs []string, isDir bool, keepTs bool, keepOwn bool, chown string, ifExists, symlinkNoFollow bool) error {
 	err := c.checkAllowed("COPY")
 	if err != nil {
 		return err
@@ -395,13 +395,13 @@ func (c *Converter) CopyArtifact(ctx context.Context, artifactName string, dest 
 	// Copy.
 	c.mts.Final.MainState = llbutil.CopyOp(
 		relevantDepState.ArtifactsState, []string{artifact.Artifact},
-		c.mts.Final.MainState, dest, true, isDir, keepTs, c.copyOwner(keepOwn, chown), ifExists, noFollow,
+		c.mts.Final.MainState, dest, true, isDir, keepTs, c.copyOwner(keepOwn, chown), ifExists, symlinkNoFollow,
 		llb.WithCustomNamef(
 			"%sCOPY %s%s%s%s%s %s",
 			c.vertexPrefix(false, false),
 			strIf(isDir, "--dir "),
 			strIf(ifExists, "--if-exists "),
-			strIf(noFollow, "--no-follow "),
+			strIf(symlinkNoFollow, "--symlink-no-follow "),
 			joinWrap(buildArgs, "(", " ", ") "),
 			artifact.String(),
 			dest))
@@ -632,7 +632,7 @@ func (c *Converter) Run(ctx context.Context, args, mounts, secretKeyValues []str
 }
 
 // SaveArtifact applies the earthly SAVE ARTIFACT command.
-func (c *Converter) SaveArtifact(ctx context.Context, saveFrom string, saveTo string, saveAsLocalTo string, keepTs bool, keepOwn bool, ifExists, noFollow bool, isPush bool) error {
+func (c *Converter) SaveArtifact(ctx context.Context, saveFrom string, saveTo string, saveAsLocalTo string, keepTs bool, keepOwn bool, ifExists, symlinkNoFollow bool, isPush bool) error {
 	err := c.checkAllowed("SAVE ARTIFACT")
 	if err != nil {
 		return err
@@ -667,12 +667,12 @@ func (c *Converter) SaveArtifact(ctx context.Context, saveFrom string, saveTo st
 	}
 	c.mts.Final.ArtifactsState = llbutil.CopyOp(
 		c.mts.Final.MainState, []string{saveFrom}, c.mts.Final.ArtifactsState,
-		saveToAdjusted, true, true, keepTs, own, ifExists, noFollow,
+		saveToAdjusted, true, true, keepTs, own, ifExists, symlinkNoFollow,
 		llb.WithCustomNamef(
 			"%sSAVE ARTIFACT %s%s%s %s",
 			c.vertexPrefix(false, false),
 			strIf(ifExists, "--if-exists "),
-			strIf(noFollow, "--no-follow "),
+			strIf(symlinkNoFollow, "--symlink-no-follow "),
 			saveFrom,
 			artifact.String()))
 	if saveAsLocalTo != "" {
@@ -680,24 +680,24 @@ func (c *Converter) SaveArtifact(ctx context.Context, saveFrom string, saveTo st
 		if isPush {
 			separateArtifactsState = llbutil.CopyOp(
 				c.mts.Final.RunPush.State, []string{saveFrom}, separateArtifactsState,
-				saveToAdjusted, true, true, keepTs, "root:root", ifExists, noFollow,
+				saveToAdjusted, true, true, keepTs, "root:root", ifExists, symlinkNoFollow,
 				llb.WithCustomNamef(
 					"%sSAVE ARTIFACT %s%s%s %s AS LOCAL %s",
 					c.vertexPrefix(false, false),
 					strIf(ifExists, "--if-exists "),
-					strIf(noFollow, "--no-follow "),
+					strIf(symlinkNoFollow, "--symlink-no-follow "),
 					saveFrom,
 					artifact.String(),
 					saveAsLocalTo))
 		} else {
 			separateArtifactsState = llbutil.CopyOp(
 				c.mts.Final.MainState, []string{saveFrom}, separateArtifactsState,
-				saveToAdjusted, true, true, keepTs, "root:root", ifExists, noFollow,
+				saveToAdjusted, true, true, keepTs, "root:root", ifExists, symlinkNoFollow,
 				llb.WithCustomNamef(
 					"%sSAVE ARTIFACT %s%s%s %s AS LOCAL %s",
 					c.vertexPrefix(false, false),
 					strIf(ifExists, "--if-exists "),
-					strIf(noFollow, "--no-follow "),
+					strIf(symlinkNoFollow, "--symlink-no-follow "),
 					saveFrom,
 					artifact.String(),
 					saveAsLocalTo))

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -632,7 +632,7 @@ func (c *Converter) Run(ctx context.Context, args, mounts, secretKeyValues []str
 }
 
 // SaveArtifact applies the earthly SAVE ARTIFACT command.
-func (c *Converter) SaveArtifact(ctx context.Context, saveFrom string, saveTo string, saveAsLocalTo string, keepTs bool, keepOwn bool, ifExists bool, isPush bool) error {
+func (c *Converter) SaveArtifact(ctx context.Context, saveFrom string, saveTo string, saveAsLocalTo string, keepTs bool, keepOwn bool, ifExists, noFollow bool, isPush bool) error {
 	err := c.checkAllowed("SAVE ARTIFACT")
 	if err != nil {
 		return err
@@ -667,25 +667,40 @@ func (c *Converter) SaveArtifact(ctx context.Context, saveFrom string, saveTo st
 	}
 	c.mts.Final.ArtifactsState = llbutil.CopyOp(
 		c.mts.Final.MainState, []string{saveFrom}, c.mts.Final.ArtifactsState,
-		saveToAdjusted, true, true, keepTs, own, ifExists, false,
+		saveToAdjusted, true, true, keepTs, own, ifExists, noFollow,
 		llb.WithCustomNamef(
-			"%sSAVE ARTIFACT %s%s %s", c.vertexPrefix(false, false), strIf(ifExists, "--if-exists "), saveFrom, artifact.String()))
+			"%sSAVE ARTIFACT %s%s%s %s",
+			c.vertexPrefix(false, false),
+			strIf(ifExists, "--if-exists "),
+			strIf(noFollow, "--no-follow "),
+			saveFrom,
+			artifact.String()))
 	if saveAsLocalTo != "" {
 		separateArtifactsState := llbutil.ScratchWithPlatform()
 		if isPush {
 			separateArtifactsState = llbutil.CopyOp(
 				c.mts.Final.RunPush.State, []string{saveFrom}, separateArtifactsState,
-				saveToAdjusted, true, true, keepTs, "root:root", ifExists, false,
+				saveToAdjusted, true, true, keepTs, "root:root", ifExists, noFollow,
 				llb.WithCustomNamef(
-					"%sSAVE ARTIFACT %s%s %s AS LOCAL %s",
-					c.vertexPrefix(false, false), strIf(ifExists, "--if-exists "), saveFrom, artifact.String(), saveAsLocalTo))
+					"%sSAVE ARTIFACT %s%s%s %s AS LOCAL %s",
+					c.vertexPrefix(false, false),
+					strIf(ifExists, "--if-exists "),
+					strIf(noFollow, "--no-follow "),
+					saveFrom,
+					artifact.String(),
+					saveAsLocalTo))
 		} else {
 			separateArtifactsState = llbutil.CopyOp(
 				c.mts.Final.MainState, []string{saveFrom}, separateArtifactsState,
-				saveToAdjusted, true, true, keepTs, "root:root", ifExists, false,
+				saveToAdjusted, true, true, keepTs, "root:root", ifExists, noFollow,
 				llb.WithCustomNamef(
-					"%sSAVE ARTIFACT %s%s %s AS LOCAL %s",
-					c.vertexPrefix(false, false), strIf(ifExists, "--if-exists "), saveFrom, artifact.String(), saveAsLocalTo))
+					"%sSAVE ARTIFACT %s%s%s %s AS LOCAL %s",
+					c.vertexPrefix(false, false),
+					strIf(ifExists, "--if-exists "),
+					strIf(noFollow, "--no-follow "),
+					saveFrom,
+					artifact.String(),
+					saveAsLocalTo))
 		}
 		c.mts.Final.SeparateArtifactsState = append(c.mts.Final.SeparateArtifactsState, separateArtifactsState)
 

--- a/earthfile2llb/flags.go
+++ b/earthfile2llb/flags.go
@@ -55,6 +55,7 @@ type saveArtifactOpts struct {
 	KeepTs   bool `long:"keep-ts" description:"Keep created time file timestamps"`
 	KeepOwn  bool `long:"keep-own" description:"Keep owner info"`
 	IfExists bool `long:"if-exists" description:"Do not fail if the artifact does not exist"`
+	NoFollow bool `long:"no-follow" description:"Do not follow symlinks"`
 }
 
 type saveImageOpts struct {

--- a/earthfile2llb/flags.go
+++ b/earthfile2llb/flags.go
@@ -45,17 +45,17 @@ type copyOpts struct {
 	KeepTs          bool     `long:"keep-ts" description:"Keep created time file timestamps"`
 	KeepOwn         bool     `long:"keep-own" description:"Keep owner info"`
 	IfExists        bool     `long:"if-exists" description:"Do not fail if the artifact does not exist"`
-	NoFollow        bool     `long:"no-follow" description:"Do not follow symlinks"`
+	SymlinkNoFollow bool     `long:"symlink-no-follow" description:"Do not follow symlinks"`
 	AllowPrivileged bool     `long:"allow-privileged" description:"Allow targets to assume privileged mode"`
 	Platform        string   `long:"platform" description:"The platform to use"`
 	BuildArgs       []string `long:"build-arg" description:"A build arg override passed on to a referenced Earthly target"`
 }
 
 type saveArtifactOpts struct {
-	KeepTs   bool `long:"keep-ts" description:"Keep created time file timestamps"`
-	KeepOwn  bool `long:"keep-own" description:"Keep owner info"`
-	IfExists bool `long:"if-exists" description:"Do not fail if the artifact does not exist"`
-	NoFollow bool `long:"no-follow" description:"Do not follow symlinks"`
+	KeepTs          bool `long:"keep-ts" description:"Keep created time file timestamps"`
+	KeepOwn         bool `long:"keep-own" description:"Keep owner info"`
+	IfExists        bool `long:"if-exists" description:"Do not fail if the artifact does not exist"`
+	SymlinkNoFollow bool `long:"symlink-no-follow" description:"Do not follow symlinks"`
 }
 
 type saveImageOpts struct {

--- a/earthfile2llb/flags.go
+++ b/earthfile2llb/flags.go
@@ -45,6 +45,7 @@ type copyOpts struct {
 	KeepTs          bool     `long:"keep-ts" description:"Keep created time file timestamps"`
 	KeepOwn         bool     `long:"keep-own" description:"Keep owner info"`
 	IfExists        bool     `long:"if-exists" description:"Do not fail if the artifact does not exist"`
+	NoFollow        bool     `long:"no-follow" description:"Do not follow symlinks"`
 	AllowPrivileged bool     `long:"allow-privileged" description:"Allow targets to assume privileged mode"`
 	Platform        string   `long:"platform" description:"The platform to use"`
 	BuildArgs       []string `long:"build-arg" description:"A build arg override passed on to a referenced Earthly target"`

--- a/earthfile2llb/interpreter.go
+++ b/earthfile2llb/interpreter.go
@@ -759,7 +759,7 @@ func (i *Interpreter) handleSaveArtifact(ctx context.Context, cmd spec.Command) 
 		return nil
 	}
 
-	err = i.converter.SaveArtifact(ctx, saveFrom, saveTo, saveAsLocalTo, opts.KeepTs, opts.KeepOwn, opts.IfExists, i.pushOnlyAllowed)
+	err = i.converter.SaveArtifact(ctx, saveFrom, saveTo, saveAsLocalTo, opts.KeepTs, opts.KeepOwn, opts.IfExists, opts.NoFollow, i.pushOnlyAllowed)
 	if err != nil {
 		return i.wrapError(err, cmd.SourceLocation, "apply SAVE ARTIFACT")
 	}

--- a/earthfile2llb/interpreter.go
+++ b/earthfile2llb/interpreter.go
@@ -692,7 +692,7 @@ func (i *Interpreter) handleCopy(ctx context.Context, cmd spec.Command) error {
 					return i.wrapError(err, cmd.SourceLocation, "copy artifact locally")
 				}
 			} else {
-				err = i.converter.CopyArtifact(ctx, src, dest, platform, allowPrivileged, srcBuildArgs, opts.IsDirCopy, opts.KeepTs, opts.KeepOwn, opts.Chown, opts.IfExists)
+				err = i.converter.CopyArtifact(ctx, src, dest, platform, allowPrivileged, srcBuildArgs, opts.IsDirCopy, opts.KeepTs, opts.KeepOwn, opts.Chown, opts.IfExists, opts.NoFollow)
 				if err != nil {
 					return i.wrapError(err, cmd.SourceLocation, "copy artifact")
 				}

--- a/earthfile2llb/interpreter.go
+++ b/earthfile2llb/interpreter.go
@@ -692,7 +692,7 @@ func (i *Interpreter) handleCopy(ctx context.Context, cmd spec.Command) error {
 					return i.wrapError(err, cmd.SourceLocation, "copy artifact locally")
 				}
 			} else {
-				err = i.converter.CopyArtifact(ctx, src, dest, platform, allowPrivileged, srcBuildArgs, opts.IsDirCopy, opts.KeepTs, opts.KeepOwn, opts.Chown, opts.IfExists, opts.NoFollow)
+				err = i.converter.CopyArtifact(ctx, src, dest, platform, allowPrivileged, srcBuildArgs, opts.IsDirCopy, opts.KeepTs, opts.KeepOwn, opts.Chown, opts.IfExists, opts.SymlinkNoFollow)
 				if err != nil {
 					return i.wrapError(err, cmd.SourceLocation, "copy artifact")
 				}
@@ -759,7 +759,7 @@ func (i *Interpreter) handleSaveArtifact(ctx context.Context, cmd spec.Command) 
 		return nil
 	}
 
-	err = i.converter.SaveArtifact(ctx, saveFrom, saveTo, saveAsLocalTo, opts.KeepTs, opts.KeepOwn, opts.IfExists, opts.NoFollow, i.pushOnlyAllowed)
+	err = i.converter.SaveArtifact(ctx, saveFrom, saveTo, saveAsLocalTo, opts.KeepTs, opts.KeepOwn, opts.IfExists, opts.SymlinkNoFollow, i.pushOnlyAllowed)
 	if err != nil {
 		return i.wrapError(err, cmd.SourceLocation, "apply SAVE ARTIFACT")
 	}

--- a/examples/tests/copy.earth
+++ b/examples/tests/copy.earth
@@ -15,6 +15,7 @@ all:
     BUILD +copy-art-multi-no-exist
     BUILD +copy-art-multi-trailing-slash
     BUILD +copy-art-multi-existing
+    BUILD +copy-invalid-symlink
 
 artifact:
     COPY --dir in in
@@ -165,3 +166,11 @@ copied/1/file
 copied/2
 copied/2/file" >./expected
     RUN diff -b ./actual ./expected
+
+copy-invalid-symlink-base:
+    RUN ln -s nonexistant symlink
+    SAVE ARTIFACT symlink
+
+copy-invalid-symlink:
+    COPY --no-follow +copy-invalid-symlink-base/symlink .
+    RUN ls -la symlink | grep nonexistant

--- a/examples/tests/copy.earth
+++ b/examples/tests/copy.earth
@@ -168,9 +168,13 @@ copied/2/file" >./expected
     RUN diff -b ./actual ./expected
 
 copy-invalid-symlink-base:
-    RUN ln -s nonexistant symlink
-    SAVE ARTIFACT symlink
+    RUN mkdir -p /symlinks
+    RUN mkdir -p /data
+    RUN echo hello > /data/hello.txt
+    RUN ln -s /data/hello.txt /symlinks/symlink
+    SAVE ARTIFACT /symlinks/ /symlinks/
 
 copy-invalid-symlink:
-    COPY --no-follow +copy-invalid-symlink-base/symlink .
-    RUN ls -la symlink | grep nonexistant
+    COPY --no-follow +copy-invalid-symlink-base/* /
+    RUN ls -la /symlinks/symlink | grep hello.txt
+    RUN ls /symlinks/symlink 2>&1 | grep 'No such file or directory'

--- a/examples/tests/copy.earth
+++ b/examples/tests/copy.earth
@@ -16,6 +16,7 @@ all:
     BUILD +copy-art-multi-trailing-slash
     BUILD +copy-art-multi-existing
     BUILD +copy-invalid-symlink
+    BUILD +copy-dir-containing-invalid-symlink
 
 artifact:
     COPY --dir in in
@@ -168,13 +169,25 @@ copied/2/file" >./expected
     RUN diff -b ./actual ./expected
 
 copy-invalid-symlink-base:
+    RUN ln -s nonexistanttarget symlink
+    SAVE ARTIFACT --no-follow symlink
+
+copy-invalid-symlink:
+    COPY --no-follow +copy-invalid-symlink-base/symlink .
+    RUN ls -la symlink | grep nonexistanttarget
+    RUN ls symlink 2>&1 | grep 'No such file or directory'
+
+copy-dir-containing-invalid-symlink-base:
     RUN mkdir -p /symlinks
     RUN mkdir -p /data
     RUN echo hello > /data/hello.txt
     RUN ln -s /data/hello.txt /symlinks/symlink
     SAVE ARTIFACT /symlinks/ /symlinks/
 
-copy-invalid-symlink:
-    COPY --no-follow +copy-invalid-symlink-base/* /
+copy-dir-containing-invalid-symlink:
+    COPY --no-follow +copy-dir-containing-invalid-symlink-base/* /
     RUN ls -la /symlinks/symlink | grep hello.txt
     RUN ls /symlinks/symlink 2>&1 | grep 'No such file or directory'
+    RUN mkdir /data
+    RUN echo hi > /data/hello.txt
+    RUN cat /symlinks/symlink | grep -w hi

--- a/examples/tests/copy.earth
+++ b/examples/tests/copy.earth
@@ -170,10 +170,10 @@ copied/2/file" >./expected
 
 copy-invalid-symlink-base:
     RUN ln -s nonexistanttarget symlink
-    SAVE ARTIFACT --no-follow symlink
+    SAVE ARTIFACT --symlink-no-follow symlink
 
 copy-invalid-symlink:
-    COPY --no-follow +copy-invalid-symlink-base/symlink .
+    COPY --symlink-no-follow +copy-invalid-symlink-base/symlink .
     RUN ls -la symlink | grep nonexistanttarget
     RUN ls symlink 2>&1 | grep 'No such file or directory'
 
@@ -185,7 +185,7 @@ copy-dir-containing-invalid-symlink-base:
     SAVE ARTIFACT /symlinks/ /symlinks/
 
 copy-dir-containing-invalid-symlink:
-    COPY --no-follow +copy-dir-containing-invalid-symlink-base/* /
+    COPY --symlink-no-follow +copy-dir-containing-invalid-symlink-base/* /
     RUN ls -la /symlinks/symlink | grep hello.txt
     RUN ls /symlinks/symlink 2>&1 | grep 'No such file or directory'
     RUN mkdir /data

--- a/util/llbutil/copyop.go
+++ b/util/llbutil/copyop.go
@@ -13,7 +13,7 @@ import (
 )
 
 // CopyOp is a simplified llb copy operation.
-func CopyOp(srcState pllb.State, srcs []string, destState pllb.State, dest string, allowWildcard bool, isDir bool, keepTs bool, chown string, ifExists, noFollow bool, opts ...llb.ConstraintsOpt) pllb.State {
+func CopyOp(srcState pllb.State, srcs []string, destState pllb.State, dest string, allowWildcard bool, isDir bool, keepTs bool, chown string, ifExists, symlinkNoFollow bool, opts ...llb.ConstraintsOpt) pllb.State {
 	destAdjusted := dest
 	if dest == "." || dest == "" || len(srcs) > 1 {
 		destAdjusted += string("/") // TODO: needs to be the containers platform, not the earthly hosts platform. For now, this is always Linux.
@@ -37,7 +37,7 @@ func CopyOp(srcState pllb.State, srcs []string, destState pllb.State, dest strin
 		}
 		copyOpts := append([]llb.CopyOption{
 			&llb.CopyInfo{
-				FollowSymlinks:      !noFollow,
+				FollowSymlinks:      !symlinkNoFollow,
 				CopyDirContentsOnly: !isDir,
 				AttemptUnpack:       false,
 				CreateDestPath:      true,

--- a/util/llbutil/copyop.go
+++ b/util/llbutil/copyop.go
@@ -13,7 +13,7 @@ import (
 )
 
 // CopyOp is a simplified llb copy operation.
-func CopyOp(srcState pllb.State, srcs []string, destState pllb.State, dest string, allowWildcard bool, isDir bool, keepTs bool, chown string, ifExists bool, opts ...llb.ConstraintsOpt) pllb.State {
+func CopyOp(srcState pllb.State, srcs []string, destState pllb.State, dest string, allowWildcard bool, isDir bool, keepTs bool, chown string, ifExists, noFollow bool, opts ...llb.ConstraintsOpt) pllb.State {
 	destAdjusted := dest
 	if dest == "." || dest == "" || len(srcs) > 1 {
 		destAdjusted += string("/") // TODO: needs to be the containers platform, not the earthly hosts platform. For now, this is always Linux.
@@ -37,7 +37,7 @@ func CopyOp(srcState pllb.State, srcs []string, destState pllb.State, dest strin
 		}
 		copyOpts := append([]llb.CopyOption{
 			&llb.CopyInfo{
-				FollowSymlinks:      true,
+				FollowSymlinks:      !noFollow,
 				CopyDirContentsOnly: !isDir,
 				AttemptUnpack:       false,
 				CreateDestPath:      true,


### PR DESCRIPTION
This introduces a `--no-follow` flag for both COPY and SAVE ARTIFACT commands, which pass the NoFollow flag to buildkit's CopyOp which will prevent symlinks from being followed. This allows users to save and copy invalid symlinks (which point to non-existent paths).

When using `SAVE ARTIFACT` on files, `--no-follow` is required if the file is an invalid symlink. Furthermore, when that file is copied `--no-follow` must also be used on the `COPY` command.

However, when using `SAVE ARTIFACT` on directories which contain one or more symlink, the `--no-follow` flag has no effect on buildkit's internal workings, and therefore is not required by earthly. The `--no-follow` flag is still however required on the `COPY` command.