### PR TITLE
prefix buildkit image with dev- when building +earthly

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -183,7 +183,7 @@ earthly:
     RUN test -n "$GOOS" && test -n "$GOARCH"
     RUN test "$GOARCH" != "arm" || test -n "$VARIANT"
     ARG EARTHLY_TARGET_TAG_DOCKER
-    ARG VERSION=$EARTHLY_TARGET_TAG_DOCKER
+    ARG VERSION="dev-$EARTHLY_TARGET_TAG_DOCKER"
     ARG EARTHLY_GIT_HASH
     ARG DEFAULT_BUILDKITD_IMAGE=earthly/buildkitd:$VERSION
     ARG BUILD_TAGS=dfrunmount dfrunsecurity dfsecrets dfssh dfrunnetwork

--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -54,7 +54,7 @@ buildkitd:
     VOLUME /tmp/earthly
     ENTRYPOINT ["/usr/bin/entrypoint.sh", "buildkitd", "--config=/etc/buildkitd.toml"]
     ARG EARTHLY_TARGET_TAG_DOCKER
-    ARG TAG=$EARTHLY_TARGET_TAG_DOCKER
+    ARG TAG="dev-$EARTHLY_TARGET_TAG_DOCKER"
     SAVE IMAGE --push --cache-from=earthly/buildkitd:main earthly/buildkitd:$TAG
 
 update-buildkit:


### PR DESCRIPTION
When version is not given, it defaults to the current git branch.
This causes a problem if someone checks out a previous branch of
earthly, modifies some code (while debugging a problem), and runs
earthly +earthly. This will overwrite the released buildkit image.

This PR adds a "dev-" prefix the buildkit when earthly is built
directly.

When performing a release via ./release+release, the VERSION tag is set
to whatever value is passed by RELEASE_TAG, (thus overridding the
default value (which includes the dev- prefix)).

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>