### PR TITLE
bugfix: absolute referenced target's relative import fails

### DIFF
--- a/domain/reference.go
+++ b/domain/reference.go
@@ -84,7 +84,7 @@ func JoinReferences(r1 Reference, r2 Reference) (Reference, error) {
 				localPath = path.Clean(localPath)
 			} else {
 				localPath = path.Join(r1.GetLocalPath(), localPath)
-				if !strings.HasPrefix(localPath, ".") {
+				if !(strings.HasPrefix(localPath, ".") || strings.HasPrefix(localPath, "/")) {
 					localPath = fmt.Sprintf("./%s", localPath)
 				}
 			}

--- a/examples/tests/Earthfile
+++ b/examples/tests/Earthfile
@@ -53,6 +53,7 @@ ga:
     BUILD +escape-dir-test
     BUILD +fail-invalid-artifact-test
     BUILD +target-first-line
+    BUILD +absolute-reference-with-relative
     BUILD +end-comment
     BUILD +if-exists
     BUILD +file-copying
@@ -373,6 +374,12 @@ eine-privileged-test:
 target-first-line:
     DO +RUN_EARTHLY --earthfile=target-first-line.earth --extra_args="--no-output" --target=+test
 
+absolute-reference-with-relative:
+    RUN mkdir -p /a/path/to/test/subdir
+    # create a base Earthfile which is referenced by target-absolute-reference.earth
+    RUN echo -e "FROM alpine:3.13\nRUN mkdir -p /dir/from/base" > /a/path/to/test/Earthfile
+    DO +RUN_EARTHLY --earthfile=absolute-reference-with-relative.earth --earthfile_dest=/a/path/to/test/subdir/Earthfile --extra_args="--no-output" --target=/a/path/to/test/subdir+test
+
 end-comment:
     DO +RUN_EARTHLY --earthfile=end-comment.earth --target=+test
 
@@ -544,12 +551,13 @@ cache-mount-arg:
 RUN_EARTHLY:
     COMMAND
     ARG earthfile=
+    ARG earthfile_dest="./Earthfile"
     ARG target=+all
     ARG extra_args
     ARG post_command
     ARG should_fail=false
     ARG use_tmpfs=true
-    COPY "$earthfile" ./Earthfile
+    COPY "$earthfile" "$earthfile_dest"
     RUN echo "
         set -x
         if $use_tmpfs; then

--- a/examples/tests/absolute-reference-with-relative.earth
+++ b/examples/tests/absolute-reference-with-relative.earth
@@ -1,0 +1,3 @@
+test:
+    FROM ../+base
+    RUN ls /dir/from/base


### PR DESCRIPTION
Fixes a bug where absolutely referencing an earthfile that contains a
relative import fails.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>