### PR TITLE
Allow user to override container and volume names

### DIFF
--- a/buildkitd/settings.go
+++ b/buildkitd/settings.go
@@ -28,6 +28,7 @@ type Settings struct {
 	ServerTLSKey         string
 	UseTCP               bool
 	UseTLS               bool
+	VolumeName           string
 }
 
 // Hash returns a secure hash of the settings.


### PR DESCRIPTION
This allows a user to switch between volume caches, which increases the
speed of testing operations where one needs to reset the volume cache.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>