### PR TITLE
Disable analytics collection when DO_NOT_TRACK is set

### DIFF
--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -533,7 +533,7 @@ func newEarthlyApp(ctx context.Context, console conslogging.ConsoleLogger) *eart
 			Destination: &app.conversionParllelism,
 		},
 		&cli.BoolFlag{
-			EnvVars:     []string{"EARTHLY_DISABLE_ANALYTICS"},
+			EnvVars:     []string{"EARTHLY_DISABLE_ANALYTICS", "DO_NOT_TRACK"},
 			Usage:       "Disable collection of analytics",
 			Destination: &app.disableAnalytics,
 		},


### PR DESCRIPTION
This follows the suggestion of https://consoledonottrack.com/
to adopt a single environment variable to disable tracking users.

Without this environment variable set, earthly will collect
anonymized data as discussed under https://docs.earthly.dev/docs/misc/data-collection

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>