### PR TITLE
Set the IncludePattern on Local Source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,44 @@ jobs:
         run: docker logs earthly-buildkitd
         if: ${{ failure() }}
 
+  test-use-copy-include-patterns:
+    runs-on: ubuntu-latest
+    env:
+      FORCE_COLOR: 1
+      EARTHLY_CONVERSION_PARALLELISM: "5"
+      EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"
+      EARTHLY_INSTALL_ID: "earthly-githubactions"
+      EARTHLY_FEATURE_FLAG_OVERRIDES: "use-copy-include-patterns"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v1
+        with:
+          go-version: 1.16
+      - name: Download released earthly
+        run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/latest/download/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly'"
+      - name: Docker Login (non fork only)
+        run: docker login --username "${{ secrets.DOCKERHUB_USERNAME }}" --password "${{ secrets.DOCKERHUB_TOKEN }}"
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+      - name: Docker mirror login (non fork only)
+        run: docker login registry-1.docker.io.mirror.corp.earthly.dev --username "${{ secrets.DOCKERHUB_MIRROR_USERNAME }}" --password "${{ secrets.DOCKERHUB_MIRROR_PASSWORD }}"
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+      - name: Configure Earthly to use mirror (non fork only)
+        run: |-
+          earthly config global.buildkit_additional_config "'[registry.\"docker.io\"]
+
+          mirrors = [\"registry-1.docker.io.mirror.corp.earthly.dev\"]'"
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+      - name: Build latest earthly using released earthly
+        run: earthly --use-inline-cache +for-linux
+      - name: Enable local registry-based exporter
+        run: ./build/linux/amd64/earthly config global.local_registry_host 'tcp://127.0.0.1:8371'
+      - name: Build examples1 (PR build)
+        run: ./build/linux/amd64/earthly --ci -P +examples1
+        if: github.event_name != 'push'
+      - name: Buildkit logs (runs on failure)
+        run: docker logs earthly-buildkitd
+        if: ${{ failure() }}
+
   examples1:
     name: +examples1
     runs-on: ubuntu-latest

--- a/buildcontext/local.go
+++ b/buildcontext/local.go
@@ -9,7 +9,7 @@ import (
 	"github.com/earthly/earthly/domain"
 	"github.com/earthly/earthly/util/gitutil"
 	"github.com/earthly/earthly/util/llbutil"
-	"github.com/earthly/earthly/util/llbutil/pllb"
+	"github.com/earthly/earthly/util/llbutil/llbfactory"
 	"github.com/earthly/earthly/util/syncutil/synccache"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/pkg/errors"
@@ -56,13 +56,13 @@ func (lr *localResolver) resolveLocal(ctx context.Context, ref domain.Reference)
 		return nil, err
 	}
 
-	var buildContext pllb.State
+	var buildContextFactory llbfactory.Factory
 	if _, isTarget := ref.(domain.Target); isTarget {
 		excludes, err := readExcludes(ref.GetLocalPath())
 		if err != nil {
 			return nil, err
 		}
-		buildContext = pllb.Local(
+		buildContextFactory = llbfactory.Local(
 			ref.GetLocalPath(),
 			llb.ExcludePatterns(excludes),
 			llb.SessionID(lr.sessionID),
@@ -74,8 +74,8 @@ func (lr *localResolver) resolveLocal(ctx context.Context, ref domain.Reference)
 	}
 
 	return &Data{
-		BuildFilePath: buildFilePath,
-		BuildContext:  buildContext,
-		GitMetadata:   metadata,
+		BuildFilePath:       buildFilePath,
+		BuildContextFactory: buildContextFactory,
+		GitMetadata:         metadata,
 	}, nil
 }

--- a/buildcontext/resolver.go
+++ b/buildcontext/resolver.go
@@ -11,7 +11,7 @@ import (
 	"github.com/earthly/earthly/conslogging"
 	"github.com/earthly/earthly/domain"
 	"github.com/earthly/earthly/util/gitutil"
-	"github.com/earthly/earthly/util/llbutil/pllb"
+	"github.com/earthly/earthly/util/llbutil/llbfactory"
 	"github.com/earthly/earthly/util/syncutil/synccache"
 
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
@@ -29,7 +29,7 @@ type Data struct {
 	// BuildFilePath is the local path where the Earthfile or Dockerfile can be found.
 	BuildFilePath string
 	// BuildContext is the state to use for the build.
-	BuildContext pllb.State
+	BuildContextFactory llbfactory.Factory
 	// GitMetadata contains git metadata information.
 	GitMetadata *gitutil.GitMetadata
 	// Target is the earthly reference.

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -155,6 +155,8 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 	}
 	sp := newSuccessPrinter(successFun(""), successFun("--push"))
 
+	sharedLocalStateCache := earthfile2llb.NewSharedLocalStateCache()
+
 	destPathWhitelist := make(map[string]bool)
 	manifestLists := make(map[string][]manifest) // parent image -> child images
 	var mts *states.MultiTarget
@@ -185,6 +187,7 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 				Console:              b.opt.Console,
 				GitLookup:            b.opt.GitLookup,
 				FeatureFlagOverrides: b.opt.FeatureFlagOverrides,
+				LocalStateCache:      sharedLocalStateCache,
 			})
 			if err != nil {
 				return nil, err

--- a/earthfile2llb/earthfile2llb.go
+++ b/earthfile2llb/earthfile2llb.go
@@ -73,6 +73,8 @@ type ConvertOpt struct {
 	AllowPrivileged bool
 	// Gitlookup is used to attach credentials to GIT CLONE operations
 	GitLookup *buildcontext.GitLookup
+	// LocalStateCache provides a cache for local pllb.States
+	LocalStateCache *LocalStateCache
 
 	// ParallelConversion is a feature flag enabling the parallel conversion algorithm.
 	ParallelConversion bool
@@ -129,7 +131,7 @@ func Earthfile2LLB(ctx context.Context, target domain.Target, opt ConvertOpt) (m
 			Visited: opt.Visited,
 		}, nil
 	}
-	converter, err := NewConverter(ctx, targetWithMetadata, bc, sts, opt)
+	converter, err := NewConverter(ctx, targetWithMetadata, bc, sts, opt, ftrs)
 	if err != nil {
 		return nil, err
 	}

--- a/earthfile2llb/local_state_cache.go
+++ b/earthfile2llb/local_state_cache.go
@@ -1,0 +1,93 @@
+package earthfile2llb
+
+import (
+	"crypto/sha1"
+	"encoding/binary"
+	"encoding/hex"
+	"strings"
+	"sync"
+
+	"github.com/earthly/earthly/util/inodeutil"
+	"github.com/earthly/earthly/util/llbutil/llbfactory"
+	"github.com/earthly/earthly/util/llbutil/pllb"
+)
+
+// LocalStateCache provides caching of local States
+type LocalStateCache struct {
+	mu    sync.Mutex
+	cache map[string]pllb.State
+}
+
+// NewSharedLocalStateCache creates a new local state cache
+func NewSharedLocalStateCache() *LocalStateCache {
+	return &LocalStateCache{
+		cache: map[string]pllb.State{},
+	}
+}
+
+// getOrConstruct returns a cached pllb.State with the same sharedkey, or creates a new one
+// if it doesn't exist.
+func (lsc *LocalStateCache) getOrConstruct(factory llbfactory.Factory) pllb.State {
+	localFactory, ok := factory.(*llbfactory.LocalFactory)
+	if !ok {
+		return factory.Construct()
+	}
+
+	lsc.mu.Lock()
+	defer lsc.mu.Unlock()
+
+	key := localFactory.GetSharedKey()
+
+	if st, ok := lsc.cache[key]; ok {
+		return st
+	}
+
+	st := factory.Construct()
+	lsc.cache[key] = st
+	return st
+}
+
+func getSharedKeyHintFromInclude(name string, incl []string) string {
+	h := sha1.New()
+	b := make([]byte, 8)
+
+	addToHash := func(path string) {
+		h.Write([]byte(path))
+		inode := inodeutil.GetInodeBestEffort(path)
+		binary.LittleEndian.PutUint64(b, inode)
+		h.Write(b)
+	}
+
+	addToHash(name)
+	for _, path := range incl {
+		addToHash(path)
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func createIncludePatterns(incl []string) []string {
+	incl2 := []string{}
+	for _, inc := range incl {
+		if inc == "." {
+			inc = "./*"
+		} else if strings.HasSuffix(inc, "/.") {
+			inc = inc[:len(inc)-1] + "*"
+		}
+		incl2 = append(incl2, inc)
+	}
+	return incl2
+}
+
+func addIncludePathAndSharedKeyHint(factory llbfactory.Factory, src []string) llbfactory.Factory {
+	localFactory, ok := factory.(*llbfactory.LocalFactory)
+	if !ok {
+		return factory
+	}
+
+	includePatterns := createIncludePatterns(src)
+	sharedKey := getSharedKeyHintFromInclude(localFactory.GetName(), includePatterns)
+
+	return localFactory.
+		WithInclude(includePatterns).
+		WithSharedKeyHint(sharedKey)
+}

--- a/earthly-entrypoint.sh
+++ b/earthly-entrypoint.sh
@@ -66,6 +66,12 @@ fi
 
 cd "$BASE_DIR"
 
+if [ -n "$EARTHLY_EXEC_CMD" ]; then
+    export earthly_config
+    exec "$EARTHLY_EXEC_CMD"
+    exit 1 # this should never be reached
+fi
+
 # Run earthly with given args.
 # Exec so we don't have to trap and manage signal propagation
 exec earthly --config $earthly_config "$@"

--- a/examples/tests/Earthfile
+++ b/examples/tests/Earthfile
@@ -19,6 +19,7 @@ ga:
     BUILD ./version+test-all
     BUILD +privileged-test
     BUILD +copy-test
+    BUILD +copy-test-verbose-output
     BUILD +cache-test
     BUILD +git-clone-test
     BUILD +builtin-args-test
@@ -95,11 +96,41 @@ copy-test:
         echo "sub" > in/sub/file
     DO +RUN_EARTHLY --earthfile=copy.earth
 
-    RUN echo "output.txt" > .earthignore
-    DO +RUN_EARTHLY --earthfile=copy.earth --extra_args="--verbose"  --post_command="2>output.txt"
+copy-test-verbose-output:
+    RUN mkdir -p subdir/a.txt && \
+        echo -n "a" > a.txt && \
+        echo -n "alpha" > alpha.txt && \
+        echo -n "beta" > subdir/a.txt/beta.txt
+
+    COPY copy-verbose.earth Earthfile
+
+    # Setup a test that runs earthly twice; both instances of earthly must be run
+    # back to back as the file caching logic references the directories inode ID while constructing
+    # the shared cache key.
+    RUN echo "#!/bin/sh
+set -x
+earthly --config \$earthly_config --verbose +all 2>output.txt;
+earthly --config \$earthly_config --verbose +all 2>output2.txt;
+" >/tmp/multiple-earthly-script && chmod +x /tmp/multiple-earthly-script
+
+    RUN --privileged \
+        --mount=type=tmpfs,target=/tmp/earthly-tmpfs \
+        set -x; \
+        export EARTHLY_TMP_DIR="/tmp/earthly-tmpfs"; \
+        export EARTHLY_EXEC_CMD="/tmp/multiple-earthly-script"; \
+        /bin/sh /usr/bin/earthly-entrypoint.sh;
+
+    # test that the first run sends a.txt and doesn't send any non-referenced files
     RUN cat output.txt
-    RUN cat output.txt | grep 'sent data for in/root (5 B)'
-    RUN cat output.txt | grep 'transferred 4 file(s) for context . (261 B, 8 file/dir stats)'
+    RUN cat output.txt | grep 'sent data for a.txt (1 B)'
+    RUN if grep "sent data for alpha.txt" output.txt >/dev/null; then echo "alpha.txt should not have been sent"; exit 1; fi
+    RUN if grep "sent data for .*beta.txt" output.txt >/dev/null; then echo "beta.txt should not have been sent"; exit 1; fi
+
+    # test that the second run did not resend a.txt (or any other non-referenced files)
+    RUN cat output2.txt
+    RUN if grep "sent data for a.txt" output2.txt >/dev/null; then echo "a.txt should not have been sent"; exit 1; fi
+    RUN if grep "sent data for alpha.txt" output2.txt >/dev/null; then echo "alpha.txt should not have been sent"; exit 1; fi
+    RUN if grep "sent data for .*beta.txt" output2.txt >/dev/null; then echo "beta.txt should not have been sent"; exit 1; fi
 
 cache-test:
     # Test that a file can be passed between runs through the mounted cache.

--- a/examples/tests/copy-verbose.earth
+++ b/examples/tests/copy-verbose.earth
@@ -1,0 +1,6 @@
+VERSION --use-copy-include-patterns 0.5
+FROM alpine:3.13
+
+all:
+    COPY a.txt .
+    RUN cat a.txt | md5sum - | grep 0cc175b9c0f1b6a831c399e269772661

--- a/util/inodeutil/inode_other.go
+++ b/util/inodeutil/inode_other.go
@@ -1,0 +1,17 @@
+// +build !windows
+
+package inodeutil
+
+import (
+	"syscall"
+)
+
+// GetInodeBestEffort returns an inode if available, or 0 on failure
+func GetInodeBestEffort(path string) uint64 {
+	var stat syscall.Stat_t
+	inode := uint64(0)
+	if err := syscall.Stat(path, &stat); err == nil {
+		inode = uint64(stat.Ino)
+	}
+	return inode
+}

--- a/util/inodeutil/inode_windows.go
+++ b/util/inodeutil/inode_windows.go
@@ -1,0 +1,26 @@
+// +build windows
+
+package inodeutil
+
+import (
+	"os"
+	"syscall"
+)
+
+// GetInodeBestEffort returns an inode if available, or 0 on failure
+func GetInodeBestEffort(path string) uint64 {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0
+	}
+	defer f.Close()
+
+	var info syscall.ByHandleFileInformation
+	if err := syscall.GetFileInformationByHandle(syscall.Handle(f.Fd()), &info); err != nil {
+		return 0
+	}
+	inode := uint64(info.FileIndexHigh)
+	inode <<= 32
+	inode += uint64(info.FileIndexLow)
+	return inode
+}

--- a/util/llbutil/llbfactory/llb_factory.go
+++ b/util/llbutil/llbfactory/llb_factory.go
@@ -1,0 +1,93 @@
+package llbfactory
+
+import (
+	"github.com/earthly/earthly/util/llbutil/pllb"
+
+	"github.com/moby/buildkit/client/llb"
+)
+
+// Factory is used for constructing llb states
+type Factory interface {
+	// Construct creates a pllb.State
+	Construct() pllb.State
+}
+
+// PreconstructedFactory holds a pre-constructed pllb.State for cases
+// where a factory is overkill.
+type PreconstructedFactory struct {
+	preconstructedState pllb.State
+}
+
+// LocalFactory holds data which can be used to create a pllb.Local state
+type LocalFactory struct {
+	name          string
+	sharedKeyHint string
+	opts          []llb.LocalOption
+}
+
+// PreconstructedState returns a pseudo-factory which returns
+// the passed in state when Construct() is called.
+// It is provided for cases where a factory is overkill.
+func PreconstructedState(state pllb.State) Factory {
+	return &PreconstructedFactory{
+		preconstructedState: state,
+	}
+}
+
+// Construct returns the preconstructed state that was passed to PreconstructedState()
+func (f *PreconstructedFactory) Construct() pllb.State {
+	return f.preconstructedState
+}
+
+// Local eventually creates a llb.Local
+func Local(name string, opts ...llb.LocalOption) Factory {
+	return &LocalFactory{
+		name: name,
+		opts: opts,
+	}
+}
+
+// Copy makes a new copy of the localFactory
+func (f *LocalFactory) Copy() *LocalFactory {
+	newOpts := []llb.LocalOption{}
+	for _, o := range f.opts {
+		newOpts = append(newOpts, o)
+	}
+
+	return &LocalFactory{
+		name: f.name,
+		opts: newOpts,
+	}
+}
+
+// GetName returns the name of the pllb.Local state that will
+// eventually be created
+func (f *LocalFactory) GetName() string {
+	return f.name
+}
+
+// GetSharedKey returns the set shared cache key of the pllb.Local state that will
+// eventually be created
+func (f *LocalFactory) GetSharedKey() string {
+	return f.sharedKeyHint
+}
+
+// WithInclude adds include patterns to the factory's llb options
+func (f *LocalFactory) WithInclude(patterns []string) *LocalFactory {
+	f = f.Copy()
+	f.opts = append(f.opts, llb.IncludePatterns(patterns))
+	return f
+}
+
+// WithSharedKeyHint adds a shared key hint to the factory's llb options
+func (f *LocalFactory) WithSharedKeyHint(key string) *LocalFactory {
+	f = f.Copy()
+	f.opts = append(f.opts, llb.SharedKeyHint(key))
+	f.sharedKeyHint = key
+	return f
+}
+
+// Construct constructs the pllb.Local state
+func (f *LocalFactory) Construct() pllb.State {
+	return pllb.Local(f.name, f.opts...)
+}


### PR DESCRIPTION
This sets the IncludePattern on local sources. Without this, the entire
directory is copied.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>