### PR TITLE
Autocomplete hidden flags on dev versions

### DIFF
--- a/autocomplete/complete.go
+++ b/autocomplete/complete.go
@@ -137,7 +137,7 @@ func getPotentialPaths(prefix string) ([]string, error) {
 	return paths, nil
 }
 
-// isHidden returns if a flag is hidden or not
+// isVisibleFlag returns if a flag is hidden or not
 // this code comes from https://github.com/urfave/cli/blob/d648edd48d89ef3a841b1ec75c2ebbd4de5f748f/flag.go#L136
 func isVisibleFlag(fl cli.Flag) bool {
 	fv := reflect.ValueOf(fl)
@@ -160,10 +160,10 @@ func getCmd(name string, cmds []*cli.Command) *cli.Command {
 	return nil
 }
 
-func getVisibleFlags(flags []cli.Flag) []string {
+func getVisibleFlags(flags []cli.Flag, showHidden bool) []string {
 	visibleFlags := []string{}
 	for _, f := range flags {
-		if isVisibleFlag(f) {
+		if isVisibleFlag(f) || showHidden {
 			for _, n := range f.Names() {
 				if len(n) > 1 {
 					visibleFlags = append(visibleFlags, n)
@@ -174,10 +174,10 @@ func getVisibleFlags(flags []cli.Flag) []string {
 	return visibleFlags
 }
 
-func getVisibleCommands(commands []*cli.Command) []string {
+func getVisibleCommands(commands []*cli.Command, showHidden bool) []string {
 	visibleCommands := []string{}
 	for _, cmd := range commands {
-		if !cmd.Hidden {
+		if !cmd.Hidden || showHidden {
 			visibleCommands = append(visibleCommands, cmd.Name)
 		}
 	}
@@ -185,7 +185,7 @@ func getVisibleCommands(commands []*cli.Command) []string {
 }
 
 // GetPotentials returns a list of potential arguments for shell auto completion
-func GetPotentials(compLine string, compPoint int, app *cli.App) ([]string, error) {
+func GetPotentials(compLine string, compPoint int, app *cli.App, showHidden bool) ([]string, error) {
 	potentials := []string{}
 
 	compLine = compLine[:compPoint]
@@ -205,18 +205,18 @@ func GetPotentials(compLine string, compPoint int, app *cli.App) ([]string, erro
 
 	var flags []string
 	if cmd != nil {
-		flags = getVisibleFlags(cmd.Flags)
+		flags = getVisibleFlags(cmd.Flags, showHidden)
 	} else {
-		flags = getVisibleFlags(app.Flags)
+		flags = getVisibleFlags(app.Flags, showHidden)
 		// append flags that urfav/cli automatically include
 		flags = append(flags, "version", "help")
 	}
 
 	var commands []string
 	if cmd != nil {
-		commands = getVisibleCommands(cmd.Subcommands)
+		commands = getVisibleCommands(cmd.Subcommands, showHidden)
 	} else {
-		commands = getVisibleCommands(app.Commands)
+		commands = getVisibleCommands(app.Commands, showHidden)
 	}
 
 	if flagPrefix, ok := trimFlag(lastWord); ok {

--- a/autocomplete/complete_test.go
+++ b/autocomplete/complete_test.go
@@ -70,49 +70,55 @@ func getApp() *cli.App {
 
 func TestFlagCompletion(t *testing.T) {
 
-	matches, err := GetPotentials("earthly --fl", 12, getApp())
+	matches, err := GetPotentials("earthly --fl", 12, getApp(), false)
 	NoError(t, err, "GetPotentials failed")
 	Equal(t, []string{"--flag ", "--fleet "}, matches)
 }
 
 func TestCommandCompletion(t *testing.T) {
-	matches, err := GetPotentials("earthly pru", 11, getApp())
+	matches, err := GetPotentials("earthly pru", 11, getApp(), false)
 	NoError(t, err, "GetPotentials failed")
 	Equal(t, []string{"prune "}, matches)
 }
 
 func TestCommandCompletionHidden(t *testing.T) {
-	matches, err := GetPotentials("earthly hid", 11, getApp())
+	matches, err := GetPotentials("earthly hid", 11, getApp(), false)
 	NoError(t, err, "GetPotentials failed")
 	Equal(t, []string{}, matches)
 }
 
+func TestCommandCompletionShowHidden(t *testing.T) {
+	matches, err := GetPotentials("earthly hid", 11, getApp(), true)
+	NoError(t, err, "GetPotentials failed")
+	Equal(t, []string{"hide "}, matches)
+}
+
 func TestCommandSubCompletion(t *testing.T) {
-	matches, err := GetPotentials("earthly sub -", 13, getApp())
+	matches, err := GetPotentials("earthly sub -", 13, getApp(), false)
 	NoError(t, err, "GetPotentials failed")
 	Equal(t, []string{"--subflag "}, matches)
 }
 
 func TestCommandSubCompletion2(t *testing.T) {
-	matches, err := GetPotentials("earthly sub --subflag abba --s", 30, getApp())
+	matches, err := GetPotentials("earthly sub --subflag abba --s", 30, getApp(), false)
 	NoError(t, err, "GetPotentials failed")
 	Equal(t, []string{"--subsubflag ", "--surf-the-internet "}, matches)
 }
 
 func TestCommandSubSubCompletion(t *testing.T) {
-	matches, err := GetPotentials("earthly sub --subflag abba --sub", 32, getApp())
+	matches, err := GetPotentials("earthly sub --subflag abba --sub", 32, getApp(), false)
 	NoError(t, err, "GetPotentials failed")
 	Equal(t, []string{"--subsubflag "}, matches)
 }
 
 func TestCommandSubSubCompletion2(t *testing.T) {
-	matches, err := GetPotentials("earthly sub --subflag abba ", 27, getApp())
+	matches, err := GetPotentials("earthly sub --subflag abba ", 27, getApp(), false)
 	NoError(t, err, "GetPotentials failed")
 	Equal(t, []string{"dancing-queen "}, matches)
 }
 
 func TestPathCompletion(t *testing.T) {
-	matches, err := GetPotentials("earthly .", 9, getApp())
+	matches, err := GetPotentials("earthly .", 9, getApp(), false)
 	NoError(t, err, "GetPotentials failed")
 	Equal(t, []string{"./", "../"}, matches)
 }

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -1298,7 +1298,9 @@ func (app *earthlyApp) autoCompleteImp() (err error) {
 		return err
 	}
 
-	potentials, err := autocomplete.GetPotentials(compLine, int(compPointInt), app.cliApp)
+	showHidden := strings.HasPrefix(Version, "dev-") || os.Getenv("EARTHLY_AUTOCOMPLETE_HIDDEN") == "1"
+
+	potentials, err := autocomplete.GetPotentials(compLine, int(compPointInt), app.cliApp, showHidden)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Autocomplete hidden flags when using any version that starts with a
"dev-" prefix (which gets added to all non-release builds built via the
+earthly target), or when the env variable EARTHLY_AUTOCOMPLETE_HIDDEN is set to "1"

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>