### PR TITLE
enable referenced-save-only mode for ./earthly

### DIFF
--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -565,8 +565,8 @@ func newEarthlyApp(ctx context.Context, console conslogging.ConsoleLogger) *eart
 			Destination: &app.disableAnalytics,
 		},
 		&cli.StringFlag{
-			Name:        "feature-flag-overrides",
-			EnvVars:     []string{"EARTHLY_FEATURE_FLAG_OVERRIDES"},
+			Name:        "version-flag-overrides",
+			EnvVars:     []string{"EARTHLY_VERSION_FLAG_OVERRIDES"},
 			Usage:       "Apply additional flags after each VERSION command across all Earthfiles, multiple flags can be seperated by commas",
 			Destination: &app.featureFlagOverrides,
 			Hidden:      true, // used for feature-flipping from ./earthly dev script

--- a/earthly
+++ b/earthly
@@ -96,6 +96,7 @@ case "$1" in
         fi
 
         export EARTHLY_CONVERSION_PARALLELISM=5
+        export EARTHLY_VERSION_FLAG_OVERRIDES="referenced-save-only"
         # enable local registry-based exports
         "$bindir/earthly-prerelease" config global.local_registry_host 'tcp://127.0.0.1:8371' || true
         exec -a "$scriptname" "$bindir/earthly-prerelease" "$@"


### PR DESCRIPTION
Forces the --referenced-save-only flag to be enabled for all VERSION
commands.

Renames EARTHLY_FEATURE_FLAG_OVERRIDES to EARTHLY_VERSION_FLAG_OVERRIDES
to reflect that this env is *only* for overriding feature flags that are
defined within a VERSION command context, and is not used to change
global features.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>