### PR TITLE
Allow boolean flags to be passed with option value

### DIFF
--- a/earthfile2llb/interpreter.go
+++ b/earthfile2llb/interpreter.go
@@ -16,6 +16,7 @@ import (
 	"github.com/earthly/earthly/util/llbutil"
 	"github.com/earthly/earthly/variables"
 
+	flags "github.com/jessevdk/go-flags"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
@@ -437,12 +438,20 @@ func (i *Interpreter) getAllowPrivilegedArtifact(artifactName string, allowPrivi
 	return i.getAllowPrivileged(artifact.Target, allowPrivileged)
 }
 
+func (i *Interpreter) flagValModifier(flagName string, flagOpt *flags.Option, flagVal *string) *string {
+	if flagOpt.IsBool() && flagVal != nil {
+		newFlag := i.expandArgs(*flagVal, false)
+		return &newFlag
+	}
+	return flagVal
+}
+
 func (i *Interpreter) handleRun(ctx context.Context, cmd spec.Command) error {
 	if len(cmd.Args) < 1 {
 		return i.errorf(cmd.SourceLocation, "not enough arguments for RUN")
 	}
 	opts := runOpts{}
-	args, err := flagutil.ParseArgs("RUN", &opts, getArgsCopy(cmd))
+	args, err := flagutil.ParseArgsWithValueModifier("RUN", &opts, getArgsCopy(cmd), i.flagValModifier)
 	if err != nil {
 		return i.wrapError(err, cmd.SourceLocation, "invalid RUN arguments %v", cmd.Args)
 	}

--- a/examples/tests/Earthfile
+++ b/examples/tests/Earthfile
@@ -74,6 +74,8 @@ ga:
     BUILD +infinite-recursion
     BUILD +from-dockerfile-arg
     BUILD +cache-mount-arg
+    BUILD +true-false-flag
+    BUILD +true-false-flag-invalid
 
 experimental:
     BUILD ./dind-auto-install+all
@@ -578,6 +580,37 @@ cache-mount-arg:
     RUN cat output.txt
     RUN cat output.txt | grep '\*cached\* --> RUN echo Doing something 1'; test "$?" != 0
     RUN cat output.txt | grep '\*cached\* --> RUN echo Doing something 2'; test "$?" != 0
+
+true-false-flag:
+    COPY true-false-flag.earth Earthfile
+    RUN echo "#!/bin/sh
+set -x
+
+# make sure the cache gets warmed up first
+earthly --config \$earthly_config --verbose +all 2>output.txt;
+
+# the +all will run one that is cached, and two --no-cache RUNs
+earthly --config \$earthly_config --verbose +all 2>output2.txt;
+" >/tmp/multiple-earthly-script && chmod +x /tmp/multiple-earthly-script
+    RUN --privileged \
+        --mount=type=tmpfs,target=/tmp/earthly-tmpfs \
+        set -x; \
+        export EARTHLY_TMP_DIR="/tmp/earthly-tmpfs"; \
+        export EARTHLY_EXEC_CMD="/tmp/multiple-earthly-script"; \
+        /bin/sh /usr/bin/earthly-entrypoint.sh;
+
+    # test that the two non-cached commands were run
+    RUN test $( cat output2.txt | grep -v echo | grep "a20594da-88d4-420c-a998-1c65c6cf8b23" | wc -l) = "2"
+    # test a single RUN was cached
+    RUN test $( cat output2.txt | grep cached | grep "a20594da-88d4-420c-a998-1c65c6cf8b23" | wc -l) = "1"
+
+true-false-flag-invalid:
+    DO +RUN_EARTHLY --earthfile=true-false-flag-invalid.earth --should_fail=true --target=+run-false --post_command="2>output.txt"
+    RUN cat output.txt | grep "Command /bin/sh -c false failed with exit code 1"
+    DO +RUN_EARTHLY --earthfile=true-false-flag-invalid.earth --should_fail=true --target=+run-false-with-args --post_command="2>output2.txt"
+    RUN cat output2.txt | grep "Command /bin/sh -c 'false echo test' failed with exit code 1"
+    DO +RUN_EARTHLY --earthfile=true-false-flag-invalid.earth --should_fail=true --target=+run-maybe --post_command="2>output3.txt"
+    RUN cat output3.txt | grep 'invalid argument for flag .*--no-cache.*expected bool'
 
 RUN_EARTHLY:
     COMMAND

--- a/examples/tests/true-false-flag-invalid.earth
+++ b/examples/tests/true-false-flag-invalid.earth
@@ -1,0 +1,15 @@
+# the first two tests validate that we enforce that flags values are explicitly given
+# with an assignment opperater; i.e. "--flag=value" and not "--flag value".
+# otherwise it's unclear if the value is the flag value or command to run.
+run-false:
+    FROM alpine:3.13
+    RUN --no-cache false
+
+run-false-with-args:
+    FROM alpine:3.13
+    RUN --no-cache false echo test
+
+# test that non-bool values cause a failure
+run-maybe:
+    FROM alpine:3.13
+    RUN --no-cache=maybe echo "call me?"

--- a/examples/tests/true-false-flag.earth
+++ b/examples/tests/true-false-flag.earth
@@ -1,0 +1,9 @@
+hello:
+    FROM alpine:3.13
+    ARG NO_CACHE=false
+    RUN --no-cache=$NO_CACHE echo "a20594da-88d4-420c-a998-1c65c6cf8b23"
+
+all:
+    BUILD --build-arg NO_CACHE=false +hello
+    BUILD --build-arg NO_CACHE=true +hello
+    BUILD --build-arg NO_CACHE=1 +hello

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,8 @@ replace (
 	github.com/containerd/stargz-snapshotter/estargz => github.com/containerd/stargz-snapshotter/estargz v0.0.0-20201217071531-2b97b583765b
 	github.com/docker/docker => github.com/docker/docker v20.10.3-0.20210609100121-ef4d47340142+incompatible
 
+	github.com/jessevdk/go-flags => github.com/alexcb/go-flags v0.0.0-20210722203016-f11d7ecb5ee5
+
 	github.com/moby/buildkit => github.com/earthly/buildkit v0.7.1-0.20210707023503-467c8f234418
 	github.com/tonistiigi/fsutil => github.com/earthly/fsutil v0.0.0-20210609160335-a94814c540b2
 )

--- a/go.sum
+++ b/go.sum
@@ -68,6 +68,8 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=
 github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
+github.com/alexcb/go-flags v0.0.0-20210722203016-f11d7ecb5ee5 h1:im0niQRZXdxO8F1rw4zwb5rJmOJ9XnNtlnMFyfLenYE=
+github.com/alexcb/go-flags v0.0.0-20210722203016-f11d7ecb5ee5/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
 github.com/alexflint/go-filemutex v0.0.0-20171022225611-72bdc8eae2ae/go.mod h1:CgnQgUtFrFz9mxFNtED3jI5tLDjKlOM+oUF/sTk6ps0=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/antlr/antlr4 v0.0.0-20200225173536-225249fdaef5 h1:nkZ9axP+MvUFCu8JRN/MCY+DmTfs6lY7hE0QnJbxSdI=
@@ -424,8 +426,6 @@ github.com/ishidawataru/sctp v0.0.0-20210226210310-f2269e66cdee/go.mod h1:co9pwD
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
 github.com/jdxcode/netrc v0.0.0-20210204082910-926c7f70242a h1:d4+I1YEKVmWZrgkt6jpXBnLgV2ZjO0YxEtLDdfIZfH4=
 github.com/jdxcode/netrc v0.0.0-20210204082910-926c7f70242a/go.mod h1:Zi/ZFkEqFHTm7qkjyNJjaWH4LQA9LQhGJyF0lTYGpxw=
-github.com/jessevdk/go-flags v1.5.0 h1:1jKYvbxEjfUl0fmqTCOfonvskHHXMjBySTLW4y9LFvc=
-github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=

--- a/util/flagutil/parse.go
+++ b/util/flagutil/parse.go
@@ -9,9 +9,28 @@ import (
 	flags "github.com/jessevdk/go-flags"
 )
 
+// ArgumentModFunc accepts a flagName which corresponds to the long flag name, and a pointer
+// to a flag value. The pointer is nil if no flag was given.
+// the function returns a new pointer set to nil if one wants to pretend as if no value was given,
+// or a pointer to a new value which will be parsed.
+// Note: this was created to allow passing --no-cache=$SOME_VALUE; where we must expand $SOME_VALUE into
+// a true/false value before it is parsed. If this feature is used extensively, then it might be time
+// to completely fork go-flags with a version where we can include control over expansion struct tags.
+type ArgumentModFunc func(flagName string, opt *flags.Option, flagVal *string) *string
+
 // ParseArgs parses flags and args from a command string
 func ParseArgs(command string, data interface{}, args []string) ([]string, error) {
-	p := flags.NewNamedParser("", flags.PrintErrors|flags.PassDoubleDash|flags.PassAfterNonOption)
+	return ParseArgsWithValueModifier(command, data, args,
+		func(_ string, _ *flags.Option, s *string) *string { return s },
+	)
+}
+
+// ParseArgsWithValueModifier parses flags and args from a command string; it accepts an optional argumentModFunc
+// which is called before each flag value is parsed, and allows one to change the value.
+// if the flag value
+func ParseArgsWithValueModifier(command string, data interface{}, args []string, argumentModFunc ArgumentModFunc) ([]string, error) {
+	p := flags.NewNamedParser("", flags.PrintErrors|flags.PassDoubleDash|flags.PassAfterNonOption|flags.AllowBoolValues)
+	p.ArgumentMod = argumentModFunc
 	_, err := p.AddGroup(fmt.Sprintf("%s [options] args", command), "", data)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to initiate parser.AddGroup for %s", command)


### PR DESCRIPTION
This is to allow passing --flag=$ARG; where $ARG is set to true/false elsewhere.
This implements #1109

This includes [some changes](https://github.com/alexcb/go-flags/compare/master...alexcb:argument-modifier?expand=1) to the flags library to support a flag value modifier function.