### PR TITLE
fix homebrew release process and instructions

### DIFF
--- a/release/Earthfile
+++ b/release/Earthfile
@@ -180,7 +180,7 @@ release-homebrew:
         echo version=$version ;\
         output=$(hub pull-request --no-edit \
             -h "$GIT_USERNAME":"release-$RELEASE_TAG" \
-            -b "$REPO_OWNER:main" \
+            -b "earthly:main" \
             -m "earthly $version" \
             -m '-------------' \
             -m '#### Debug data' \

--- a/release/README.md
+++ b/release/README.md
@@ -37,7 +37,15 @@
   ```bash
   ./earthly --build-arg RELEASE_TAG --push ./release+release-homebrew
   ```
-* Important: Subscribe to the PR that griswoldthecat created in homebrew-core, so that you can address any review comments that may come up.
+* Visit the newly created pull request (which is both listed in the previous command's stdout and the `#release` slack channel); there should be two checks that are automatically applied:
+  * `brew test-bot / test-bot (ubuntu-latest)`
+  * `brew test-bot / test-bot (macos-latest)`
+
+  Once these two jobs complete, add the `pr-pull` label, which will trigger a third job `brew pr-pull / pr-pull`, which will save the artifacts produced by the prior jobs
+  and eventually merge the PR automatically.
+
+  IMPORTANT: do not merge this PR manually, the `pr-pull`-triggered job will do this for you.
+
 * Run
   ```bash
   ./earthly --build-arg RELEASE_TAG --push ./release+release-repo


### PR DESCRIPTION
fixes issue where PR was from `griswoldthecat/homebrew-earthly` was
opened against `griswoldthecat/homebrew-earthly` rather than `earthly/homebrew-earthly`

Update instructions to document how to apply the `pr-pull` label.
This label must be applied manually once the test checks complete and is
equivalent to approving the PR. For this reason this label can not be
automatically applied.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>