### PR TITLE
bugfix: insecure check was checking for https rather than http

### DIFF
--- a/buildcontext/gitlookup.go
+++ b/buildcontext/gitlookup.go
@@ -122,7 +122,7 @@ func (gl *GitLookup) AddMatcher(name, pattern, sub, user, password, suffix, prot
 	gl.mu.Lock()
 	defer gl.mu.Unlock()
 	p := gitProtocol(protocol)
-	if p == httpsProtocol && password != "" {
+	if p == httpProtocol && password != "" {
 		return errors.Errorf("using a password with http for %s is insecure", name)
 	}
 


### PR DESCRIPTION
https://github.com/earthly/earthly/pull/1111 accidentally swapped http for https, changing back.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>