### PR TITLE
change isFrom to pass command name

### DIFF
--- a/earthfile2llb/interpreter.go
+++ b/earthfile2llb/interpreter.go
@@ -855,7 +855,7 @@ func (i *Interpreter) handleBuild(ctx context.Context, cmd spec.Command, async b
 	for _, bas := range crossProductBuildArgs {
 		for _, platform := range platformsSlice {
 			if async {
-				errChan := i.converter.BuildAsync(ctx, fullTargetName, platform, allowPrivileged, bas)
+				errChan := i.converter.BuildAsync(ctx, fullTargetName, platform, allowPrivileged, bas, buildCmd)
 				i.monitorErrChan(ctx, errChan)
 			} else {
 				err = i.converter.Build(ctx, fullTargetName, platform, allowPrivileged, bas)

--- a/earthfile2llb/withdockerrun.go
+++ b/earthfile2llb/withdockerrun.go
@@ -288,7 +288,7 @@ func (wdr *withDockerRun) load(ctx context.Context, opt DockerLoadOpt) error {
 	if err != nil {
 		return errors.Wrapf(err, "parse target %s", opt.Target)
 	}
-	mts, err := wdr.c.buildTarget(ctx, depTarget.String(), opt.Platform, opt.AllowPrivileged, opt.BuildArgs, false, false)
+	mts, err := wdr.c.buildTarget(ctx, depTarget.String(), opt.Platform, opt.AllowPrivileged, opt.BuildArgs, false, loadCmd)
 	if err != nil {
 		return err
 	}

--- a/earthfile2llb/withdockerrunlocal.go
+++ b/earthfile2llb/withdockerrunlocal.go
@@ -43,7 +43,7 @@ func (wdrl *withDockerRunLocal) load(ctx context.Context, opt DockerLoadOpt) (st
 	if err != nil {
 		return "", errors.Wrapf(err, "parse target %s", opt.Target)
 	}
-	mts, err := wdrl.c.buildTarget(ctx, depTarget.String(), opt.Platform, opt.AllowPrivileged, opt.BuildArgs, false, false)
+	mts, err := wdrl.c.buildTarget(ctx, depTarget.String(), opt.Platform, opt.AllowPrivileged, opt.BuildArgs, false, loadCmd)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Currently we only need to know if the command being passed is "FROM"; however, in a future PR the prepBuildTarget() method will have to include this check:
    
    opt.DoSaves = (cmdT == buildCmd && c.opt.DoSaves)
    
Signed-off-by: Alex Couture-Beil <alex@earthly.dev>
