### PR TITLE
integration test was setting incorrect tag

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -276,7 +276,7 @@ earthly-docker:
     COPY earthly-entrypoint.sh /usr/bin/earthly-entrypoint.sh
     ENTRYPOINT ["/usr/bin/earthly-entrypoint.sh"]
     ARG EARTHLY_TARGET_TAG_DOCKER
-    ARG TAG=$EARTHLY_TARGET_TAG_DOCKER
+    ARG TAG="dev-$EARTHLY_TARGET_TAG_DOCKER"
     COPY --build-arg VERSION=$TAG +earthly/earthly /usr/bin/earthly
     SAVE IMAGE --push --cache-from=earthly/earthly:main earthly/earthly:$TAG
 

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -1298,7 +1298,14 @@ func (app *earthlyApp) autoCompleteImp() (err error) {
 		return err
 	}
 
-	showHidden := strings.HasPrefix(Version, "dev-") || os.Getenv("EARTHLY_AUTOCOMPLETE_HIDDEN") == "1"
+	showHidden := strings.HasPrefix(Version, "dev-")
+	showHiddenOverride := os.Getenv("EARTHLY_AUTOCOMPLETE_HIDDEN")
+	if showHiddenOverride != "" {
+		showHidden, err = strconv.ParseBool(showHiddenOverride)
+		if err != nil {
+			return err
+		}
+	}
 
 	potentials, err := autocomplete.GetPotentials(compLine, int(compPointInt), app.cliApp, showHidden)
 	if err != nil {

--- a/examples/tests/autocompletion/Earthfile
+++ b/examples/tests/autocompletion/Earthfile
@@ -1,11 +1,28 @@
 FROM ../../..+earthly-integration-test-base
 
+ENV EARTHLY_AUTOCOMPLETE_HIDDEN=0
+
 test-root-commands:
     RUN echo "./
 bootstrap 
 org 
 secrets 
 account 
+prune 
+config " > expected
+    RUN COMP_LINE="earthly " COMP_POINT=8 earthly > actual
+    RUN diff expected actual
+
+test-hidden-root-commands:
+    ENV EARTHLY_AUTOCOMPLETE_HIDDEN=1
+    RUN echo "./
+bootstrap 
+docker 
+docker2earthly 
+org 
+secrets 
+account 
+debug 
 prune 
 config " > expected
     RUN COMP_LINE="earthly " COMP_POINT=8 earthly > actual
@@ -35,5 +52,6 @@ test-relative-dir-targets:
 
 test-all:
     BUILD +test-root-commands
+    BUILD +test-hidden-root-commands
     BUILD +test-targets
     BUILD +test-relative-dir-targets


### PR DESCRIPTION
When 61cc32c55c7bd8578e57b31aed963715eecd473a was introduced, the
integration test tag should have also have been updated to include the
"dev-" prefix.

Without this, whenever ./build/linux/amd64/earthly
./example/tests+some-test is run, it will overwrite ./build/linux/amd64/earthly
with a new version which compiles a new version of earthly without the
"dev-" version prefix.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>