### PR TITLE
Incoorporating .earthlyignore - Issue #1029

### DIFF
--- a/buildcontext/excludes.go
+++ b/buildcontext/excludes.go
@@ -23,7 +23,7 @@ var ImplicitExcludes = []string{
 }
 
 func readExcludes(dir string) ([]string, error) {
-	ignoreFile := EarthIgnoreFile
+	var ignoreFile = EarthIgnoreFile
 
 	// if non (doesNotExist) errors appear then we need to return them.
 	//EarthIgnoreFile
@@ -42,7 +42,7 @@ func readExcludes(dir string) ([]string, error) {
 		// return just ImplicitExcludes if neither of them exist
 		return ImplicitExcludes, nil
 	} else if earthlyExists {
-		ignoreFile := EarthlyIgnoreFile
+		ignoreFile = EarthlyIgnoreFile
 	}
 
 	filePath := filepath.Join(dir, ignoreFile)

--- a/buildcontext/excludes.go
+++ b/buildcontext/excludes.go
@@ -1,6 +1,7 @@
 package buildcontext
 
 import (
+	"github.com/earthly/earthly/util/fileutil"
 	"os"
 	"path/filepath"
 
@@ -25,14 +26,13 @@ func readExcludes(dir string) ([]string, error) {
 	ignoreFile := EarthIgnoreFile
 
 	// if non (doesNotExist) errors appear then we need to return them.
-	earthExists, err := ignoreFileExists(dir, EarthIgnoreFile)
-	if err != nil {
-		return ImplicitExcludes, err
-	}
-	earthlyExists, err := ignoreFileExists(dir, EarthlyIgnoreFile)
-	if err != nil {
-		return ImplicitExcludes, err
-	}
+	//EarthIgnoreFile
+	var earthIgnoreFilePath = filepath.Join(dir, EarthIgnoreFile)
+	earthExists := fileutil.FileExists(earthIgnoreFilePath)
+
+	//EarthlyIgnoreFile
+	var earthlyIgnoreFilePath = filepath.Join(dir, EarthlyIgnoreFile)
+	earthlyExists := fileutil.FileExists(earthlyIgnoreFilePath)
 
 	// Check which ones exists and which don't
 	if earthExists && earthlyExists {
@@ -55,15 +55,4 @@ func readExcludes(dir string) ([]string, error) {
 		return nil, errors.Wrapf(err, "parse %s", filePath)
 	}
 	return append(excludes, ImplicitExcludes...), nil
-}
-
-// cleanest way I could imagine to iterate and check if both of them exist - If the file is a bash/executable file then it could return an error other than (os.IsNotExist(err))
-func ignoreFileExists(dir, file string) (exists bool, err error) {
-	filePath := filepath.Join(dir, file)
-	if _, err := os.Stat(filePath); os.IsNotExist(err) {
-		return false, nil
-	} else if err != nil {
-		return false, err
-	}
-	return true, nil
 }

--- a/buildcontext/excludes.go
+++ b/buildcontext/excludes.go
@@ -1,11 +1,11 @@
 package buildcontext
 
 import (
-	"github.com/earthly/earthly/util/fileutil"
 	"os"
 	"path/filepath"
 
 	"github.com/docker/docker/builder/dockerignore"
+	"github.com/earthly/earthly/util/fileutil"
 	"github.com/pkg/errors"
 )
 
@@ -25,7 +25,6 @@ var ImplicitExcludes = []string{
 func readExcludes(dir string) ([]string, error) {
 	var ignoreFile = EarthIgnoreFile
 
-	// if non (doesNotExist) errors appear then we need to return them.
 	//EarthIgnoreFile
 	var earthIgnoreFilePath = filepath.Join(dir, EarthIgnoreFile)
 	earthExists := fileutil.FileExists(earthIgnoreFilePath)


### PR DESCRIPTION
Issue:
https://github.com/earthly/earthly/issues/1029

What?:
- Allow for the ignore file `.earthignore` to be incorporated/used as `.earthlyignore`.
- If both exist then return an error

How:
- Check both the possible filenames to see if they both exist
- If both Exists then return error and implicit exclusion
- If only one exists then treat it as the ignore file
- If neither exist then return just implicit exlusion (as was behaviour before)

Acceptance:
- `.earthlyignore` files can be used in the place of `.earthignore`files
-  If both exist then an error is thrown or registered

Notes:
- Not sure that I threw the error correctly - Maybe if both exists it should be a hard stop
- I am sure the code could be more consise and cleaner