### PR TITLE
fixes inconsistent BUILD execution

### DIFF
--- a/earthfile2llb/earthfile2llb.go
+++ b/earthfile2llb/earthfile2llb.go
@@ -120,7 +120,7 @@ func Earthfile2LLB(ctx context.Context, target domain.Target, opt ConvertOpt) (m
 	}
 
 	targetWithMetadata := bc.Ref.(domain.Target)
-	sts, found, err := opt.Visited.Add(ctx, targetWithMetadata, opt.Platform, opt.AllowPrivileged, opt.OverridingVars, opt.parentDepSub)
+	sts, found, err := opt.Visited.Add(ctx, targetWithMetadata, opt.Platform, opt.AllowPrivileged, opt.HasDangling, opt.OverridingVars, opt.parentDepSub)
 	if err != nil {
 		return nil, err
 	}

--- a/states/visited.go
+++ b/states/visited.go
@@ -36,7 +36,7 @@ func (vc *VisitedCollection) All() []*SingleTarget {
 
 // Add adds a target to the collection, if it hasn't yet been visited. The returned sts is
 // either the previously visited one or a brand new one.
-func (vc *VisitedCollection) Add(ctx context.Context, target domain.Target, platform *specs.Platform, allowPrivileged bool, overridingVars *variables.Scope, parentDepSub chan string) (*SingleTarget, bool, error) {
+func (vc *VisitedCollection) Add(ctx context.Context, target domain.Target, platform *specs.Platform, allowPrivileged, HasDangling bool, overridingVars *variables.Scope, parentDepSub chan string) (*SingleTarget, bool, error) {
 	dependents, err := vc.waitAllDoneAndLock(ctx, target, parentDepSub)
 	if err != nil {
 		return nil, false, err
@@ -67,6 +67,8 @@ func (vc *VisitedCollection) Add(ctx context.Context, target domain.Target, plat
 			}
 			// Subscribe that sts to the dependencies of our parent.
 			sts.MonitorDependencySubscription(ctx, parentDepSub)
+			// previously cached state might not have been dangling if it was created via an async BUILD
+			sts.HasDangling = sts.HasDangling || HasDangling
 			return sts, true, nil
 		}
 	}


### PR DESCRIPTION
Fixes bug where an earthfile such as:

    a:
        RUN echo A

    b:
        RUN echo B

    all:
        BUILD +A
        BUILD +B

would not consistently exectute a or b when +all was referenced.
This was due to BuildAsync calling c.prepBuildTarget with isDangling
explicitly set to false.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>