### PR TITLE
Add EARTHLY_SOURCE_DATE_EPOCH to support reproducible builds

### DIFF
--- a/states/dedup/targetinput.go
+++ b/states/dedup/targetinput.go
@@ -160,6 +160,7 @@ var BuiltinVariables = map[string]bool{
 	"TARGETOS":                        true,
 	"TARGETARCH":                      true,
 	"TARGETVARIANT":                   true,
+	"EARTHLY_SOURCE_DATE_EPOCH":       true,
 }
 
 // IsDefaultValue returns whether the value of the BuildArgInput

--- a/util/gitutil/detectgit.go
+++ b/util/gitutil/detectgit.go
@@ -246,11 +246,11 @@ func detectGitTimestamp(ctx context.Context, dir string) (string, error) {
 	cmd.Dir = dir
 	out, err := cmd.Output()
 	if err != nil {
-		return "0", nil
+		return "", nil
 	}
 	outStr := string(out)
 	if outStr == "" {
-		return "0", nil
+		return "", nil
 	}
 	return strings.SplitN(outStr, "\n", 2)[0], nil
 }

--- a/variables/builtin.go
+++ b/variables/builtin.go
@@ -43,6 +43,15 @@ func BuiltinArgs(target domain.Target, platform specs.Platform, gitMeta *gitutil
 		ret.AddInactive("EARTHLY_GIT_ORIGIN_URL_SCRUBBED", stringutil.ScrubCredentials(gitMeta.RemoteURL))
 		ret.AddInactive("EARTHLY_GIT_PROJECT_NAME", getProjectName(gitMeta.RemoteURL))
 		ret.AddInactive("EARTHLY_GIT_COMMIT_TIMESTAMP", gitMeta.Timestamp)
+
+		if gitMeta.Timestamp == "" {
+			ret.AddInactive("EARTHLY_SOURCE_DATE_EPOCH", "0")
+		} else {
+			ret.AddInactive("EARTHLY_SOURCE_DATE_EPOCH", gitMeta.Timestamp)
+		}
+	} else {
+		// Ensure SOURCE_DATE_EPOCH is always available
+		ret.AddInactive("EARTHLY_SOURCE_DATE_EPOCH", "0")
 	}
 	// Note: Please update targetinput.go BuiltinVariables if adding more builtin variables.
 	for _, key := range ret.SortedAny() {


### PR DESCRIPTION
`EARTHLY_SOURCE_DATE_EPOCH` will be set to the timestamp of the last git commit. If that is not available then it defaults to the string `0`.

This ensures that there is always a reproducible timestamp to use, either the UNIX epoch itself, or the UNIX timestamp of the last git commit.

This PR also restores `EARTHLY_GIT_COMMIT_TIMESTAMP` to the same behaviour as other `EARTHLY_GIT_` args that return an empty string when the value is unavailable.

Background: https://reproducible-builds.org/docs/source-date-epoch/