### PR TITLE
Enable conversion parallelism in all our CIs

### DIFF
--- a/.buildkite/tests.sh
+++ b/.buildkite/tests.sh
@@ -4,8 +4,7 @@ set -xeu
 
 trap 'kill $(jobs -p); wait' SIGINT SIGTERM
 
-# TODO: This has been disabled as it's causing context deadline exceeded errors regularly.
-# export EARTHLY_CONVERSION_PARALLELISM=5
+export EARTHLY_CONVERSION_PARALLELISM=5
 
 case "$EARTHLY_OS" in
     darwin)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       FORCE_COLOR: 1
-      # EARTHLY_CONVERSION_PARALLELISM: "5" # TODO: Getting random errors like these Error: failed to compute cache key: failed to copy: httpReadSeeker: failed open: failed to authorize: no active session for ...: context deadline exceeded
+      EARTHLY_CONVERSION_PARALLELISM: "5"
       EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"
       EARTHLY_INSTALL_ID: "earthly-githubactions"
     steps:


### PR DESCRIPTION
This used to be flaky in the past but seems to be fine now.