### PR TITLE
Remove dind support for arm/v7

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -379,9 +379,6 @@ all-dind:
         --platform=linux/amd64 \
         --platform=linux/arm64 \
         +dind
-    BUILD \
-        --platform=linux/arm/v7 \
-        +dind-alpine
 
 all:
     BUILD +all-buildkitd

--- a/release/Earthfile
+++ b/release/Earthfile
@@ -18,7 +18,6 @@ release-dockerhub:
         ../+all-dind
     BUILD \
         --platform=linux/amd64 \
-        --platform=linux/arm/v7 \
         --platform=linux/arm64 \
         --build-arg DIND_ALPINE_TAG=latest \
         ../+dind-alpine


### PR DESCRIPTION
Main branch build is failing due to this.

The base image `docker:dind` is no longer released for `linux/arm/v7`. It seems that this issue is the root cause: https://github.com/docker-library/docker/issues/260