### PR TITLE
Add login so we can push examples on merge to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,9 @@ jobs:
       - name: Docker mirror login (non fork only)
         run: docker login registry-1.docker.io.mirror.corp.earthly.dev --username "${{ secrets.DOCKERHUB_MIRROR_USERNAME }}" --password "${{ secrets.DOCKERHUB_MIRROR_PASSWORD }}"
         if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+      - name: Docker Login (main build)
+        run: docker login --username "${{ secrets.DOCKERHUB_USERNAME }}" --password "${{ secrets.DOCKERHUB_TOKEN }}"
+        if: github.event_name == 'push'
       - name: Configure Earthly to use mirror (non fork only)
         run: |-
           earthly config global.buildkit_additional_config "'[registry.\"docker.io\"]
@@ -240,6 +243,9 @@ jobs:
       - name: Docker mirror login (non fork only)
         run: docker login registry-1.docker.io.mirror.corp.earthly.dev --username "${{ secrets.DOCKERHUB_MIRROR_USERNAME }}" --password "${{ secrets.DOCKERHUB_MIRROR_PASSWORD }}"
         if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+      - name: Docker Login (main build)
+        run: docker login --username "${{ secrets.DOCKERHUB_USERNAME }}" --password "${{ secrets.DOCKERHUB_TOKEN }}"
+        if: github.event_name == 'push'
       - name: Configure Earthly to use mirror (non fork only)
         run: |-
           earthly config global.buildkit_additional_config "'[registry.\"docker.io\"]


### PR DESCRIPTION
On pushing to main, we run a `--push`, which requires the service account to be logged in. Add back the login in just these two cases.