### PR TITLE
Prevent saving artifacts to parent directories

### DIFF
--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/earthly/earthly/analytics"
 	"github.com/earthly/earthly/buildcontext"
 	"github.com/earthly/earthly/debugger/common"
 	"github.com/earthly/earthly/domain"
@@ -714,6 +715,7 @@ func (c *Converter) SaveArtifact(ctx context.Context, saveFrom string, saveTo st
 				if c.ftrs.RequireForceForUnsafeSaves {
 					return fmt.Errorf("unable to save to %s; path must be located under %s", saveAsLocalTo, c.target.LocalPath)
 				}
+				analytics.Count("breaking-change", "save-artifact-force-flag-required-warning")
 				c.opt.Console.Warnf("saving to path (%s) outside of current directory (%s) will require a --force flag in a future version", saveAsLocalTo, c.target.LocalPath)
 			}
 		}

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -628,7 +628,7 @@ func (c *Converter) RunExpression(ctx context.Context, expressionName string, op
 }
 
 // SaveArtifact applies the earthly SAVE ARTIFACT command.
-func (c *Converter) SaveArtifact(ctx context.Context, saveFrom string, saveTo string, saveAsLocalTo string, keepTs bool, keepOwn bool, ifExists, symlinkNoFollow bool, isPush bool) error {
+func (c *Converter) SaveArtifact(ctx context.Context, saveFrom string, saveTo string, saveAsLocalTo string, keepTs bool, keepOwn bool, ifExists, symlinkNoFollow, force bool, isPush bool) error {
 	err := c.checkAllowed(saveArtifactCmd)
 	if err != nil {
 		return err
@@ -705,7 +705,7 @@ func (c *Converter) SaveArtifact(ctx context.Context, saveFrom string, saveTo st
 			saveAsLocalToAdj = "./"
 		}
 
-		if !c.ftrs.AllowParentSaves {
+		if !force {
 			canSave, err := c.canSave(ctx, saveAsLocalToAdj)
 			if err != nil {
 				return err

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -711,7 +711,10 @@ func (c *Converter) SaveArtifact(ctx context.Context, saveFrom string, saveTo st
 				return err
 			}
 			if !canSave {
-				return fmt.Errorf("unable to save to %s; path must be located under %s", saveAsLocalTo, c.target.LocalPath)
+				if c.ftrs.RequireForceForUnsafeSaves {
+					return fmt.Errorf("unable to save to %s; path must be located under %s", saveAsLocalTo, c.target.LocalPath)
+				}
+				c.opt.Console.Warnf("saving to path (%s) outside of current directory (%s) will require a --force flag in a future version", saveAsLocalTo, c.target.LocalPath)
 			}
 		}
 

--- a/earthfile2llb/flags.go
+++ b/earthfile2llb/flags.go
@@ -65,6 +65,7 @@ type saveArtifactOpts struct {
 	KeepOwn         bool `long:"keep-own" description:"Keep owner info"`
 	IfExists        bool `long:"if-exists" description:"Do not fail if the artifact does not exist"`
 	SymlinkNoFollow bool `long:"symlink-no-follow" description:"Do not follow symlinks"`
+	Force           bool `long:"force" description:"Force artifact to be saved, even if it means overwriting files or directories outside of the relative directory"`
 }
 
 type saveImageOpts struct {

--- a/earthfile2llb/interpreter.go
+++ b/earthfile2llb/interpreter.go
@@ -798,7 +798,7 @@ func (i *Interpreter) handleSaveArtifact(ctx context.Context, cmd spec.Command) 
 		return nil
 	}
 
-	err = i.converter.SaveArtifact(ctx, saveFrom, saveTo, saveAsLocalTo, opts.KeepTs, opts.KeepOwn, opts.IfExists, opts.SymlinkNoFollow, i.pushOnlyAllowed)
+	err = i.converter.SaveArtifact(ctx, saveFrom, saveTo, saveAsLocalTo, opts.KeepTs, opts.KeepOwn, opts.IfExists, opts.SymlinkNoFollow, opts.Force, i.pushOnlyAllowed)
 	if err != nil {
 		return i.wrapError(err, cmd.SourceLocation, "apply SAVE ARTIFACT")
 	}

--- a/examples/tests/Earthfile
+++ b/examples/tests/Earthfile
@@ -60,6 +60,9 @@ ga:
     BUILD +if-exists
     BUILD +file-copying
     BUILD +run-no-cache
+    BUILD +save-artifact-file-as-dot
+    BUILD +save-artifact-dir-as-dot
+    BUILD +save-artifact-dont-overwrite
     BUILD +save-artifact-after-push
     BUILD +save-artifact-selective
     BUILD +save-artifact-selective-legacy
@@ -469,6 +472,38 @@ file-copying:
 
     # Saving the root dir is not allowed. This should fail.
     DO +RUN_EARTHLY --earthfile=file-copying.earth --should_fail=true --target=+test-dot-scratch
+
+save-artifact-dont-overwrite:
+    RUN --no-cache echo hello > important-data
+
+    DO +RUN_EARTHLY --should_fail=true --earthfile=save-artifact-dont-overwrite.earth --target=+dont-overwrite-abs-ref --post_command="> /tmp/output 2>&1"
+    RUN cat /tmp/output | grep 'Error.*path must be located under'
+
+    DO +RUN_EARTHLY --should_fail=true --earthfile=save-artifact-dont-overwrite.earth --target=+dont-overwrite-rel-ref --post_command="> /tmp/output 2>&1"
+    RUN cat /tmp/output | grep 'Error.*path must be located under'
+
+    DO +RUN_EARTHLY --should_fail=true --earthfile=save-artifact-dont-overwrite.earth --target=+dont-overwrite-rel-other-ref --post_command="> /tmp/output 2>&1"
+    RUN cat /tmp/output | grep 'Error.*path must be located under'
+
+    DO +RUN_EARTHLY --should_fail=true --earthfile=save-artifact-dont-overwrite.earth --target=+dont-overwrite-root --post_command="> /tmp/output 2>&1"
+    RUN cat /tmp/output | grep 'Error.*path must be located under'
+
+    DO +RUN_EARTHLY --should_fail=true --earthfile=save-artifact-dont-overwrite.earth --target=+dont-overwrite-root2 --post_command="> /tmp/output 2>&1"
+    RUN cat /tmp/output | grep 'Error.*path must be located under'
+
+    DO +RUN_EARTHLY --should_fail=true --earthfile=save-artifact-dont-overwrite.earth --target=+dont-overwrite-root3 --post_command="> /tmp/output 2>&1"
+    RUN cat /tmp/output | grep 'Error.*path must be located under'
+
+    RUN ls important-data
+
+save-artifact-file-as-dot:
+    DO +RUN_EARTHLY --earthfile=save-artifact-dot.earth --target=+save-local-file-as-dot
+    RUN cat uuid | grep eeee5a95-1506-428f-8ef0-94bbad5bd22b
+
+save-artifact-dir-as-dot:
+    DO +RUN_EARTHLY --earthfile=save-artifact-dot.earth --target=+save-local-dir-as-dot
+    RUN cat the-data/file1 | grep 7be91098-1823-41df-911b-2a8907fe5da7
+    RUN cat the-data/file2 | grep b0359c17-d08b-411c-9db7-1333ef3673d0
 
 run-no-cache:
     # Run twice to allow the second one to attempt to cache things

--- a/examples/tests/Earthfile
+++ b/examples/tests/Earthfile
@@ -477,29 +477,35 @@ file-copying:
 save-artifact-dont-overwrite:
     RUN --no-cache echo hello > important-data
 
-    DO +RUN_EARTHLY --should_fail=true --earthfile=save-artifact-dont-overwrite.earth --target=+dont-overwrite-abs-ref --post_command="> /tmp/output 2>&1"
+    DO +RUN_EARTHLY --should_fail=true --earthfile=save-artifact-dont-overwrite.earth --extra_args="--version-flag-overrides=require-force-for-unsafe-saves" \
+        --target=+dont-overwrite-abs-ref --post_command="> /tmp/output 2>&1"
     RUN cat /tmp/output | grep 'Error.*path must be located under'
 
-    DO +RUN_EARTHLY --should_fail=true --earthfile=save-artifact-dont-overwrite.earth --target=+dont-overwrite-rel-ref --post_command="> /tmp/output 2>&1"
+    DO +RUN_EARTHLY --should_fail=true --earthfile=save-artifact-dont-overwrite.earth --extra_args="--version-flag-overrides=require-force-for-unsafe-saves" \
+        --target=+dont-overwrite-rel-ref --post_command="> /tmp/output 2>&1"
     RUN cat /tmp/output | grep 'Error.*path must be located under'
 
-    DO +RUN_EARTHLY --should_fail=true --earthfile=save-artifact-dont-overwrite.earth --target=+dont-overwrite-rel-other-ref --post_command="> /tmp/output 2>&1"
+    DO +RUN_EARTHLY --should_fail=true --earthfile=save-artifact-dont-overwrite.earth --extra_args="--version-flag-overrides=require-force-for-unsafe-saves" \
+        --target=+dont-overwrite-rel-other-ref --post_command="> /tmp/output 2>&1"
     RUN cat /tmp/output | grep 'Error.*path must be located under'
 
-    DO +RUN_EARTHLY --should_fail=true --earthfile=save-artifact-dont-overwrite.earth --target=+dont-overwrite-root --post_command="> /tmp/output 2>&1"
+    DO +RUN_EARTHLY --should_fail=true --earthfile=save-artifact-dont-overwrite.earth --extra_args="--version-flag-overrides=require-force-for-unsafe-saves" \
+        --target=+dont-overwrite-root --post_command="> /tmp/output 2>&1"
     RUN cat /tmp/output | grep 'Error.*path must be located under'
 
-    DO +RUN_EARTHLY --should_fail=true --earthfile=save-artifact-dont-overwrite.earth --target=+dont-overwrite-root2 --post_command="> /tmp/output 2>&1"
+    DO +RUN_EARTHLY --should_fail=true --earthfile=save-artifact-dont-overwrite.earth --extra_args="--version-flag-overrides=require-force-for-unsafe-saves" \
+        --target=+dont-overwrite-root2 --post_command="> /tmp/output 2>&1"
     RUN cat /tmp/output | grep 'Error.*path must be located under'
 
-    DO +RUN_EARTHLY --should_fail=true --earthfile=save-artifact-dont-overwrite.earth --target=+dont-overwrite-root3 --post_command="> /tmp/output 2>&1"
+    DO +RUN_EARTHLY --should_fail=true --earthfile=save-artifact-dont-overwrite.earth --extra_args="--version-flag-overrides=require-force-for-unsafe-saves" \
+        --target=+dont-overwrite-root3 --post_command="> /tmp/output 2>&1"
     RUN cat /tmp/output | grep 'Error.*path must be located under'
 
     RUN ls important-data
 
 save-artifact-force-overwrite:
     RUN --no-cache echo hello > /root/important-data
-    DO +RUN_EARTHLY --earthfile=save-artifact-overwrite.earth --target=+overwrite-root
+    DO +RUN_EARTHLY --earthfile=save-artifact-overwrite.earth --extra_args="--version-flag-overrides=require-force-for-unsafe-saves" --target=+overwrite-root
     RUN cat /root/base | grep 88716877-039f-4dea-8ec3-84eb64f326c5
     RUN cat /root/sub/data1 | grep ff42c40d-034a-4855-8db7-febfa7322576
     RUN cat /root/sub/data2 | grep 2b4a653d-cdf6-4574-ac5e-f02bb6993365

--- a/examples/tests/Earthfile
+++ b/examples/tests/Earthfile
@@ -63,6 +63,7 @@ ga:
     BUILD +save-artifact-file-as-dot
     BUILD +save-artifact-dir-as-dot
     BUILD +save-artifact-dont-overwrite
+    BUILD +save-artifact-force-overwrite
     BUILD +save-artifact-after-push
     BUILD +save-artifact-selective
     BUILD +save-artifact-selective-legacy
@@ -495,6 +496,14 @@ save-artifact-dont-overwrite:
     RUN cat /tmp/output | grep 'Error.*path must be located under'
 
     RUN ls important-data
+
+save-artifact-force-overwrite:
+    RUN --no-cache echo hello > /root/important-data
+    DO +RUN_EARTHLY --earthfile=save-artifact-overwrite.earth --target=+overwrite-root
+    RUN cat /root/base | grep 88716877-039f-4dea-8ec3-84eb64f326c5
+    RUN cat /root/sub/data1 | grep ff42c40d-034a-4855-8db7-febfa7322576
+    RUN cat /root/sub/data2 | grep 2b4a653d-cdf6-4574-ac5e-f02bb6993365
+    RUN ! ls /root/important-data
 
 save-artifact-file-as-dot:
     DO +RUN_EARTHLY --earthfile=save-artifact-dot.earth --target=+save-local-file-as-dot

--- a/examples/tests/save-artifact-dont-overwrite.earth
+++ b/examples/tests/save-artifact-dont-overwrite.earth
@@ -1,0 +1,24 @@
+FROM alpine:3.13
+
+RUN mkdir -p /data/sub
+RUN echo d9e31cbc-d4a5-43d3-a112-ff3eec8c964d > /data/base
+RUN echo 926acd99-3c24-4318-932a-4172ab536b92 > /data/sub/data1
+RUN echo 4053a56a-d329-4ca0-b597-6236d8bcca66 > /data/sub/data2
+
+dont-overwrite-abs-ref:
+    SAVE ARTIFACT /data AS LOCAL /test
+
+dont-overwrite-rel-ref:
+    SAVE ARTIFACT /data AS LOCAL ../test
+
+dont-overwrite-rel-other-ref:
+    SAVE ARTIFACT /data AS LOCAL ../other
+
+dont-overwrite-root:
+    SAVE ARTIFACT /data AS LOCAL /
+
+dont-overwrite-root2:
+    SAVE ARTIFACT /data AS LOCAL /.
+
+dont-overwrite-root3:
+    SAVE ARTIFACT /data AS LOCAL /tmp/..

--- a/examples/tests/save-artifact-dot.earth
+++ b/examples/tests/save-artifact-dot.earth
@@ -1,0 +1,15 @@
+FROM alpine:3.13
+WORKDIR base
+
+all:
+    BUILD +save-local-as-dot
+
+save-local-file-as-dot:
+    RUN echo eeee5a95-1506-428f-8ef0-94bbad5bd22b > uuid
+    SAVE ARTIFACT uuid AS LOCAL .
+
+save-local-dir-as-dot:
+    RUN mkdir /the-data
+    RUN echo 7be91098-1823-41df-911b-2a8907fe5da7 > /the-data/file1
+    RUN echo b0359c17-d08b-411c-9db7-1333ef3673d0 > /the-data/file2
+    SAVE ARTIFACT /the-data AS LOCAL .

--- a/examples/tests/save-artifact-overwrite.earth
+++ b/examples/tests/save-artifact-overwrite.earth
@@ -1,0 +1,9 @@
+FROM alpine:3.13
+
+RUN mkdir -p /data/sub
+RUN echo 88716877-039f-4dea-8ec3-84eb64f326c5 > /data/base
+RUN echo ff42c40d-034a-4855-8db7-febfa7322576 > /data/sub/data1
+RUN echo 2b4a653d-cdf6-4574-ac5e-f02bb6993365 > /data/sub/data2
+
+overwrite-root:
+    SAVE ARTIFACT --force /data AS LOCAL /root

--- a/features/features.go
+++ b/features/features.go
@@ -21,6 +21,7 @@ type Features struct {
 	ReferencedSaveOnly     bool `long:"referenced-save-only" description:"only save artifacts that are directly referenced"`
 	UseCopyIncludePatterns bool `long:"use-copy-include-patterns" description:"specify an include pattern to buildkit when performing copies"`
 	ForIn                  bool `long:"for-in" description:"allow the use of the FOR command"`
+	AllowParentSaves       bool `long:"allow-parent-saves" description:"allow SAVE ARTIFACT AS LOCAL to save targets to parent directories"`
 
 	Major int
 	Minor int

--- a/features/features.go
+++ b/features/features.go
@@ -21,7 +21,6 @@ type Features struct {
 	ReferencedSaveOnly     bool `long:"referenced-save-only" description:"only save artifacts that are directly referenced"`
 	UseCopyIncludePatterns bool `long:"use-copy-include-patterns" description:"specify an include pattern to buildkit when performing copies"`
 	ForIn                  bool `long:"for-in" description:"allow the use of the FOR command"`
-	AllowParentSaves       bool `long:"allow-parent-saves" description:"allow SAVE ARTIFACT AS LOCAL to save targets to parent directories"`
 
 	Major int
 	Minor int

--- a/features/features.go
+++ b/features/features.go
@@ -18,9 +18,10 @@ import (
 // Features is used to denote which features to flip on or off; this is for use in maintaining
 // backwards compatibility
 type Features struct {
-	ReferencedSaveOnly     bool `long:"referenced-save-only" description:"only save artifacts that are directly referenced"`
-	UseCopyIncludePatterns bool `long:"use-copy-include-patterns" description:"specify an include pattern to buildkit when performing copies"`
-	ForIn                  bool `long:"for-in" description:"allow the use of the FOR command"`
+	ReferencedSaveOnly         bool `long:"referenced-save-only" description:"only save artifacts that are directly referenced"`
+	UseCopyIncludePatterns     bool `long:"use-copy-include-patterns" description:"specify an include pattern to buildkit when performing copies"`
+	ForIn                      bool `long:"for-in" description:"allow the use of the FOR command"`
+	RequireForceForUnsafeSaves bool `long:"require-force-for-unsafe-saves" description:"require the --force flag when saving to path outside of current path"`
 
 	Major int
 	Minor int


### PR DESCRIPTION
Currently if a user specifies

    SAVE ARTIFACT some-file AS LOCAL .

This error occurs:

    $ ./earthly ~/broken/save-dot+sd
               buildkitd | Found buildkit daemon as docker container (earthly-buildkitd)
                  alpine | --> Load metadata linux/amd64
      /h/a/b/save-dot+sd | --> FROM alpine
      /h/a/b/save-dot+sd | [██████████] resolve docker.io/library/alpine@sha256:eb3e4e175ba6d212ba1d6e04fc0782916c08e1c9d7b45892e9796141b1d379ae ... 100%
      /h/a/b/save-dot+sd | --> RUN ls -la > output
      /h/a/b/save-dot+sd | --> SAVE ARTIFACT output /home/alex/broken/save-dot+sd/output AS LOCAL .
                  output | --> exporting outputs
                  output | [██████████] copying files ... 100%
    ================================ SUCCESS [main] ================================
    Error: build target: rm /home/alex/broken/save-dot: remove /home/alex/broken/save-dot: directory not empty

Instead the user most likely wanted to specify

    SAVE ARTIFACT some-file AS LOCAL ./

Either we should raise a more appropriate error (rather than attempt to
delete the current directory, which fortunately fails), or as this PR
suggests, we can just assume the user meant save "some-file" to the
current directory.

This makes it more consistent with the current
non-local SAVE ARTIFACT commands:

    SAVE ARTIFACT some-file .
    SAVE ARTIFACT some-file ./
    SAVE ARTIFACT some-file ./some-file

which are currently interpreted the same way.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>