### PR TITLE
Extend COPY --if-exists to classical COPY

### DIFF
--- a/ast/tests/if-exists.ast.json
+++ b/ast/tests/if-exists.ast.json
@@ -290,6 +290,32 @@
           }
         }
       ]
+    },
+    {
+      "name": "classic-copy",
+      "recipe": [
+        {
+          "command": {
+            "args": [
+              "--if-exists",
+              "this-file-does-not-exist",
+              "."
+            ],
+            "name": "COPY"
+          }
+        },
+        {
+          "command": {
+            "args": [
+              "test",
+              "!",
+              "-f",
+              "this-file-does-not-exist"
+            ],
+            "name": "RUN"
+          }
+        }
+      ]
     }
   ]
 }

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -441,7 +441,7 @@ func (c *Converter) CopyArtifact(ctx context.Context, artifactName string, dest 
 }
 
 // CopyClassical applies the earthly COPY command, with classical args.
-func (c *Converter) CopyClassical(ctx context.Context, srcs []string, dest string, isDir bool, keepTs bool, keepOwn bool, chown string) error {
+func (c *Converter) CopyClassical(ctx context.Context, srcs []string, dest string, isDir bool, keepTs bool, keepOwn bool, chown string, ifExists bool) error {
 	err := c.checkAllowed(copyCmd)
 	if err != nil {
 		return err
@@ -460,11 +460,12 @@ func (c *Converter) CopyClassical(ctx context.Context, srcs []string, dest strin
 	c.mts.Final.MainState = llbutil.CopyOp(
 		srcState,
 		srcs,
-		c.mts.Final.MainState, dest, true, isDir, keepTs, c.copyOwner(keepOwn, chown), false, false,
+		c.mts.Final.MainState, dest, true, isDir, keepTs, c.copyOwner(keepOwn, chown), ifExists, false,
 		llb.WithCustomNamef(
-			"%sCOPY %s%s %s",
+			"%sCOPY %s%s%s %s",
 			c.vertexPrefix(false, false),
 			strIf(isDir, "--dir "),
+			strIf(ifExists, "--if-exists "),
 			strings.Join(srcs, " "),
 			dest))
 	return nil

--- a/earthfile2llb/interpreter.go
+++ b/earthfile2llb/interpreter.go
@@ -745,7 +745,7 @@ func (i *Interpreter) handleCopy(ctx context.Context, cmd spec.Command) error {
 			return i.errorf(cmd.SourceLocation, "unhandled locally artifact copy when allArtifacts is false")
 		}
 
-		err = i.converter.CopyClassical(ctx, srcs, dest, opts.IsDirCopy, opts.KeepTs, opts.KeepOwn, opts.Chown)
+		err = i.converter.CopyClassical(ctx, srcs, dest, opts.IsDirCopy, opts.KeepTs, opts.KeepOwn, opts.Chown, opts.IfExists)
 		if err != nil {
 			return i.wrapError(err, cmd.SourceLocation, "copy classical")
 		}

--- a/examples/tests/Earthfile
+++ b/examples/tests/Earthfile
@@ -428,6 +428,7 @@ if-exists:
       --post_command="2>&1 | perl -pe 'BEGIN {\\\$status=1} END {exit \\\$status} \\\$status=0 if /bad-wildcard-copy/;'"
     DO +RUN_EARTHLY --earthfile=if-exists.earth --target=+bad-wildcard-save \
       --post_command="2>&1 | perl -pe 'BEGIN {\\\$status=1} END {exit \\\$status} \\\$status=0 if /bad-wildcard-save/;'"
+    DO +RUN_EARTHLY --earthfile=if-exists.earth --target=+classic-copy
 
 file-copying:
     DO +RUN_EARTHLY --earthfile=file-copying.earth
@@ -477,7 +478,7 @@ run-no-cache:
     # Fail if we cached any of the motd2 lines, which are after the --no-cache
     DO +RUN_EARTHLY --earthfile=run-no-cache.earth --use_tmpfs=false --target=+test \
         --post_command="2>&1 | perl -pe 'BEGIN {\\\$status=0} END {exit \\\$status} \\\$status=1 if /\\\*cached\\\* --> .* motd2/;'"
-    
+
     # Run twice to allow the second one to attempt to cache things
     DO +RUN_EARTHLY --earthfile=run-no-cache.earth --use_tmpfs=false --target=+test-from
     # Fail if we cached any of the COPY motd2 lines, which are after the --no-cache

--- a/examples/tests/if-exists.earth
+++ b/examples/tests/if-exists.earth
@@ -44,3 +44,7 @@ bad-wildcard-copy:
 bad-wildcard-save:
     FROM +save
     SAVE ARTIFACT baddir/* AS LOCAL baddir
+
+classic-copy:
+    COPY --if-exists this-file-does-not-exist .
+    RUN test ! -f this-file-does-not-exist


### PR DESCRIPTION
extend --if-exists to support the clasic COPY command for copying files
from the local host; if the file doesn't exist, the copy doesn't execute
and earthly continues to the next command.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>