### PR TITLE
dont remove cache on upgrade

### DIFF
--- a/release/apt-repo/postrm
+++ b/release/apt-repo/postrm
@@ -1,25 +1,27 @@
 #!/usr/bin/env bash
 set -e
 
-UNABLE_TO_REMOVE="unable to remove earthly-related docker resources"
+if [ "$1" = "remove" ]; then
+    UNABLE_TO_REMOVE="unable to remove earthly-related docker resources"
 
-rm -f /usr/share/bash-completion/completions/earthly
-rm -f /usr/local/share/zsh/site-functions/_earthly
+    rm -f /usr/share/bash-completion/completions/earthly
+    rm -f /usr/local/share/zsh/site-functions/_earthly
 
-if ! command -v docker &> /dev/null
-then
-    echo "docker was not found; $UNABLE_TO_REMOVE"
-    exit
+    if ! command -v docker &> /dev/null
+    then
+        echo "docker was not found; $UNABLE_TO_REMOVE"
+        exit
+    fi
+
+    if ! docker info 2>/dev/null >/dev/null
+    then
+        echo "unable to query docker daemon; $UNABLE_TO_REMOVE"
+        exit
+    fi
+
+    echo "removing earthly-buildkitd docker container"
+    docker rm --force earthly-buildkitd
+
+    echo "removing earthly-cache docker volume"
+    docker volume rm --force earthly-cache
 fi
-
-if ! docker info 2>/dev/null >/dev/null
-then
-    echo "unable to query docker daemon; $UNABLE_TO_REMOVE"
-    exit
-fi
-
-echo "removing earthly-buildkitd docker container"
-docker rm --force earthly-buildkitd
-
-echo "removing earthly-cache docker volume"
-docker volume rm --force earthly-cache

--- a/release/yum-repo/earthly.spec
+++ b/release/yum-repo/earthly.spec
@@ -46,28 +46,31 @@ if ! docker info 2>/dev/null >/dev/null
 %postun
 set -e
 
-UNABLE_TO_REMOVE="unable to remove earthly-related docker resources"
+if [ "$1" -eq 0 ]; then
+  # "$1" is set to the number of packages left after operation; should be 1 on upgrade, 0 on uninstall.
+  UNABLE_TO_REMOVE="unable to remove earthly-related docker resources"
 
-rm -f /usr/share/bash-completion/completions/earthly
-rm -f /usr/local/share/zsh/site-functions/_earthly
+  rm -f /usr/share/bash-completion/completions/earthly
+  rm -f /usr/local/share/zsh/site-functions/_earthly
 
-if ! command -v docker &> /dev/null
-then
-    echo "docker was not found; $UNABLE_TO_REMOVE"
-    exit
+  if ! command -v docker &> /dev/null
+  then
+      echo "docker was not found; $UNABLE_TO_REMOVE"
+      exit
+  fi
+
+  if ! docker info 2>/dev/null >/dev/null
+  then
+      echo "unable to query docker daemon; $UNABLE_TO_REMOVE"
+      exit
+  fi
+
+  echo "removing earthly-buildkitd docker container"
+  docker rm --force earthly-buildkitd
+
+  echo "removing earthly-cache docker volume"
+  docker volume rm --force earthly-cache
 fi
-
-if ! docker info 2>/dev/null >/dev/null
-then
-    echo "unable to query docker daemon; $UNABLE_TO_REMOVE"
-    exit
-fi
-
-echo "removing earthly-buildkitd docker container"
-docker rm --force earthly-buildkitd
-
-echo "removing earthly-cache docker volume"
-docker volume rm --force earthly-cache
 
 %changelog
 * Thu Feb 25 2021 alex <alex@earthly.dev>


### PR DESCRIPTION
earthly cache should only be removed on uninstalls.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>