### PR TITLE
the homebrew test now runs earthly --version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,8 +133,6 @@ jobs:
         run: go test ./analytics --tags=hasgitdirectory
       - name: Execute earthly docker command
         run: (cd examples/tests/docker && ../../.././build/linux/amd64/earthly docker --tag examples-test-docker:latest && diff <(docker run --rm examples-test-docker:latest) <(echo "hello dockerfile") )
-      - name: Execute test similar to homebrew test in https://github.com/Homebrew/homebrew-core/blob/master/Formula/earthly.rb
-        run: "./build/linux/amd64/earthly --buildkit-host 127.0.0.1 ./examples/tests/with-docker+all 2>&1 | grep 'buildkitd failed to start'"
       - name: Execute private image test (non fork only)
         run: ./build/linux/amd64/earthly --ci ./examples/tests+private-image-test
         if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository

--- a/Earthfile
+++ b/Earthfile
@@ -196,7 +196,7 @@ earthly:
         printf ' '"$GO_EXTRA_LDFLAGS" >> ./build/ldflags && \
         echo "$(cat ./build/ldflags)"
     # Important! If you change the go build options, you may need to also change them
-    # in https://github.com/Homebrew/homebrew-core/blob/master/Formula/earthly.rb.
+    # in https://github.com/earthly/homebrew-earthly/blob/main/Formula/earthly.rb
     RUN --mount=type=cache,target=$GOCACHE \
         GOARM=${VARIANT#v} go build \
             -tags "$(cat ./build/tags)" \

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -1168,10 +1168,6 @@ func parseAndvalidateURL(addr string) (*url.URL, error) {
 	}
 
 	if parsed.Scheme != "tcp" && parsed.Scheme != "docker-container" {
-		if parsed.Scheme == "" {
-			// This text should satisfy the homebrew test, as it pases a schemeless URL
-			return nil, fmt.Errorf("buildkitd failed to start: %w", errURLValidationFailure)
-		}
 		return nil, fmt.Errorf("%s is not a valid scheme. Only tcp or docker-container is allowed at this time: %w", parsed.Scheme, errURLValidationFailure)
 	}
 

--- a/examples/tests/Earthfile
+++ b/examples/tests/Earthfile
@@ -91,6 +91,7 @@ ga:
     BUILD +true-false-flag-invalid
     BUILD +dont-save-indirect-remote-artifact
     BUILD +sequential-locally-test
+    BUILD +homebrew-test
 
 experimental:
     BUILD ./dind-auto-install+all
@@ -823,6 +824,10 @@ done
 echo test passed: RUNs were sequentially grouped
 " > test-output.sh && chmod +x test-output.sh
     RUN cat output-filtered.txt | ./test-output.sh
+
+homebrew-test:
+    # This is to ensure the assert in https://github.com/earthly/homebrew-earthly/blob/main/Formula/earthly.rb continues to work
+    RUN earthly --version | grep '^earthly version'
 
 
 RUN_EARTHLY:


### PR DESCRIPTION
There is no need to satisfy this homebrew-specific exit code text as the
homebrew test has been changed to run earthly --version instead.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>