### PR TITLE
Fix vscode not highlight port number when have space after EXPOSE more than 1 space

### DIFF
--- a/contrib/earthfile-syntax-highlighting/syntaxes/earthfile.tmLanguage.json
+++ b/contrib/earthfile-syntax-highlighting/syntaxes/earthfile.tmLanguage.json
@@ -71,7 +71,7 @@
 					"name": "constant.character.escape.earthfile"
 				},
 				{
-					"match": "(?<=EXPOSE\\s)(\\d+)",
+					"match": "(?<=EXPOSE\\s+)(\\d+)",
 					"name": "constant.numeric.earthfile"
 				}
 			]


### PR DESCRIPTION
If have more than 1 space after EXPOSE. It'll highlight:

<img width="181" alt="Screen Shot 2564-08-29 at 14 02 40" src="https://user-images.githubusercontent.com/484530/131241829-8f5b2bf8-e53c-48da-9177-a3413e6cf368.png">

After fix:

<img width="160" alt="Screen Shot 2564-08-29 at 14 02 58" src="https://user-images.githubusercontent.com/484530/131241832-633c895c-b21a-49ac-9985-069f26b28585.png">
