### PR TITLE
Perform error handling when checking if file or dir exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 
 - Ability to change mounted secret file mode. fixes [#1434](https://github.com/earthly/earthly/issues/1434)
 
+### Changed
+
+- Permission errors related to reading `~/.earthly/config.yml` and `.env` files are now treated as errors rather than silently ignored (and assuming the file does not exist).
+
 ## v0.6.5 - 2022-01-24
 
 ### Added

--- a/analytics/analytics.go
+++ b/analytics/analytics.go
@@ -134,7 +134,11 @@ func getInstallID() (string, error) {
 	}
 
 	path := filepath.Join(earthlyDir, "install_id")
-	if !fileutil.FileExists(path) {
+	pathExists, err := fileutil.FileExists(path)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to check if %s exists", path)
+	}
+	if !pathExists {
 		u, err := uuid.NewUUID()
 		if err != nil {
 			u, err = uuid.NewRandom()
@@ -227,7 +231,9 @@ func CollectAnalytics(ctx context.Context, earthlyServer string, displayErrors b
 		} else {
 			installID, err = getInstallID()
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "Failed to get install ID: %s\n", err.Error())
+				if displayErrors {
+					fmt.Fprintf(os.Stderr, "Failed to get install ID: %s\n", err.Error())
+				}
 				installID = "unknown"
 			}
 		}

--- a/autocomplete/complete.go
+++ b/autocomplete/complete.go
@@ -157,8 +157,13 @@ func getPotentialPaths(ctx context.Context, resolver *buildcontext.Resolver, gwC
 		return potentials, nil
 	}
 
+	prefixDirExists, err := fileutil.DirExists(prefix)
+	if err != nil {
+		return nil, err
+	}
+
 	var f, dir string
-	if fileutil.DirExists(prefix) {
+	if prefixDirExists {
 		dir = prefix
 	} else {
 		dir, f = path.Split(prefix)
@@ -423,7 +428,7 @@ func GetPotentials(ctx context.Context, resolver *buildcontext.Resolver, gwClien
 			if containsDirectories(".") {
 				potentials = append(potentials, "./")
 			}
-			if fileutil.FileExists("Earthfile") {
+			if fileutil.FileExistsBestEffort("Earthfile") {
 				potentials = append(potentials, "+")
 			}
 		}

--- a/buildcontext/excludes.go
+++ b/buildcontext/excludes.go
@@ -28,11 +28,17 @@ func readExcludes(dir string, noImplicitIgnore bool) ([]string, error) {
 
 	//earthIgnoreFile
 	var earthIgnoreFilePath = filepath.Join(dir, earthIgnoreFile)
-	earthExists := fileutil.FileExists(earthIgnoreFilePath)
+	earthExists, err := fileutil.FileExists(earthIgnoreFilePath)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to check if %s exists", earthIgnoreFilePath)
+	}
 
 	//earthlyIgnoreFile
 	var earthlyIgnoreFilePath = filepath.Join(dir, earthlyIgnoreFile)
-	earthlyExists := fileutil.FileExists(earthlyIgnoreFilePath)
+	earthlyExists, err := fileutil.FileExists(earthlyIgnoreFilePath)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to check if %s exists", earthlyIgnoreFilePath)
+	}
 
 	defaultExcludes := ImplicitExcludes
 	if noImplicitIgnore {

--- a/buildcontext/gitlookup.go
+++ b/buildcontext/gitlookup.go
@@ -593,8 +593,11 @@ func loadKnownHosts() ([]string, error) {
 	}
 
 	knownHosts := filepath.Join(homeDir, ".ssh/known_hosts")
-
-	if !fileutil.FileExists(knownHosts) {
+	knownHostsExists, err := fileutil.FileExists(knownHosts)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to check if %s exists", knownHosts)
+	}
+	if !knownHostsExists {
 		return nil, nil
 	}
 

--- a/buildkitd/buildkitd.go
+++ b/buildkitd/buildkitd.go
@@ -779,7 +779,11 @@ func makeTLSPath(path string) (string, error) {
 		fullPath = filepath.Join(earthlyDir, path)
 	}
 
-	if !fileutil.FileExists(fullPath) {
+	exists, err := fileutil.FileExists(fullPath)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to check if %s exists", fullPath)
+	}
+	if !exists {
 		return "", fmt.Errorf("path '%s' does not exist", path)
 	}
 

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -1057,9 +1057,11 @@ func (app *earthlyApp) before(context *cli.Context) error {
 	var yamlData []byte
 	var err error
 	if app.configPath != "" {
-		yamlData, err = config.ReadConfigFile(app.configPath, context.IsSet("config"))
+		yamlData, err = config.ReadConfigFile(app.configPath)
 		if err != nil {
-			return errors.Wrapf(err, "read config")
+			if context.IsSet("config") || !errors.Is(err, os.ErrNotExist) {
+				return errors.Wrapf(err, "read config")
+			}
 		}
 	}
 
@@ -1268,7 +1270,8 @@ func (app *earthlyApp) warnIfEarth() {
 			return
 		}
 		earthlyPath := path.Join(path.Dir(absPath), "earthly")
-		if fileutil.FileExists(earthlyPath) {
+		earthlyPathExists, _ := fileutil.FileExists(earthlyPath)
+		if earthlyPathExists {
 			app.console.Warnf("Once you are ready to switch over to earthly, you can `rm %s`", absPath)
 		}
 	}
@@ -1426,12 +1429,20 @@ func (app *earthlyApp) insertBashCompleteEntry() error {
 	}
 	dirPath := filepath.Dir(path)
 
-	if !fileutil.DirExists(dirPath) {
+	dirPathExists, err := fileutil.DirExists(dirPath)
+	if err != nil {
+		return errors.Wrapf(err, "failed checking if %s exists", dirPath)
+	}
+	if !dirPathExists {
 		fmt.Fprintf(os.Stderr, "Warning: unable to enable bash-completion: %s does not exist\n", dirPath)
 		return nil // bash-completion isn't available, silently fail.
 	}
 
-	if fileutil.FileExists(path) {
+	pathExists, err := fileutil.FileExists(path)
+	if err != nil {
+		return errors.Wrapf(err, "failed checking if %s exists", path)
+	}
+	if pathExists {
 		return nil // file already exists, don't update it.
 	}
 
@@ -1518,12 +1529,20 @@ func (app *earthlyApp) insertZSHCompleteEntry() error {
 	path := "/usr/local/share/zsh/site-functions/_earthly"
 	dirPath := filepath.Dir(path)
 
-	if !fileutil.DirExists(dirPath) {
+	dirPathExists, err := fileutil.DirExists(dirPath)
+	if err != nil {
+		return errors.Wrapf(err, "failed to check if %s exists", dirPath)
+	}
+	if !dirPathExists {
 		fmt.Fprintf(os.Stderr, "Warning: unable to enable zsh-completion: %s does not exist\n", dirPath)
 		return nil // zsh-completion isn't available, silently fail.
 	}
 
-	if fileutil.FileExists(path) {
+	pathExists, err := fileutil.FileExists(path)
+	if err != nil {
+		return errors.Wrapf(err, "failed to check if %s exists", path)
+	}
+	if pathExists {
 		return nil // file already exists, don't update it.
 	}
 
@@ -1689,7 +1708,11 @@ func symlinkEarthlyToEarth() error {
 
 	earthPath := path.Join(path.Dir(binPath), "earth")
 
-	if !fileutil.FileExists(earthPath) && termutil.IsTTY() {
+	earthPathExists, err := fileutil.FileExists(earthPath)
+	if err != nil {
+		return errors.Wrapf(err, "failed to check if %s exists", earthPath)
+	}
+	if !earthPathExists && termutil.IsTTY() {
 		return nil // legacy earth binary doesn't exist, don't create it (unless we're under a non-tty system e.g. CI)
 	}
 
@@ -2570,12 +2593,16 @@ func (app *earthlyApp) actionDocker(c *cli.Context) error {
 
 	dir := filepath.Dir(app.dockerfilePath)
 	earthfilePath := filepath.Join(dir, "Earthfile")
-	if fileutil.FileExists(earthfilePath) {
+	earthfilePathExists, err := fileutil.FileExists(earthfilePath)
+	if err != nil {
+		return errors.Wrapf(err, "failed to check if %s exists", earthfilePath)
+	}
+	if earthfilePathExists {
 		return errors.Errorf("earthfile already exists; please delete it if you wish to continue")
 	}
 	defer os.Remove(earthfilePath)
 
-	err := docker2earthly.Docker2Earthly(app.dockerfilePath, earthfilePath, app.earthfileFinalImage)
+	err = docker2earthly.Docker2Earthly(app.dockerfilePath, earthfilePath, app.earthfileFinalImage)
 	if err != nil {
 		return err
 	}
@@ -2608,9 +2635,11 @@ func (app *earthlyApp) actionConfig(c *cli.Context) error {
 	}
 
 	args := c.Args().Slice()
-	inConfig, err := config.ReadConfigFile(app.configPath, c.IsSet("config"))
+	inConfig, err := config.ReadConfigFile(app.configPath)
 	if err != nil {
-		return errors.Wrap(err, "read config")
+		if c.IsSet("config") || !errors.Is(err, os.ErrNotExist) {
+			return errors.Wrapf(err, "read config")
+		}
 	}
 
 	var outConfig []byte
@@ -3153,7 +3182,9 @@ func defaultConfigPath() string {
 	earthlyDir := cliutil.GetEarthlyDir()
 	oldConfig := filepath.Join(earthlyDir, "config.yaml")
 	newConfig := filepath.Join(earthlyDir, "config.yml")
-	if fileutil.FileExists(oldConfig) && !fileutil.FileExists(newConfig) {
+	oldConfigExists, _ := fileutil.FileExists(oldConfig)
+	newConfigExists, _ := fileutil.FileExists(newConfig)
+	if oldConfigExists && !newConfigExists {
 		return oldConfig
 	}
 	return newConfig

--- a/config/config.go
+++ b/config/config.go
@@ -430,14 +430,11 @@ func deleteYamlValue(node *yaml.Node, path []string) []string {
 }
 
 // ReadConfigFile reads in the config file from the disk, into a byte slice.
-func ReadConfigFile(configPath string, contextSet bool) ([]byte, error) {
+func ReadConfigFile(configPath string) ([]byte, error) {
 	yamlData, err := os.ReadFile(configPath)
-	if os.IsNotExist(err) && !contextSet {
-		return []byte{}, nil
-	} else if err != nil {
+	if err != nil {
 		return []byte{}, errors.Wrapf(err, "failed to read from %s", configPath)
 	}
-
 	return yamlData, nil
 }
 

--- a/docker2earthly/convert.go
+++ b/docker2earthly/convert.go
@@ -23,7 +23,7 @@ func getArtifactName(s string) string {
 // Docker2Earthly converts an existing Dockerfile in the current directory and writes out an Earthfile in the current directory
 // and error is returned if an Earthfile already exists.
 func Docker2Earthly(dockerfilePath, earthfilePath, imageTag string) error {
-	if fileutil.FileExists(earthfilePath) {
+	if exists, _ := fileutil.FileExists(earthfilePath); exists {
 		return errors.Errorf("earthfile already exists; please delete it if you wish to continue")
 	}
 

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -772,7 +772,11 @@ func (c *Converter) canSave(ctx context.Context, saveAsLocalTo string) (bool, er
 	if err != nil {
 		return false, errors.Wrapf(err, "failed to get absolute path of %s", basepath)
 	}
-	if !fileutil.DirExists(basepath) {
+	basePathExists, err := fileutil.DirExists(basepath)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to check if %s exists", basepath)
+	}
+	if !basePathExists {
 		return false, fmt.Errorf("no such directory: %s", basepath)
 	}
 	basepath += "/"

--- a/secretsclient/client.go
+++ b/secretsclient/client.go
@@ -893,7 +893,7 @@ func (c *client) loadAuthToken() error {
 	if err != nil {
 		return err
 	}
-	if !fileutil.FileExists(tokenPath) {
+	if exists, _ := fileutil.FileExists(tokenPath); !exists {
 		return nil
 	}
 	data, err := os.ReadFile(tokenPath)
@@ -1038,13 +1038,20 @@ func (c *client) DeleteCachedCredentials() error {
 	c.email = ""
 	c.password = ""
 	c.authToken = ""
+
 	tokenPath, err := c.getAuthTokenPath(false)
 	if err != nil {
 		return err
 	}
-	if !fileutil.FileExists(tokenPath) {
+
+	tokenPathExists, err := fileutil.FileExists(tokenPath)
+	if err != nil {
+		return errors.Wrapf(err, "failed to check if %s exists", tokenPath)
+	}
+	if !tokenPathExists {
 		return nil
 	}
+
 	err = os.Remove(tokenPath)
 	if err != nil {
 		return errors.Wrapf(err, "failed to delete %s", tokenPath)

--- a/tests/config/Earthfile
+++ b/tests/config/Earthfile
@@ -10,24 +10,28 @@ FROM ../..+earthly-integration-test-base \
     --DOCKERHUB_TOKEN_SECRET=$DOCKERHUB_TOKEN_SECRET \
     --DOCKERHUB_MIRROR=$DOCKERHUB_MIRROR
 
+IMPORT .. AS tests
+
+WORKDIR /test
+
 test:
     COPY expected-*.yml .
-    
+
     # Ensure earthly doesn't create overridden config files when they don't exist
     RUN earthly --config config.yml config global.disable_analytics true 2>&1 | grep 'failed to read from config.yml: open config.yml: no such file or directory'
-    
+
     RUN touch config.yml
 
     # Adding various configs of different types
     RUN earthly --config config.yml config global.disable_analytics true
     RUN test "$(cat config.yml)" = "$(cat expected-1.yml)"
-    
+
     RUN earthly --config config.yml config 'git."example.com".password' hunter2
     RUN test "$(cat config.yml)" = "$(cat expected-2.yml)"
-    
+
     RUN earthly --config config.yml config global.buildkit_additional_args "['userns', '--host']"
     RUN test "$(cat config.yml)" = "$(cat expected-3.yml)"
-    
+
     RUN earthly --config config.yml config global.conversion_parallelism 5
     RUN test "$(cat config.yml)" = "$(cat expected-4.yml)"
 
@@ -45,3 +49,67 @@ test:
     RUN earthly --config config.yml config global.conversion_parallelism oops; test $? = 1
     RUN earthly --config config.yml config global.conversion_parallelism ""; test $? = 1
     RUN earthly --config config.yml config global.buildkit_image ""
+
+    # test earthly runs when no default config is present
+    RUN ! test -f /root/.earthly/config.yml
+    DO +RUN_EARTHLY_ARGS --earthfile="hello.earth" --target="+hello" --output_contains="greetings"
+
+    # test earthly can write to default config location
+    RUN earthly config global.disable_analytics true
+    RUN test "$(cat /root/.earthly/config.yml)" = "$(cat expected-1.yml)"
+
+    # test earthly fails when explicitly set to use a different config that doesn't exist
+    DO +RUN_EARTHLY_ARGS --extra_args="--config=this-does-not-exist.yml" --earthfile="hello.earth" --target="+hello" --should_fail="true" --output_contains="failed to read from this-does-not-exist.yml"
+
+    RUN touch /tmp/config.yml
+    RUN chmod 400 /tmp/config.yml
+
+    # test permission-related errors
+    RUN addgroup -S testgroup
+    RUN adduser -S -G testgroup testuser
+
+    # required to allow testuser to call +RUN_EARTHLY_ARGS
+    RUN chmod 0777 /tmp/earthly-script
+
+    # required to allow testuser to call +RUN_EARTHLY_ARGS
+
+    USER testuser
+    WORKDIR /home/testuser
+
+    # test correct user location is used by default
+    RUN earthly config global.disable_analytics true
+    RUN test "$(cat /home/testuser/.earthly/config.yml)" = "$(cat /test/expected-1.yml)"
+
+    # check permission error is correctly returned
+    COPY hello.earth Earthfile
+    RUN ! earthly --config=/tmp/config.yml --verbose +hello > output.txt 2>&1
+    RUN cat output.txt | grep 'Error: read config: failed to read from /tmp/config.yml: open /tmp/config.yml: permission denied'
+
+    # check permission error is correctly returned even when earthly attempts to read from the default location
+    # to make this test work, a symbolic link is required (chown root:root /home/testuser/.earthly/config.yml doesnt work)
+    RUN rm /home/testuser/.earthly/config.yml
+    RUN ln -s /tmp/config.yml /home/testuser/.earthly/config.yml
+
+    RUN ! earthly --verbose +hello > output.txt 2>&1
+    RUN cat output.txt | grep 'Error: read config: failed to read from /home/testuser/.earthly/config.yml: open /home/testuser/.earthly/config.yml: permission denied'
+
+
+RUN_EARTHLY_ARGS:
+    COMMAND
+    ARG earthfile
+    ARG target="+all"
+    ARG extra_args
+    ARG exec_cmd
+    ARG should_fail=false
+    ARG output_contains
+    DO tests+RUN_EARTHLY \
+        --earthfile=$earthfile \
+        --target=$target \
+        --should_fail=$should_fail \
+        --exec_cmd=$exec_cmd \
+        --output_contains=$output_contains \
+        --extra_args=$extra_args \
+        --DOCKERHUB_AUTH=$DOCKERHUB_AUTH \
+        --DOCKERHUB_USER_SECRET=$DOCKERHUB_USER_SECRET \
+        --DOCKERHUB_TOKEN_SECRET=$DOCKERHUB_TOKEN_SECRET \
+        --DOCKERHUB_MIRROR=$DOCKERHUB_MIRROR

--- a/tests/config/hello.earth
+++ b/tests/config/hello.earth
@@ -1,0 +1,4 @@
+FROM alpine:3.13
+
+hello:
+    RUN echo "Z3JlZXRpbmdzCg==" | base64 -d

--- a/util/fileutil/expand.go
+++ b/util/fileutil/expand.go
@@ -9,8 +9,8 @@ func ExpandPath(s string) string {
 	if !strings.HasPrefix(s, "~") {
 		return s
 	}
-	homeDir, _ := HomeDir()
-	if homeDir == "" {
+	homeDir, err := HomeDir()
+	if err != nil || homeDir == "" {
 		return s // best effort
 	}
 

--- a/util/fileutil/fileutil.go
+++ b/util/fileutil/fileutil.go
@@ -6,39 +6,62 @@ import (
 	"os/user"
 	"path/filepath"
 	"strconv"
+
+	"github.com/pkg/errors"
 )
 
 // FileExists returns true if the file exists
-func FileExists(filename string) bool {
+func FileExists(filename string) (bool, error) {
 	info, err := os.Stat(filename)
-	if os.IsNotExist(err) {
-		return false
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, errors.Wrapf(err, "unable to stat %s", filename)
 	}
-	return !info.IsDir()
+	return !info.IsDir(), nil
+}
+
+// FileExistsBestEffort returns true if the directory exists and ignores errors
+func FileExistsBestEffort(filename string) bool {
+	ok, _ := FileExists(filename)
+	return ok
 }
 
 // DirExists returns true if the directory exists
-func DirExists(filename string) bool {
+func DirExists(filename string) (bool, error) {
 	info, err := os.Stat(filename)
-	if os.IsNotExist(err) {
-		return false
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, errors.Wrapf(err, "unable to stat %s", filename)
 	}
-	return info.IsDir()
+	return info.IsDir(), nil
+}
+
+// DirExistsBestEffort returns true if the directory exists and ignores errors
+func DirExistsBestEffort(filename string) bool {
+	ok, _ := DirExists(filename)
+	return ok
 }
 
 // EnsureUserOwned changes the files in the directory to be owned by the use and their group, as specified by the provided user.
-func EnsureUserOwned(dir string, owner *user.User) {
-	if DirExists(dir) {
-		uid, _ := strconv.Atoi(owner.Uid)
-
-		gid := 0
-		if owner.Gid != "" {
-			// If cannot convert will use gid 0.
-			gid, _ = strconv.Atoi(owner.Gid)
-		}
-
-		_ = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
-			return os.Chown(path, uid, gid)
-		})
+func EnsureUserOwned(dir string, owner *user.User) error {
+	exists, err := DirExists(dir)
+	if err != nil || !exists {
+		return err
 	}
+
+	uid, _ := strconv.Atoi(owner.Uid)
+
+	gid := 0
+	if owner.Gid != "" {
+		// If cannot convert will use gid 0.
+		gid, _ = strconv.Atoi(owner.Gid)
+	}
+
+	return filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		return os.Chown(path, uid, gid)
+	})
 }


### PR DESCRIPTION
Error handling needs to be performed to catch permission-related errors
from obscuiring if a file exists or not.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>