### PR TITLE
move DetectHomeDir to fileutil

### DIFF
--- a/buildcontext/gitlookup.go
+++ b/buildcontext/gitlookup.go
@@ -18,7 +18,6 @@ import (
 	"golang.org/x/crypto/ssh/knownhosts"
 
 	"github.com/earthly/earthly/conslogging"
-	"github.com/earthly/earthly/util/cliutil"
 	"github.com/earthly/earthly/util/fileutil"
 
 	"github.com/jdxcode/netrc"
@@ -250,7 +249,7 @@ func (gl *GitLookup) detectProtocol(host string) (protocol gitProtocol, err erro
 var errNoRCHostEntry = fmt.Errorf("no netrc host entry")
 
 func (gl *GitLookup) lookupNetRCCredential(host string) (login, password string, err error) {
-	homeDir, _ := cliutil.DetectHomeDir()
+	homeDir, _ := fileutil.HomeDir()
 	n, err := netrc.Parse(filepath.Join(homeDir, ".netrc"))
 	if err != nil {
 		return "", "", errors.Wrap(err, "failed to parse .netrc")

--- a/util/cliutil/earthlydir.go
+++ b/util/cliutil/earthlydir.go
@@ -27,7 +27,7 @@ func GetEarthlyDir() string {
 }
 
 func getEarthlyDirAndUser() (string, *user.User) {
-	homeDir, u := DetectHomeDir()
+	homeDir, u := fileutil.HomeDir()
 	earthlyDir := filepath.Join(homeDir, ".earthly")
 	return earthlyDir, u
 }
@@ -51,61 +51,6 @@ func GetOrCreateEarthlyDir() (string, error) {
 	})
 
 	return earthlyDir, earthlyDirCreateErr
-}
-
-func getHomeFromSudoUser() (string, *user.User, bool) {
-	sudoUserName, ok := os.LookupEnv("SUDO_USER")
-	if !ok {
-		return "", nil, false
-	}
-	u, err := user.Lookup(sudoUserName)
-	if err != nil {
-		return "", nil, false
-	}
-	if u.HomeDir == "" {
-		return "", nil, false
-	}
-	return u.HomeDir, u, true
-}
-
-func getHomeFromHomeEnv() (string, *user.User, bool) {
-	home, ok := os.LookupEnv("HOME")
-	if !ok {
-		return "", nil, false
-	}
-	return home, nil, true
-}
-
-func getHomeFromUserCurrent() (string, *user.User, bool) {
-	u, err := user.Current()
-	if err != nil {
-		return "", nil, false
-	}
-	if u.HomeDir == "" {
-		return "", nil, false
-	}
-
-	// do NOT return the user here, because the user is only
-	// required during the SUDO_USER case; where as this case
-	// the permissions will belong to the current user and won't need changing.
-	return u.HomeDir, nil, true
-}
-
-// DetectHomeDir returns the home directory of the current user, together with
-// the user object who owns it. If SUDO_USER is detected, then that user's
-// home directory will be used instead.
-func DetectHomeDir() (string, *user.User) {
-	for _, fn := range []func() (string, *user.User, bool){
-		getHomeFromSudoUser,
-		getHomeFromHomeEnv,
-		getHomeFromUserCurrent,
-	} {
-		home, u, ok := fn()
-		if ok {
-			return home, u
-		}
-	}
-	return "/etc", nil
 }
 
 // IsBootstrapped provides a tentatively correct guess about the state of our bootstrapping.

--- a/util/fileutil/expand.go
+++ b/util/fileutil/expand.go
@@ -9,8 +9,8 @@ func ExpandPath(s string) string {
 	if !strings.HasPrefix(s, "~") {
 		return s
 	}
-	homeDir, _, err := HomeDir()
-	if err != nil || homeDir == "" {
+	homeDir, _ := HomeDir()
+	if homeDir == "" {
 		return s // best effort
 	}
 

--- a/util/fileutil/homedir.go
+++ b/util/fileutil/homedir.go
@@ -3,34 +3,64 @@ package fileutil
 import (
 	"os"
 	"os/user"
-	"runtime"
 )
 
-// HomeDir returns the home directory of the current user, an additional sudoUser
-// is returned if the user is currently running as root
-func HomeDir() (homeDir string, sudoUser *user.User, err error) {
-	if runtime.GOOS == "windows" {
-		homeDir, err := os.UserHomeDir()
-		return homeDir, nil, err
-	}
-	// See if SUDO_USER exists. Use that user's home dir.
+func getHomeFromSudoUser() (string, *user.User, bool) {
 	sudoUserName, ok := os.LookupEnv("SUDO_USER")
-	if ok {
-		sudoUser, err := user.Lookup(sudoUserName)
-		if err == nil && sudoUser.HomeDir != "" {
-			return sudoUser.HomeDir, sudoUser, nil
-		}
+	if !ok {
+		return "", nil, false
 	}
-	// Try to use current user's home dir.
-	homeDir, err = os.UserHomeDir()
+	u, err := user.Lookup(sudoUserName)
 	if err != nil {
-		// Try $HOME.
-		homeDir, ok := os.LookupEnv("HOME")
-		if ok {
-			return homeDir, nil, nil
-		}
-		// No home dir available - use /etc instead.
-		return "", nil, nil
+		return "", nil, false
 	}
-	return homeDir, nil, nil
+	if u.HomeDir == "" {
+		return "", nil, false
+	}
+	writable, _ := IsDirWritable(u.HomeDir)
+	if !writable {
+		return "", nil, false
+	}
+
+	return u.HomeDir, u, true
+}
+
+func getHomeFromHomeEnv() (string, *user.User, bool) {
+	home, ok := os.LookupEnv("HOME")
+	if !ok {
+		return "", nil, false
+	}
+	return home, nil, true
+}
+
+func getHomeFromUserCurrent() (string, *user.User, bool) {
+	u, err := user.Current()
+	if err != nil {
+		return "", nil, false
+	}
+	if u.HomeDir == "" {
+		return "", nil, false
+	}
+
+	// do NOT return the user here, because the user is only
+	// required during the SUDO_USER case; where as this case
+	// the permissions will belong to the current user and won't need changing.
+	return u.HomeDir, nil, true
+}
+
+// HomeDir returns the home directory of the current user, together with
+// the user object who owns it. If SUDO_USER is detected, then that user's
+// home directory will be used instead.
+func HomeDir() (string, *user.User) {
+	for _, fn := range []func() (string, *user.User, bool){
+		getHomeFromSudoUser,
+		getHomeFromHomeEnv,
+		getHomeFromUserCurrent,
+	} {
+		home, u, ok := fn()
+		if ok {
+			return home, u
+		}
+	}
+	return "/etc", nil
 }

--- a/util/fileutil/iswritable_other.go
+++ b/util/fileutil/iswritable_other.go
@@ -1,0 +1,32 @@
+// +build !windows
+
+package fileutil
+
+import (
+	"os"
+	"syscall"
+)
+
+// IsDirWritable returns if the path is a directory that the user can write to
+func IsDirWritable(path string) (bool, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false, err
+	}
+
+	if !info.IsDir() {
+		return false, nil
+	}
+
+	// Check if the user bit is enabled in file permission
+	if info.Mode().Perm()&(1<<(uint(7))) == 0 {
+		return false, nil
+	}
+
+	var stat syscall.Stat_t
+	if err = syscall.Stat(path, &stat); err != nil {
+		return false, err
+	}
+
+	return true, nil
+}

--- a/util/fileutil/iswritable_windows.go
+++ b/util/fileutil/iswritable_windows.go
@@ -1,0 +1,27 @@
+// +build windows
+
+package fileutil
+
+import (
+	"os"
+)
+
+// IsDirWritable returns if the path is a directory that the user can write to
+func IsDirWritable(path string) (bool, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false, err
+	}
+
+	err = nil
+	if !info.IsDir() {
+		return false, nil
+	}
+
+	// Check if the user bit is enabled in file permission
+	if info.Mode().Perm()&(1<<(uint(7))) == 0 {
+		return false, nil
+	}
+
+	return true, nil
+}


### PR DESCRIPTION
Both cliutil and fileutil contain similar code to detect the home
directory; this combines the two functions into a single function.
This will ensure we consistently use the same home dir detection.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>