### PR TITLE
Only create outdir when needed

### DIFF
--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -1,0 +1,24 @@
+package builder
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/earthly/earthly/cleanup"
+)
+
+// TestTempEarthlyOutDir tests that tempEarthlyOutDir always returns the same directory
+func TestTempEarthlyOutDir(t *testing.T) {
+	b, _ := NewBuilder(nil, Opt{
+		CleanCollection: cleanup.NewCollection(),
+	})
+
+	outDir1, err := b.tempEarthlyOutDir()
+	assert.NoError(t, err)
+
+	outDir2, err := b.tempEarthlyOutDir()
+	assert.NoError(t, err)
+
+	assert.Equal(t, outDir1, outDir2)
+}


### PR DESCRIPTION
The temp output directory should only be created when needed; without
this PR, running a target that doesn't output artifacts (or running
under --no-output), will still cause the temp directory to be created,
which will fail if earthly is being run on a read-only directory.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>