### PR TITLE
pin ubuntu to 20.10

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -331,7 +331,7 @@ dind-alpine:
     SAVE IMAGE --push --cache-from=earthly/dind:main earthly/dind:$DIND_ALPINE_TAG
 
 dind-ubuntu:
-    FROM ubuntu:latest
+    FROM ubuntu:20.10
     COPY ./buildkitd/docker-auto-install.sh /usr/local/bin/docker-auto-install.sh
     RUN docker-auto-install.sh
     ARG DIND_UBUNTU_TAG=ubuntu-$EARTHLY_TARGET_TAG_DOCKER

--- a/docs/earthfile/earthfile.md
+++ b/docs/earthfile/earthfile.md
@@ -970,7 +970,7 @@ ARG base=alpine
 IF [ "$base" = "alpine" ]
     FROM alpine:3.13
 ELSE
-    FROM ubuntu:20.04
+    FROM ubuntu:20.10
 END
 ```
 
@@ -984,7 +984,7 @@ FROM busybox
 IF [ "$base" = "alpine" ]
     FROM alpine:3.13
 ELSE
-    FROM ubuntu:20.04
+    FROM ubuntu:20.10
 END
 ```
 

--- a/release/msi/Earthfile
+++ b/release/msi/Earthfile
@@ -1,6 +1,6 @@
 
 build-msi:
-    FROM ubuntu:20.04
+    FROM ubuntu:20.10
     ENV TZ=Etc/UTC
     RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
     RUN dpkg --add-architecture i386 && \


### PR DESCRIPTION
rather than using ubuntu:latest for our dind image, pin to a specific
version to speed up release times so we don't have to rebuild it as
frequently.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>