### PR TITLE
Add Podman Support, Automatic Configuration

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -395,7 +395,7 @@ test:
     BUILD +lint
     BUILD +lint-scripts
     BUILD +lint-newline-ending
-    BUILD --privileged +unit-test
+    BUILD +unit-test
     BUILD ./ast/tests+all
     ARG DOCKERHUB_AUTH=true
     BUILD ./examples/tests+ga --DOCKERHUB_AUTH=$DOCKERHUB_AUTH

--- a/Earthfile
+++ b/Earthfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine3.13
+FROM golang:1.16-alpine3.14
 
 RUN apk add --update --no-cache \
     bash \
@@ -141,7 +141,11 @@ lint-newline-ending:
 
 unit-test:
     FROM +code
-    RUN go test ./...
+    RUN apk add --no-cache --update podman
+    WITH DOCKER
+        RUN sed -i 's/\/var\/lib\/containers\/storage/$EARTHLY_DOCKERD_DATA_ROOT/g' /etc/containers/storage.conf && \
+            go test ./...
+    END
 
 shellrepeater:
     FROM +code
@@ -391,7 +395,7 @@ test:
     BUILD +lint
     BUILD +lint-scripts
     BUILD +lint-newline-ending
-    BUILD +unit-test
+    BUILD --privileged +unit-test
     BUILD ./ast/tests+all
     ARG DOCKERHUB_AUTH=true
     BUILD ./examples/tests+ga --DOCKERHUB_AUTH=$DOCKERHUB_AUTH

--- a/builder/docker.go
+++ b/builder/docker.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
-	"os/exec"
 	"strings"
 
 	"github.com/containerd/containerd/platforms"
 	"github.com/docker/distribution/reference"
 	"github.com/earthly/earthly/conslogging"
+	"github.com/earthly/earthly/util/containerutil"
 	"github.com/earthly/earthly/util/llbutil"
 	"golang.org/x/sync/errgroup"
 
@@ -40,7 +39,7 @@ func platformSpecificImageName(imgName string, platform specs.Platform) (string,
 	return reference.FamiliarString(r2), nil
 }
 
-func loadDockerManifest(ctx context.Context, console conslogging.ConsoleLogger, parentImageName string, children []manifest) error {
+func loadDockerManifest(ctx context.Context, console conslogging.ConsoleLogger, fe containerutil.ContainerFrontend, parentImageName string, children []manifest) error {
 	console = console.WithPrefix(parentImageName)
 	if len(children) == 0 {
 		return errors.Errorf("no images in manifest list for %s", parentImageName)
@@ -69,58 +68,56 @@ func loadDockerManifest(ctx context.Context, console conslogging.ConsoleLogger, 
 		"%s is a multi-platform image. The following per-platform images have been produced:\n\t%s\n%s\n",
 		parentImageName, strings.Join(childImgs, "\n\t"), noteDetail)
 
-	cmd := exec.CommandContext(ctx, "docker", "tag", children[defaultChild].imageName, parentImageName)
-	cmd.Stdout = os.Stderr // Preserve desired output on stdout, all logs to stderr
-	cmd.Stderr = os.Stderr
-	err := cmd.Run()
+	err := fe.ImageTag(ctx, containerutil.ImageTag{
+		SourceRef: children[defaultChild].imageName,
+		TargetRef: parentImageName,
+	})
 	if err != nil {
 		return errors.Wrap(err, "docker tag default platform image")
 	}
 	return nil
 }
 
-func loadDockerTar(ctx context.Context, r io.ReadCloser, console conslogging.ConsoleLogger) error {
-	cmd := exec.CommandContext(ctx, "docker", "load")
-	cmd.Stdin = r
-	output, err := cmd.CombinedOutput()
+func loadDockerTar(ctx context.Context, fe containerutil.ContainerFrontend, r io.ReadCloser, console conslogging.ConsoleLogger) error {
+	err := fe.ImageLoad(ctx, r)
 	if err != nil {
-		console.Warnf("%+v output:\n%s\n", cmd.Args, string(output))
-		return errors.Wrapf(err, "docker load")
+		console.Warnf(err.Error())
+		return errors.Wrapf(err, "load tar")
 	}
 	return nil
 }
 
-func dockerPullLocalImages(ctx context.Context, localRegistryAddr string, pullMap map[string]string, console conslogging.ConsoleLogger) error {
+func dockerPullLocalImages(ctx context.Context, fe containerutil.ContainerFrontend, localRegistryAddr string, pullMap map[string]string, console conslogging.ConsoleLogger) error {
 	eg, ctx := errgroup.WithContext(ctx)
 	for pullName, finalName := range pullMap {
 		pn := pullName
 		fn := finalName
 		eg.Go(func() error {
-			return dockerPullLocalImage(ctx, localRegistryAddr, pn, fn, console)
+			return dockerPullLocalImage(ctx, fe, localRegistryAddr, pn, fn, console)
 		})
 	}
 	return eg.Wait()
 }
 
-func dockerPullLocalImage(ctx context.Context, localRegistryAddr string, pullName string, finalName string, console conslogging.ConsoleLogger) error {
+func dockerPullLocalImage(ctx context.Context, fe containerutil.ContainerFrontend, localRegistryAddr string, pullName string, finalName string, console conslogging.ConsoleLogger) error {
 	fullPullName := fmt.Sprintf("%s/%s", localRegistryAddr, pullName)
-	cmd := exec.CommandContext(ctx, "docker", "pull", fullPullName)
-	output, err := cmd.CombinedOutput()
+	err := fe.ImagePull(ctx, fullPullName)
 	if err != nil {
-		console.Warnf("%+v output:\n%s\n", cmd.Args, string(output))
-		return errors.Wrapf(err, "docker pull")
+		console.Warnf(err.Error())
+		return errors.Wrapf(err, "image pull")
 	}
-	cmd = exec.CommandContext(ctx, "docker", "tag", fullPullName, finalName)
-	output, err = cmd.CombinedOutput()
+	err = fe.ImageTag(ctx, containerutil.ImageTag{
+		SourceRef: fullPullName,
+		TargetRef: finalName,
+	})
 	if err != nil {
-		console.Warnf("%+v output:\n%s\n", cmd.Args, string(output))
-		return errors.Wrap(err, "docker tag after pull")
+		console.Warnf(err.Error())
+		return errors.Wrap(err, "image tag after pull")
 	}
-	cmd = exec.CommandContext(ctx, "docker", "rmi", fullPullName)
-	output, err = cmd.CombinedOutput()
+	err = fe.ImageRemove(ctx, false, fullPullName)
 	if err != nil {
-		console.Warnf("%+v output:\n%s\n", cmd.Args, string(output))
-		return errors.Wrap(err, "docker rmi after pull and retag")
+		console.Warnf(err.Error())
+		return errors.Wrap(err, "image rmi after pull and retag")
 	}
 	return nil
 }

--- a/builder/docker.go
+++ b/builder/docker.go
@@ -81,7 +81,6 @@ func loadDockerManifest(ctx context.Context, console conslogging.ConsoleLogger, 
 func loadDockerTar(ctx context.Context, fe containerutil.ContainerFrontend, r io.ReadCloser, console conslogging.ConsoleLogger) error {
 	err := fe.ImageLoad(ctx, r)
 	if err != nil {
-		console.Warnf(err.Error())
 		return errors.Wrapf(err, "load tar")
 	}
 	return nil
@@ -103,7 +102,6 @@ func dockerPullLocalImage(ctx context.Context, fe containerutil.ContainerFronten
 	fullPullName := fmt.Sprintf("%s/%s", localRegistryAddr, pullName)
 	err := fe.ImagePull(ctx, fullPullName)
 	if err != nil {
-		console.Warnf(err.Error())
 		return errors.Wrapf(err, "image pull")
 	}
 	err = fe.ImageTag(ctx, containerutil.ImageTag{
@@ -111,12 +109,10 @@ func dockerPullLocalImage(ctx context.Context, fe containerutil.ContainerFronten
 		TargetRef: finalName,
 	})
 	if err != nil {
-		console.Warnf(err.Error())
 		return errors.Wrap(err, "image tag after pull")
 	}
 	err = fe.ImageRemove(ctx, false, fullPullName)
 	if err != nil {
-		console.Warnf(err.Error())
 		return errors.Wrap(err, "image rmi after pull and retag")
 	}
 	return nil

--- a/buildkitd/buildkitd.go
+++ b/buildkitd/buildkitd.go
@@ -44,8 +44,12 @@ func DefaultAddressForSetting(setting string) (string, error) {
 	switch setting {
 	case containerutil.FrontendDockerShell:
 		return DockerAddress, nil
+
 	case containerutil.FrontendPodmanShell:
 		return TCPAddress, nil // Right now, podman only works over TCP. There are weird errors when trying to use the provided helper from buildkit.
+
+	case containerutil.FrontendStub:
+		return DockerAddress, nil // Maintiain old behavior
 	}
 
 	return "", fmt.Errorf("no default buildkit address for %s", setting)

--- a/buildkitd/buildkitd.go
+++ b/buildkitd/buildkitd.go
@@ -39,6 +39,7 @@ var DockerAddress = "docker-container://earthly-buildkitd"
 // Currently unused due to image export issues
 var PodmanAddress = "podman-container://earthly-buildkitd"
 
+// DefaultAddressForSetting returns an address (signifying the desired/default transport) for a given frontend specified by setting.
 func DefaultAddressForSetting(setting string) (string, error) {
 	switch setting {
 	case containerutil.FrontendDockerShell:

--- a/buildkitd/buildkitd.go
+++ b/buildkitd/buildkitd.go
@@ -72,8 +72,8 @@ func NewClient(ctx context.Context, console conslogging.ConsoleLogger, image, co
 	}
 
 	if !isDockerAvailable(ctx, fe) {
-		console.WithPrefix("buildkitd").Printf("Is %[1]s installed and running? Are you part of any needed groups?\n", fe.Config().FrontendBinary)
-		return nil, fmt.Errorf("%s not available", fe.Config().FrontendBinary)
+		console.WithPrefix("buildkitd").Printf("Is %[1]s installed and running? Are you part of any needed groups?\n", fe.Config().Binary)
+		return nil, fmt.Errorf("%s not available", fe.Config().Binary)
 	}
 	address, err := MaybeStart(ctx, console, image, containerName, fe, settings, opts...)
 	if err != nil {
@@ -144,7 +144,7 @@ func MaybeStart(ctx context.Context, console conslogging.ConsoleLogger, image, c
 	if isStarted {
 		console.
 			WithPrefix("buildkitd").
-			Printf("Found buildkit daemon as %s container (%s)\n", fe.Config().FrontendBinary, containerName)
+			Printf("Found buildkit daemon as %s container (%s)\n", fe.Config().Binary, containerName)
 		err := MaybeRestart(ctx, console, image, containerName, fe, settings, opts...)
 		if err != nil {
 			return "", errors.Wrap(err, "maybe restart")
@@ -152,7 +152,7 @@ func MaybeStart(ctx context.Context, console conslogging.ConsoleLogger, image, c
 	} else {
 		console.
 			WithPrefix("buildkitd").
-			Printf("Starting buildkit daemon as a %s container (%s)...\n", fe.Config().FrontendBinary, containerName)
+			Printf("Starting buildkit daemon as a %s container (%s)...\n", fe.Config().Binary, containerName)
 		err := Start(ctx, console, image, containerName, fe, settings, false)
 		if err != nil {
 			return "", errors.Wrap(err, "start")

--- a/buildkitd/buildkitd.go
+++ b/buildkitd/buildkitd.go
@@ -1,22 +1,20 @@
 package buildkitd
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"net"
 	"net/url"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
 	"github.com/earthly/earthly/conslogging"
 	"github.com/earthly/earthly/util/cliutil"
+	"github.com/earthly/earthly/util/containerutil"
 	"github.com/earthly/earthly/util/fileutil"
 	"github.com/moby/buildkit/client"
 	_ "github.com/moby/buildkit/client/connhelper/dockercontainer" // Load "docker-container://" helper.
@@ -37,17 +35,29 @@ var TCPAddress = "tcp://127.0.0.1:8372"
 // DockerAddress is the address at which the daemon is avaliable whe using a Docker Container directly
 var DockerAddress = "docker-container://earthly-buildkitd"
 
-// TODO: Implement all this properly with the docker client.
+// PodmanAddress is the address at which the daemon is avaliable whe using a Docker Container directly
+var PodmanAddress = "podman-container://earthly-buildkitd"
+
+func DefaultAddressForSetting(setting string) (string, error) {
+	switch setting {
+	case containerutil.FrontendDockerShell:
+		return DockerAddress, nil
+	case containerutil.FrontendPodmanShell:
+		return TCPAddress, nil // Right now, podman only works over TCP. There are weird errors when trying to use the provided helper from buildkit.
+	}
+
+	return "", fmt.Errorf("no default buildkit address for %s", setting)
+}
 
 // NewClient returns a new buildkitd client, together with a boolean specifying whether the buildkit is local.
-func NewClient(ctx context.Context, console conslogging.ConsoleLogger, image, containerName string, settings Settings, opts ...client.ClientOpt) (*client.Client, error) {
+func NewClient(ctx context.Context, console conslogging.ConsoleLogger, image, containerName string, fe containerutil.ContainerFrontend, settings Settings, opts ...client.ClientOpt) (*client.Client, error) {
 	opts, err := addRequiredOpts(settings, opts...)
 	if err != nil {
 		return nil, errors.Wrap(err, "add required client opts")
 	}
 
 	if !IsLocal(settings.BuildkitAddress) {
-		err := waitForConnection(ctx, containerName, settings.BuildkitAddress, settings.Timeout, opts...)
+		err := waitForConnection(ctx, containerName, settings.BuildkitAddress, settings.Timeout, fe, opts...)
 		if err != nil {
 			return nil, errors.Wrap(err, "connect provided buildkit")
 		}
@@ -60,11 +70,11 @@ func NewClient(ctx context.Context, console conslogging.ConsoleLogger, image, co
 		return bkClient, nil
 	}
 
-	if !isDockerAvailable(ctx) {
+	if !isDockerAvailable(ctx, fe) {
 		console.WithPrefix("buildkitd").Printf("Is docker installed and running? Are you part of the docker group?\n")
 		return nil, errors.New("docker not available")
 	}
-	address, err := MaybeStart(ctx, console, image, containerName, settings, opts...)
+	address, err := MaybeStart(ctx, console, image, containerName, fe, settings, opts...)
 	if err != nil {
 		return nil, errors.Wrap(err, "maybe start buildkitd")
 	}
@@ -76,7 +86,7 @@ func NewClient(ctx context.Context, console conslogging.ConsoleLogger, image, co
 }
 
 // ResetCache restarts the buildkitd daemon with the reset command.
-func ResetCache(ctx context.Context, console conslogging.ConsoleLogger, image, containerName string, settings Settings, opts ...client.ClientOpt) error {
+func ResetCache(ctx context.Context, console conslogging.ConsoleLogger, image, containerName string, fe containerutil.ContainerFrontend, settings Settings, opts ...client.ClientOpt) error {
 	// Prune by resetting container.
 	if !IsLocal(settings.BuildkitAddress) {
 		return errors.New("cannot reset cache of a provided buildkit-host setting")
@@ -95,25 +105,25 @@ func ResetCache(ctx context.Context, console conslogging.ConsoleLogger, image, c
 	// (needs extra time to also remove the files).
 	settings.Timeout *= 2
 
-	isStarted, err := IsStarted(ctx, containerName)
+	isStarted, err := IsStarted(ctx, containerName, fe)
 	if err != nil {
 		return errors.Wrap(err, "check is started buildkitd")
 	}
 	if isStarted {
-		err = Stop(ctx, containerName)
+		err = Stop(ctx, containerName, fe)
 		if err != nil {
 			return err
 		}
-		err = WaitUntilStopped(ctx, containerName, settings.Timeout)
+		err = WaitUntilStopped(ctx, containerName, settings.Timeout, fe)
 		if err != nil {
 			return err
 		}
 	}
-	err = Start(ctx, console, image, containerName, settings, true)
+	err = Start(ctx, console, image, containerName, fe, settings, true)
 	if err != nil {
 		return err
 	}
-	err = WaitUntilStarted(ctx, console, containerName, settings.VolumeName, settings.BuildkitAddress, settings.Timeout, opts...)
+	err = WaitUntilStarted(ctx, console, containerName, settings.VolumeName, settings.BuildkitAddress, settings.Timeout, fe, opts...)
 	if err != nil {
 		return err
 	}
@@ -125,8 +135,8 @@ func ResetCache(ctx context.Context, console conslogging.ConsoleLogger, image, c
 
 // MaybeStart ensures that the buildkitd daemon is started. It returns the URL
 // that can be used to connect to it.
-func MaybeStart(ctx context.Context, console conslogging.ConsoleLogger, image, containerName string, settings Settings, opts ...client.ClientOpt) (string, error) {
-	isStarted, err := IsStarted(ctx, containerName)
+func MaybeStart(ctx context.Context, console conslogging.ConsoleLogger, image, containerName string, fe containerutil.ContainerFrontend, settings Settings, opts ...client.ClientOpt) (string, error) {
+	isStarted, err := IsStarted(ctx, containerName, fe)
 	if err != nil {
 		return "", errors.Wrap(err, "check is started buildkitd")
 	}
@@ -134,7 +144,7 @@ func MaybeStart(ctx context.Context, console conslogging.ConsoleLogger, image, c
 		console.
 			WithPrefix("buildkitd").
 			Printf("Found buildkit daemon as docker container (%s)\n", containerName)
-		err := MaybeRestart(ctx, console, image, containerName, settings, opts...)
+		err := MaybeRestart(ctx, console, image, containerName, fe, settings, opts...)
 		if err != nil {
 			return "", errors.Wrap(err, "maybe restart")
 		}
@@ -142,11 +152,11 @@ func MaybeStart(ctx context.Context, console conslogging.ConsoleLogger, image, c
 		console.
 			WithPrefix("buildkitd").
 			Printf("Starting buildkit daemon as a docker container (%s)...\n", containerName)
-		err := Start(ctx, console, image, containerName, settings, false)
+		err := Start(ctx, console, image, containerName, fe, settings, false)
 		if err != nil {
 			return "", errors.Wrap(err, "start")
 		}
-		err = WaitUntilStarted(ctx, console, containerName, settings.VolumeName, settings.BuildkitAddress, settings.Timeout, opts...)
+		err = WaitUntilStarted(ctx, console, containerName, settings.VolumeName, settings.BuildkitAddress, settings.Timeout, fe, opts...)
 		if err != nil {
 			return "", errors.Wrap(err, "wait until started")
 		}
@@ -160,12 +170,12 @@ func MaybeStart(ctx context.Context, console conslogging.ConsoleLogger, image, c
 // MaybeRestart checks whether the there is a different buildkitd image available locally or if
 // settings of the current container are different from the provided settings. In either case,
 // the container is restarted.
-func MaybeRestart(ctx context.Context, console conslogging.ConsoleLogger, image, containerName string, settings Settings, opts ...client.ClientOpt) error {
-	containerImageID, err := GetContainerImageID(ctx, containerName)
+func MaybeRestart(ctx context.Context, console conslogging.ConsoleLogger, image, containerName string, fe containerutil.ContainerFrontend, settings Settings, opts ...client.ClientOpt) error {
+	containerImageID, err := GetContainerImageID(ctx, containerName, fe)
 	if err != nil {
 		return err
 	}
-	availableImageID, err := GetAvailableImageID(ctx, image)
+	availableImageID, err := GetAvailableImageID(ctx, image, fe)
 	if err != nil {
 		// Could not get available image ID. This happens when a new image tag is given and that
 		// tag has not yet been pulled locally. Restarting will cause that tag to be pulled.
@@ -177,7 +187,7 @@ func MaybeRestart(ctx context.Context, console conslogging.ConsoleLogger, image,
 		VerbosePrintf("Comparing running container image (%q) with available image (%q)\n", containerImageID, availableImageID)
 	if containerImageID == availableImageID {
 		// Images are the same. Check settings hash.
-		hash, err := GetSettingsHash(ctx, containerName)
+		hash, err := GetSettingsHash(ctx, containerName, fe)
 		if err != nil {
 			return err
 		}
@@ -203,19 +213,19 @@ func MaybeRestart(ctx context.Context, console conslogging.ConsoleLogger, image,
 	}
 
 	// Replace.
-	err = Stop(ctx, containerName)
+	err = Stop(ctx, containerName, fe)
 	if err != nil {
 		return err
 	}
-	err = WaitUntilStopped(ctx, containerName, settings.Timeout)
+	err = WaitUntilStopped(ctx, containerName, settings.Timeout, fe)
 	if err != nil {
 		return err
 	}
-	err = Start(ctx, console, image, containerName, settings, false)
+	err = Start(ctx, console, image, containerName, fe, settings, false)
 	if err != nil {
 		return err
 	}
-	err = WaitUntilStarted(ctx, console, containerName, settings.VolumeName, settings.BuildkitAddress, settings.Timeout, opts...)
+	err = WaitUntilStarted(ctx, console, containerName, settings.VolumeName, settings.BuildkitAddress, settings.Timeout, fe, opts...)
 	if err != nil {
 		return err
 	}
@@ -226,86 +236,112 @@ func MaybeRestart(ctx context.Context, console conslogging.ConsoleLogger, image,
 }
 
 // RemoveExited removes any stopped or exited buildkitd containers
-func RemoveExited(ctx context.Context, containerName string) error {
-	cmd := exec.CommandContext(ctx, "docker", "ps", "-a", "-q", "-f", fmt.Sprintf("name=%s", containerName))
-	output, err := cmd.CombinedOutput()
+func RemoveExited(ctx context.Context, fe containerutil.ContainerFrontend, containerName string) error {
+	infos, err := fe.ContainerInfo(ctx, containerName)
 	if err != nil {
-		return errors.Wrap(err, "get combined output")
+		return errors.Wrapf(err, "get info to remove exited %s", containerName)
 	}
-	if len(output) == 0 {
+	if infos[containerName].Status == containerutil.StatusMissing {
 		return nil
 	}
-	return exec.CommandContext(ctx, "docker", "rm", containerName).Run()
+
+	err = fe.ContainerRemove(ctx, false, containerName)
+	if err != nil {
+		return errors.Wrapf(err, "remove exited %s", containerName)
+	}
+
+	return nil
 }
 
 // Start starts the buildkitd daemon.
-func Start(ctx context.Context, console conslogging.ConsoleLogger, image, containerName string, settings Settings, reset bool) error {
-	err := CheckCompatibility(ctx, settings)
-	if len(settings.AdditionalArgs) == 0 && err != nil {
-		return errors.Wrap(err, "compatibility")
-	}
-
+func Start(ctx context.Context, console conslogging.ConsoleLogger, image, containerName string, fe containerutil.ContainerFrontend, settings Settings, reset bool) error {
 	settingsHash, err := settings.Hash()
 	if err != nil {
 		return errors.Wrap(err, "settings hash")
 	}
-	err = RemoveExited(ctx, containerName)
+	err = RemoveExited(ctx, fe, containerName)
 	if err != nil {
 		return err
 	}
 	// Pulling is not strictly needed, but it helps display some progress status to the user in
 	// case the image is not available locally.
-	err = MaybePull(ctx, console, image)
+	err = MaybePull(ctx, console, image, fe)
 	if err != nil {
 		console.
 			WithPrefix("buildkitd-pull").
 			Printf("Error: %s. Attempting to start buildkitd anyway...\n", err.Error())
 		// Keep going - it might still work.
 	}
-	env := os.Environ()
-	args := []string{
-		"run",
-		"-d",
-		"-v", fmt.Sprintf("%s:/tmp/earthly:rw", settings.VolumeName),
-		"-e", fmt.Sprintf("BUILDKIT_DEBUG=%t", settings.Debug),
-		"-e", fmt.Sprintf("BUILDKIT_TCP_TRANSPORT_ENABLED=%t", settings.UseTCP),
-		"-e", fmt.Sprintf("BUILDKIT_TLS_ENABLED=%t", settings.UseTCP && settings.UseTLS),
-		"--label", fmt.Sprintf("dev.earthly.settingshash=%s", settingsHash),
-		"--name", containerName,
-		"--privileged",
+
+	envOpts := map[string]string{
+		"BUILDKIT_DEBUG":                 strconv.FormatBool(settings.Debug),
+		"BUILDKIT_TCP_TRANSPORT_ENABLED": strconv.FormatBool(settings.UseTCP),
+		"BUILDKIT_TLS_ENABLED":           strconv.FormatBool(settings.UseTCP && settings.UseTLS),
 	}
 
+	labelOpts := map[string]string{
+		"dev.earthly.settingshash": settingsHash,
+	}
+
+	volumeOpts := containerutil.MountOpt{
+		containerutil.Mount{
+			Type:     containerutil.MountVolume,
+			Source:   settings.VolumeName,
+			Dest:     "/tmp/earthly",
+			ReadOnly: false,
+		},
+	}
+
+	portOpts := containerutil.PortOpt{}
+
 	if settings.AdditionalConfig != "" {
-		args = append(args, "-e", fmt.Sprintf("EARTHLY_ADDITIONAL_BUILDKIT_CONFIG=%s", settings.AdditionalConfig))
+		envOpts["EARTHLY_ADDITIONAL_BUILDKIT_CONFIG"] = settings.AdditionalConfig
 	}
 
 	if settings.IPTables != "" {
-		args = append(args, "-e", fmt.Sprintf("IP_TABLES=%s", settings.IPTables))
+		envOpts["IP_TABLES"] = settings.IPTables
 	}
 
-	args = append(args, settings.AdditionalArgs...)
 	if os.Getenv("EARTHLY_WITH_DOCKER") == "1" {
 		// Add /sys/fs/cgroup if it's earthly-in-earthly.
-		args = append(args, "-v", "/sys/fs/cgroup:/sys/fs/cgroup")
+		volumeOpts = append(volumeOpts, containerutil.Mount{
+			Type:   containerutil.MountBind,
+			Source: "/sys/fs/cgroup",
+			Dest:   "/sys/fs/cgroup",
+		})
 	} else {
 		// TCP ports only supported in top-most earthly.
 		// TODO: Main reason for this is port clash. This could be improved in the future,
 		//       if needed.
 		// These are controlled by us and should have been validated already - hence panics.
 
-		dbURL, err := url.Parse(settings.DebuggerAddress)
+		_, err := url.Parse(settings.DebuggerAddress)
 		if err != nil {
 			panic("Debugger address was not a URL when attempting to start buildkit")
 		}
-		args = append(args, "-p", fmt.Sprintf("127.0.0.1:%s:8373", dbURL.Port()))
+		portOpts = append(portOpts, containerutil.Port{
+			IP:            "127.0.0.1",
+			HostPort:      8373, //strconv.FormatInt(dbURL.Port(), 10),
+			ContainerPort: 8373,
+			Protocol:      containerutil.ProtocolTCP,
+		})
 
 		if settings.LocalRegistryAddress != "" {
 			lrURL, err := url.Parse(settings.LocalRegistryAddress)
 			if err != nil {
 				panic("Local registry address was not a URL when attempting to start buildkit")
 			}
-			args = append(args, "-p", fmt.Sprintf("127.0.0.1:%s:8371", lrURL.Port()))
-			args = append(args, "-e", "BUILDKIT_LOCAL_REGISTRY_LISTEN_PORT=8371")
+			hostPort, err := strconv.Atoi(lrURL.Port())
+			if err != nil {
+				panic("Local registry host port was not a numver when attempting to start buildkit")
+			}
+			portOpts = append(portOpts, containerutil.Port{
+				IP:            "127.0.0.1",
+				HostPort:      hostPort,
+				ContainerPort: 8371,
+				Protocol:      containerutil.ProtocolTCP,
+			})
+			envOpts["BUILDKIT_LOCAL_REGISTRY_LISTEN_PORT"] = "8371"
 		}
 
 		bkURL, err := url.Parse(settings.BuildkitAddress)
@@ -313,15 +349,28 @@ func Start(ctx context.Context, console conslogging.ConsoleLogger, image, contai
 			panic("Buildkit address was not a URL when attempting to start buildkit")
 		}
 		if settings.UseTCP {
-			args = append(args, "-p", fmt.Sprintf("127.0.0.1:%s:8372", bkURL.Port()))
-
+			hostPort, err := strconv.Atoi(bkURL.Port())
+			if err != nil {
+				panic("Local registry host port was not a numver when attempting to start buildkit")
+			}
+			portOpts = append(portOpts, containerutil.Port{
+				IP:            "127.0.0.1",
+				HostPort:      hostPort,
+				ContainerPort: 8372,
+				Protocol:      containerutil.ProtocolTCP,
+			})
 			if settings.UseTLS {
 				if settings.TLSCA != "" {
 					caPath, err := makeTLSPath(settings.TLSCA)
 					if err != nil {
 						return errors.Wrap(err, "start buildkitd")
 					}
-					args = append(args, "-v", fmt.Sprintf("%s:/etc/ca.pem", caPath))
+					volumeOpts = append(volumeOpts, containerutil.Mount{
+						Type:     containerutil.MountBind,
+						Source:   caPath,
+						Dest:     "/etc/ca.pem",
+						ReadOnly: true,
+					})
 				}
 
 				if settings.ServerTLSCert != "" {
@@ -329,7 +378,12 @@ func Start(ctx context.Context, console conslogging.ConsoleLogger, image, contai
 					if err != nil {
 						return errors.Wrap(err, "start buildkitd")
 					}
-					args = append(args, "-v", fmt.Sprintf("%s:/etc/cert.pem", certPath))
+					volumeOpts = append(volumeOpts, containerutil.Mount{
+						Type:     containerutil.MountBind,
+						Source:   certPath,
+						Dest:     "/etc/cert.pem",
+						ReadOnly: true,
+					})
 				}
 
 				if settings.ServerTLSKey != "" {
@@ -337,65 +391,65 @@ func Start(ctx context.Context, console conslogging.ConsoleLogger, image, contai
 					if err != nil {
 						return errors.Wrap(err, "start buildkitd")
 					}
-					args = append(args, "-v", fmt.Sprintf("%s:/etc/key.pem", keyPath))
+					volumeOpts = append(volumeOpts, containerutil.Mount{
+						Type:     containerutil.MountBind,
+						Source:   keyPath,
+						Dest:     "/etc/key.pem",
+						ReadOnly: true,
+					})
 				}
 			}
 		}
 	}
 
-	if supportsPlatform(ctx) {
-		args = append(args, platformFlag())
-	}
-
 	if settings.CniMtu > 0 {
-		args = append(args, "-e", fmt.Sprintf("CNI_MTU=%v", settings.CniMtu))
+		envOpts["CNI_MTU"] = strconv.FormatUint(uint64(settings.CniMtu), 10)
 	}
 
 	if settings.CacheSizeMb > 0 {
-		args = append(args, "-e", fmt.Sprintf("CACHE_SIZE_MB=%d", settings.CacheSizeMb))
+		envOpts["CACHE_SIZE_MB"] = strconv.FormatInt(int64(settings.CacheSizeMb), 10)
 	}
 
 	if settings.GitURLInsteadOf != "" {
-		args = append(args, "-e", fmt.Sprintf("GIT_URL_INSTEAD_OF=%s", settings.GitURLInsteadOf))
+		envOpts["GIT_URL_INSTEAD_OF"] = strconv.FormatInt(int64(settings.CacheSizeMb), 10)
 	}
 
 	// Apply reset.
 	if reset {
-		args = append(args, "-e", "EARTHLY_RESET_TMP_DIR=true")
+		envOpts["EARTHLY_RESET_TMP_DIR"] = "true"
 	}
+
 	// Execute.
-	args = append(args, image)
-	cmd := exec.CommandContext(ctx, "docker", args...)
-	cmd.Env = env
-	output, err := cmd.CombinedOutput()
+	err = fe.ContainerRun(ctx, containerutil.ContainerRun{
+		NameOrID:       containerName,
+		ImageRef:       image,
+		Privileged:     true,
+		Envs:           envOpts,
+		Labels:         labelOpts,
+		Mounts:         volumeOpts,
+		Ports:          portOpts,
+		AdditionalArgs: settings.AdditionalArgs,
+	})
 	if err != nil {
-		return errors.Wrapf(err, "docker run %s: %s", image, string(output))
+		return errors.Wrap(err, "could not start buildkit")
 	}
+
 	return nil
 }
 
 // Stop stops the buildkitd container.
-func Stop(ctx context.Context, containerName string) error {
-	cmd := exec.CommandContext(ctx, "docker", "stop", containerName)
-	_, err := cmd.CombinedOutput()
-	if err != nil {
-		return errors.Wrap(err, "get combined output")
-	}
-	return nil
+func Stop(ctx context.Context, containerName string, fe containerutil.ContainerFrontend) error {
+	return fe.ContainerStop(ctx, 10, containerName)
 }
 
 // IsStarted checks if the buildkitd container has been started.
-func IsStarted(ctx context.Context, containerName string) (bool, error) {
-	cmd := exec.CommandContext(ctx, "docker", "ps", "-q", "-f", fmt.Sprintf("name=%s", containerName))
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return false, errors.Wrap(err, "get combined output")
-	}
-	return (len(output) != 0), nil
+func IsStarted(ctx context.Context, containerName string, fe containerutil.ContainerFrontend) (bool, error) {
+	infos, err := fe.ContainerInfo(ctx, containerName)
+	return err == nil && infos[containerName].Status == containerutil.StatusRunning, nil
 }
 
 // WaitUntilStarted waits until the buildkitd daemon has started and is healthy.
-func WaitUntilStarted(ctx context.Context, console conslogging.ConsoleLogger, containerName, volumeName, address string, opTimeout time.Duration, opts ...client.ClientOpt) error {
+func WaitUntilStarted(ctx context.Context, console conslogging.ConsoleLogger, containerName, volumeName, address string, opTimeout time.Duration, fe containerutil.ContainerFrontend, opts ...client.ClientOpt) error {
 	// First, wait for the container to be marked as started.
 	ctxTimeout, cancel := context.WithTimeout(ctx, opTimeout)
 	defer cancel()
@@ -403,7 +457,7 @@ ContainerRunningLoop:
 	for {
 		select {
 		case <-time.After(1 * time.Second):
-			isRunning, err := isContainerRunning(ctxTimeout, containerName)
+			isRunning, err := isContainerRunning(ctxTimeout, containerName, fe)
 			if err != nil {
 				// Has not yet started. Keep waiting.
 				continue
@@ -421,13 +475,13 @@ ContainerRunningLoop:
 	}
 
 	// Wait for the connection to be available.
-	err := waitForConnection(ctx, containerName, address, opTimeout, opts...)
+	err := waitForConnection(ctx, containerName, address, opTimeout, fe, opts...)
 	if err != nil {
 		if !errors.Is(err, ErrBuildkitStartFailure) {
 			return err
 		}
 		// We timed out. Check if the user has a lot of cache and give buildkit another chance.
-		cacheSize, cacheSizeErr := getCacheSize(ctx, volumeName)
+		cacheSize, cacheSizeErr := getCacheSize(ctx, volumeName, fe)
 		if cacheSizeErr != nil {
 			console.
 				WithPrefix("buildkitd").
@@ -445,14 +499,14 @@ ContainerRunningLoop:
 					"\t\tearthly config 'global.cache_size_mb' <new-size>\n" +
 					"This sets the BuildKit GC target to a specific value. For more information see " +
 					"the Earthly config reference page: https://docs.earthly.dev/configuration/earthly-config\n")
-			return waitForConnection(ctx, containerName, address, opTimeout)
+			return waitForConnection(ctx, containerName, address, opTimeout, fe)
 		}
 		return err
 	}
 	return nil
 }
 
-func waitForConnection(ctx context.Context, containerName, address string, opTimeout time.Duration, opts ...client.ClientOpt) error {
+func waitForConnection(ctx context.Context, containerName, address string, opTimeout time.Duration, fe containerutil.ContainerFrontend, opts ...client.ClientOpt) error {
 	ctxTimeout, cancel := context.WithTimeout(ctx, opTimeout)
 	defer cancel()
 	for {
@@ -460,7 +514,7 @@ func waitForConnection(ctx context.Context, containerName, address string, opTim
 		case <-time.After(1 * time.Second):
 			if address == "" {
 				// Make sure that our managed buildkit has not crashed on startup.
-				isRunning, err := isContainerRunning(ctxTimeout, containerName)
+				isRunning, err := isContainerRunning(ctxTimeout, containerName, fe)
 				if err != nil {
 					return err
 				}
@@ -524,25 +578,21 @@ func checkConnection(ctx context.Context, address string, opts ...client.ClientO
 }
 
 // MaybePull checks whether an image is available locally and pulls it if it is not.
-func MaybePull(ctx context.Context, console conslogging.ConsoleLogger, image string) error {
-	cmd := exec.CommandContext(ctx, "docker", "image", "inspect", image)
-	_, err := cmd.CombinedOutput()
-	if err == nil {
-		// We found the image locally - no need to pull.
+func MaybePull(ctx context.Context, console conslogging.ConsoleLogger, image string, fe containerutil.ContainerFrontend) error {
+	infos, err := fe.ImageInfo(ctx, image)
+	if err != nil {
+		return errors.Wrap(err, "could not get container info")
+	}
+	if len(infos) > 0 { // the presence of an item implies its local
 		return nil
 	}
-	args := []string{"pull"}
-	if supportsPlatform(ctx) {
-		args = append(args, platformFlag())
-	}
-	args = append(args, image)
-	cmd = exec.CommandContext(ctx, "docker", args...)
+
 	console.
 		WithPrefix("buildkitd-pull").
 		Printf("Pulling buildkitd image...\n")
-	err = cmd.Run()
+	err = fe.ImagePull(ctx, image)
 	if err != nil {
-		return errors.Wrapf(err, "docker pull %s", image)
+		return errors.Wrapf(err, "could not pull %s", image)
 	}
 	console.
 		WithPrefix("buildkitd-pull").
@@ -551,51 +601,52 @@ func MaybePull(ctx context.Context, console conslogging.ConsoleLogger, image str
 }
 
 // GetDockerVersion returns the docker version command output
-func GetDockerVersion(ctx context.Context) (string, error) {
-	cmd := exec.CommandContext(ctx, "docker", "version")
-	versionOutput, err := cmd.CombinedOutput()
+func GetDockerVersion(ctx context.Context, fe containerutil.ContainerFrontend) (string, error) {
+	info, err := fe.Information(ctx)
 	if err != nil {
-		return "", errors.Wrapf(err, "docker version")
+		return "", errors.Wrap(err, "get info from frontend")
 	}
-	return string(versionOutput), nil
+
+	return fmt.Sprintf("%#v", info), nil
 }
 
 // GetLogs returns earthly-buildkitd logs
-func GetLogs(ctx context.Context, containerName string, settings Settings) (string, error) {
+func GetLogs(ctx context.Context, containerName string, fe containerutil.ContainerFrontend, settings Settings) (string, error) {
 	if !IsLocal(settings.BuildkitAddress) {
 		return "", nil
 	}
 
-	cmd := exec.CommandContext(ctx, "docker", "logs", containerName)
-	logs, err := cmd.CombinedOutput()
+	logs, err := fe.ContainerLogs(ctx, containerName)
 	if err != nil {
-		return "", errors.Wrapf(err, "docker logs %s", containerName)
+		return "", errors.Wrap(err, "")
 	}
-	return string(logs), nil
+
+	return logs[containerName].Stdout, nil
 }
 
 // GetContainerIP returns the IP of the buildkit container.
-func GetContainerIP(ctx context.Context, containerName string, settings Settings) (string, error) {
+func GetContainerIP(ctx context.Context, containerName string, fe containerutil.ContainerFrontend, settings Settings) (string, error) {
 	if !IsLocal(settings.BuildkitAddress) {
 		return "", nil // Remote buildkitd is not an error,  but we don't know its IP
 	}
 
-	cmd := exec.CommandContext(ctx, "docker", "inspect", "-f", "{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}", containerName)
-	output, err := cmd.CombinedOutput()
+	infos, err := fe.ContainerInfo(ctx, containerName)
 	if err != nil {
-		return "", errors.Wrap(err, "get combined output ip")
+		return "", errors.Wrap(err, "could not get container info to determine ip")
 	}
-	return string(bytes.TrimSpace(output)), nil
+
+	// default is bridge. If someone has a weirdo setup this should be able to handle it with some config option.
+	return infos[containerName].IPs["bridge"], nil
 }
 
 // WaitUntilStopped waits until the buildkitd daemon has stopped.
-func WaitUntilStopped(ctx context.Context, containerName string, opTimeout time.Duration) error {
+func WaitUntilStopped(ctx context.Context, containerName string, opTimeout time.Duration, fe containerutil.ContainerFrontend) error {
 	ctxTimeout, cancel := context.WithTimeout(ctx, opTimeout)
 	defer cancel()
 	for {
 		select {
 		case <-time.After(1 * time.Second):
-			isRunning, err := isContainerRunning(ctxTimeout, containerName)
+			isRunning, err := isContainerRunning(ctxTimeout, containerName, fe)
 			if err != nil {
 				// The container can no longer be found at all.
 				return nil
@@ -610,143 +661,54 @@ func WaitUntilStopped(ctx context.Context, containerName string, opTimeout time.
 }
 
 // GetSettingsHash fetches the hash of the currently running buildkitd container.
-func GetSettingsHash(ctx context.Context, containerName string) (string, error) {
-	cmd := exec.CommandContext(ctx,
-		"docker", "inspect",
-		"--format={{index .Config.Labels \"dev.earthly.settingshash\"}}",
-		containerName)
-	output, err := cmd.CombinedOutput()
+func GetSettingsHash(ctx context.Context, containerName string, fe containerutil.ContainerFrontend) (string, error) {
+	infos, err := fe.ContainerInfo(ctx, containerName)
 	if err != nil {
-		return "", errors.Wrap(err, "get output for settings hash")
+		return "", errors.Wrap(err, "get container info for settings")
 	}
-	return string(output), nil
+
+	return infos[containerName].Labels["dev.earthly.settingshash"], nil
 }
 
 // GetContainerImageID fetches the ID of the image used for the running buildkitd container.
-func GetContainerImageID(ctx context.Context, containerName string) (string, error) {
-	cmd := exec.CommandContext(ctx,
-		"docker", "inspect", "--format={{index .Image}}", containerName)
-	output, err := cmd.CombinedOutput()
+func GetContainerImageID(ctx context.Context, containerName string, fe containerutil.ContainerFrontend) (string, error) {
+	infos, err := fe.ContainerInfo(ctx, containerName)
 	if err != nil {
-		return "", errors.Wrap(err, "get output for container image ID")
+		return "", errors.Wrap(err, "get container info for current container image ID")
 	}
-	return string(output), nil
+	return infos[containerName].ImageID, nil
 }
 
 // GetAvailableImageID fetches the ID of the image buildkitd image available.
-func GetAvailableImageID(ctx context.Context, image string) (string, error) {
-	cmd := exec.CommandContext(ctx,
-		"docker", "inspect", "--format={{index .Id}}", image)
-	output, err := cmd.CombinedOutput()
+func GetAvailableImageID(ctx context.Context, image string, fe containerutil.ContainerFrontend) (string, error) {
+	infos, err := fe.ImageInfo(ctx, image)
 	if err != nil {
 		return "", errors.Wrap(err, "get output for available image ID")
 	}
-	return string(output), nil
+	return infos[image].ID, nil
 }
 
-// CheckCompatibility runs all avaliable compatibility checks before starting the buildkitd daemon.
-func CheckCompatibility(ctx context.Context, settings Settings) error {
-	isNamespaced, err := isNamespacedDocker(ctx)
-	if isNamespaced {
-		return errors.New(`user namespaces are enabled, set "buildkit_additional_args" in ~/.earthly/config.yml to ["--userns", "host"] to disable`)
-	} else if err != nil {
-		return errors.Wrap(err, "failed compatibilty check")
-	}
-
-	isRootless, err := isRootlessDocker(ctx)
-	if isRootless {
-		return errors.New(`rootless docker detected. Compatibility is limited. Configure "buildkit_additional_args" in ~/.earthly/config.yml with some additional arguments like ["--log-opt"] to give it a shot`)
-	} else if err != nil {
-		return errors.Wrap(err, "failed compatibilty check")
-	}
-
-	return nil
-}
-
-func isNamespacedDocker(ctx context.Context) (bool, error) {
-	cmd := exec.CommandContext(ctx,
-		"docker", "info", "--format={{.SecurityOptions}}")
-	output, err := cmd.CombinedOutput()
+func isContainerRunning(ctx context.Context, containerName string, fe containerutil.ContainerFrontend) (bool, error) {
+	infos, err := fe.ContainerInfo(ctx, containerName)
 	if err != nil {
-		return false, errors.Wrap(err, "get docker security info")
+		return false, errors.Wrap(err, "failed to get container info while checking if running")
 	}
 
-	return strings.Contains(string(output), "name=userns"), nil
+	return infos[containerName].Status == containerutil.StatusRunning, nil
 }
 
-func isRootlessDocker(ctx context.Context) (bool, error) {
-	cmd := exec.CommandContext(ctx,
-		"docker", "info", "--format={{.SecurityOptions}}")
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return false, errors.Wrap(err, "get docker security info")
-	}
-
-	return strings.Contains(string(output), "rootless"), nil
-}
-
-func supportsPlatform(ctx context.Context) bool {
-	// We can't run scratch, but the error is different depending on whether
-	// --platform is supported or not. This is faster than attempting to run
-	// an actual image which may require downloading.
-	cmd := exec.CommandContext(ctx,
-		"docker", "run", "--rm", platformFlag(), "scratch")
-	output, _ := cmd.CombinedOutput()
-	return bytes.Contains(output, []byte("Unable to find image"))
-}
-
-func platformFlag() string {
-	arch := runtime.GOARCH
-	if runtime.GOARCH == "arm" {
-		arch = "arm/v7"
-	}
-	return fmt.Sprintf("--platform=linux/%s", arch)
-}
-
-func isContainerRunning(ctx context.Context, containerName string) (bool, error) {
-	cmd := exec.CommandContext(
-		ctx, "docker", "inspect", "--format={{.State.Running}}", containerName)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return false, errors.Wrapf(err, "docker inspect running")
-	}
-	isRunning, err := strconv.ParseBool(strings.TrimSpace(string(output)))
-	if err != nil {
-		return false, errors.Wrapf(err, "cannot interpret output %s", output)
-	}
-	return isRunning, nil
-}
-
-func isDockerAvailable(ctx context.Context) bool {
-	cmd := exec.CommandContext(ctx, "docker", "ps")
-	err := cmd.Run()
-	return err == nil
+func isDockerAvailable(ctx context.Context, fe containerutil.ContainerFrontend) bool {
+	return fe.IsAvaliable(ctx)
 }
 
 // getCacheSize returns the size of the earthly cache in KiB.
-func getCacheSize(ctx context.Context, volumeName string) (int, error) {
-	cmd := exec.CommandContext(
-		ctx, "docker", "volume", "inspect", volumeName, "--format", "{{.Mountpoint}}")
-	out, err := cmd.CombinedOutput()
+func getCacheSize(ctx context.Context, volumeName string, fe containerutil.ContainerFrontend) (int, error) {
+	infos, err := fe.VolumeInfo(ctx, volumeName)
 	if err != nil {
-		return 0, errors.Wrapf(err, "get volume %s mount point", volumeName)
+		return 0, errors.Wrapf(err, "failed to get volume info for cache size %s", volumeName)
 	}
-	mountpoint := string(bytes.TrimSpace(out))
 
-	cmd = exec.CommandContext(
-		ctx, "docker", "run", "--privileged", "--pid=host", "--rm", "busybox",
-		"nsenter", "-t", "1", "-m", "-u", "-n", "-i", "--",
-		"du", "-d", "0", "--", mountpoint)
-	out, cmdErr := cmd.Output() // can exit with 1 if there are warnings
-	parts := bytes.SplitN(bytes.TrimSpace(out), []byte("\t"), 2)
-	size, err := strconv.ParseInt(string(parts[0]), 10, 64)
-	if err != nil {
-		if cmdErr != nil {
-			return 0, errors.Wrapf(cmdErr, "parse cache size \"%s\"", parts[0])
-		}
-		return 0, errors.Wrapf(err, "parse cache size %s", parts[0])
-	}
-	return int(size), nil
+	return int(infos[volumeName].Size), nil
 }
 
 // IsLocal parses a URL and returns whether it is considered a local buildkit host + port that we
@@ -762,7 +724,8 @@ func IsLocal(addr string) bool {
 	return hostname == "127.0.0.1" || // The only IP v4 Loopback we honor. Because we need to include it in the TLS certificates.
 		hostname == net.IPv6loopback.String() ||
 		hostname == "localhost" || // Convention. Users hostname omitted; this is only really here for convenience.
-		parsed.Scheme == "docker-container" // Accomodate feature flagging during transition. This will have omitted TLS?
+		parsed.Scheme == "docker-container" || // Accomodate feature flagging during transition. This will have omitted TLS?
+		parsed.Scheme == "podman-container"
 }
 
 func makeTLSPath(path string) (string, error) {

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -997,10 +997,6 @@ func (app *earthlyApp) before(context *cli.Context) error {
 		return fmt.Errorf("buildkit-container-name is not currently supported")
 	}
 
-	if app.buildkitHost == "" {
-		app.buildkitHost = fmt.Sprintf("docker-container://%s", app.containerName)
-	}
-
 	var yamlData []byte
 	var err error
 	if app.configPath != "" {
@@ -1097,7 +1093,8 @@ func (app *earthlyApp) setupAndValidateAddresses(context *cli.Context) error {
 			app.buildkitHost = app.cfg.Global.BuildkitHost
 		} else {
 			var err error
-			app.buildkitHost, err = buildkitd.DefaultAddressForSetting(app.cfg.Global.ContainerFrontend)
+			feConfig := app.containerFrontend.Config()
+			app.buildkitHost, err = buildkitd.DefaultAddressForSetting(feConfig.Setting)
 			if err != nil {
 				return errors.Wrap(err, "could not validate default address")
 			}

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -1022,7 +1022,8 @@ func (app *earthlyApp) before(context *cli.Context) error {
 
 	fe, err := containerutil.FrontendForSetting(context.Context, app.cfg.Global.ContainerFrontend)
 	if err != nil {
-		return errors.Wrapf(err, "%s frontend could not be initialized", app.cfg.Global.ContainerFrontend)
+		app.console.Warnf("%s frontend could not be initialized, using stub: %s", app.cfg.Global.ContainerFrontend, err.Error())
+		fe, _ = containerutil.NewStubFrontend(context.Context)
 	}
 	app.containerFrontend = fe
 
@@ -1098,6 +1099,7 @@ func (app *earthlyApp) setupAndValidateAddresses(context *cli.Context) error {
 			if err != nil {
 				return errors.Wrap(err, "could not validate default address")
 			}
+
 		}
 	}
 

--- a/cmd/earthly/settings_test.go
+++ b/cmd/earthly/settings_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/earthly/earthly/buildkitd"
 	"github.com/earthly/earthly/config"
 	"github.com/earthly/earthly/conslogging"
+	"github.com/earthly/earthly/util/containerutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli/v2"
 )
@@ -191,6 +192,7 @@ func TestBuildArgMatrix(t *testing.T) {
 
 		earthlyApp := newEarthlyApp(ctx, logger)
 		earthlyApp.cfg = &config.Config{Global: tt.config}
+		earthlyApp.containerFrontend, _ = containerutil.FrontendForSetting(ctx, containerutil.FrontendDockerShell)
 		earthlyApp.cliApp.Writer = &trash    // Just chuck the help output
 		earthlyApp.cliApp.ErrWriter = &trash // All of it, we dont care
 
@@ -319,6 +321,7 @@ func TestBuildArgMatrixValidationFailures(t *testing.T) {
 
 		earthlyApp := newEarthlyApp(ctx, logger)
 		earthlyApp.cfg = &config.Config{Global: tt.config}
+		earthlyApp.containerFrontend, _ = containerutil.FrontendForSetting(ctx, containerutil.FrontendDockerShell)
 		earthlyApp.cliApp.Writer = &output
 		earthlyApp.cliApp.ErrWriter = &output
 
@@ -424,6 +427,7 @@ func TestBuildArgMatrixValidationNonIssues(t *testing.T) {
 
 		earthlyApp := newEarthlyApp(ctx, logger)
 		earthlyApp.cfg = &config.Config{Global: tt.config}
+		earthlyApp.containerFrontend, _ = containerutil.FrontendForSetting(ctx, containerutil.FrontendDockerShell)
 		earthlyApp.cliApp.Writer = &output
 		earthlyApp.cliApp.ErrWriter = &output
 

--- a/config/config.go
+++ b/config/config.go
@@ -37,6 +37,9 @@ const (
 
 	// DefaultServerTLSKey is the default path to use when looking for the Buildkit TLS key
 	DefaultServerTLSKey = "./certs/buildkit_key.pem"
+
+	// DefaultContainerFrontend is the default frontend program or interfacing with the running containers and saved images
+	DefaultContainerFrontend = "docker-shell"
 )
 
 var (
@@ -65,6 +68,7 @@ type GlobalConfig struct {
 	ServerTLSCert            string   `yaml:"buildkitd_tlscert"          help:"The path to the server cert for verification. Relative paths are interpreted as relative to ~/.earthly. Only used when Earthly manages buildkit."`
 	ServerTLSKey             string   `yaml:"buildkitd_tlskey"           help:"The path to the server key for verification. Relative paths are interpreted as relative to ~/.earthly. Only used when Earthly manages buildkit."`
 	TLSEnabled               bool     `yaml:"tls_enabled"                help:"If TLS should be used to communicate with Buildkit. Only honored when BuildkitScheme is 'tcp'."`
+	ContainerFrontend        string   `yaml:"container_frontend"         help:"What program should be used to start and stop buildkitd, save images. Default is 'docker'. Valid options are 'docker' and 'podman' (experimental)."`
 	IPTables                 string   `yaml:"ip_tables"                  help:"Which iptables binary to use. Valid values are iptables-legacy or iptables-nft. Bypasses any autodetection."`
 
 	// Obsolete.
@@ -110,6 +114,7 @@ func ParseConfigFile(yamlData []byte) (*Config, error) {
 			ClientTLSKey:            DefaultClientTLSKey,
 			ServerTLSCert:           DefaultServerTLSCert,
 			ServerTLSKey:            DefaultServerTLSKey,
+			ContainerFrontend:       DefaultContainerFrontend,
 		},
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -39,7 +39,7 @@ const (
 	DefaultServerTLSKey = "./certs/buildkit_key.pem"
 
 	// DefaultContainerFrontend is the default frontend program or interfacing with the running containers and saved images
-	DefaultContainerFrontend = "docker-shell"
+	DefaultContainerFrontend = "auto"
 )
 
 var (

--- a/examples/tests/Earthfile
+++ b/examples/tests/Earthfile
@@ -791,7 +791,7 @@ true-false-flag-invalid:
 
 sequential-locally-test:
     DO +RUN_EARTHLY --earthfile=sequential-locally.earth --use_tmpfs=false --target="+run-lots" --post_command="2>output.txt"
-    RUN cat output.txt | grep -vw RUN | grep -vw char | grep -o '\(start\|mid\|end\).*' > output-filtered.txt
+    RUN cat output.txt | grep -vw RUN | grep -vw char | grep -o '\(start\|mid\|end\)\s[a-d]$' > output-filtered.txt
     RUN echo "set -e
 expectedmode=\"start\"
 expectedchar=\"?\"

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/dustin/go-humanize v1.0.0
 	github.com/fatih/color v1.9.0
 	github.com/golang/protobuf v1.5.2
-	github.com/google/uuid v1.2.0
+	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/jdxcode/netrc v0.0.0-20210204082910-926c7f70242a
 	github.com/jessevdk/go-flags v1.5.0
@@ -23,11 +23,12 @@ require (
 	github.com/mitchellh/hashstructure/v2 v2.0.1
 	github.com/moby/buildkit v0.8.2-0.20210129065303-6b9ea0c202cf
 	github.com/opencontainers/go-digest v1.0.0
-	github.com/opencontainers/image-spec v1.0.1
+	github.com/opencontainers/image-spec v1.0.2-0.20190823105129-775207bd45b6
 	github.com/otiai10/copy v1.1.1
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0
+	github.com/tetratelabs/multierror v1.1.0
 	github.com/tonistiigi/fsutil v0.0.0-20210609172227-d72af97c0eaf
 	github.com/urfave/cli/v2 v2.3.0
 	github.com/wille/osutil v0.0.0-20201124133013-e7a03eb09286

--- a/go.sum
+++ b/go.sum
@@ -384,8 +384,9 @@ github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
 github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gnostic v0.4.1/go.mod h1:LRhVm6pbyptWbWbuZ38d1eyptfvIytN3ir6b65WBswg=
@@ -536,8 +537,9 @@ github.com/opencontainers/go-digest v1.0.0-rc1.0.20180430190053-c9281466c8b2/go.
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.0/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
-github.com/opencontainers/image-spec v1.0.1 h1:JMemWkRwHx4Zj+fVxWoMCFm/8sYGGrUVojFA6h/TRcI=
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
+github.com/opencontainers/image-spec v1.0.2-0.20190823105129-775207bd45b6 h1:yN8BPXVwMBAm3Cuvh1L5XE8XpvYRMdsVLd82ILprhUU=
+github.com/opencontainers/image-spec v1.0.2-0.20190823105129-775207bd45b6/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/runc v0.0.0-20190115041553-12f6a991201f/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runc v0.1.1/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runc v1.0.0-rc8.0.20190926000215-3e425f80a8c9/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
@@ -660,6 +662,8 @@ github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
+github.com/tetratelabs/multierror v1.1.0 h1:cKmV/Pbf42K5wp8glxa2YIausbxIraPN8fzru9Pn1Cg=
+github.com/tetratelabs/multierror v1.1.0/go.mod h1:kH3SzI/z+FwEbV9bxQDx4GiIgE2djuyb8wiB2DaUBnY=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tonistiigi/go-actions-cache v0.0.0-20210714033416-b93d7f1b2e70/go.mod h1:dNS+PPTqGnSl80x3wEyWWCHeON5xiBGtcM0uD6CgHNU=

--- a/util/containerutil/docker.go
+++ b/util/containerutil/docker.go
@@ -1,0 +1,143 @@
+package containerutil
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/dustin/go-humanize"
+	"github.com/hashicorp/go-multierror"
+	_ "github.com/moby/buildkit/client/connhelper/dockercontainer" // Load "docker-container://" helper.
+	"github.com/pkg/errors"
+)
+
+type dockerShellFrontend struct {
+	*shellFrontend
+	userNamespaced bool
+}
+
+func NewDockerShellFrontend(ctx context.Context) (ContainerFrontend, error) {
+	fe := &dockerShellFrontend{
+		shellFrontend: &shellFrontend{
+			binaryName: "docker",
+		},
+	}
+
+	output, err := fe.commandContextOutput(ctx, "info", "--format={{.SecurityOptions}}")
+	if err != nil {
+		return nil, err
+	}
+	fe.rootless = strings.Contains(output.string(), "rootless")
+	fe.userNamespaced = strings.Contains(output.string(), "name=userns")
+
+	if fe.userNamespaced {
+		fe.compatibilityArgs = []string{"--userns", "host"}
+	}
+
+	return fe, nil
+}
+
+func (dsf *dockerShellFrontend) Scheme() string {
+	return "docker-container"
+}
+
+func (dsf *dockerShellFrontend) Information(ctx context.Context) (*FrontendInfo, error) {
+	output, err := dsf.commandContextOutput(ctx, "version", "--format={{json .}}")
+	if err != nil {
+		return nil, err
+	}
+
+	type versionInfo struct {
+		Version    string
+		APIVersion string
+		OS         string
+		Arch       string
+	}
+
+	type info struct {
+		Client versionInfo
+		Server versionInfo
+	}
+
+	allInfo := info{}
+	json.Unmarshal([]byte(output.string()), &allInfo)
+
+	host, exists := os.LookupEnv("DOCKER_HOST")
+	if !exists {
+		host = "/var/run/docker.sock"
+	}
+
+	return &FrontendInfo{
+		ClientVersion:    allInfo.Client.Version,
+		ClientAPIVersion: allInfo.Client.APIVersion,
+		ClientPlatform:   fmt.Sprintf("%s/%s", allInfo.Client.OS, allInfo.Client.Arch),
+		ServerVersion:    allInfo.Server.Version,
+		ServerAPIVersion: allInfo.Server.APIVersion,
+		ServerPlatform:   fmt.Sprintf("%s/%s", allInfo.Server.OS, allInfo.Server.Arch),
+		ServerAddress:    host,
+	}, nil
+}
+
+func (dsf *dockerShellFrontend) ContainerInfo(ctx context.Context, namesOrIDs ...string) (map[string]*ContainerInfo, error) {
+	results, err := dsf.shellFrontend.ContainerInfo(ctx, namesOrIDs...)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, v := range results {
+		// Docker prepends a `\`. This is as intended, according to docker; but unexpected in our
+		// case. So remove it. If the status is missing, it was passed through so do not remove.
+		if v.Status != StatusMissing {
+			v.Name = v.Name[1:]
+		}
+	}
+
+	return results, nil
+}
+
+func (dsf *dockerShellFrontend) VolumeInfo(ctx context.Context, volumeNames ...string) (map[string]*VolumeInfo, error) {
+	// Ignore the error. This is because one or more of the provided names could be missing.
+	// This allows for Info to report that the volume itself is missing.
+	output, _ := dsf.commandContextOutput(ctx, "system", "df", "-v", "--format={{json  .}}")
+
+	results := map[string]*VolumeInfo{}
+	for _, name := range volumeNames {
+		// Pre-initialize all as missing. It will get overwritten when we encounter a real one from the actual output.
+		results[name] = &VolumeInfo{Name: name}
+	}
+
+	// Anonymous struct to just pick out what we need
+	volumeInfos := struct {
+		Volumes []struct {
+			Name       string `json:"Name"`
+			Size       string `json:"Size"`
+			Mountpoint string `json:"Mountpoint"`
+		} `json:"Volumes"`
+	}{}
+	err := json.Unmarshal([]byte(output.stdout.String()), &volumeInfos)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to decode docker volume info for %v", volumeNames)
+	}
+
+	for _, name := range volumeNames {
+		for _, volumeInfo := range volumeInfos.Volumes {
+			if name == volumeInfo.Name {
+				bytes, parseErr := humanize.ParseBytes(volumeInfo.Size)
+				if parseErr != nil {
+					multierror.Append(err, parseErr)
+				} else {
+					results[name] = &VolumeInfo{
+						Name:       volumeInfo.Name,
+						Size:       bytes,
+						Mountpoint: volumeInfo.Mountpoint,
+					}
+				}
+				break
+			}
+		}
+	}
+
+	return results, err
+}

--- a/util/containerutil/docker.go
+++ b/util/containerutil/docker.go
@@ -43,6 +43,14 @@ func (dsf *dockerShellFrontend) Scheme() string {
 	return "docker-container"
 }
 
+func (dsf *dockerShellFrontend) Config() *FrontendConfig {
+	return &FrontendConfig{
+		Setting: FrontendDockerShell,
+		Binary:  dsf.binaryName,
+		Type:    FrontendTypeShell,
+	}
+}
+
 func (dsf *dockerShellFrontend) Information(ctx context.Context) (*FrontendInfo, error) {
 	output, err := dsf.commandContextOutput(ctx, "version", "--format={{json .}}")
 	if err != nil {

--- a/util/containerutil/docker.go
+++ b/util/containerutil/docker.go
@@ -18,6 +18,8 @@ type dockerShellFrontend struct {
 	userNamespaced bool
 }
 
+// NewDockerShellFrontend constructs a new Frontend using the docker binary installed on the host.
+// It also ensures that the binary is functional for our needs and collects compatibility information.
 func NewDockerShellFrontend(ctx context.Context) (ContainerFrontend, error) {
 	fe := &dockerShellFrontend{
 		shellFrontend: &shellFrontend{

--- a/util/containerutil/docker.go
+++ b/util/containerutil/docker.go
@@ -136,7 +136,7 @@ func (dsf *dockerShellFrontend) VolumeInfo(ctx context.Context, volumeNames ...s
 			if name == volumeInfo.Name {
 				bytes, parseErr := humanize.ParseBytes(volumeInfo.Size)
 				if parseErr != nil {
-					multierror.Append(err, parseErr)
+					err = multierror.Append(err, parseErr)
 				} else {
 					results[name] = &VolumeInfo{
 						Name:       volumeInfo.Name,

--- a/util/containerutil/frontend.go
+++ b/util/containerutil/frontend.go
@@ -1,0 +1,81 @@
+package containerutil
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"runtime"
+
+	"github.com/pkg/errors"
+)
+
+type ContainerFrontend interface {
+	Scheme() string
+
+	IsAvaliable(ctx context.Context) bool
+	Information(ctx context.Context) (*FrontendInfo, error)
+
+	ContainerInfo(ctx context.Context, namesOrIDs ...string) (map[string]*ContainerInfo, error)
+	ContainerRemove(ctx context.Context, force bool, namesOrIDs ...string) error
+	ContainerStop(ctx context.Context, timeoutSec uint, namesOrIDs ...string) error
+	ContainerLogs(ctx context.Context, namesOrIDs ...string) (map[string]*ContainerLogs, error)
+	ContainerRun(ctx context.Context, containers ...ContainerRun) error
+
+	ImageInfo(ctx context.Context, refs ...string) (map[string]*ImageInfo, error)
+	ImagePull(ctx context.Context, refs ...string) error
+	ImageRemove(ctx context.Context, force bool, refs ...string) error
+	ImageTag(ctx context.Context, tags ...ImageTag) error
+	ImageLoad(ctx context.Context, image ...io.Reader) error
+
+	VolumeInfo(ctx context.Context, volumeNames ...string) (map[string]*VolumeInfo, error)
+}
+
+func FrontendForSetting(ctx context.Context, feType string) (ContainerFrontend, error) {
+	if feType == FrontendAutomatic {
+		return autodetectFrontend(ctx)
+	}
+
+	return frontendIfAvaliable(ctx, feType)
+}
+
+func autodetectFrontend(ctx context.Context) (ContainerFrontend, error) {
+	if fe, err := frontendIfAvaliable(ctx, FrontendDockerShell); err == nil {
+		return fe, nil
+	}
+
+	if fe, err := frontendIfAvaliable(ctx, FrontendPodmanShell); err == nil {
+		return fe, nil
+	}
+
+	return nil, errors.New("failed to autodetect a supported frontend")
+}
+
+func frontendIfAvaliable(ctx context.Context, feType string) (ContainerFrontend, error) {
+	var newFe func(context.Context) (ContainerFrontend, error)
+	switch feType {
+	case FrontendDockerShell:
+		newFe = NewDockerShellFrontend
+	case FrontendPodmanShell:
+		newFe = NewPodmanShellFrontend
+	default:
+		return nil, fmt.Errorf("%s is not a supported container frontend", feType)
+	}
+
+	fe, err := newFe(ctx)
+	if err != nil {
+		return nil, errors.Wrapf(err, "%s frontend failed to initalize", feType)
+	}
+	if !fe.IsAvaliable(ctx) {
+		return nil, fmt.Errorf("%s frontend not avaliable", feType)
+	}
+
+	return fe, nil
+}
+
+func getPlatform() string {
+	arch := runtime.GOARCH
+	if runtime.GOARCH == "arm" {
+		arch = "arm/v7"
+	}
+	return fmt.Sprintf("linux/%s", arch)
+}

--- a/util/containerutil/frontend.go
+++ b/util/containerutil/frontend.go
@@ -13,6 +13,7 @@ type ContainerFrontend interface {
 	Scheme() string
 
 	IsAvaliable(ctx context.Context) bool
+	Config() *FrontendConfig
 	Information(ctx context.Context) (*FrontendInfo, error)
 
 	ContainerInfo(ctx context.Context, namesOrIDs ...string) (map[string]*ContainerInfo, error)
@@ -31,7 +32,7 @@ type ContainerFrontend interface {
 }
 
 func FrontendForSetting(ctx context.Context, feType string) (ContainerFrontend, error) {
-	if feType == FrontendAutomatic {
+	if feType == FrontendAuto {
 		return autodetectFrontend(ctx)
 	}
 

--- a/util/containerutil/frontend.go
+++ b/util/containerutil/frontend.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 )
 
+// ContainerFrontend is an interface specifying all the container options Earthly needs to do.
 type ContainerFrontend interface {
 	Scheme() string
 
@@ -31,6 +32,7 @@ type ContainerFrontend interface {
 	VolumeInfo(ctx context.Context, volumeNames ...string) (map[string]*VolumeInfo, error)
 }
 
+// FrontendForSetting returns a frontend given a setting. This includes automatic detection.
 func FrontendForSetting(ctx context.Context, feType string) (ContainerFrontend, error) {
 	if feType == FrontendAuto {
 		return autodetectFrontend(ctx)

--- a/util/containerutil/frontend_test.go
+++ b/util/containerutil/frontend_test.go
@@ -131,10 +131,10 @@ func TestFrontendContainerInfo(t *testing.T) {
 			assert.Len(t, info, 3)
 
 			assert.Equal(t, info[getInfos[0]].Name, getInfos[0])
-			assert.Equal(t, info[getInfos[0]].Image, "docker.io/hashicorp/http-echo")
+			assert.Equal(t, info[getInfos[0]].Image, "docker.io/hashicorp/http-echo:latest")
 
 			assert.Equal(t, info[getInfos[1]].Name, getInfos[1])
-			assert.Equal(t, info[getInfos[1]].Image, "docker.io/hashicorp/http-echo")
+			assert.Equal(t, info[getInfos[1]].Image, "docker.io/hashicorp/http-echo:latest")
 
 			assert.Equal(t, info[getInfos[2]].Name, getInfos[2])
 			assert.Equal(t, info[getInfos[2]].Status, containerutil.StatusMissing)
@@ -171,6 +171,7 @@ func TestFrontendContainerRemove(t *testing.T) {
 			assert.NoError(t, err)
 
 			info, err = fe.ContainerInfo(ctx, testContainers...)
+			assert.NoError(t, err)
 			assert.Equal(t, info[testContainers[0]].Status, containerutil.StatusMissing)
 			assert.Equal(t, info[testContainers[1]].Status, containerutil.StatusMissing)
 		})
@@ -553,7 +554,7 @@ func isBinaryInstalled(ctx context.Context, binary string) bool {
 func spawnTestContainers(ctx context.Context, feBinary string, names ...string) (func(), error) {
 	var err error
 	for _, name := range names {
-		cmd := exec.CommandContext(ctx, feBinary, "run", "-d", "--name", name, "docker.io/hashicorp/http-echo", `-text="test"`)
+		cmd := exec.CommandContext(ctx, feBinary, "run", "-d", "--name", name, "docker.io/hashicorp/http-echo:latest", `-text="test"`)
 		output, createErr := cmd.CombinedOutput()
 		if err != nil {
 			// the frontend exists but is non-functional. This is... not likely to work at all.

--- a/util/containerutil/frontend_test.go
+++ b/util/containerutil/frontend_test.go
@@ -1,0 +1,617 @@
+package containerutil_test
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"testing"
+
+	"github.com/earthly/earthly/util/containerutil"
+	"github.com/hashicorp/go-multierror"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFrontendNew(t *testing.T) {
+	testCases := []struct {
+		binary  string
+		newFunc func(context.Context) (containerutil.ContainerFrontend, error)
+	}{
+		{"docker", containerutil.NewDockerShellFrontend},
+		{"podman", containerutil.NewPodmanShellFrontend},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.binary, func(t *testing.T) {
+			ctx := context.Background()
+			onlyIfBinaryIsInstalled(ctx, t, tC.binary)
+
+			fe, err := tC.newFunc(ctx)
+			assert.NoError(t, err)
+			assert.NotNil(t, fe)
+		})
+	}
+}
+
+func TestFrontendScheme(t *testing.T) {
+	testCases := []struct {
+		binary  string
+		newFunc func(context.Context) (containerutil.ContainerFrontend, error)
+		scheme  string
+	}{
+		{"docker", containerutil.NewDockerShellFrontend, "docker-container"},
+		{"podman", containerutil.NewPodmanShellFrontend, "podman-container"},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.binary, func(t *testing.T) {
+			ctx := context.Background()
+			onlyIfBinaryIsInstalled(ctx, t, tC.binary)
+
+			fe, err := tC.newFunc(ctx)
+			assert.NoError(t, err)
+
+			scheme := fe.Scheme()
+			assert.Equal(t, tC.scheme, scheme)
+		})
+	}
+}
+
+func TestFrontendIsAvaliable(t *testing.T) {
+	testCases := []struct {
+		binary  string
+		newFunc func(context.Context) (containerutil.ContainerFrontend, error)
+	}{
+		{"docker", containerutil.NewDockerShellFrontend},
+		{"podman", containerutil.NewPodmanShellFrontend},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.binary, func(t *testing.T) {
+			ctx := context.Background()
+			onlyIfBinaryIsInstalled(ctx, t, tC.binary)
+
+			fe, err := tC.newFunc(ctx)
+			assert.NoError(t, err)
+
+			avaliable := fe.IsAvaliable(ctx)
+			assert.True(t, avaliable)
+		})
+	}
+}
+
+func TestFrontendInformation(t *testing.T) {
+	testCases := []struct {
+		binary  string
+		newFunc func(context.Context) (containerutil.ContainerFrontend, error)
+	}{
+		{"docker", containerutil.NewDockerShellFrontend},
+		{"podman", containerutil.NewPodmanShellFrontend},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.binary, func(t *testing.T) {
+			ctx := context.Background()
+			onlyIfBinaryIsInstalled(ctx, t, tC.binary)
+
+			fe, err := tC.newFunc(ctx)
+			assert.NoError(t, err)
+
+			info, err := fe.Information(ctx)
+			assert.NoError(t, err)
+			assert.NotNil(t, info)
+		})
+	}
+}
+
+func TestFrontendContainerInfo(t *testing.T) {
+	testCases := []struct {
+		binary  string
+		newFunc func(context.Context) (containerutil.ContainerFrontend, error)
+	}{
+		{"docker", containerutil.NewDockerShellFrontend},
+		{"podman", containerutil.NewPodmanShellFrontend},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.binary, func(t *testing.T) {
+			ctx := context.Background()
+			onlyIfBinaryIsInstalled(ctx, t, tC.binary)
+
+			testContainers := []string{"test-1", "test-2"}
+			cleanup, err := spawnTestContainers(ctx, tC.binary, testContainers...)
+			assert.NoError(t, err)
+			defer cleanup()
+
+			fe, err := tC.newFunc(ctx)
+			assert.NoError(t, err)
+
+			getInfos := append(testContainers, "missing")
+			info, err := fe.ContainerInfo(ctx, getInfos...)
+			assert.NoError(t, err)
+			assert.NotNil(t, info)
+
+			assert.Len(t, info, 3)
+
+			assert.Equal(t, info[getInfos[0]].Name, getInfos[0])
+			assert.Equal(t, info[getInfos[0]].Image, "docker.io/hashicorp/http-echo")
+
+			assert.Equal(t, info[getInfos[1]].Name, getInfos[1])
+			assert.Equal(t, info[getInfos[1]].Image, "docker.io/hashicorp/http-echo")
+
+			assert.Equal(t, info[getInfos[2]].Name, getInfos[2])
+			assert.Equal(t, info[getInfos[2]].Status, containerutil.StatusMissing)
+		})
+	}
+}
+
+func TestFrontendContainerRemove(t *testing.T) {
+	testCases := []struct {
+		binary  string
+		newFunc func(context.Context) (containerutil.ContainerFrontend, error)
+	}{
+		{"docker", containerutil.NewDockerShellFrontend},
+		{"podman", containerutil.NewPodmanShellFrontend},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.binary, func(t *testing.T) {
+			ctx := context.Background()
+			onlyIfBinaryIsInstalled(ctx, t, tC.binary)
+
+			testContainers := []string{"remove-1", "remove-2"}
+			cleanup, err := spawnTestContainers(ctx, tC.binary, testContainers...)
+			assert.NoError(t, err)
+			defer cleanup()
+
+			fe, err := tC.newFunc(ctx)
+			assert.NoError(t, err)
+
+			info, err := fe.ContainerInfo(ctx, testContainers...)
+			assert.NoError(t, err)
+			assert.Len(t, info, 2)
+
+			err = fe.ContainerRemove(ctx, true, testContainers...)
+			assert.NoError(t, err)
+
+			info, err = fe.ContainerInfo(ctx, testContainers...)
+			assert.Equal(t, info[testContainers[0]].Status, containerutil.StatusMissing)
+			assert.Equal(t, info[testContainers[1]].Status, containerutil.StatusMissing)
+		})
+	}
+}
+
+func TestFrontendContainerStop(t *testing.T) {
+	testCases := []struct {
+		binary  string
+		newFunc func(context.Context) (containerutil.ContainerFrontend, error)
+	}{
+		{"docker", containerutil.NewDockerShellFrontend},
+		{"podman", containerutil.NewPodmanShellFrontend},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.binary, func(t *testing.T) {
+			ctx := context.Background()
+			onlyIfBinaryIsInstalled(ctx, t, tC.binary)
+
+			testContainers := []string{"stop-1", "stop-2"}
+			cleanup, err := spawnTestContainers(ctx, tC.binary, testContainers...)
+			assert.NoError(t, err)
+			defer cleanup()
+
+			fe, err := tC.newFunc(ctx)
+			assert.NoError(t, err)
+
+			info, err := fe.ContainerInfo(ctx, testContainers...)
+			assert.NoError(t, err)
+			assert.Len(t, info, 2)
+
+			err = fe.ContainerStop(ctx, 0, testContainers...)
+			assert.NoError(t, err)
+
+			_, err = fe.ContainerInfo(ctx, testContainers...)
+			assert.NoError(t, err)
+			assert.Len(t, info, 2)
+		})
+	}
+}
+
+func TestFrontendContainerLogs(t *testing.T) {
+	testCases := []struct {
+		binary  string
+		newFunc func(context.Context) (containerutil.ContainerFrontend, error)
+	}{
+		{"docker", containerutil.NewDockerShellFrontend},
+		{"podman", containerutil.NewPodmanShellFrontend},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.binary, func(t *testing.T) {
+			ctx := context.Background()
+			onlyIfBinaryIsInstalled(ctx, t, tC.binary)
+
+			testContainers := []string{"logs-1", "logs-2"}
+			cleanup, err := spawnTestContainers(ctx, tC.binary, testContainers...)
+			assert.NoError(t, err)
+			defer cleanup()
+
+			fe, err := tC.newFunc(ctx)
+			assert.NoError(t, err)
+
+			logs, err := fe.ContainerLogs(ctx, testContainers...)
+			assert.NoError(t, err)
+			assert.Len(t, logs, 2)
+
+			assert.Empty(t, logs[testContainers[0]].Stdout)
+			assert.NotEmpty(t, logs[testContainers[0]].Stderr)
+
+			assert.Empty(t, logs[testContainers[1]].Stdout)
+			assert.NotEmpty(t, logs[testContainers[1]].Stderr)
+		})
+	}
+}
+
+func TestFrontendContainerRun(t *testing.T) {
+	testCases := []struct {
+		binary  string
+		newFunc func(context.Context) (containerutil.ContainerFrontend, error)
+	}{
+		{"docker", containerutil.NewDockerShellFrontend},
+		{"podman", containerutil.NewPodmanShellFrontend},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.binary, func(t *testing.T) {
+			ctx := context.Background()
+			onlyIfBinaryIsInstalled(ctx, t, tC.binary)
+
+			fe, err := tC.newFunc(ctx)
+			assert.NoError(t, err)
+
+			testContainers := []string{"create-1", "create-2"}
+			runs := []containerutil.ContainerRun{}
+			for _, name := range testContainers {
+				runs = append(runs, containerutil.ContainerRun{
+					NameOrID:       name,
+					ImageRef:       "docker.io/hashicorp/http-echo:latest",
+					Privileged:     false,
+					Envs:           containerutil.EnvMap{"test": name},
+					Labels:         containerutil.LabelMap{"test": name},
+					ContainerArgs:  []string{"--text", "create-test"},
+					AdditionalArgs: []string{"--rm"},
+					Mounts: containerutil.MountOpt{
+						containerutil.Mount{
+							Type:     containerutil.MountVolume,
+							Source:   fmt.Sprintf("vol-%s", name),
+							Dest:     "/test",
+							ReadOnly: true,
+						},
+					},
+					Ports: containerutil.PortOpt{
+						containerutil.Port{
+							IP:            "127.0.0.1",
+							HostPort:      0,
+							ContainerPort: 5678,
+							Protocol:      containerutil.ProtocolTCP,
+						},
+					},
+				})
+			}
+
+			defer func() {
+				for _, name := range testContainers {
+					// Roll our own cleanup since we can't use the spawn test containers helper... since
+					// the whole point of this test is to create them with a frontend. Also theres a volume
+					cmd := exec.CommandContext(ctx, tC.binary, "rm", "-f", name)
+					cmd.Run() // Just best effort
+
+					cmd = exec.CommandContext(ctx, tC.binary, "volume", "rm", "-f", fmt.Sprintf("vol-%s", name))
+					cmd.Run()
+				}
+			}()
+
+			info, err := fe.ContainerInfo(ctx, testContainers...)
+			assert.NoError(t, err)
+			assert.Equal(t, info[testContainers[0]].Status, containerutil.StatusMissing)
+			assert.Equal(t, info[testContainers[1]].Status, containerutil.StatusMissing)
+
+			err = fe.ContainerRun(ctx, runs...)
+			assert.NoError(t, err)
+
+			info, err = fe.ContainerInfo(ctx, testContainers...)
+			assert.NoError(t, err)
+			assert.Equal(t, info[testContainers[0]].Status, containerutil.StatusRunning)
+			assert.Equal(t, info[testContainers[1]].Status, containerutil.StatusRunning)
+		})
+	}
+}
+
+func TestFrontendImagePull(t *testing.T) {
+	testCases := []struct {
+		binary  string
+		newFunc func(context.Context) (containerutil.ContainerFrontend, error)
+		refList []string
+	}{
+		{"docker", containerutil.NewDockerShellFrontend, []string{"hello-world", "alpine:3.13"}},
+		{"podman", containerutil.NewPodmanShellFrontend, []string{"docker.io/hello-world", "docker.io/alpine:3.13"}}, // Podman prefers... and exports fully-qualified image tags
+	}
+	for _, tC := range testCases {
+		t.Run(tC.binary, func(t *testing.T) {
+			ctx := context.Background()
+			onlyIfBinaryIsInstalled(ctx, t, tC.binary)
+
+			fe, err := tC.newFunc(ctx)
+			assert.NoError(t, err)
+
+			refList := []string{"hello-world", "alpine:3.13"}
+
+			err = fe.ImagePull(ctx, refList...)
+			assert.NoError(t, err)
+
+			defer func() {
+				for _, ref := range refList {
+					cmd := exec.CommandContext(ctx, "docker", "image", "rm", "-f", ref)
+					cmd.Run()
+				}
+			}()
+		})
+	}
+}
+
+func TestFrontendImageInfo(t *testing.T) {
+	testCases := []struct {
+		binary  string
+		newFunc func(context.Context) (containerutil.ContainerFrontend, error)
+		refList []string
+	}{
+		{"docker", containerutil.NewDockerShellFrontend, []string{"info:1", "info:2"}},
+		{"podman", containerutil.NewPodmanShellFrontend, []string{"localhost/info:1", "localhost/info:2"}},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.binary, func(t *testing.T) {
+			ctx := context.Background()
+			onlyIfBinaryIsInstalled(ctx, t, tC.binary)
+
+			cleanup, err := spawnTestImages(ctx, tC.binary, tC.refList...)
+			assert.NoError(t, err)
+			defer cleanup()
+
+			fe, err := tC.newFunc(ctx)
+			assert.NoError(t, err)
+
+			info, err := fe.ImageInfo(ctx, tC.refList...)
+			assert.NoError(t, err)
+
+			assert.Len(t, info, 2)
+
+			assert.Contains(t, info[tC.refList[0]].Tags, tC.refList[0])
+			assert.Contains(t, info[tC.refList[1]].Tags, tC.refList[1])
+		})
+	}
+}
+
+func TestFrontendImageRemove(t *testing.T) {
+	testCases := []struct {
+		binary  string
+		newFunc func(context.Context) (containerutil.ContainerFrontend, error)
+	}{
+		{"docker", containerutil.NewDockerShellFrontend},
+		{"podman", containerutil.NewPodmanShellFrontend},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.binary, func(t *testing.T) {
+			ctx := context.Background()
+			onlyIfBinaryIsInstalled(ctx, t, tC.binary)
+
+			refList := []string{"remove:1", "remove:2"}
+			cleanup, err := spawnTestImages(ctx, tC.binary, refList...)
+			assert.NoError(t, err)
+			defer cleanup()
+
+			fe, err := tC.newFunc(ctx)
+			assert.NoError(t, err)
+
+			info, err := fe.ImageInfo(ctx, refList...)
+			assert.NoError(t, err)
+			assert.Len(t, info, 2)
+
+			err = fe.ImageRemove(ctx, true, refList...)
+			assert.NoError(t, err)
+
+			info, err = fe.ImageInfo(ctx, refList...)
+			assert.NoError(t, err)
+			assert.Empty(t, info[refList[0]].ID)
+			assert.Empty(t, info[refList[1]].ID)
+		})
+	}
+}
+
+func TestFrontendImageTag(t *testing.T) {
+	testCases := []struct {
+		binary  string
+		newFunc func(context.Context) (containerutil.ContainerFrontend, error)
+		tagList []string
+	}{
+		{"docker", containerutil.NewDockerShellFrontend, []string{"tag:1", "tag:2"}},
+		{"podman", containerutil.NewPodmanShellFrontend, []string{"localhost/tag:1", "localhost/tag:2"}},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.binary, func(t *testing.T) {
+			ctx := context.Background()
+			onlyIfBinaryIsInstalled(ctx, t, tC.binary)
+
+			ref := "tag:me"
+			cleanup, err := spawnTestImages(ctx, tC.binary, ref)
+			assert.NoError(t, err)
+			defer cleanup()
+
+			fe, err := tC.newFunc(ctx)
+			assert.NoError(t, err)
+
+			info, err := fe.ImageInfo(ctx, ref)
+			assert.NoError(t, err)
+
+			imageID := info[ref].ID
+			tags := []containerutil.ImageTag{}
+			for _, tagName := range tC.tagList {
+				tags = append(tags, containerutil.ImageTag{
+					SourceRef: imageID,
+					TargetRef: tagName,
+				})
+			}
+
+			err = fe.ImageTag(ctx, tags...)
+			assert.NoError(t, err)
+
+			info, err = fe.ImageInfo(ctx, tC.tagList...)
+			assert.NoError(t, err)
+
+			assert.Contains(t, info[tC.tagList[0]].Tags, tC.tagList[0])
+			assert.Contains(t, info[tC.tagList[1]].Tags, tC.tagList[1])
+		})
+	}
+}
+
+func TestFrontendImageLoad(t *testing.T) {
+	testCases := []struct {
+		binary  string
+		newFunc func(context.Context) (containerutil.ContainerFrontend, error)
+		ref     string
+	}{
+		{"docker", containerutil.NewDockerShellFrontend, "load:me"},
+		{"podman", containerutil.NewPodmanShellFrontend, "localhost/load:me"},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.binary, func(t *testing.T) {
+			ctx := context.Background()
+			onlyIfBinaryIsInstalled(ctx, t, tC.binary)
+
+			cleanup, err := spawnTestImages(ctx, tC.binary, tC.ref)
+			assert.NoError(t, err)
+
+			imgBuffer := &bytes.Buffer{}
+			cmd := exec.CommandContext(ctx, tC.binary, "image", "save", tC.ref)
+			cmd.Stdout = bufio.NewWriter(imgBuffer)
+			err = cmd.Run()
+			assert.NoError(t, err)
+
+			cleanup()
+
+			fe, err := tC.newFunc(ctx)
+			assert.NoError(t, err)
+
+			err = fe.ImageLoad(ctx, bufio.NewReader(imgBuffer))
+			assert.NoError(t, err)
+
+			defer func() {
+				cmd := exec.CommandContext(ctx, tC.binary, "image", "rm", "-f", tC.ref)
+				cmd.Run()
+			}()
+
+			info, err := fe.ImageInfo(ctx, tC.ref)
+			assert.NoError(t, err)
+			assert.Contains(t, info[tC.ref].Tags, tC.ref)
+		})
+	}
+}
+
+func TestFrontendVolumeInfo(t *testing.T) {
+	testCases := []struct {
+		binary  string
+		newFunc func(context.Context) (containerutil.ContainerFrontend, error)
+	}{
+		{"docker", containerutil.NewDockerShellFrontend},
+		{"podman", containerutil.NewPodmanShellFrontend},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.binary, func(t *testing.T) {
+			ctx := context.Background()
+			onlyIfBinaryIsInstalled(ctx, t, tC.binary)
+
+			volList := []string{"test1", "test2"}
+			cleanup, err := spawnTestVolumes(ctx, tC.binary, volList...)
+			assert.NoError(t, err)
+			defer cleanup()
+
+			fe, err := tC.newFunc(ctx)
+			assert.NoError(t, err)
+
+			info, err := fe.VolumeInfo(ctx, volList...)
+			assert.NoError(t, err)
+			assert.Len(t, info, 2)
+		})
+	}
+}
+
+func onlyIfBinaryIsInstalled(ctx context.Context, t *testing.T, binary string) {
+	if !isBinaryInstalled(ctx, binary) {
+		t.Skipf("%s is not avaliable for tests, skipping", binary)
+	}
+}
+
+func isBinaryInstalled(ctx context.Context, binary string) bool {
+	// This is almost a re-implementation of IsAvaliable... but relying on that presupposes the
+	// binary exists to allow the New**** to run (it gathers info from the CLI).
+	cmd := exec.CommandContext(ctx, binary, "--help")
+	return cmd.Run() == nil
+}
+
+func spawnTestContainers(ctx context.Context, feBinary string, names ...string) (func(), error) {
+	var err error
+	for _, name := range names {
+		cmd := exec.CommandContext(ctx, feBinary, "run", "-d", "--name", name, "docker.io/hashicorp/http-echo", `-text="test"`)
+		output, createErr := cmd.CombinedOutput()
+		if err != nil {
+			// the frontend exists but is non-functional. This is... not likely to work at all.
+			multierror.Append(err, errors.Wrap(createErr, string(output)))
+		}
+	}
+
+	return func() {
+		for _, name := range names {
+			cmd := exec.CommandContext(ctx, feBinary, "rm", "-f", name)
+			cmd.Run() // Just best effort
+		}
+	}, nil
+}
+
+func spawnTestImages(ctx context.Context, feBinary string, refs ...string) (func(), error) {
+	var err error
+	for _, ref := range refs {
+		cmd := exec.CommandContext(ctx, feBinary, "image", "pull", "docker.io/hello-world")
+		output, createErr := cmd.CombinedOutput()
+		if err != nil {
+			// the frontend exists but is non-functional. This is... not likely to work at all.
+			multierror.Append(err, errors.Wrap(createErr, string(output)))
+			break
+		}
+
+		cmd = exec.CommandContext(ctx, feBinary, "image", "tag", "docker.io/hello-world", ref)
+		output, tagErr := cmd.CombinedOutput()
+		if err != nil {
+			// the frontend exists but is non-functional. This is... not likely to work at all.
+			multierror.Append(err, errors.Wrap(tagErr, string(output)))
+			break
+		}
+	}
+
+	return func() {
+		for _, ref := range refs {
+			cmd := exec.CommandContext(ctx, feBinary, "image", "rm", "-f", ref)
+			cmd.Run() // Just best effort
+		}
+	}, nil
+}
+
+func spawnTestVolumes(ctx context.Context, feBinary string, names ...string) (func(), error) {
+	var err error
+	for _, name := range names {
+		cmd := exec.CommandContext(ctx, feBinary, "volume", "create", name)
+		output, createErr := cmd.CombinedOutput()
+		if err != nil {
+			// the frontend exists but is non-functional. This is... not likely to work at all.
+			multierror.Append(err, errors.Wrap(createErr, string(output)))
+		}
+	}
+
+	return func() {
+		for _, name := range names {
+			cmd := exec.CommandContext(ctx, feBinary, "volume", "rm", "-f", name)
+			cmd.Run() // Just best effort
+		}
+	}, nil
+}

--- a/util/containerutil/frontend_test.go
+++ b/util/containerutil/frontend_test.go
@@ -315,8 +315,8 @@ func TestFrontendContainerRun(t *testing.T) {
 
 			info, err = fe.ContainerInfo(ctx, testContainers...)
 			assert.NoError(t, err)
-			assert.Equal(t, containerutil.StatusRunning, info[testContainers[0]].Statuszs)
-			assert.Equal(t, containerutil.StatusRunning, info[testContainers[1]].Statuszs)
+			assert.Equal(t, containerutil.StatusRunning, info[testContainers[0]].Status)
+			assert.Equal(t, containerutil.StatusRunning, info[testContainers[1]].Status)
 		})
 	}
 }

--- a/util/containerutil/frontend_test.go
+++ b/util/containerutil/frontend_test.go
@@ -379,8 +379,8 @@ func TestFrontendImageInfo(t *testing.T) {
 
 			assert.Len(t, info, 2)
 
-			assert.Contains(t, tC.refList[0], info[tC.refList[0]].Tags)
-			assert.Contains(t, tC.refList[1], info[tC.refList[1]].Tags)
+			assert.Contains(t, info[tC.refList[0]].Tags, tC.refList[0])
+			assert.Contains(t, info[tC.refList[1]].Tags, tC.refList[1])
 		})
 	}
 }
@@ -461,8 +461,8 @@ func TestFrontendImageTag(t *testing.T) {
 			info, err = fe.ImageInfo(ctx, tC.tagList...)
 			assert.NoError(t, err)
 
-			assert.Contains(t, tC.tagList[0], info[tC.tagList[0]].Tags)
-			assert.Contains(t, tC.tagList[1], info[tC.tagList[1]].Tags)
+			assert.Contains(t, info[tC.tagList[0]].Tags, tC.tagList[0])
+			assert.Contains(t, info[tC.tagList[1]].Tags, tC.tagList[1])
 		})
 	}
 }

--- a/util/containerutil/frontend_test.go
+++ b/util/containerutil/frontend_test.go
@@ -130,14 +130,14 @@ func TestFrontendContainerInfo(t *testing.T) {
 
 			assert.Len(t, info, 3)
 
-			assert.Equal(t, info[getInfos[0]].Name, getInfos[0])
-			assert.Equal(t, info[getInfos[0]].Image, "docker.io/hashicorp/http-echo:latest")
+			assert.Equal(t, getInfos[0], info[getInfos[0]].Name)
+			assert.Equal(t, "docker.io/hashicorp/http-echo:latest", info[getInfos[0]].Image)
 
-			assert.Equal(t, info[getInfos[1]].Name, getInfos[1])
-			assert.Equal(t, info[getInfos[1]].Image, "docker.io/hashicorp/http-echo:latest")
+			assert.Equal(t, getInfos[1], info[getInfos[1]].Name)
+			assert.Equal(t, "docker.io/hashicorp/http-echo:latest", info[getInfos[1]].Image)
 
-			assert.Equal(t, info[getInfos[2]].Name, getInfos[2])
-			assert.Equal(t, info[getInfos[2]].Status, containerutil.StatusMissing)
+			assert.Equal(t, getInfos[2], info[getInfos[2]].Name)
+			assert.Equal(t, containerutil.StatusMissing, info[getInfos[2]].Status)
 		})
 	}
 }
@@ -172,8 +172,8 @@ func TestFrontendContainerRemove(t *testing.T) {
 
 			info, err = fe.ContainerInfo(ctx, testContainers...)
 			assert.NoError(t, err)
-			assert.Equal(t, info[testContainers[0]].Status, containerutil.StatusMissing)
-			assert.Equal(t, info[testContainers[1]].Status, containerutil.StatusMissing)
+			assert.Equal(t, containerutil.StatusMissing, info[testContainers[0]].Status)
+			assert.Equal(t, containerutil.StatusMissing, info[testContainers[1]].Status)
 		})
 	}
 }
@@ -307,16 +307,16 @@ func TestFrontendContainerRun(t *testing.T) {
 
 			info, err := fe.ContainerInfo(ctx, testContainers...)
 			assert.NoError(t, err)
-			assert.Equal(t, info[testContainers[0]].Status, containerutil.StatusMissing)
-			assert.Equal(t, info[testContainers[1]].Status, containerutil.StatusMissing)
+			assert.Equal(t, containerutil.StatusMissing, info[testContainers[0]].Status)
+			assert.Equal(t, containerutil.StatusMissing, info[testContainers[1]].Status)
 
 			err = fe.ContainerRun(ctx, runs...)
 			assert.NoError(t, err)
 
 			info, err = fe.ContainerInfo(ctx, testContainers...)
 			assert.NoError(t, err)
-			assert.Equal(t, info[testContainers[0]].Status, containerutil.StatusRunning)
-			assert.Equal(t, info[testContainers[1]].Status, containerutil.StatusRunning)
+			assert.Equal(t, containerutil.StatusRunning, info[testContainers[0]].Statuszs)
+			assert.Equal(t, containerutil.StatusRunning, info[testContainers[1]].Statuszs)
 		})
 	}
 }
@@ -379,8 +379,8 @@ func TestFrontendImageInfo(t *testing.T) {
 
 			assert.Len(t, info, 2)
 
-			assert.Contains(t, info[tC.refList[0]].Tags, tC.refList[0])
-			assert.Contains(t, info[tC.refList[1]].Tags, tC.refList[1])
+			assert.Contains(t, tC.refList[0], info[tC.refList[0]].Tags)
+			assert.Contains(t, tC.refList[1], info[tC.refList[1]].Tags)
 		})
 	}
 }
@@ -461,8 +461,8 @@ func TestFrontendImageTag(t *testing.T) {
 			info, err = fe.ImageInfo(ctx, tC.tagList...)
 			assert.NoError(t, err)
 
-			assert.Contains(t, info[tC.tagList[0]].Tags, tC.tagList[0])
-			assert.Contains(t, info[tC.tagList[1]].Tags, tC.tagList[1])
+			assert.Contains(t, tC.tagList[0], info[tC.tagList[0]].Tags)
+			assert.Contains(t, tC.tagList[1], info[tC.tagList[1]].Tags)
 		})
 	}
 }

--- a/util/containerutil/podman.go
+++ b/util/containerutil/podman.go
@@ -1,0 +1,145 @@
+package containerutil
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+	"strings"
+
+	"github.com/dustin/go-humanize"
+	"github.com/hashicorp/go-multierror"
+	_ "github.com/moby/buildkit/client/connhelper/podmancontainer" // Load "podman-container://" helper.
+	"github.com/pkg/errors"
+)
+
+type podmanShellFrontend struct {
+	*shellFrontend
+}
+
+func NewPodmanShellFrontend(ctx context.Context) (ContainerFrontend, error) {
+	fe := &podmanShellFrontend{
+		shellFrontend: &shellFrontend{
+			binaryName: "podman",
+		},
+	}
+
+	output, err := fe.commandContextOutput(ctx, "info", "--format={{.Host.Security.Rootless}}")
+	if err != nil {
+		return nil, err
+	}
+
+	isRootless, err := strconv.ParseBool(output.string())
+	if err != nil {
+		return nil, errors.Wrapf(err, "info returned invalid value %s", output.string())
+	}
+	fe.rootless = isRootless
+
+	return fe, nil
+}
+
+func (psf *podmanShellFrontend) Scheme() string {
+	return "podman-container"
+}
+
+func (psf *podmanShellFrontend) Information(ctx context.Context) (*FrontendInfo, error) {
+	output, err := psf.commandContextOutput(ctx, "info", "--format={{.Host.RemoteSocket.Exists}}")
+	if err != nil {
+		return nil, err
+	}
+
+	hasRemote, err := strconv.ParseBool(output.string())
+	if err != nil {
+		return nil, errors.Wrapf(err, "info returned invalid value %s", output.string())
+	}
+
+	args := []string{"version", "--format=json"}
+	if hasRemote {
+		args = append([]string{"-r"}, args...)
+	}
+
+	output, err = psf.commandContextOutput(ctx, args...)
+	if err != nil {
+		return nil, err
+	}
+
+	type versionInfo struct {
+		Version    string
+		APIVersion string
+		OSArch     string
+	}
+
+	type info struct {
+		Client versionInfo
+		Server versionInfo
+	}
+
+	allInfo := info{}
+	json.Unmarshal([]byte(output.string()), &allInfo)
+
+	host := "daemonless"
+	if hasRemote {
+		output, err = psf.commandContextOutput(ctx, "info", "--format={{.Host.RemoteSocket.Path}}")
+		if err != nil {
+			return nil, err
+		}
+		host = string(output.string())
+	}
+
+	return &FrontendInfo{
+		ClientVersion:    allInfo.Client.Version,
+		ClientAPIVersion: allInfo.Client.APIVersion,
+		ClientPlatform:   allInfo.Client.OSArch,
+		ServerVersion:    allInfo.Server.Version,
+		ServerAPIVersion: allInfo.Server.APIVersion,
+		ServerPlatform:   allInfo.Server.OSArch,
+		ServerAddress:    host,
+	}, nil
+}
+
+func (psf *podmanShellFrontend) VolumeInfo(ctx context.Context, volumeNames ...string) (map[string]*VolumeInfo, error) {
+	// Older podman versions do no support --format. This means we are stuck parsing the verbose tabular output for compat.
+	output, err := psf.commandContextOutput(ctx, "system", "df", "-v")
+	if err != nil {
+		return nil, err
+	}
+
+	idx := strings.Index(output.string(), "Local Volumes space usage:")
+	val := output.string()[idx:]
+	lines := strings.Split(string(val), "\n")[3:]
+	results := map[string]*VolumeInfo{}
+
+	for _, line := range lines {
+		lineParts := strings.Fields(line)
+		for _, volumeName := range volumeNames {
+			// There are three columns. By index:
+			// 0 -> name, 1 -> links, 2 -> size
+			// There may be straggler lines after due to parsing, ignore them. They will not have enough length.
+			// The volume lines are last so we are safe.
+			if len(lineParts) == 3 && volumeName == lineParts[0] {
+				// Get size
+				var bytes uint64
+				bytes, parseErr := humanize.ParseBytes(lineParts[2])
+				if err != nil {
+					multierror.Append(err, parseErr)
+					break
+				}
+
+				// The mountpoint is not included in the df output. Get that from inspect.
+				mountpoint, mountpointErr := psf.commandContextOutput(ctx, "volume", "inspect", volumeName, "--format={{.Mountpoint}}")
+				if err != nil {
+					multierror.Append(err, mountpointErr)
+					break
+				}
+
+				results[volumeName] = &VolumeInfo{
+					Name:       volumeName,
+					Size:       bytes,
+					Mountpoint: string(mountpoint.string()),
+				}
+				break
+			}
+		}
+	}
+
+	return results, err
+}

--- a/util/containerutil/podman.go
+++ b/util/containerutil/podman.go
@@ -16,6 +16,8 @@ type podmanShellFrontend struct {
 	*shellFrontend
 }
 
+// NewPodmanShellFrontend constructs a new Frontend using the podman binary installed on the host.
+// It also ensures that the binary is functional for our needs and collects compatibility information.
 func NewPodmanShellFrontend(ctx context.Context) (ContainerFrontend, error) {
 	fe := &podmanShellFrontend{
 		shellFrontend: &shellFrontend{

--- a/util/containerutil/podman.go
+++ b/util/containerutil/podman.go
@@ -41,6 +41,14 @@ func (psf *podmanShellFrontend) Scheme() string {
 	return "podman-container"
 }
 
+func (psf *podmanShellFrontend) Config() *FrontendConfig {
+	return &FrontendConfig{
+		Setting: FrontendPodmanShell,
+		Binary:  psf.binaryName,
+		Type:    FrontendTypeShell,
+	}
+}
+
 func (psf *podmanShellFrontend) Information(ctx context.Context) (*FrontendInfo, error) {
 	output, err := psf.commandContextOutput(ctx, "info", "--format={{.Host.RemoteSocket.Exists}}")
 	if err != nil {

--- a/util/containerutil/podman.go
+++ b/util/containerutil/podman.go
@@ -130,14 +130,14 @@ func (psf *podmanShellFrontend) VolumeInfo(ctx context.Context, volumeNames ...s
 				var bytes uint64
 				bytes, parseErr := humanize.ParseBytes(lineParts[2])
 				if err != nil {
-					multierror.Append(err, parseErr)
+					err = multierror.Append(err, parseErr)
 					break
 				}
 
 				// The mountpoint is not included in the df output. Get that from inspect.
 				mountpoint, mountpointErr := psf.commandContextOutput(ctx, "volume", "inspect", volumeName, "--format={{.Mountpoint}}")
 				if err != nil {
-					multierror.Append(err, mountpointErr)
+					err = multierror.Append(err, mountpointErr)
 					break
 				}
 

--- a/util/containerutil/shell_shared.go
+++ b/util/containerutil/shell_shared.go
@@ -283,7 +283,7 @@ type commmandContextOutput struct {
 }
 
 func (cco *commmandContextOutput) string() string {
-	return cco.stdout.String() + cco.stderr.String()
+	return strings.TrimSpace(cco.stdout.String() + cco.stderr.String())
 }
 
 func (sf *shellFrontend) commandContextOutput(ctx context.Context, args ...string) (*commmandContextOutput, error) {

--- a/util/containerutil/shell_shared.go
+++ b/util/containerutil/shell_shared.go
@@ -1,0 +1,311 @@
+package containerutil
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	_ "github.com/moby/buildkit/client/connhelper/dockercontainer" // Load "docker-container://" helper.
+	"github.com/pkg/errors"
+)
+
+type shellFrontend struct {
+	binaryName        string
+	rootless          bool
+	compatibilityArgs []string
+}
+
+func (sf *shellFrontend) IsAvaliable(ctx context.Context) bool {
+	cmd := exec.CommandContext(ctx, sf.binaryName, "ps")
+	err := cmd.Run()
+	return err == nil
+}
+
+func (sf *shellFrontend) ContainerInfo(ctx context.Context, namesOrIDs ...string) (map[string]*ContainerInfo, error) {
+	args := append([]string{"container", "inspect"}, namesOrIDs...)
+
+	// Ignore the error. This is because one or more of the provided names or IDs could be missing.
+	// This allows for Info to report that the container itself is missing.
+	output, _ := sf.commandContextOutput(ctx, args...)
+
+	infos := map[string]*ContainerInfo{}
+	for _, nameOrID := range namesOrIDs {
+		// Pre-initialize all as missing. It will get overwritten when we encounter a real one from the actual output.
+		infos[nameOrID] = &ContainerInfo{
+			Name:   nameOrID,
+			Status: StatusMissing,
+		}
+	}
+
+	// Anonymous struct to just pick out what we need
+	containers := []struct {
+		ID    string `json:"Id"`
+		Name  string `json:"Name"`
+		State struct {
+			Status string `json:"Status"`
+		} `json:"State"`
+		NetworkSettings struct {
+			Networks map[string]struct {
+				IPAddress string `json:"IPAddress"`
+			} `json:"Networks"`
+		} `json:"NetworkSettings"`
+		Config struct {
+			Image  string            `json:"Image"`
+			Labels map[string]string `json:"Labels"`
+		} `json:"Config"`
+		Image string `json:"Image"`
+	}{}
+	json.Unmarshal([]byte(output.stdout.String()), &containers)
+
+	for i, container := range containers {
+		ipAddresses := map[string]string{}
+		for k, v := range container.NetworkSettings.Networks {
+			ipAddresses[k] = v.IPAddress
+		}
+
+		infos[namesOrIDs[i]] = &ContainerInfo{
+			ID:      container.ID,
+			Name:    container.Name,
+			Status:  container.State.Status,
+			IPs:     ipAddresses,
+			Image:   container.Config.Image,
+			ImageID: container.Image,
+			Labels:  container.Config.Labels,
+		}
+	}
+
+	return infos, nil
+}
+
+func (sf *shellFrontend) ContainerRemove(ctx context.Context, force bool, namesOrIDs ...string) error {
+	args := []string{"rm"}
+
+	if force {
+		args = append(args, "-f")
+	}
+
+	args = append(args, namesOrIDs...)
+
+	_, err := sf.commandContextOutput(ctx, args...)
+	return err
+}
+
+func (sf *shellFrontend) ContainerStop(ctx context.Context, timeoutSec uint, namesOrIDs ...string) error {
+	args := append([]string{"stop", "-t", strconv.FormatUint(uint64(timeoutSec), 10)}, namesOrIDs...)
+
+	_, err := sf.commandContextOutput(ctx, args...)
+	return err
+}
+
+func (sf *shellFrontend) ContainerLogs(ctx context.Context, namesOrIDs ...string) (map[string]*ContainerLogs, error) {
+	logs := map[string]*ContainerLogs{}
+	var err error
+
+	for _, nameOrId := range namesOrIDs {
+		// Don't use the wrapper so we can capture stderr and stdout individually
+		cmd := exec.CommandContext(ctx, sf.binaryName, "logs", nameOrId)
+
+		var stdout, stderr strings.Builder
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+
+		cmdErr := cmd.Run()
+		if cmdErr != nil {
+			err = multierror.Append(err, cmdErr)
+			continue
+		}
+		logs[nameOrId] = &ContainerLogs{
+			Stdout: stdout.String(),
+			Stderr: stderr.String(),
+		}
+	}
+
+	return logs, err
+}
+
+func (sf *shellFrontend) ContainerRun(ctx context.Context, containers ...ContainerRun) error {
+	var err error
+	for _, container := range containers {
+		args := []string{"run"}
+
+		if container.Privileged {
+			args = append(args, "--privileged")
+		}
+
+		for k, v := range container.Envs {
+			env := fmt.Sprintf("%s=%s", k, v)
+			args = append(args, "--env", env)
+		}
+
+		for k, v := range container.Labels {
+			label := fmt.Sprintf("%s=%s", k, v)
+			args = append(args, "--label", label)
+		}
+
+		for _, mnt := range container.Mounts {
+			mount := fmt.Sprintf("type=%s,source=%s,dst=%s", mnt.Type, mnt.Source, mnt.Dest)
+			// Older podmans do not support "readonly" as an option for the mount, but all CLIs so far support "ro"
+			// Also some older podmans interpret the presence of the "ro" flag existing at all as meaning readonly
+			if mnt.ReadOnly {
+				mount = fmt.Sprintf("%s,ro=%t", mount, mnt.ReadOnly)
+			}
+			args = append(args, "--mount", mount)
+		}
+
+		for _, prt := range container.Ports {
+			hostPort := strconv.FormatInt(int64(prt.HostPort), 10)
+			if prt.HostPort <= 0 {
+				// Docker allows 0 as a port for autoassign. Podman does not.
+				// Both honor omission to allow a random open host port.
+				hostPort = ""
+			}
+
+			port := fmt.Sprintf("%s:%v:%v", prt.IP, hostPort, prt.ContainerPort)
+
+			if prt.Protocol != "" {
+				// Unspecified protocol means we dont specify a protocol either.
+				port = fmt.Sprintf("%s/%s", port, prt.Protocol)
+			}
+
+			args = append(args, "--publish", port)
+		}
+
+		if sf.supportsPlatformArg(ctx) {
+			args = append(args, "--platform", getPlatform())
+		}
+
+		args = append(args, "-d") // Run detached, this feels implied by the API
+		args = append(args, "--name", container.NameOrID)
+		args = append(args, container.AdditionalArgs...)
+		args = append(args, sf.compatibilityArgs...)
+		args = append(args, container.ImageRef)
+		args = append(args, container.ContainerArgs...)
+
+		_, cmdErr := sf.commandContextOutput(ctx, args...)
+		if cmdErr != nil {
+			err = multierror.Append(err, cmdErr)
+		}
+	}
+
+	return err
+}
+
+func (sf *shellFrontend) ImageInfo(ctx context.Context, refs ...string) (map[string]*ImageInfo, error) {
+	args := append([]string{"image", "inspect"}, refs...)
+
+	// Ignore the error. This is because one or more of the provided refs could be missing.
+	// This allows for Info to report that the image itself is missing.
+	output, _ := sf.commandContextOutput(ctx, args...)
+
+	infos := map[string]*ImageInfo{}
+	for _, ref := range refs {
+		// Pre-initialize all as missing. It will get overwritten when we encounter a real one from the actual output.
+		infos[ref] = &ImageInfo{}
+	}
+
+	// Anonymous struct to just pick out what we need
+	images := []struct {
+		ID   string   `json:"Id"`
+		Tags []string `json:"RepoTags"`
+	}{}
+	json.Unmarshal([]byte(output.stdout.String()), &images)
+
+	for i, image := range images {
+		infos[refs[i]] = &ImageInfo{
+			ID:   image.ID,
+			Tags: image.Tags,
+		}
+	}
+
+	return infos, nil
+}
+
+func (sf *shellFrontend) ImagePull(ctx context.Context, refs ...string) error {
+	var err error
+	for _, ref := range refs {
+		_, cmdErr := sf.commandContextOutput(ctx, "pull", ref)
+		if cmdErr != nil {
+			err = multierror.Append(err, cmdErr)
+		}
+	}
+
+	return err
+}
+
+func (sf *shellFrontend) ImageRemove(ctx context.Context, force bool, refs ...string) error {
+	args := []string{"image", "rm"}
+	if force {
+		args = append(args, "-f")
+	}
+
+	args = append(args, refs...)
+
+	_, err := sf.commandContextOutput(ctx, args...)
+	return err
+}
+
+func (sf *shellFrontend) ImageTag(ctx context.Context, tags ...ImageTag) error {
+	var err error
+	for _, tag := range tags {
+		_, cmdErr := sf.commandContextOutput(ctx, "tag", tag.SourceRef, tag.TargetRef)
+		if cmdErr != nil {
+			multierror.Append(err)
+		}
+	}
+
+	return err
+}
+
+func (sf *shellFrontend) ImageLoad(ctx context.Context, images ...io.Reader) error {
+	var err error
+	for _, image := range images {
+		// Do not use the wrapper to allow the image to come in on stdin
+		cmd := exec.CommandContext(ctx, sf.binaryName, "load")
+		cmd.Stdin = image
+		output, cmdErr := cmd.CombinedOutput()
+		if cmdErr != nil {
+			err = multierror.Append(err, errors.Wrapf(cmdErr, "image load failed: %s", string(output)))
+		}
+	}
+
+	return err
+}
+
+type commmandContextOutput struct {
+	stdout strings.Builder
+	stderr strings.Builder
+}
+
+func (cco *commmandContextOutput) string() string {
+	return cco.stdout.String() + cco.stderr.String()
+}
+
+func (sf *shellFrontend) commandContextOutput(ctx context.Context, args ...string) (*commmandContextOutput, error) {
+	output := &commmandContextOutput{}
+
+	cmd := exec.CommandContext(ctx, sf.binaryName, args...)
+	cmd.Env = os.Environ() // Ensure all shellouts are using the current environment, picks up DOCKER_/PODMAN_ env vars when they matter
+	cmd.Stdout = &output.stdout
+	cmd.Stderr = &output.stderr
+
+	err := cmd.Run()
+	if err != nil {
+		return output, errors.Wrapf(err, "command failed: %s %s: %s: %s", sf.binaryName, strings.Join(args, " "), err.Error(), output.string())
+	}
+
+	return output, nil
+}
+
+func (sf *shellFrontend) supportsPlatformArg(ctx context.Context) bool {
+	// We can't run scratch, but the error is different depending on whether
+	// --platform is supported or not. This is faster than attempting to run
+	// an actual image which may require downloading.
+	output, _ := sf.commandContextOutput(ctx, "run", "--rm", "--platform", getPlatform(), "scratch")
+	return strings.Contains(output.string(), "Unable to find image")
+}

--- a/util/containerutil/shell_shared.go
+++ b/util/containerutil/shell_shared.go
@@ -255,7 +255,7 @@ func (sf *shellFrontend) ImageTag(ctx context.Context, tags ...ImageTag) error {
 	for _, tag := range tags {
 		_, cmdErr := sf.commandContextOutput(ctx, "tag", tag.SourceRef, tag.TargetRef)
 		if cmdErr != nil {
-			multierror.Append(err)
+			err = multierror.Append(err, cmdErr)
 		}
 	}
 

--- a/util/containerutil/shell_shared.go
+++ b/util/containerutil/shell_shared.go
@@ -107,9 +107,9 @@ func (sf *shellFrontend) ContainerLogs(ctx context.Context, namesOrIDs ...string
 	logs := map[string]*ContainerLogs{}
 	var err error
 
-	for _, nameOrId := range namesOrIDs {
+	for _, nameOrID := range namesOrIDs {
 		// Don't use the wrapper so we can capture stderr and stdout individually
-		cmd := exec.CommandContext(ctx, sf.binaryName, "logs", nameOrId)
+		cmd := exec.CommandContext(ctx, sf.binaryName, "logs", nameOrID)
 
 		var stdout, stderr strings.Builder
 		cmd.Stdout = &stdout
@@ -120,7 +120,7 @@ func (sf *shellFrontend) ContainerLogs(ctx context.Context, namesOrIDs ...string
 			err = multierror.Append(err, cmdErr)
 			continue
 		}
-		logs[nameOrId] = &ContainerLogs{
+		logs[nameOrID] = &ContainerLogs{
 			Stdout: stdout.String(),
 			Stderr: stderr.String(),
 		}

--- a/util/containerutil/stub.go
+++ b/util/containerutil/stub.go
@@ -1,0 +1,64 @@
+package containerutil
+
+import (
+	"context"
+	"io"
+)
+
+// This is a stub for use in internal testing when its too much effort to provide a legitimate backend.
+// Should never be used IRL.
+type stubFrontend struct{}
+
+// NewStubFrontend creates a stubbed frontend. Useful in cases where a frontend could not be detected, but we still need a frontend.
+// Examples include earthly/earthly, or integration tests. It is currently only used as a fallback when docker or other frontends are missing.
+func NewStubFrontend(ctx context.Context) (ContainerFrontend, error) {
+	return &stubFrontend{}, nil
+}
+
+func (*stubFrontend) Scheme() string {
+	return ""
+}
+func (*stubFrontend) IsAvaliable(ctx context.Context) bool {
+	return true
+}
+func (*stubFrontend) Config() *FrontendConfig {
+	return &FrontendConfig{
+		Setting: FrontendStub,
+	}
+}
+func (*stubFrontend) Information(ctx context.Context) (*FrontendInfo, error) {
+	return &FrontendInfo{}, nil
+}
+func (*stubFrontend) ContainerInfo(ctx context.Context, namesOrIDs ...string) (map[string]*ContainerInfo, error) {
+	return make(map[string]*ContainerInfo), nil
+}
+func (*stubFrontend) ContainerRemove(ctx context.Context, force bool, namesOrIDs ...string) error {
+	return nil
+}
+func (*stubFrontend) ContainerStop(ctx context.Context, timeoutSec uint, namesOrIDs ...string) error {
+	return nil
+}
+func (*stubFrontend) ContainerLogs(ctx context.Context, namesOrIDs ...string) (map[string]*ContainerLogs, error) {
+	return make(map[string]*ContainerLogs), nil
+}
+func (*stubFrontend) ContainerRun(ctx context.Context, containers ...ContainerRun) error {
+	return nil
+}
+func (*stubFrontend) ImageInfo(ctx context.Context, refs ...string) (map[string]*ImageInfo, error) {
+	return make(map[string]*ImageInfo), nil
+}
+func (*stubFrontend) ImagePull(ctx context.Context, refs ...string) error {
+	return nil
+}
+func (*stubFrontend) ImageRemove(ctx context.Context, force bool, refs ...string) error {
+	return nil
+}
+func (*stubFrontend) ImageTag(ctx context.Context, tags ...ImageTag) error {
+	return nil
+}
+func (*stubFrontend) ImageLoad(ctx context.Context, image ...io.Reader) error {
+	return nil
+}
+func (*stubFrontend) VolumeInfo(ctx context.Context, volumeNames ...string) (map[string]*VolumeInfo, error) {
+	return make(map[string]*VolumeInfo), nil
+}

--- a/util/containerutil/types.go
+++ b/util/containerutil/types.go
@@ -1,0 +1,113 @@
+package containerutil
+
+// ContainerInfo is a representation of things we may care about from inspect output for a given container.
+type ContainerInfo struct {
+	ID      string
+	Name    string
+	Status  string
+	IPs     map[string]string
+	Image   string
+	ImageID string
+	Labels  map[string]string
+}
+
+const (
+	StatusMissing    = "missing"
+	StatusCreated    = "created"
+	StatusRestarting = "restarting"
+	StatusRunning    = "running"
+	StatusRemoving   = "removing"
+	StatusPaused     = "paused"
+	StatusExited     = "exited"
+	StatusDead       = "dead"
+)
+
+type ContainerLogs struct {
+	Stdout string
+	Stderr string
+}
+
+type FrontendInfo struct {
+	ClientVersion    string
+	ClientAPIVersion string
+	ClientPlatform   string
+
+	ServerVersion    string
+	ServerAPIVersion string
+	ServerPlatform   string
+	ServerAddress    string
+}
+
+type ImageInfo struct {
+	ID   string
+	Tags []string
+}
+
+type VolumeInfo struct {
+	Name       string
+	Mountpoint string
+	Size       uint64
+}
+
+type ImageTag struct {
+	SourceRef string
+	TargetRef string
+}
+
+type MountType string
+
+const (
+	MountBind   = MountType("bind")
+	MountVolume = MountType("volume")
+)
+
+type Mount struct {
+	Type     MountType
+	Source   string
+	Dest     string
+	ReadOnly bool
+}
+type MountOpt []Mount
+
+type ProtocolType string
+
+const (
+	ProtocolTCP = ProtocolType("tcp")
+	ProtocolUDP = ProtocolType("udp")
+)
+
+type Port struct {
+	IP            string
+	HostPort      int
+	ContainerPort int
+	Protocol      ProtocolType
+}
+type PortOpt []Port
+
+type EnvMap map[string]string
+
+type LabelMap map[string]string
+type ContainerRun struct {
+	NameOrID      string
+	ImageRef      string
+	Privileged    bool
+	Envs          EnvMap
+	Labels        LabelMap
+	Mounts        MountOpt
+	Ports         PortOpt
+	ContainerArgs []string
+
+	// We would like to shift to the non-shell providers. However, we do provide an option for supplying
+	// additional arguments to the CLI when starting buildkit. While this allowed great flexibility, we
+	// also do not know what or how it is being used. This gives us the option to support those users until
+	// we decide to pull the plug. This argument is ignored by non-shell providers.
+	AdditionalArgs []string
+}
+
+const (
+	FrontendAutomatic   = "automatic"
+	FrontendDocker      = "docker"
+	FrontendDockerShell = "docker-shell"
+	FrontendPodman      = "podman"
+	FrontendPodmanShell = "podman-shell"
+)

--- a/util/containerutil/types.go
+++ b/util/containerutil/types.go
@@ -1,6 +1,6 @@
 package containerutil
 
-// ContainerInfo is a representation of things we may care about from inspect output for a given container.
+// ContainerInfo contains things we may care about from inspect output for a given container.
 type ContainerInfo struct {
 	ID      string
 	Name    string
@@ -12,21 +12,38 @@ type ContainerInfo struct {
 }
 
 const (
-	StatusMissing    = "missing"
-	StatusCreated    = "created"
+	// StatusMissing signifies that a container is not present.
+	StatusMissing = "missing"
+
+	// StatusCreated signifies that a container has been created, but not started.
+	StatusCreated = "created"
+
+	// StatusRestarting signifies that a container has started, stopped, and is currently restarting.
 	StatusRestarting = "restarting"
-	StatusRunning    = "running"
-	StatusRemoving   = "removing"
-	StatusPaused     = "paused"
-	StatusExited     = "exited"
-	StatusDead       = "dead"
+
+	// StatusRunning signifies that a container is currently running.
+	StatusRunning = "running"
+
+	// StatusRemoving signifies that a container has exited and is currently being removed.
+	StatusRemoving = "removing"
+
+	// StatusPaused means a container has been suspended.
+	StatusPaused = "paused"
+
+	// StatusExited means that a container was running and has been stopped, but not removed.
+	StatusExited = "exited"
+
+	// StatusDead means that a container was killed for some reason and has not yet been restarted.
+	StatusDead = "dead"
 )
 
+// ContainerLogs contains the stdout and stderr logs of a given container.
 type ContainerLogs struct {
 	Stdout string
 	Stderr string
 }
 
+// FrontendInfo contains the client and server information for a frontend.
 type FrontendInfo struct {
 	ClientVersion    string
 	ClientAPIVersion string
@@ -38,55 +55,76 @@ type FrontendInfo struct {
 	ServerAddress    string
 }
 
+// ImageInfo contains information about a given image ref, including all relevant tags.
 type ImageInfo struct {
 	ID   string
 	Tags []string
 }
 
+// VolumeInfo contains information about a given volume, including its name, where its mounted from, and the size of the volume.
 type VolumeInfo struct {
 	Name       string
 	Mountpoint string
 	Size       uint64
 }
 
+// ImageTag contains a source and target ref, used for tagging an image. It means that the SourceRef is tagged as the value in TargetRef.
 type ImageTag struct {
 	SourceRef string
 	TargetRef string
 }
 
+// MountType constrains the kinds of mounts the Frontend API needs to support. Current valid values are bind and volume.
 type MountType string
 
 const (
-	MountBind   = MountType("bind")
+	// MountBind is the bind MountType
+	MountBind = MountType("bind")
+
+	// MountVolume is the volume MountType
 	MountVolume = MountType("volume")
 )
 
+// Mount contains the needed data to construct a mount for a container in a given frontend.
 type Mount struct {
 	Type     MountType
 	Source   string
 	Dest     string
 	ReadOnly bool
 }
+
+// MountOpt is a list of Mounts to perform
 type MountOpt []Mount
 
+// ProtocolType constrains the kinds of protocols the frontend API needs to support. Current valid values are tcp and udp.
 type ProtocolType string
 
 const (
+	// ProtocolTCP is the TCP protocol type
 	ProtocolTCP = ProtocolType("tcp")
+
+	// ProtocolUDP is the UDP protocol type
 	ProtocolUDP = ProtocolType("udp")
 )
 
+// Port contains the needed data to publish a port for a given container in a given frontend.
 type Port struct {
 	IP            string
 	HostPort      int
 	ContainerPort int
 	Protocol      ProtocolType
 }
+
+// PortOpt is a list of Ports to publish
 type PortOpt []Port
 
+// EnvMap is a map of environment variable names (key) to values. Values must be strings.
 type EnvMap map[string]string
 
+// LabelMap is a map of label names (key) to values. Values must be strings.
 type LabelMap map[string]string
+
+// ContainerRun contains the information needed to create and run a container.
 type ContainerRun struct {
 	NameOrID      string
 	ImageRef      string
@@ -105,13 +143,23 @@ type ContainerRun struct {
 }
 
 const (
-	FrontendAuto        = "auto"
-	FrontendDocker      = "docker"
+	// FrontendAuto is automatic frontend detection.
+	FrontendAuto = "auto"
+
+	// FrontendDocker forces usage of the (future, currently unimplemented) docker API for container operations.
+	FrontendDocker = "docker"
+
+	// FrontendDockerShell forces usage of the docker binary for container operations.
 	FrontendDockerShell = "docker-shell"
-	FrontendPodman      = "podman"
+
+	// FrontendPodman forces usage of the (future, currently unimplemented) podman API for container operations.
+	FrontendPodman = "podman"
+
+	// FrontendPodmanShell forces usage of the podman binary for container operations.
 	FrontendPodmanShell = "podman-shell"
 )
 
+// FrontendConfig contains information about the current container frontend. Useful when the frontend was configured using FrontendAuto for deciding transport.
 type FrontendConfig struct {
 	Setting string
 	Binary  string
@@ -119,6 +167,9 @@ type FrontendConfig struct {
 }
 
 const (
+	// FrontendTypeShell signifies that a given frontend is using an external binary via shell.
 	FrontendTypeShell = "shell"
-	FrontendTypeAPI   = "api"
+
+	// FrontendTypeAPI signifies that a given frontend is using an API, typically through some external daemon.
+	FrontendTypeAPI = "api"
 )

--- a/util/containerutil/types.go
+++ b/util/containerutil/types.go
@@ -158,7 +158,7 @@ const (
 	// FrontendPodmanShell forces usage of the podman binary for container operations.
 	FrontendPodmanShell = "podman-shell"
 
-	// frontendStub is for when there is no valid provider but attempting to run anyways is desired; like integration tests, or the earthly/earthly image when NO_DOCKER is set.
+	// FrontendStub is for when there is no valid provider but attempting to run anyways is desired; like integration tests, or the earthly/earthly image when NO_DOCKER is set.
 	FrontendStub = "stub"
 )
 

--- a/util/containerutil/types.go
+++ b/util/containerutil/types.go
@@ -105,9 +105,20 @@ type ContainerRun struct {
 }
 
 const (
-	FrontendAutomatic   = "automatic"
+	FrontendAuto        = "auto"
 	FrontendDocker      = "docker"
 	FrontendDockerShell = "docker-shell"
 	FrontendPodman      = "podman"
 	FrontendPodmanShell = "podman-shell"
+)
+
+type FrontendConfig struct {
+	Setting string
+	Binary  string
+	Type    string
+}
+
+const (
+	FrontendTypeShell = "shell"
+	FrontendTypeAPI   = "api"
 )

--- a/util/containerutil/types.go
+++ b/util/containerutil/types.go
@@ -157,6 +157,9 @@ const (
 
 	// FrontendPodmanShell forces usage of the podman binary for container operations.
 	FrontendPodmanShell = "podman-shell"
+
+	// frontendStub is for when there is no valid provider but attempting to run anyways is desired; like integration tests, or the earthly/earthly image when NO_DOCKER is set.
+	FrontendStub = "stub"
 )
 
 // FrontendConfig contains information about the current container frontend. Useful when the frontend was configured using FrontendAuto for deciding transport.


### PR DESCRIPTION
Adds podman as a compatible frontend for Earthly to use when exporting images, and running buildkit. Podman works in rootless and rootful modes, daemonless or not. As far as I have tested.

Also, autodetects some compatibility issues and ensures they are properly dealt with rather than relying on user configuration.

---

Its a draft for now, a few more tweaks need to be made and GoDoc comments to pass the linter. Its necessarily a large PR (I mean, creating the seam for pluggable container frontends was just touching a _lot_ of code), so any head start is probably worth it in reviewing.