### PR TITLE
Merge github, dockerhub, and homebrew release into one command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,17 +48,17 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 
 ## v0.5.18 - 2021-07-08
 
-* Added a `--symlink-no-follow` flag to allow copying invalid symbolic links (https://github.com/earthly/earthly/issues/1067)
-* Updated buildkit, which contains a fix for "failed to get edge" panic errors (https://github.com/earthly/earthly/issues/1016)
-* Fix bug that prevented using an absolute path to reference targets which contained relative imports
-* Added option to disable analytics data collection when environment variables `EARTHLY_DISABLE_ANALYTICS` or `DO_NOT_TRACK` are set.
-* Include version and help flags in autocompletion output.
+- Added a `--symlink-no-follow` flag to allow copying invalid symbolic links (https://github.com/earthly/earthly/issues/1067)
+- Updated buildkit, which contains a fix for "failed to get edge" panic errors (https://github.com/earthly/earthly/issues/1016)
+- Fix bug that prevented using an absolute path to reference targets which contained relative imports
+- Added option to disable analytics data collection when environment variables `EARTHLY_DISABLE_ANALYTICS` or `DO_NOT_TRACK` are set.
+- Include version and help flags in autocompletion output.
 
 ## v0.5.17 - 2021-06-15
 
-* Begin experimental official support for `earthly/earthly` and `earthly/buildkitd` images; including a new `entrypoint` for `earthly/earthly` (https://github.com/earthly/earthly/pull/1050)
-* When running in `verbose` mode, log all files sent to buildkit (https://github.com/earthly/earthly/pull/1051, https://github.com/earthly/earthly/pull/1056)
-* Adjust `deb` and `rpm` packages to auto-install the shell completions though post-installation mechanisms (https://github.com/earthly/earthly/pull/1019, https://github.com/earthly/earthly/pull/1057)
+- Begin experimental official support for `earthly/earthly` and `earthly/buildkitd` images; including a new `entrypoint` for `earthly/earthly` (https://github.com/earthly/earthly/pull/1050)
+- When running in `verbose` mode, log all files sent to buildkit (https://github.com/earthly/earthly/pull/1051, https://github.com/earthly/earthly/pull/1056)
+- Adjust `deb` and `rpm` packages to auto-install the shell completions though post-installation mechanisms (https://github.com/earthly/earthly/pull/1019, https://github.com/earthly/earthly/pull/1057)
 
 ## v0.5.16 - 2021-06-03
 
@@ -67,23 +67,23 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 
 ## v0.5.15 - 2021-05-27
 
-* `earthly config` is no longer experimental. (https://github.com/earthly/earthly/pull/979)
-* Running a target, will now `bootstrap` automatically, if it looks like `earthly bootstrap` has not been run yet. (https://github.com/earthly/earthly/pull/989)
-* `earthly bootstrap` ensures the permissions on the `.earthly` folder are correct (belonging to the user) ( https://github.com/earthly/earthly/pull/993)
-* Cache mount ID now depends on a target input hash which does not include inactive variables (https://github.com/earthly/earthly/pull/1000)
-* Added `EARTHLY_TARGET_PROJECT_NO_TAG` built-in argument (https://github.com/earthly/earthly/pull/1011)
-* When `~` is used as the path to a secret file, it now expands as expected. (https://github.com/earthly/earthly/pull/977)
-* Use the environment-specified `$HOME`, unless `$SUDO_USER` is set. If it is, use the users home directory. (https://github.com/earthly/earthly/pull/1015)
+- `earthly config` is no longer experimental. (https://github.com/earthly/earthly/pull/979)
+- Running a target, will now `bootstrap` automatically, if it looks like `earthly bootstrap` has not been run yet. (https://github.com/earthly/earthly/pull/989)
+- `earthly bootstrap` ensures the permissions on the `.earthly` folder are correct (belonging to the user) ( https://github.com/earthly/earthly/pull/993)
+- Cache mount ID now depends on a target input hash which does not include inactive variables (https://github.com/earthly/earthly/pull/1000)
+- Added `EARTHLY_TARGET_PROJECT_NO_TAG` built-in argument (https://github.com/earthly/earthly/pull/1011)
+- When `~` is used as the path to a secret file, it now expands as expected. (https://github.com/earthly/earthly/pull/977)
+- Use the environment-specified `$HOME`, unless `$SUDO_USER` is set. If it is, use the users home directory. (https://github.com/earthly/earthly/pull/1015)
 
 
 ## v0.5.14 - 2021-05-27
 
-* `earthly config` is no longer experimental. (https://github.com/earthly/earthly/pull/979)
-* Running a target, will now `bootstrap` automatically, if it looks like `earthly bootstrap` has not been run yet. (https://github.com/earthly/earthly/pull/989)
-* `earthly bootstrap` ensures the permissions on the `.earthly` folder are correct (belonging to the user) ( https://github.com/earthly/earthly/pull/993)
-* Cache mount ID now depends on a target input hash which does not include inactive variables (https://github.com/earthly/earthly/pull/1000)
-* Added `EARTHLY_TARGET_PROJECT_NO_TAG` built-in argument (https://github.com/earthly/earthly/pull/1011)
-* When `~` is used as the path to a secret file, it now expands as expected. (https://github.com/earthly/earthly/pull/977)
+- `earthly config` is no longer experimental. (https://github.com/earthly/earthly/pull/979)
+- Running a target, will now `bootstrap` automatically, if it looks like `earthly bootstrap` has not been run yet. (https://github.com/earthly/earthly/pull/989)
+- `earthly bootstrap` ensures the permissions on the `.earthly` folder are correct (belonging to the user) ( https://github.com/earthly/earthly/pull/993)
+- Cache mount ID now depends on a target input hash which does not include inactive variables (https://github.com/earthly/earthly/pull/1000)
+- Added `EARTHLY_TARGET_PROJECT_NO_TAG` built-in argument (https://github.com/earthly/earthly/pull/1011)
+- When `~` is used as the path to a secret file, it now expands as expected. (https://github.com/earthly/earthly/pull/977)
 
 
 ## v0.5.13 - 2021-05-13
@@ -92,53 +92,44 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 
 ## v0.5.12 - 2021-05-07
 
-* Adds a retry for remote Buildkit hosts when using the `EARTHLY_BUILDKIT_HOST` configuration option. (#952)
-* Re-fetch credentials when they expire (#957)
-* Make use of `~/.netrc` credentials when no config is set under `~/.earthly/config.yml` (#964)
-* Make use of auth credentials when performing a GIT CLONE command within an Earthfile. (#964)
-* Improved error output when desired secret does not exist, including the name of the missing secret. (#972)
-* Warn if `build-arg` appears after the target in CLI invocations.(#959)
+- Adds a retry for remote Buildkit hosts when using the `EARTHLY_BUILDKIT_HOST` configuration option. (#952)
+- Re-fetch credentials when they expire (#957)
+- Make use of `~/.netrc` credentials when no config is set under `~/.earthly/config.yml` (#964)
+- Make use of auth credentials when performing a GIT CLONE command within an Earthfile. (#964)
+- Improved error output when desired secret does not exist, including the name of the missing secret. (#972)
+- Warn if `build-arg` appears after the target in CLI invocations.(#959)
 
 ## v0.5.11 - 2021-04-27
 
-Changes:
-
-* Support for `FROM DOCKERFILE -f` (https://github.com/earthly/earthly/pull/950)
-* Fixes missing access to global arguments in user defined commands (https://github.com/earthly/earthly/pull/947)
-* Users's `~/.earthly` directory is now referenced when earthly is invoked with sudo
+- Support for `FROM DOCKERFILE -f` (https://github.com/earthly/earthly/pull/950)
+- Fixes missing access to global arguments in user defined commands (https://github.com/earthly/earthly/pull/947)
+- Users's `~/.earthly` directory is now referenced when earthly is invoked with sudo
 
 
 ## v0.5.10 - 2021-04-19
 
-Changes:
-
-* Added ability to run `WITH DOCKER` under `LOCALLY` (https://github.com/earthly/earthly/pull/840)
-* Fix `FROM DOCKERFILE` `--build-arg`s not being passed correctly (https://github.com/earthly/earthly/issues/932)
-* Docs: Add uninstall instructions
-* Docs: Improve onboarding tutorial based on user feedback
+- Added ability to run `WITH DOCKER` under `LOCALLY` (https://github.com/earthly/earthly/pull/840)
+- Fix `FROM DOCKERFILE` `--build-arg`s not being passed correctly (https://github.com/earthly/earthly/issues/932)
+- Docs: Add uninstall instructions
+- Docs: Improve onboarding tutorial based on user feedback
 
 
 ## v0.5.9 - 2021-04-05
 
-Changes:
-
-* [**experimental**] Improved parallelization when using commands such as `IF`, `WITH DOCKER`, `FROM DOCKERFILE`, `ARG X=$(...)` and others. To enable this feature, pass `--conversion-parallelism=5` or set `EARTHLY_CONVERSION_PARALLELISM=5`. (https://github.com/earthly/earthly/issues/888)
-* Auto-detect MTU (https://github.com/earthly/earthly/issues/847)
-* MTU may set via config `earthly config global.cni_mtu 12345` (https://github.com/earthly/earthly/pull/906)
-* Hide `--debug` flag since it is only used for development on Earthly itself
-* Download and start buildkitd as part of the earthly bootstrap command
-* Improved buildkitd startup logic (https://github.com/earthly/earthly/pull/892)
-* Check for reserved target names and disallow them (e.g. `+base`) (https://github.com/earthly/earthly/pull/898)
-* Fix use of self-hosted repos when a subdirectory is used (https://github.com/earthly/earthly/pull/897)
+- [**experimental**] Improved parallelization when using commands such as `IF`, `WITH DOCKER`, `FROM DOCKERFILE`, `ARG X=$(...)` and others. To enable this feature, pass `--conversion-parallelism=5` or set `EARTHLY_CONVERSION_PARALLELISM=5`. (https://github.com/earthly/earthly/issues/888)
+- Auto-detect MTU (https://github.com/earthly/earthly/issues/847)
+- MTU may set via config `earthly config global.cni_mtu 12345` (https://github.com/earthly/earthly/pull/906)
+- Hide `--debug` flag since it is only used for development on Earthly itself
+- Download and start buildkitd as part of the earthly bootstrap command
+- Improved buildkitd startup logic (https://github.com/earthly/earthly/pull/892)
+- Check for reserved target names and disallow them (e.g. `+base`) (https://github.com/earthly/earthly/pull/898)
+- Fix use of self-hosted repos when a subdirectory is used (https://github.com/earthly/earthly/pull/897)
 
 
 ## v0.5.8 - 2021-03-23
 
-
-Changes:
-
-* [**experimental**] Support for ARGs in user-defined commands (UDCs). UDCs are templates (much like functions in regular programming languages), which can be used to define a series of steps to be executed in sequence. In other words, it is a way to reuse common build steps in multiple contexts. This completes the implementation of UDCs and the feature is now in **experimental** phase (https://github.com/earthly/earthly/issues/581). For more information see the [UDC guide](https://docs.earthly.dev/guides/udc).
-* [**experimental**] New command: `IMPORT` (https://github.com/earthly/earthly/pull/868)
+- [**experimental**] Support for ARGs in user-defined commands (UDCs). UDCs are templates (much like functions in regular programming languages), which can be used to define a series of steps to be executed in sequence. In other words, it is a way to reuse common build steps in multiple contexts. This completes the implementation of UDCs and the feature is now in **experimental** phase (https://github.com/earthly/earthly/issues/581). For more information see the [UDC guide](https://docs.earthly.dev/guides/udc).
+- [**experimental**] New command: `IMPORT` (https://github.com/earthly/earthly/pull/868)
   ```
   IMPORT github.com/foo/bar:v1.2.3
   IMPORT github.com/foo/buz:main AS zulu
@@ -148,12 +139,11 @@ Changes:
   FROM bar+target
   BUILD zulu+something
   ```
-* Fix handling of some escaped quotes (https://github.com/earthly/earthly/issues/859)
-* Fix: empty targets are now valid (https://github.com/earthly/earthly/pull/872)
-* Fix some line continuation issues (https://github.com/earthly/earthly/pull/873 & https://github.com/earthly/earthly/pull/874)
-* Earthly now limits parallelism to `20`. This fixes some very large builds attempting to use resources all at the same time
-* Automatically retry TLS handshake timeout errors
-
+- Fix handling of some escaped quotes (https://github.com/earthly/earthly/issues/859)
+- Fix: empty targets are now valid (https://github.com/earthly/earthly/pull/872)
+- Fix some line continuation issues (https://github.com/earthly/earthly/pull/873 & https://github.com/earthly/earthly/pull/874)
+- Earthly now limits parallelism to `20`. This fixes some very large builds attempting to use resources all at the same time
+- Automatically retry TLS handshake timeout errors
 
 ## v0.5.7 - 2021-03-13
 
@@ -171,70 +161,65 @@ This release removes the `ongoing` updates "Provide intermittent updates on long
 
 ## v0.5.5 - 2021-03-08
 
-* Keep `.git` directory in build context. (#815 )
-* Wait extra time for buildkitd to start if the cache is larger than 30 GB  (#827)
-* *Experimental:* Allow RUN commands to open an interactive session (`RUN --interactive`), with the option to save the manual changes into the final image (`RUN --interactive-keep`) (#833)
-* Provide intermittent updates on long-running targets (#844)
-* Fix ZSH autocompletion in some instances (#838)
+- Keep `.git` directory in build context. (#815 )
+- Wait extra time for buildkitd to start if the cache is larger than 30 GB  (#827)
+- *Experimental:* Allow RUN commands to open an interactive session (`RUN --interactive`), with the option to save the manual changes into the final image (`RUN --interactive-keep`) (#833)
+- Provide intermittent updates on long-running targets (#844)
+- Fix ZSH autocompletion in some instances (#838)
 
 ## v0.5.4 - 2021-02-26
 
-* New experimental `--strict` flag, which doesn't allow the use of `LOCALLY`. `--strict` is now implied when using `--ci`. (https://github.com/earthly/earthly/pull/801)
-* Add help text when issuing `earthly config <item> --help`. Improved user experience. (https://github.com/earthly/earthly/pull/814)
-* Detect if the build doesn't start with a FROM-like command and return a meaningful error. Previously `FROM scratch` was assumed automatically. (https://github.com/earthly/earthly/issues/807)
-* Fix an issue where `.tmpXXXXX` directories were created in the current directory (https://github.com/earthly/earthly/pull/821)
-* Fix auto-complete in zsh (https://github.com/earthly/earthly/pull/811)
-* Improved startup logic for buildkit daemon, which speeds up some rare edge cases (https://github.com/earthly/earthly/pull/808)
-* Print buildkit logs if it crashes or times out on startup (https://github.com/earthly/earthly/pull/819)
-* Create config path if it's missing (https://github.com/earthly/earthly/pull/812)
+- New experimental `--strict` flag, which doesn't allow the use of `LOCALLY`. `--strict` is now implied when using `--ci`. (https://github.com/earthly/earthly/pull/801)
+- Add help text when issuing `earthly config <item> --help`. Improved user experience. (https://github.com/earthly/earthly/pull/814)
+- Detect if the build doesn't start with a FROM-like command and return a meaningful error. Previously `FROM scratch` was assumed automatically. (https://github.com/earthly/earthly/issues/807)
+- Fix an issue where `.tmpXXXXX` directories were created in the current directory (https://github.com/earthly/earthly/pull/821)
+- Fix auto-complete in zsh (https://github.com/earthly/earthly/pull/811)
+- Improved startup logic for buildkit daemon, which speeds up some rare edge cases (https://github.com/earthly/earthly/pull/808)
+- Print buildkit logs if it crashes or times out on startup (https://github.com/earthly/earthly/pull/819)
+- Create config path if it's missing (https://github.com/earthly/earthly/pull/812)
 
 
 ## v0.5.3 - 2021-02-24
 
-Changes
- - Support for conditional logic using new `IF`, `ELSE IF`, and `ELSE` keywords (required for #779)
- - Support for copying artifacts to `LOCALLY` targets (required for #580)
- - bugfix: segfault when no output or error is displayed (fixes #798)
- - bugfix: unable to run earthly in docker container with mounted host-docker socket (fixes #791)
- - bugfix: `./.tmp-earthly-outXXXXXX` temp files are now stored under `./.tmp-earthly-out/tmpXXXXXX` and are correctly excluded from the builld context 
+- Support for conditional logic using new `IF`, `ELSE IF`, and `ELSE` keywords (required for #779)
+- Support for copying artifacts to `LOCALLY` targets (required for #580)
+- bugfix: segfault when no output or error is displayed (fixes #798)
+- bugfix: unable to run earthly in docker container with mounted host-docker socket (fixes #791)
+- bugfix: `./.tmp-earthly-outXXXXXX` temp files are now stored under `./.tmp-earthly-out/tmpXXXXXX` and are correctly excluded from the builld context 
 
 
 ## v0.5.2 - 2021-02-18
 
-Changes:
-
-* New experimental command for editing the Earthly config (https://github.com/earthly/earthly/issues/675)
-* `SAVE IMAGE --push` after a `RUN --push` now includes the effects of the `RUN --push` too (https://github.com/earthly/earthly/pull/754)
-* Improved syntax errors when parsing Earthfiles
-* Improved error message when QEMU is missing
-* Fix `earthly-linux-arm64` binary - was a Mac binary by mistake (https://github.com/earthly/earthly/issues/789)
-* Fix override of build arg not being detected properly (https://github.com/earthly/earthly/pull/790)
-* Fix image export error when it doesn't contain any `RUN` commands (https://github.com/earthly/earthly/issues/782)
+- New experimental command for editing the Earthly config (https://github.com/earthly/earthly/issues/675)
+- `SAVE IMAGE --push` after a `RUN --push` now includes the effects of the `RUN --push` too (https://github.com/earthly/earthly/pull/754)
+- Improved syntax errors when parsing Earthfiles
+- Improved error message when QEMU is missing
+- Fix `earthly-linux-arm64` binary - was a Mac binary by mistake (https://github.com/earthly/earthly/issues/789)
+- Fix override of build arg not being detected properly (https://github.com/earthly/earthly/pull/790)
+- Fix image export error when it doesn't contain any `RUN` commands (https://github.com/earthly/earthly/issues/782)
 
 
 ## v0.5.1 - 2021-02-08
 
-Changes
- - Support for SAVE ARTIFACT under LOCALLY contexts; this allows one to run a command locally and save the output to a different container.
- - Support for build arg matrix; supplying multiple `--build-args` for the same value will cause the `BUILD` target to be built for each different build arg value.
- - Improvements for Apple M1 support
- - Improved errors when parsing invalid Earthfiles (to enable the new experimental code, set the `EARTHLY_ENABLE_AST` variable to `true`)
+- Support for SAVE ARTIFACT under LOCALLY contexts; this allows one to run a command locally and save the output to a different container.
+- Support for build arg matrix; supplying multiple `--build-args` for the same value will cause the `BUILD` target to be built for each different build arg value.
+- Improvements for Apple M1 support
+- Improved errors when parsing invalid Earthfiles (to enable the new experimental code, set the `EARTHLY_ENABLE_AST` variable to `true`)
 
 ## v0.5.0 - 2021-02-01
 
-Changes:
-* Switch to BSL license. For [more information about this decision, take a look at our blog post](https://blog.earthly.dev/every-open-core-company-should-be-a-source-available-company/).
-* `--platform` setting is now automatically propagated between Earthfiles. In addition, you can now specify the empty string `--platform=` to automatically detect your system's architecture.
-* `earthly/dind` images now available for `linux/arm/v7` and `linux/arm64`
-* Improved visibility of platform used for each build step, as well as for any build args that have been overridden.
-* Allow saving an artifact after a `RUN --push` (https://github.com/earthly/earthly/pull/735)
-* Allow specifying `--no-cache` for a single `RUN` command (https://github.com/earthly/earthly/issues/585)
-* There are now separate `SUCCESS` lines for each of the two possible phases of an earthly run: `main` and `push`.
-* [Support of popular cloud registries for the experimental shared cache feature is now properly documented](https://docs.earthly.dev/guides/shared-cache#compatibility-with-major-registry-providers)
-* Fix `SAVE IMAGE --cache-hint` not working correctly (https://github.com/earthly/earthly/issues/744)
-* Fix `i/o timeout` errors being cached and requiring BuildKit restart
-* Experimental support for running commands on the host system via `LOCALLY` (https://github.com/earthly/earthly/issues/580)
-* Bug fixes for Apple Silicon. `earthly-darwin-arm64` binary is now available. Please treat this version as highly experimental for now. (https://github.com/earthly/earthly/issues/722)
+- Switch to BSL license. For [more information about this decision, take a look at our blog post](https://blog.earthly.dev/every-open-core-company-should-be-a-source-available-company/).
+- `--platform` setting is now automatically propagated between Earthfiles. In addition, you can now specify the empty string `--platform=` to automatically detect your system's architecture.
+- `earthly/dind` images now available for `linux/arm/v7` and `linux/arm64`
+- Improved visibility of platform used for each build step, as well as for any build args that have been overridden.
+- Allow saving an artifact after a `RUN --push` (https://github.com/earthly/earthly/pull/735)
+- Allow specifying `--no-cache` for a single `RUN` command (https://github.com/earthly/earthly/issues/585)
+- There are now separate `SUCCESS` lines for each of the two possible phases of an earthly run: `main` and `push`.
+- [Support of popular cloud registries for the experimental shared cache feature is now properly documented](https://docs.earthly.dev/guides/shared-cache#compatibility-with-major-registry-providers)
+- Fix `SAVE IMAGE --cache-hint` not working correctly (https://github.com/earthly/earthly/issues/744)
+- Fix `i/o timeout` errors being cached and requiring BuildKit restart
+- Experimental support for running commands on the host system via `LOCALLY` (https://github.com/earthly/earthly/issues/580)
+- Bug fixes for Apple Silicon. `earthly-darwin-arm64` binary is now available. Please treat this version as highly experimental for now. (https://github.com/earthly/earthly/issues/722)
 
 ## v0.5.0-rc2 - 2021-02-01
 
@@ -250,29 +235,26 @@ No details provided
 
 ## v0.4.5 - 2021-01-13
 
- * Fix inconsistent `COPY --dir` behavior [https://github.com/earthly/earthly/issues/705](#705)
- * Fix `AS LOCAL` behavior with directories [https://github.com/earthly/earthly/issues/703](#703)
+- Fix inconsistent `COPY --dir` behavior [https://github.com/earthly/earthly/issues/705](#705)
+- Fix `AS LOCAL` behavior with directories [https://github.com/earthly/earthly/issues/703](#703)
 
 ## v0.4.4 - 2021-01-06
 
-Changes:
-* Improved experimental support for arm-based platforms, including Apple M1. Builds run natively on arm platforms now. (For Apple M1, you need to use darwin-amd64 download and have Rosetta 2 installed - the build steps themselves will run natively, however, via the buildkit daemon).
-* Add `SAVE ARTIFACT --if-exists` (https://github.com/earthly/earthly/issues/588)
-* Fix an issue where comments at the end of the Earthfile were not allowed (https://github.com/earthly/earthly/issues/681)
-* Fix an issue where multiple `WITH DOCKER --load` with the same target, but different image tag were not working (https://github.com/earthly/earthly/issues/685)
-* Fix an issue where `SAVE ARTIFACT ./* AS LOCAL` was flattening subdirectories (https://github.com/earthly/earthly/issues/689)
-* Binaries for `arm5` and `arm6` are no longer supported
+- Improved experimental support for arm-based platforms, including Apple M1. Builds run natively on arm platforms now. (For Apple M1, you need to use darwin-amd64 download and have Rosetta 2 installed - the build steps themselves will run natively, however, via the buildkit daemon).
+- Add `SAVE ARTIFACT --if-exists` (https://github.com/earthly/earthly/issues/588)
+- Fix an issue where comments at the end of the Earthfile were not allowed (https://github.com/earthly/earthly/issues/681)
+- Fix an issue where multiple `WITH DOCKER --load` with the same target, but different image tag were not working (https://github.com/earthly/earthly/issues/685)
+- Fix an issue where `SAVE ARTIFACT ./* AS LOCAL` was flattening subdirectories (https://github.com/earthly/earthly/issues/689)
+- Binaries for `arm5` and `arm6` are no longer supported
 
 ## v0.4.3 - 2020-12-23
 
-Changes:
-* Fix regression for `WITH DOCKER --compose=... --load=...` (https://github.com/earthly/earthly/issues/676)
-* Improvements to the multiplatform experimental support. See the [multiplatform example](https://github.com/earthly/earthly/blob/main/examples/multiplatform/Earthfile).
+- Fix regression for `WITH DOCKER --compose=... --load=...` (https://github.com/earthly/earthly/issues/676)
+- Improvements to the multiplatform experimental support. See the [multiplatform example](https://github.com/earthly/earthly/blob/main/examples/multiplatform/Earthfile).
 
 ## v0.4.2 - 2020-12-22
 
-Changes:
- - bugfix: EARTHLY_GIT_PROJECT_NAME contained the raw git url when https-based auth was used (fixes #671)
- - feature: support for mounting secrets as files rather than environment variables
- - feature: experimental support for multi-platform builds
- - misc: sending anonymized usage metrics to earthly
+- bugfix: `EARTHLY_GIT_PROJECT_NAME` contained the raw git url when https-based auth was used (fixes #671)
+- feature: support for mounting secrets as files rather than environment variables
+- feature: experimental support for multi-platform builds
+- misc: sending anonymized usage metrics to earthly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,278 @@
-Please visit the [Earthly Releases page](https://github.com/earthly/earthly/releases).
+# Earthly Changelog
+
+All notable changes to [Earthly](https://github.com/earthly/earthly) will be documented in this file.
+
+## Unreleased
+
+### Added
+
+- New ./release+all target that combines existing release commands into a single command
+  that can be run as a single command.
+
+## v0.5.23 - 2021-08-24
+
+- introduced `COPY --if-exists` which allows users to ignore errors which would have occurred [if the file did not exist](https://docs.earthly.dev/docs/earthfile#if-exists).
+- introduced new `ip_tables` config option for controlling which iptables binary is used; fixes #1160
+- introduced warning message when saving to paths above the current directory of the current Earthfile; these warnings will eventually become errors unless the `--force` [flag](https://docs.earthly.dev/docs/earthfile#force) is passed to `SAVE ARTIFACT`.
+- bugfix for remote buildkit configuration options being ignored; fixes #1177
+- suppressed erroneous internal-term error messages which occurred when running under non-interactive ( e.g. ci ) modes; fixes #1108
+- changed help text for `--artifact` mode
+- deb and yum packages no longer clear the earthly cache on upgrades
+
+
+## v0.5.22 - 2021-08-11
+
+- when running under --ci mode, earthly now raises an error if a user attempts to use the interactive debugger
+- updated underlying buildkit version
+- print all request and responses to buildkit when running under --debug mode
+- support for specifying files to ignore under .earthlyignore in addition to .earthignore; an error is raised if both exist
+- new ARG `EARTHLY_GIT_SHORT_HASH` will contain an 8 char representation of the current git commit hash
+- new ARG `EARTHLY_GIT_COMMIT_TIMESTAMP` will contain the timestamp of the current git commit
+- new ARG `EARTHLY_SOURCE_DATE_EPOCH` will contain the same value as `EARTHLY_GIT_COMMIT_TIMESTAMP` or 0 when the timestamp is not available
+- only directly referenced artifacts or images will be saved when the VERSION's --referenced-save-only feature flag is defined #896
+- experimental support for FOR statements, when the VERSION's --for-in feature flag is defined #1142
+- fixes bug where error was not being repeated as the final output
+- fixes bug where https-based git credentials were leaked to stdout
+
+## v0.5.20 - 2021-07-22
+
+- Support for passing true/false values to boolean flags #1109
+- fixes error that stated `http is insecure` when configuring a https git source. #1115
+
+## v0.5.19 - 2021-07-21
+
+- Improved selective file-transferring via buildkit's include patterns; this feature is currently disabled by default, but can be enabled by including the `--use-copy-include-patterns` feature-flag in the `VERSION` definition (e.g. add `VERSION --use-copy-include-patterns 0.5` to the top of your Earthfiles). This will become enabled by default in a later version.
+- Support for host systems that have `nf_tables` rather than `ip_tables`.
+- Show hidden dev flags when `EARTHLY_AUTOCOMPLETE_HIDDEN="1"` is set (or when running a custom-built version).
+- Improved crash logs.
+
+## v0.5.18 - 2021-07-08
+
+* Added a `--symlink-no-follow` flag to allow copying invalid symbolic links (https://github.com/earthly/earthly/issues/1067)
+* Updated buildkit, which contains a fix for "failed to get edge" panic errors (https://github.com/earthly/earthly/issues/1016)
+* Fix bug that prevented using an absolute path to reference targets which contained relative imports
+* Added option to disable analytics data collection when environment variables `EARTHLY_DISABLE_ANALYTICS` or `DO_NOT_TRACK` are set.
+* Include version and help flags in autocompletion output.
+
+## v0.5.17 - 2021-06-15
+
+* Begin experimental official support for `earthly/earthly` and `earthly/buildkitd` images; including a new `entrypoint` for `earthly/earthly` (https://github.com/earthly/earthly/pull/1050)
+* When running in `verbose` mode, log all files sent to buildkit (https://github.com/earthly/earthly/pull/1051, https://github.com/earthly/earthly/pull/1056)
+* Adjust `deb` and `rpm` packages to auto-install the shell completions though post-installation mechanisms (https://github.com/earthly/earthly/pull/1019, https://github.com/earthly/earthly/pull/1057)
+
+## v0.5.16 - 2021-06-03
+
+- fixes handling of `Error getting earthly dir` lookup failures which prevents earthly from running (https://github.com/earthly/earthly/issues/1026)
+- implements ability to perform local exports via buildkit-hosted local registery in order to speed up exports; the feature is currently disabled by default but can be enabled with `earthly config global.local_registry_host 'tcp://127.0.0.1:8371'` (https://github.com/earthly/earthly/issues/500)
+
+## v0.5.15 - 2021-05-27
+
+* `earthly config` is no longer experimental. (https://github.com/earthly/earthly/pull/979)
+* Running a target, will now `bootstrap` automatically, if it looks like `earthly bootstrap` has not been run yet. (https://github.com/earthly/earthly/pull/989)
+* `earthly bootstrap` ensures the permissions on the `.earthly` folder are correct (belonging to the user) ( https://github.com/earthly/earthly/pull/993)
+* Cache mount ID now depends on a target input hash which does not include inactive variables (https://github.com/earthly/earthly/pull/1000)
+* Added `EARTHLY_TARGET_PROJECT_NO_TAG` built-in argument (https://github.com/earthly/earthly/pull/1011)
+* When `~` is used as the path to a secret file, it now expands as expected. (https://github.com/earthly/earthly/pull/977)
+* Use the environment-specified `$HOME`, unless `$SUDO_USER` is set. If it is, use the users home directory. (https://github.com/earthly/earthly/pull/1015)
+
+
+## v0.5.14 - 2021-05-27
+
+* `earthly config` is no longer experimental. (https://github.com/earthly/earthly/pull/979)
+* Running a target, will now `bootstrap` automatically, if it looks like `earthly bootstrap` has not been run yet. (https://github.com/earthly/earthly/pull/989)
+* `earthly bootstrap` ensures the permissions on the `.earthly` folder are correct (belonging to the user) ( https://github.com/earthly/earthly/pull/993)
+* Cache mount ID now depends on a target input hash which does not include inactive variables (https://github.com/earthly/earthly/pull/1000)
+* Added `EARTHLY_TARGET_PROJECT_NO_TAG` built-in argument (https://github.com/earthly/earthly/pull/1011)
+* When `~` is used as the path to a secret file, it now expands as expected. (https://github.com/earthly/earthly/pull/977)
+
+
+## v0.5.13 - 2021-05-13
+
+- fixes panic on invalid (or incomplete) `~/.netrc` file (https://github.com/earthly/earthly/issues/980)
+
+## v0.5.12 - 2021-05-07
+
+* Adds a retry for remote Buildkit hosts when using the `EARTHLY_BUILDKIT_HOST` configuration option. (#952)
+* Re-fetch credentials when they expire (#957)
+* Make use of `~/.netrc` credentials when no config is set under `~/.earthly/config.yml` (#964)
+* Make use of auth credentials when performing a GIT CLONE command within an Earthfile. (#964)
+* Improved error output when desired secret does not exist, including the name of the missing secret. (#972)
+* Warn if `build-arg` appears after the target in CLI invocations.(#959)
+
+## v0.5.11 - 2021-04-27
+
+Changes:
+
+* Support for `FROM DOCKERFILE -f` (https://github.com/earthly/earthly/pull/950)
+* Fixes missing access to global arguments in user defined commands (https://github.com/earthly/earthly/pull/947)
+* Users's `~/.earthly` directory is now referenced when earthly is invoked with sudo
+
+
+## v0.5.10 - 2021-04-19
+
+Changes:
+
+* Added ability to run `WITH DOCKER` under `LOCALLY` (https://github.com/earthly/earthly/pull/840)
+* Fix `FROM DOCKERFILE` `--build-arg`s not being passed correctly (https://github.com/earthly/earthly/issues/932)
+* Docs: Add uninstall instructions
+* Docs: Improve onboarding tutorial based on user feedback
+
+
+## v0.5.9 - 2021-04-05
+
+Changes:
+
+* [**experimental**] Improved parallelization when using commands such as `IF`, `WITH DOCKER`, `FROM DOCKERFILE`, `ARG X=$(...)` and others. To enable this feature, pass `--conversion-parallelism=5` or set `EARTHLY_CONVERSION_PARALLELISM=5`. (https://github.com/earthly/earthly/issues/888)
+* Auto-detect MTU (https://github.com/earthly/earthly/issues/847)
+* MTU may set via config `earthly config global.cni_mtu 12345` (https://github.com/earthly/earthly/pull/906)
+* Hide `--debug` flag since it is only used for development on Earthly itself
+* Download and start buildkitd as part of the earthly bootstrap command
+* Improved buildkitd startup logic (https://github.com/earthly/earthly/pull/892)
+* Check for reserved target names and disallow them (e.g. `+base`) (https://github.com/earthly/earthly/pull/898)
+* Fix use of self-hosted repos when a subdirectory is used (https://github.com/earthly/earthly/pull/897)
+
+
+## v0.5.8 - 2021-03-23
+
+
+Changes:
+
+* [**experimental**] Support for ARGs in user-defined commands (UDCs). UDCs are templates (much like functions in regular programming languages), which can be used to define a series of steps to be executed in sequence. In other words, it is a way to reuse common build steps in multiple contexts. This completes the implementation of UDCs and the feature is now in **experimental** phase (https://github.com/earthly/earthly/issues/581). For more information see the [UDC guide](https://docs.earthly.dev/guides/udc).
+* [**experimental**] New command: `IMPORT` (https://github.com/earthly/earthly/pull/868)
+  ```
+  IMPORT github.com/foo/bar:v1.2.3
+  IMPORT github.com/foo/buz:main AS zulu
+  
+  ...
+  
+  FROM bar+target
+  BUILD zulu+something
+  ```
+* Fix handling of some escaped quotes (https://github.com/earthly/earthly/issues/859)
+* Fix: empty targets are now valid (https://github.com/earthly/earthly/pull/872)
+* Fix some line continuation issues (https://github.com/earthly/earthly/pull/873 & https://github.com/earthly/earthly/pull/874)
+* Earthly now limits parallelism to `20`. This fixes some very large builds attempting to use resources all at the same time
+* Automatically retry TLS handshake timeout errors
+
+
+## v0.5.7 - 2021-03-13
+
+- raise error when duplicate target names exists in Earthfile
+- fix zsh autocompletion issue for mac users
+- basic user defined commands (experimental)
+- cleans up console output for saving artifacts (#848)
+- implement support for WORKDIR under LOCALLY targets
+
+If the autocompletion bug persists for anyone (e.g. seeing an error like `command not found: __earthly__`), and the issues persists after upgrading to v0.5.7; it might be necessary to delete the _earthly autocompletion file before re-running earthly bootstrap (or alternatively manually replace `__earthly__` with the full path to the earthly binary).
+
+## v0.5.6 - 2021-03-09
+
+This release removes the `ongoing` updates "Provide intermittent updates on long-running targets (#844)" from the previous release, as it has issues in the interactive mode.
+
+## v0.5.5 - 2021-03-08
+
+* Keep `.git` directory in build context. (#815 )
+* Wait extra time for buildkitd to start if the cache is larger than 30 GB  (#827)
+* *Experimental:* Allow RUN commands to open an interactive session (`RUN --interactive`), with the option to save the manual changes into the final image (`RUN --interactive-keep`) (#833)
+* Provide intermittent updates on long-running targets (#844)
+* Fix ZSH autocompletion in some instances (#838)
+
+## v0.5.4 - 2021-02-26
+
+* New experimental `--strict` flag, which doesn't allow the use of `LOCALLY`. `--strict` is now implied when using `--ci`. (https://github.com/earthly/earthly/pull/801)
+* Add help text when issuing `earthly config <item> --help`. Improved user experience. (https://github.com/earthly/earthly/pull/814)
+* Detect if the build doesn't start with a FROM-like command and return a meaningful error. Previously `FROM scratch` was assumed automatically. (https://github.com/earthly/earthly/issues/807)
+* Fix an issue where `.tmpXXXXX` directories were created in the current directory (https://github.com/earthly/earthly/pull/821)
+* Fix auto-complete in zsh (https://github.com/earthly/earthly/pull/811)
+* Improved startup logic for buildkit daemon, which speeds up some rare edge cases (https://github.com/earthly/earthly/pull/808)
+* Print buildkit logs if it crashes or times out on startup (https://github.com/earthly/earthly/pull/819)
+* Create config path if it's missing (https://github.com/earthly/earthly/pull/812)
+
+
+## v0.5.3 - 2021-02-24
+
+Changes
+ - Support for conditional logic using new `IF`, `ELSE IF`, and `ELSE` keywords (required for #779)
+ - Support for copying artifacts to `LOCALLY` targets (required for #580)
+ - bugfix: segfault when no output or error is displayed (fixes #798)
+ - bugfix: unable to run earthly in docker container with mounted host-docker socket (fixes #791)
+ - bugfix: `./.tmp-earthly-outXXXXXX` temp files are now stored under `./.tmp-earthly-out/tmpXXXXXX` and are correctly excluded from the builld context 
+
+
+## v0.5.2 - 2021-02-18
+
+Changes:
+
+* New experimental command for editing the Earthly config (https://github.com/earthly/earthly/issues/675)
+* `SAVE IMAGE --push` after a `RUN --push` now includes the effects of the `RUN --push` too (https://github.com/earthly/earthly/pull/754)
+* Improved syntax errors when parsing Earthfiles
+* Improved error message when QEMU is missing
+* Fix `earthly-linux-arm64` binary - was a Mac binary by mistake (https://github.com/earthly/earthly/issues/789)
+* Fix override of build arg not being detected properly (https://github.com/earthly/earthly/pull/790)
+* Fix image export error when it doesn't contain any `RUN` commands (https://github.com/earthly/earthly/issues/782)
+
+
+## v0.5.1 - 2021-02-08
+
+Changes
+ - Support for SAVE ARTIFACT under LOCALLY contexts; this allows one to run a command locally and save the output to a different container.
+ - Support for build arg matrix; supplying multiple `--build-args` for the same value will cause the `BUILD` target to be built for each different build arg value.
+ - Improvements for Apple M1 support
+ - Improved errors when parsing invalid Earthfiles (to enable the new experimental code, set the `EARTHLY_ENABLE_AST` variable to `true`)
+
+## v0.5.0 - 2021-02-01
+
+Changes:
+* Switch to BSL license. For [more information about this decision, take a look at our blog post](https://blog.earthly.dev/every-open-core-company-should-be-a-source-available-company/).
+* `--platform` setting is now automatically propagated between Earthfiles. In addition, you can now specify the empty string `--platform=` to automatically detect your system's architecture.
+* `earthly/dind` images now available for `linux/arm/v7` and `linux/arm64`
+* Improved visibility of platform used for each build step, as well as for any build args that have been overridden.
+* Allow saving an artifact after a `RUN --push` (https://github.com/earthly/earthly/pull/735)
+* Allow specifying `--no-cache` for a single `RUN` command (https://github.com/earthly/earthly/issues/585)
+* There are now separate `SUCCESS` lines for each of the two possible phases of an earthly run: `main` and `push`.
+* [Support of popular cloud registries for the experimental shared cache feature is now properly documented](https://docs.earthly.dev/guides/shared-cache#compatibility-with-major-registry-providers)
+* Fix `SAVE IMAGE --cache-hint` not working correctly (https://github.com/earthly/earthly/issues/744)
+* Fix `i/o timeout` errors being cached and requiring BuildKit restart
+* Experimental support for running commands on the host system via `LOCALLY` (https://github.com/earthly/earthly/issues/580)
+* Bug fixes for Apple Silicon. `earthly-darwin-arm64` binary is now available. Please treat this version as highly experimental for now. (https://github.com/earthly/earthly/issues/722)
+
+## v0.5.0-rc2 - 2021-02-01
+
+No details provided
+
+## v0.5.0-rc1 - 2021-02-01
+
+No details provided
+
+## v0.4.6 - 2021-01-29
+
+No details provided
+
+## v0.4.5 - 2021-01-13
+
+ * Fix inconsistent `COPY --dir` behavior [https://github.com/earthly/earthly/issues/705](#705)
+ * Fix `AS LOCAL` behavior with directories [https://github.com/earthly/earthly/issues/703](#703)
+
+## v0.4.4 - 2021-01-06
+
+Changes:
+* Improved experimental support for arm-based platforms, including Apple M1. Builds run natively on arm platforms now. (For Apple M1, you need to use darwin-amd64 download and have Rosetta 2 installed - the build steps themselves will run natively, however, via the buildkit daemon).
+* Add `SAVE ARTIFACT --if-exists` (https://github.com/earthly/earthly/issues/588)
+* Fix an issue where comments at the end of the Earthfile were not allowed (https://github.com/earthly/earthly/issues/681)
+* Fix an issue where multiple `WITH DOCKER --load` with the same target, but different image tag were not working (https://github.com/earthly/earthly/issues/685)
+* Fix an issue where `SAVE ARTIFACT ./* AS LOCAL` was flattening subdirectories (https://github.com/earthly/earthly/issues/689)
+* Binaries for `arm5` and `arm6` are no longer supported
+
+## v0.4.3 - 2020-12-23
+
+Changes:
+* Fix regression for `WITH DOCKER --compose=... --load=...` (https://github.com/earthly/earthly/issues/676)
+* Improvements to the multiplatform experimental support. See the [multiplatform example](https://github.com/earthly/earthly/blob/main/examples/multiplatform/Earthfile).
+
+## v0.4.2 - 2020-12-22
+
+Changes:
+ - bugfix: EARTHLY_GIT_PROJECT_NAME contained the raw git url when https-based auth was used (fixes #671)
+ - feature: support for mounting secrets as files rather than environment variables
+ - feature: experimental support for multi-platform builds
+ - misc: sending anonymized usage metrics to earthly

--- a/Earthfile
+++ b/Earthfile
@@ -328,14 +328,16 @@ dind-alpine:
     RUN apk add --update --no-cache docker-compose
     ARG EARTHLY_TARGET_TAG_DOCKER
     ARG DIND_ALPINE_TAG=alpine-$EARTHLY_TARGET_TAG_DOCKER
-    SAVE IMAGE --push --cache-from=earthly/dind:main earthly/dind:$DIND_ALPINE_TAG
+    ARG DOCKERHUB_USER=earthly
+    SAVE IMAGE --push --cache-from=earthly/dind:main $DOCKERHUB_USER/dind:$DIND_ALPINE_TAG
 
 dind-ubuntu:
     FROM ubuntu:latest
     COPY ./buildkitd/docker-auto-install.sh /usr/local/bin/docker-auto-install.sh
     RUN docker-auto-install.sh
     ARG DIND_UBUNTU_TAG=ubuntu-$EARTHLY_TARGET_TAG_DOCKER
-    SAVE IMAGE --push --cache-from=earthly/dind:ubuntu-main earthly/dind:$DIND_UBUNTU_TAG
+    ARG DOCKERHUB_USER=earthly
+    SAVE IMAGE --push --cache-from=earthly/dind:ubuntu-main $DOCKERHUB_USER/dind:$DIND_UBUNTU_TAG
 
 for-own:
     ARG BUILDKIT_PROJECT

--- a/Earthfile
+++ b/Earthfile
@@ -143,6 +143,11 @@ unit-test:
     FROM +code
     RUN go test ./...
 
+changelog:
+    FROM scratch
+    COPY CHANGELOG.md .
+    SAVE ARTIFACT CHANGELOG.md
+
 shellrepeater:
     FROM +code
     ARG GOCACHE=/go-cache

--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -55,7 +55,8 @@ buildkitd:
     ENTRYPOINT ["/usr/bin/entrypoint.sh", "buildkitd", "--config=/etc/buildkitd.toml"]
     ARG EARTHLY_TARGET_TAG_DOCKER
     ARG TAG="dev-$EARTHLY_TARGET_TAG_DOCKER"
-    SAVE IMAGE --push --cache-from=earthly/buildkitd:main earthly/buildkitd:$TAG
+    ARG DOCKERHUB_USER="earthly"
+    SAVE IMAGE --push --cache-from=earthly/buildkitd:main $DOCKERHUB_USER/buildkitd:$TAG
 
 update-buildkit:
     LOCALLY

--- a/release/Earthfile
+++ b/release/Earthfile
@@ -3,6 +3,57 @@ FROM alpine:3.13
 RUN apk add --update --no-cache \
     curl
 
+all:
+    LOCALLY
+    ARG RELEASE_TAG
+    ARG GITHUB_USER=earthly
+    ARG DOCKERHUB_USER=earthly
+    ARG EARTHLY_REPO=earthly
+    ARG BREW_REPO=homebrew-earthly
+    RUN test -n "$RELEASE_TAG" || (echo "ERROR: RELEASE_TAG is not set" && exit 1)
+
+    # validate args: if doing a prod-release make sure no args are changed
+    # otherwise if a test release is detected, make sure all users are changed
+    # (this is to prevent a case where only the github user is changed, but dockerhub is not, and the dockerhub binary is accidentally overwritten)
+    RUN set -e; \
+        test -n "$RELEASE_TAG" || (echo "ERROR: RELEASE_TAG is not set" && exit 1); \
+        (echo "$RELEASE_TAG" | grep '^v[0-9]\+.[0-9]\+.[0-9]\+$' > /dev/null) || (echo "ERROR: RELEASE_TAG must be formatted as v1.2.3; instead got \"$RELEASE_TAG\""; exit 1); \
+        if [ "$GITHUB_USER" = "earthly" ] && [ "$DOCKERHUB_USER" = "earthly" ]; then \
+          test "$BREW_REPO" = "homebrew-earthly" || (echo "ERROR: prod release detected; expecting BREW_REPO=earthly, but got $BREW_REPO" && exit 1); \
+          test "$EARTHLY_REPO" = "earthly" || (echo "ERROR: prod release detected; expecting EARTHLY_REPO=earthly, but got $EARTHLY_REPO" && exit 1); \
+          test "$EARTHLY_GIT_BRANCH" = "main" || (echo "ERROR: performing release on non-main branch" && exit 1); \
+        else \
+          test "$GITHUB_USER" != "earthly" || (echo "ERROR: non-prod release detected but got GITHUB_USER=$GITHUB_USER" && exit 1); \
+          test "$DOCKERHUB_USER" != "earthly" || (echo "ERROR: non-prod release detected but got DOCKERHUB_USER=$DOCKERHUB_USER" && exit 1); \
+        fi; \
+        echo "performing release to repo=$GITHUB_USER/$EARTHLY_REPO; homebrew=$GITHUB_USER/$BREW_REPO; dockerhub=$DOCKERHUB_USER"
+
+    # terrible unsafe hack to determine --push flag
+    IF ps auxw | grep -v grep | grep earthly | grep -e --push
+        ARG PUSH="--push"
+    ELSE
+        ARG PUSH=""
+    END
+
+    RUN set -e; \
+        earthly_pid=$(ps axw | grep -v grep | grep earthly | grep 'all' | awk '{print $1}'); \
+        expected_hash=$(cat ~/.earthly/earthly-prerelease | md5sum); \
+        actual_hash=$(cat /proc/$earthly_pid/exe | md5sum); \
+        if [ "$expected_hash" != "$actual_hash" ]; then \
+          echo "\nERROR: +all requires the ./earthly script be used (rather than directly using any earthly binary).\n"; \
+          exit 1; \
+        fi;
+
+    RUN ../earthly $PUSH --build-arg DOCKERHUB_USER="$DOCKERHUB_USER" --build-arg RELEASE_TAG="$RELEASE_TAG" +release-dockerhub
+    RUN ../earthly $PUSH --build-arg GITHUB_USER="$GITHUB_USER" --build-arg EARTHLY_REPO="$EARTHLY_REPO" --build-arg BREW_REPO="$BREW_REPO" --build-arg DOCKERHUB_USER="$DOCKERHUB_USER" --build-arg RELEASE_TAG="$RELEASE_TAG" +release-github
+    RUN ../earthly $PUSH --build-arg GITHUB_USER="$GITHUB_USER" --build-arg EARTHLY_REPO="$EARTHLY_REPO" --build-arg BREW_REPO="$BREW_REPO" --build-arg DOCKERHUB_USER="$DOCKERHUB_USER" --build-arg RELEASE_TAG="$RELEASE_TAG" +release-homebrew
+
+    # TODO pass along a RELEASE_REPO_TEST_SUFFIX which would cause us to host our yum/apt repos under https://test-pkg.earthly.dev/$RELEASE_REPO_TEST_SUFFIX/...
+    # and when it is empty, we would use https://pkg.earthly.dev/...
+    #RUN ../earthly --build-arg GITHUB_USER="$GITHUB_USER" --build-arg RELEASE_TAG="$RELEASE_TAG" +release-repo
+    # until then, we will just print this out:
+    RUN echo "TODO: the apt/yum release must be triggered seperately; once we get https://test-pkg.earthly.dev/ setup"
+
 release:
     ARG RELEASE_TAG
     RUN test -n "$RELEASE_TAG"
@@ -11,15 +62,18 @@ release:
 
 release-dockerhub:
     ARG RELEASE_TAG
+    ARG DOCKERHUB_USER="earthly"
     RUN test -n "$RELEASE_TAG"
     BUILD \
         --build-arg DIND_ALPINE_TAG=alpine \
         --build-arg DIND_UBUNTU_TAG=ubuntu \
+        --build-arg DOCKERHUB_USER="$DOCKERHUB_USER" \
         ../+all-dind
     BUILD \
         --platform=linux/amd64 \
         --platform=linux/arm64 \
         --build-arg DIND_ALPINE_TAG=latest \
+        --build-arg DOCKERHUB_USER="$DOCKERHUB_USER" \
         ../+dind-alpine
     BUILD --build-arg TAG="$RELEASE_TAG" ../+earthly-docker
     BUILD \
@@ -27,6 +81,7 @@ release-dockerhub:
         --platform=linux/arm/v7 \
         --platform=linux/arm64 \
         --build-arg TAG="$RELEASE_TAG" \
+        --build-arg DOCKERHUB_USER="$DOCKERHUB_USER" \
         ../buildkitd+buildkitd
     BUILD --build-arg TAG=latest ../+earthly-docker
     BUILD \
@@ -34,17 +89,23 @@ release-dockerhub:
         --platform=linux/arm/v7 \
         --platform=linux/arm64 \
         --build-arg TAG=latest \
+        --build-arg DOCKERHUB_USER="$DOCKERHUB_USER" \
         ../buildkitd+buildkitd
 
 release-github:
     FROM node:13.10.1-alpine3.11
-    RUN apk add file
+    RUN apk add file curl jq git
+    RUN apk add --update --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing hub
     RUN npm install -g github-release-cli@v1.3.1
     WORKDIR /earthly
     ARG RELEASE_TAG
+    ARG GITHUB_USER="earthly"
+    ARG EARTHLY_REPO="earthly"
+    ARG DOCKERHUB_USER="earthly"
     ARG EARTHLY_GIT_HASH
     RUN test -n "$RELEASE_TAG" && test -n "$EARTHLY_GIT_HASH"
     COPY --build-arg VERSION=$RELEASE_TAG \
+         --build-arg DEFAULT_BUILDKITD_IMAGE="$DOCKERHUB_USER/buildkitd:$RELEASE_TAG" \
         ../+earthly-all/* ./release/
     RUN ls ./release
     RUN test -f ./release/earthly-linux-amd64 && \
@@ -63,18 +124,43 @@ release-github:
     RUN file ./release/earthly-linux-arm64 | grep "ELF 64-bit"
     RUN file ./release/earthly-windows-amd64.exe | grep "PE32"
     ARG BODY="No details provided"
-    RUN --secret GITHUB_TOKEN=+secrets/earthly-technologies/github/griswoldthecat/token test -n "$GITHUB_TOKEN"
+    ARG GITHUB_SECRET_PATH="+secrets/earthly-technologies/github/griswoldthecat/token"
+    RUN --secret GITHUB_TOKEN="$GITHUB_SECRET_PATH" test -n "$GITHUB_TOKEN" && echo $GITHUB_TOKEN
     RUN --push \
-        --secret GITHUB_TOKEN=+secrets/earthly-technologies/github/griswoldthecat/token \
+        --secret GITHUB_TOKEN="$GITHUB_SECRET_PATH" \
+        set -e; \
+        # test github token works
+        curl -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/user" | jq .login | grep "$GITHUB_USER"; \
+        # first delete any previously released files (needed in case the previous upload attempt failed)
+        PREV_RELEASE_ID=$(curl -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/repos/$GITHUB_USER/$EARTHLY_REPO/releases/tags/$RELEASE_TAG" | jq .id); \
+        if [ -n "$PREV_RELEASE_ID" ] && [ "$PREV_RELEASE_ID" != "null" ]; then \
+          echo "deleting previous release ID $PREV_RELEASE_ID"; \
+          curl -H "Authorization: token $GITHUB_TOKEN" --request DELETE "https://api.github.com/repos/$GITHUB_USER/$EARTHLY_REPO/releases/$PREV_RELEASE_ID"; \
+        fi; \
+        # next make sure any previous tag is deleted (otherwise github will create an untagged release name vX.Y.Z)
+        curl -H "Authorization: token $GITHUB_TOKEN" --request DELETE "https://api.github.com/repos/$GITHUB_USER/$EARTHLY_REPO/git/refs/tags/$RELEASE_TAG"; \
+        # next, upload binaries
         github-release upload \
-        --owner earthly \
-        --repo earthly \
-        --prerelease true \
+        --owner "$GITHUB_USER" \
+        --repo "$EARTHLY_REPO" \
+        --prerelease false \
         --commitish "$EARTHLY_GIT_HASH" \
         --tag "$RELEASE_TAG" \
         --name "$RELEASE_TAG" \
         --body "$BODY" \
-        ./release/*
+        ./release/* 2>&1 | tee /tmp/release.log && \
+        if grep -i "already_exists" /tmp/release.log > /dev/null; then \
+          echo "ERROR: github-release upload failed: file already exists -- you must delete if from github before proceeding" && exit 1; \
+        fi; \
+        if grep -i "tag_name is not a valid tag" /tmp/release.log > /dev/null; then \
+          echo "ERROR: github-release upload failed: tag_name is not a valid tag (it could be that the branch you are releasing doesnt exist on $GITHUB_USER/$EARTHLY_REPO)"; \
+          echo "you might need to do a git push $GITHUB_USER $EARTHLY_GIT_HASH:main ASSUMING YOU ARE NOT DOINT A PROD RELEASE"; \
+          exit 1; \
+        fi; \
+        if grep -i error /tmp/release.log > /dev/null; then \
+          echo "ERROR: github-release upload failed: check the above release.log output" && exit 1; \
+        fi
+
 
 release-homebrew:
     RUN apk add --update --no-cache \
@@ -91,6 +177,7 @@ release-homebrew:
         less \
         make \
         openssl \
+        openssh \
         util-linux
     RUN apk add --update --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing hub
     
@@ -99,102 +186,55 @@ release-homebrew:
     ARG GIT_USERNAME="griswoldthecat"
     ARG GIT_NAME="griswoldthecat"
     ARG GIT_EMAIL="griswoldthecat@users.noreply.github.com"
-    ARG HOMEBREW_EARTHLY_URL="https://github.com/earthly/homebrew-earthly"
+    ARG GITHUB_USER
+    ARG BREW_REPO
+    ARG EARTHLY_REPO
+    ARG GITHUB_TOKEN_SECRET_PATH="+secrets/user/610f09a9-4493-4d3c-bb00-b8e0cf36f1e0"
+    ARG HOMEBREW_EARTHLY_URL="https://github.com/$GITHUB_USER/$BREW_REPO"
     RUN test -n "$RELEASE_TAG" && \
         test -n "$GIT_USERNAME" && \
         test -n "$GIT_NAME" && \
         test -n "$GIT_EMAIL" && \
         test -n "$HOMEBREW_EARTHLY_URL"
-    ARG NEW_URL=https://github.com/earthly/earthly/archive/"$RELEASE_TAG".tar.gz
+    ARG NEW_URL=https://github.com/"$GITHUB_USER"/"$EARTHLY_REPO"/archive/"$RELEASE_TAG".tar.gz
     RUN test -n "$NEW_URL"
-    GIT CLONE --branch main "$HOMEBREW_EARTHLY_URL" /earthly/homebrew-earthly
     WORKDIR /earthly/homebrew-earthly
 
-    # Git setup.
-    # Force use of https.
-    RUN git remote set-url origin "$HOMEBREW_EARTHLY_URL" && \
-        git remote -v
-    RUN --secret GIT_PASSWORD=+secrets/earthly-technologies/github/griswoldthecat/token \
-        git fetch --unshallow origin main
-    RUN git branch -f main && \
-        git checkout main && \
-        git branch -u origin/main
     RUN git config --global user.name "$GIT_NAME" && \
         git config --global user.email "$GIT_EMAIL"
+
     COPY ./envcredhelper.sh /usr/bin/envcredhelper.sh
     RUN git config --global credential.helper "/bin/sh /usr/bin/envcredhelper.sh"
 
+    RUN --secret GIT_PASSWORD="$GITHUB_TOKEN_SECRET_PATH" --no-cache \
+        git clone "https://$GITHUB_USER@github.com/$GITHUB_USER/$BREW_REPO.git" .
+
+    ARG RELEASE_BRANCH="release-$RELEASE_TAG"
+    RUN git switch -c "$RELEASE_BRANCH"
+
     # Make the change in a new branch.
-    RUN git checkout -b "release-$RELEASE_TAG"
+    #RUN git checkout -b "release-$RELEASE_TAG"
     RUN mkdir -p /params
     RUN curl -L "$NEW_URL" | sha256sum | cut -f 1 -d ' ' > /params/downloadsha256
     COPY --build-arg VERSION=$RELEASE_TAG \
         ../+earthly-darwin-amd64/tags ../+earthly-darwin-amd64/ldflags /params/
-
-    # Split /params/ldflags over two lines (to satisfy ruby linter).
-    RUN split --numeric-suffixes=1 --suffix-length=1 --bytes=80 /params/ldflags /params/ldflags && \
-        touch /params/ldflags2 && \
-        if [ -f "/params/ldflags3" ]; then \
-            echo "More than two lines for ldflags not supported" && \
-            exit 1 ;\
-        fi
 
     # replace version with #{version} variable to conform to homebrew PR requests
     RUN escapedversion=`echo "${RELEASE_TAG}" | sed 's/\./\\\./g'`; \
         sed -i -e "s/${escapedversion}/v#{version}/g" /params/ldflags*
 
     RUN sed -i \
-        -e 's^url ".*"^url "'"$NEW_URL"'"^' \
-        -e 's^sha256 ".*"$^sha256 "'$(cat /params/downloadsha256)'"^' \
-        -e 's^tags = ".*"^tags = "'"$(cat /params/tags)"'"^' \
-        -e 's^ldflags = ".*"^ldflags = "'"$(cat /params/ldflags1)"'"^' \
-        -e '/ldflags = ".*"/{n;s^".*"^"'"$(cat /params/ldflags2)"'"^}' \
+        -e 's^\burl ".*"^url "'"$NEW_URL"'"^' \
+        -e 's^\bsha256 ".*"$^sha256 "'$(cat /params/downloadsha256)'"^' \
+        -e 's^\btags = ".*"^tags = "'"$(cat /params/tags)"'"^' \
+        -e 's^\bldflags = ".*"^ldflags = "'"$(cat /params/ldflags)"'"^' \
         ./Formula/earthly.rb
     RUN echo "Diff:" && git diff
     RUN version=${RELEASE_TAG#v} ;\
         echo version=$version ;\
-        git commit -a -m "earthly $version"
-    
-    # Fork, push branch to fork and create upstream PR.
-    RUN --secret GITHUB_TOKEN=+secrets/earthly-technologies/github/griswoldthecat/token test -n "$GITHUB_TOKEN"
-    RUN --push \
-        --secret GITHUB_TOKEN=+secrets/earthly-technologies/github/griswoldthecat/token \
-        -- \
-        hub fork
-    # Force use of https so we can use GITHUB_TOKEN via envcredhelper.sh.
-    RUN --push \
-        -- \
-        git remote set-url "$GIT_USERNAME" "https://github.com/$GIT_USERNAME/homebrew-earthly.git" && \
-        git remote -v
-    RUN --push \
-        --secret GIT_PASSWORD=+secrets/earthly-technologies/github/griswoldthecat/token \
-        -- \
-        git push "$GIT_USERNAME" "release-$RELEASE_TAG"
-    RUN --push \
-        --secret GIT_PASSWORD=+secrets/earthly-technologies/github/griswoldthecat/token \
-        --secret GITHUB_TOKEN=+secrets/earthly-technologies/github/griswoldthecat/token \
-        --secret SLACK_WEBHOOK_URL=+secrets/earthly-technologies/slack/release-webhook \
-        -- \
-        version=${RELEASE_TAG#v} ;\
-        echo version=$version ;\
-        output=$(hub pull-request --no-edit \
-            -h "$GIT_USERNAME":"release-$RELEASE_TAG" \
-            -b "earthly:main" \
-            -m "earthly $version" \
-            -m '-------------' \
-            -m '#### Debug data' \
-            -m 'PR generated by the [Earthly build](https://github.com/earthly/earthly/blob/main/release/Earthfile) (target +release-homebrew)' \
-            -m '* `RELEASE_TAG='"$RELEASE_TAG"'`' \
-            -m '* `GIT_USERNAME='"$GIT_USERNAME"'`' \
-            -m '* `NEW_URL='"$NEW_URL"'`' \
-            -m '* `NEW_SHA256='"$(cat /params/downloadsha256)"'`' \
-            -m '* `TAGS='"$(cat /params/tags)"'`' \
-            -m '* `LDFLAGS='"$(cat /params/ldflags)"'`' \
-            -m '* `LDFLAGS1='"$(cat /params/ldflags1)"'`' \
-            -m '* `LDFLAGS2='"$(cat /params/ldflags2)"'`') && \
-        echo $output && \
-        curl -X POST -H 'Content-type: application/json' --data '{"text":"Successfully released `'$RELEASE_TAG'`: https://github.com/earthly/earthly/releases/tag/'$RELEASE_TAG'"}' $SLACK_WEBHOOK_URL && \
-        curl -X POST -H 'Content-type: application/json' --data '{"text":"Successfully released homebrew PR for `'$RELEASE_TAG'`: '"$output"'"}' $SLACK_WEBHOOK_URL
+        git commit -a -m "earthly $version" || true
+    RUN --secret GIT_PASSWORD="$GITHUB_TOKEN_SECRET_PATH" \
+        --push git push --force --set-upstream origin "$RELEASE_BRANCH"
 
 release-vscode-syntax-highlighting:
     ARG VSCODE_RELEASE_TAG

--- a/release/Earthfile
+++ b/release/Earthfile
@@ -87,7 +87,12 @@ release-github:
         --secret GITHUB_TOKEN="$GITHUB_SECRET_PATH" \
         set -e; \
         # test github token works
+        test -n "$GITHUB_TOKEN"; \
         curl -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/user" | jq -r .login > /tmp/authenticated.github.user; \
+        if [ "$(cat /tmp/authenticated.github.user)" = "null" ]; then \
+          echo "failed to authenticate; check your git token"; \
+          exit 1; \
+        fi; \
         # first delete any previously released files (needed in case the previous upload attempt failed)
         PREV_RELEASE_ID=$(curl -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/repos/$GITHUB_USER/$EARTHLY_REPO/releases/tags/$RELEASE_TAG" | jq .id); \
         if [ -n "$PREV_RELEASE_ID" ] && [ "$PREV_RELEASE_ID" != "null" ]; then \
@@ -159,13 +164,10 @@ release-homebrew:
 
     RUN git config --global user.name "$GIT_NAME" && \
         git config --global user.email "$GIT_EMAIL"
-
     COPY ./envcredhelper.sh /usr/bin/envcredhelper.sh
     RUN git config --global credential.helper "/bin/sh /usr/bin/envcredhelper.sh"
-
     RUN --secret GIT_PASSWORD="$GITHUB_TOKEN_SECRET_PATH" --no-cache \
         git clone "https://$GITHUB_USER@github.com/$GITHUB_USER/$BREW_REPO.git" .
-
     # Make the change in a new branch.
     ARG RELEASE_BRANCH="release-$RELEASE_TAG"
     RUN git switch -c "$RELEASE_BRANCH"

--- a/release/Earthfile
+++ b/release/Earthfile
@@ -92,6 +92,15 @@ release-dockerhub:
         --build-arg DOCKERHUB_USER="$DOCKERHUB_USER" \
         ../buildkitd+buildkitd
 
+release-notes:
+    FROM python:3
+    WORKDIR /changelog
+    COPY changelogparser.py /usr/bin/changelogparser
+    COPY ..+changelog/CHANGELOG.md .
+    ARG RELEASE_TAG
+    RUN changelogparser CHANGELOG.md $RELEASE_TAG > notes.txt
+    SAVE ARTIFACT notes.txt
+
 release-github:
     FROM node:13.10.1-alpine3.11
     RUN apk add file curl jq git
@@ -104,6 +113,7 @@ release-github:
     ARG DOCKERHUB_USER="earthly"
     ARG EARTHLY_GIT_HASH
     RUN test -n "$RELEASE_TAG" && test -n "$EARTHLY_GIT_HASH"
+    COPY +release-notes/notes.txt release-notes.txt
     COPY --build-arg VERSION=$RELEASE_TAG \
          --build-arg DEFAULT_BUILDKITD_IMAGE="$DOCKERHUB_USER/buildkitd:$RELEASE_TAG" \
         ../+earthly-all/* ./release/
@@ -123,14 +133,12 @@ release-github:
     RUN file ./release/earthly-linux-arm64 | grep "aarch64"
     RUN file ./release/earthly-linux-arm64 | grep "ELF 64-bit"
     RUN file ./release/earthly-windows-amd64.exe | grep "PE32"
-    ARG BODY="No details provided"
     ARG GITHUB_SECRET_PATH="+secrets/earthly-technologies/github/griswoldthecat/token"
-    RUN --secret GITHUB_TOKEN="$GITHUB_SECRET_PATH" test -n "$GITHUB_TOKEN" && echo $GITHUB_TOKEN
     RUN --push \
         --secret GITHUB_TOKEN="$GITHUB_SECRET_PATH" \
         set -e; \
         # test github token works
-        curl -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/user" | jq .login | grep "$GITHUB_USER"; \
+        curl -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/user" | jq -r .login > /tmp/authenticated.github.user; \
         # first delete any previously released files (needed in case the previous upload attempt failed)
         PREV_RELEASE_ID=$(curl -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/repos/$GITHUB_USER/$EARTHLY_REPO/releases/tags/$RELEASE_TAG" | jq .id); \
         if [ -n "$PREV_RELEASE_ID" ] && [ "$PREV_RELEASE_ID" != "null" ]; then \
@@ -147,7 +155,7 @@ release-github:
         --commitish "$EARTHLY_GIT_HASH" \
         --tag "$RELEASE_TAG" \
         --name "$RELEASE_TAG" \
-        --body "$BODY" \
+        --body "$(cat release-notes.txt)" \
         ./release/* 2>&1 | tee /tmp/release.log && \
         if grep -i "already_exists" /tmp/release.log > /dev/null; then \
           echo "ERROR: github-release upload failed: file already exists -- you must delete if from github before proceeding" && exit 1; \

--- a/release/Earthfile
+++ b/release/Earthfile
@@ -3,57 +3,6 @@ FROM alpine:3.13
 RUN apk add --update --no-cache \
     curl
 
-all:
-    LOCALLY
-    ARG RELEASE_TAG
-    ARG GITHUB_USER=earthly
-    ARG DOCKERHUB_USER=earthly
-    ARG EARTHLY_REPO=earthly
-    ARG BREW_REPO=homebrew-earthly
-    RUN test -n "$RELEASE_TAG" || (echo "ERROR: RELEASE_TAG is not set" && exit 1)
-
-    # validate args: if doing a prod-release make sure no args are changed
-    # otherwise if a test release is detected, make sure all users are changed
-    # (this is to prevent a case where only the github user is changed, but dockerhub is not, and the dockerhub binary is accidentally overwritten)
-    RUN set -e; \
-        test -n "$RELEASE_TAG" || (echo "ERROR: RELEASE_TAG is not set" && exit 1); \
-        (echo "$RELEASE_TAG" | grep '^v[0-9]\+.[0-9]\+.[0-9]\+$' > /dev/null) || (echo "ERROR: RELEASE_TAG must be formatted as v1.2.3; instead got \"$RELEASE_TAG\""; exit 1); \
-        if [ "$GITHUB_USER" = "earthly" ] && [ "$DOCKERHUB_USER" = "earthly" ]; then \
-          test "$BREW_REPO" = "homebrew-earthly" || (echo "ERROR: prod release detected; expecting BREW_REPO=earthly, but got $BREW_REPO" && exit 1); \
-          test "$EARTHLY_REPO" = "earthly" || (echo "ERROR: prod release detected; expecting EARTHLY_REPO=earthly, but got $EARTHLY_REPO" && exit 1); \
-          test "$EARTHLY_GIT_BRANCH" = "main" || (echo "ERROR: performing release on non-main branch" && exit 1); \
-        else \
-          test "$GITHUB_USER" != "earthly" || (echo "ERROR: non-prod release detected but got GITHUB_USER=$GITHUB_USER" && exit 1); \
-          test "$DOCKERHUB_USER" != "earthly" || (echo "ERROR: non-prod release detected but got DOCKERHUB_USER=$DOCKERHUB_USER" && exit 1); \
-        fi; \
-        echo "performing release to repo=$GITHUB_USER/$EARTHLY_REPO; homebrew=$GITHUB_USER/$BREW_REPO; dockerhub=$DOCKERHUB_USER"
-
-    # terrible unsafe hack to determine --push flag
-    IF ps auxw | grep -v grep | grep earthly | grep -e --push
-        ARG PUSH="--push"
-    ELSE
-        ARG PUSH=""
-    END
-
-    RUN set -e; \
-        earthly_pid=$(ps axw | grep -v grep | grep earthly | grep 'all' | awk '{print $1}'); \
-        expected_hash=$(cat ~/.earthly/earthly-prerelease | md5sum); \
-        actual_hash=$(cat /proc/$earthly_pid/exe | md5sum); \
-        if [ "$expected_hash" != "$actual_hash" ]; then \
-          echo "\nERROR: +all requires the ./earthly script be used (rather than directly using any earthly binary).\n"; \
-          exit 1; \
-        fi;
-
-    RUN ../earthly $PUSH --build-arg DOCKERHUB_USER="$DOCKERHUB_USER" --build-arg RELEASE_TAG="$RELEASE_TAG" +release-dockerhub
-    RUN ../earthly $PUSH --build-arg GITHUB_USER="$GITHUB_USER" --build-arg EARTHLY_REPO="$EARTHLY_REPO" --build-arg BREW_REPO="$BREW_REPO" --build-arg DOCKERHUB_USER="$DOCKERHUB_USER" --build-arg RELEASE_TAG="$RELEASE_TAG" +release-github
-    RUN ../earthly $PUSH --build-arg GITHUB_USER="$GITHUB_USER" --build-arg EARTHLY_REPO="$EARTHLY_REPO" --build-arg BREW_REPO="$BREW_REPO" --build-arg DOCKERHUB_USER="$DOCKERHUB_USER" --build-arg RELEASE_TAG="$RELEASE_TAG" +release-homebrew
-
-    # TODO pass along a RELEASE_REPO_TEST_SUFFIX which would cause us to host our yum/apt repos under https://test-pkg.earthly.dev/$RELEASE_REPO_TEST_SUFFIX/...
-    # and when it is empty, we would use https://pkg.earthly.dev/...
-    #RUN ../earthly --build-arg GITHUB_USER="$GITHUB_USER" --build-arg RELEASE_TAG="$RELEASE_TAG" +release-repo
-    # until then, we will just print this out:
-    RUN echo "TODO: the apt/yum release must be triggered seperately; once we get https://test-pkg.earthly.dev/ setup"
-
 release:
     ARG RELEASE_TAG
     RUN test -n "$RELEASE_TAG"

--- a/release/Earthfile
+++ b/release/Earthfile
@@ -180,7 +180,7 @@ release-homebrew:
         openssh \
         util-linux
     RUN apk add --update --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing hub
-    
+
     # Deps and preconditions.
     ARG RELEASE_TAG
     ARG GIT_USERNAME="griswoldthecat"
@@ -209,11 +209,10 @@ release-homebrew:
     RUN --secret GIT_PASSWORD="$GITHUB_TOKEN_SECRET_PATH" --no-cache \
         git clone "https://$GITHUB_USER@github.com/$GITHUB_USER/$BREW_REPO.git" .
 
+    # Make the change in a new branch.
     ARG RELEASE_BRANCH="release-$RELEASE_TAG"
     RUN git switch -c "$RELEASE_BRANCH"
 
-    # Make the change in a new branch.
-    #RUN git checkout -b "release-$RELEASE_TAG"
     RUN mkdir -p /params
     RUN curl -L "$NEW_URL" | sha256sum | cut -f 1 -d ' ' > /params/downloadsha256
     COPY --build-arg VERSION=$RELEASE_TAG \
@@ -232,7 +231,7 @@ release-homebrew:
     RUN echo "Diff:" && git diff
     RUN version=${RELEASE_TAG#v} ;\
         echo version=$version ;\
-        git commit -a -m "earthly $version" || true
+        git commit -a --allow-empty -m "earthly $version"
     RUN --secret GIT_PASSWORD="$GITHUB_TOKEN_SECRET_PATH" \
         --push git push --force --set-upstream origin "$RELEASE_BRANCH"
 

--- a/release/README.md
+++ b/release/README.md
@@ -22,31 +22,28 @@
   * Update the year (`(c) 2021`) to point to the current year
   * Update the `Change Date` to the first April 1st after a three year period. So if today is Jan 2077, then update to 2080-04-01. If it's June 2077, then update to 2081-04-01.
   * Commit this to the `main` branch before continuing.
+* Update the CHANGELOG.md with the corresponding release notes and open a PR
+  * Use a comparison such as https://github.com/earthly/earthly/compare/v0.3.0...v0.3.1 (replace the right versions in the URL) to see which PRs went into this release.
 * Make sure that main build is green for all platforms (check build status for the latest commit on GitHub).
 * Run
   ```bash
-  ./earthly reset
+  ./release.sh
   ```
-* Run
-  ```bash
-  ./earthly --build-arg RELEASE_TAG --push -P ./release+release
-  ```
-* Go to the [releases page](https://github.com/earthly/earthly/releases) and edit the latest release to add release notes. Use a comparison such as https://github.com/earthly/earthly/compare/v0.3.0...v0.3.1 (replace the right versions in the URL) to see which PRs went into this release.
 * Run
   ```bash
   ./earthly --build-arg RELEASE_TAG --push ./release+release-repo
   ```
+  TODO: This step will be merged into the release.sh command once our staging environment is setup
 * Merge branch `main` into `next`, then merge branch `next` into `main`.
 * Update the version for the installation command in the following places:
   * [ci-integration.md](../docs/ci-integration.md)
   * [circle-integration.md](../docs/ci-integration/guides/circle-integration.md)
   * [gh-actions-integration.md](../docs/ci-integration/guides/gh-actions-integration.md)
   * [codebuild-integration.md](../docs/ci-integration/guides/codebuild-integration.md)
-  * [build-an-earthly-ci-image.md](../docs/ci-integration/build-an-earthly-ci-image.md)  
+  * [build-an-earthly-ci-image.md](../docs/ci-integration/build-an-earthly-ci-image.md)
   * you can try doing that with:
     ```
     REGEX='\(earthly\/releases\/download\/\)v[0-9]\+\.[0-9]\+\.[0-9]\+\(\/\)'; grep -Ril './docs/' -e $REGEX | xargs -n1 sed -i 's/'$REGEX'/\1'$RELEASE_TAG'\2/g'
-    
     ```
 * Update the pinned image tags used in the following places:
   * [all-in-one.md](../docs/docker-images/all-in-one.md)
@@ -74,12 +71,13 @@ To perform a test release to a personal repo, first:
 
 1. fork a copy of both `earthly/earthly`, and `earthly/homebrew-earthly`
 2. commit your changes you wish to release and push them to your personal repo.
+3. save a copy of your github token to `+secrets/user/github-token` (e.g. `earthly secrets set /user/github-token keep-it-secret`)
 
 Then run:
 
   ``bash
-  ./earthly --push +all --DOCKERHUB_USER=mydockerhubuser --GITHUB_USER=mygithubuser --GITHUB_SECRET_PATH=+secrets/user/path-to-my/github-token --RELEASE_TAG=v...
-  ``
+  RELEASE_TAG=v0.5.10 GITHUB_USER=mygithubuser DOCKERHUB_USER=mydockerhubuser EARTHLY_REPO=earthly BREW_REPO=homebrew-earthly GITHUB_SECRET_PATH=+secrets/user/github-token ./release.sh
+  ```
 
 NOTE: apt and yum repos do not currently support test releases. (TODO: fix this)
 

--- a/release/README.md
+++ b/release/README.md
@@ -32,20 +32,6 @@
   ./earthly --build-arg RELEASE_TAG --push -P ./release+release
   ```
 * Go to the [releases page](https://github.com/earthly/earthly/releases) and edit the latest release to add release notes. Use a comparison such as https://github.com/earthly/earthly/compare/v0.3.0...v0.3.1 (replace the right versions in the URL) to see which PRs went into this release.
-* Once everything looks good, uncheck the "pre-release" checkbox on the GitHub release page. This will make this release the "latest" when people install Earthly with the one-liner. Important: You **have** to do this before the next step.
-* Run
-  ```bash
-  ./earthly --build-arg RELEASE_TAG --push ./release+release-homebrew
-  ```
-* Visit the newly created pull request (which is both listed in the previous command's stdout and the `#release` slack channel); there should be two checks that are automatically applied:
-  * `brew test-bot / test-bot (ubuntu-latest)`
-  * `brew test-bot / test-bot (macos-latest)`
-
-  Once these two jobs complete, add the `pr-pull` label, which will trigger a third job `brew pr-pull / pr-pull`, which will save the artifacts produced by the prior jobs
-  and eventually merge the PR automatically.
-
-  IMPORTANT: do not merge this PR manually, the `pr-pull`-triggered job will do this for you.
-
 * Run
   ```bash
   ./earthly --build-arg RELEASE_TAG --push ./release+release-repo
@@ -74,12 +60,28 @@
   * [all-in-one.md](../docs/docker-images/all-in-one.md)
   * [buildkit-standalone.md](../docs/docker-images/buildkit-standalone.md)
 * After gitbook has processed the `main` branch, run a broken link checker over https://docs.earthly.dev. This one is fast and easy: https://www.deadlinkchecker.com/.
+* Verify the [homebrew release job](https://github.com/earthly/homebrew-earthly) has successfully run and has merged the new `release-v...` branch into `main`.
 * Copy the release notes you have written before and paste them in the Earthly Community slack channel `#announcements`, together with a link to the release's GitHub page. If you have Slack markdown editing activated, you can copy the markdown version of the text.
 * Ask Adam to tweet about the release.
 
 ### One-Time (clear this section when done during release)
 
 * Add new one-time items here.
+
+#### Performing a test release
+
+To perform a test release to a personal repo, first:
+
+1. fork a copy of both `earthly/earthly`, and `earthly/homebrew-earthly`
+2. commit your changes you wish to release and push them to your personal repo.
+
+Then run:
+
+  ``bash
+  ./earthly --push +all --DOCKERHUB_USER=mydockerhubuser --GITHUB_USER=mygithubuser --GITHUB_SECRET_PATH=+secrets/user/path-to-my/github-token --RELEASE_TAG=v...
+  ``
+
+NOTE: apt and yum repos do not currently support test releases. (TODO: fix this)
 
 #### Troubleshooting
 

--- a/release/apt-repo/Earthfile
+++ b/release/apt-repo/Earthfile
@@ -176,5 +176,4 @@ upload:
         aws s3 cp --recursive --acl public-read /repo s3://staging-pkg/deb/
 
 build-and-release:
-    ARG STAGING_PREFIX=""
-    BUILD --build-arg STAGING_PREFIX=$STAGING_PREFIX --build-arg USE_OUTPUT_COPY=false +upload
+    BUILD --build-arg USE_OUTPUT_COPY=false +upload

--- a/release/apt-repo/Earthfile
+++ b/release/apt-repo/Earthfile
@@ -176,4 +176,5 @@ upload:
         aws s3 cp --recursive --acl public-read /repo s3://staging-pkg/deb/
 
 build-and-release:
-    BUILD --build-arg USE_OUTPUT_COPY=false +upload
+    ARG STAGING_PREFIX=""
+    BUILD --build-arg STAGING_PREFIX=$STAGING_PREFIX --build-arg USE_OUTPUT_COPY=false +upload

--- a/release/changelogparser.py
+++ b/release/changelogparser.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+import argparse
+import re
+import sys
+from collections import OrderedDict
+
+class UnexpectedHeaderError(Exception):
+    pass
+
+class MissingTitleError(Exception):
+    pass
+
+class MalformedVersionHeaderError(Exception):
+    pass
+
+class MalformedHeaderError(Exception):
+    pass
+
+class DuplicateVersionError(KeyError):
+    pass
+
+
+def parse_line(line):
+    '''
+    parses lines of the form "# <title>", "## <sub title>", etc.
+    if line is not a header, a regular string is returned.
+    headers must contain exactly once space between the '#' and title, and may not contain trailling space.
+    tabs are not friends.
+    '''
+    num_headers = 0
+    for c in line:
+        if c == '#':
+            num_headers += 1
+        else:
+            break
+    if num_headers == 0:
+        return 0, line
+    line = line[num_headers:]
+    if line == "":
+        raise MalformedHeaderError(line)
+    if line[0] != " ":
+        raise MalformedHeaderError(line)
+    line = line[1:]
+    if line.startswith(" ") or line.endswith(" "):
+        raise MalformedHeaderError(line)
+
+    return num_headers, line
+
+version_line_re = re.compile(r'^(v[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?) - ([0-9]{4}-[0-9]{2}-[0-9]{2})$')
+
+def parse_changelog(changelog_data):
+    lines = changelog_data.splitlines()
+    num_headers, title = parse_line(lines[0])
+    if num_headers != 1:
+        raise MissingTitleError
+    if not title.endswith(' Changelog'):
+        raise MissingTitleError
+
+    versions = OrderedDict()
+    def save_version(version, release_date, body):
+        if version in versions:
+            raise DuplicateVersionError(version)
+        versions[version] = {
+            'date': release_date,
+            'body': '\n'.join(body),
+        }
+
+    lines = lines[1:]
+    version = None
+    for line in lines:
+        num_headers, line = parse_line(line)
+        if num_headers == 1:
+            raise UnexpectedHeaderError(line)
+        elif num_headers == 2:
+            if version:
+                save_version(version, release_date, body)
+            if line == 'Unreleased':
+                version = line
+                release_date = None
+            else:
+                m = version_line_re.match(line)
+                if not m:
+                    raise MalformedVersionHeaderError(line)
+                version = m.group(1)
+                release_date = m.group(2)
+            body = []
+        elif version:
+            body.append(line)
+
+    if version:
+        save_version(version, release_date, body)
+
+    return versions
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('changelog', help='path to change log')
+    parser.add_argument('version', help='version to display')
+    args = parser.parse_args()
+
+    try:
+        with open(args.changelog, 'rb') as fp:
+            changelog = parse_changelog(fp.read().decode('utf8'))
+    except MalformedVersionHeaderError as e:
+        print(f'failed to parse changelog: unable to parse "{e}"; should be of the form "v1.2.3 - YYYY-MM-DD"', file=sys.stderr)
+        sys.exit(1)
+    except MalformedHeaderError as e:
+        print(f'failed to parse changelog: malformed header found ({e}); should be "#[#[...]] <title>"', file=sys.stderr)
+        sys.exit(1)
+    except DuplicateVersionError as e:
+        print(f'failed to parse changelog: duplicate titles ({e}) detected', file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f'failed to parse changelog: unhandled exception {e.__class__.__name__}: {e}', file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        details = changelog[args.version]
+    except KeyError:
+        print('No changelog entry exists for {args.version}', file=sys.stderr)
+        sys.exit(1)
+    print(details['body'].strip())

--- a/release/changelogparser.py
+++ b/release/changelogparser.py
@@ -24,7 +24,7 @@ def parse_line(line):
     '''
     parses lines of the form "# <title>", "## <sub title>", etc.
     if line is not a header, a regular string is returned.
-    headers must contain exactly once space between the '#' and title, and may not contain trailling space.
+    headers must contain exactly one space between the '#' and title, and may not contain trailing spaces.
     tabs are not friends.
     '''
     num_headers = 0

--- a/release/release.sh
+++ b/release/release.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -e
+
+# earthly does not (yet) have fine control over controlling the order of RUN --push commands (they all happen at the end)
+# Our release process requires the following commands be done in order:
+# - uploading binaries to github (as a --push command)
+# - pushing a new commit to the earthly/earthly-homebrew repo
+# - downloading the binaries from github and existing binaries from s3 buckets
+# - signing those apt and yum packages containing those binaries
+# - and pushing signed up to s3 buckets (which back our apt and yum repos)
+
+# Args
+#   Required
+#     RELEASE_TAG
+#   Optional
+#     GITHUB_USER         override the default earthly github user
+#     DOCKERHUB_USER      override the default earthly dockerhub user
+#     EARTHLY_REPO        override the default earthly repo name
+#     BREW_REPO           override the default homebrew-earthly repo name
+#     GITHUB_SECRET_PATH  override the default +secrets/earthly-technologies/github/griswoldthecat/token secrets location where the github token is stored
+#
+# for example
+#  RELEASE_TAG=v0.5.10 GITHUB_USER=alexcb DOCKERHUB_USER=alexcb132 EARTHLY_REPO=earthly BREW_REPO=homebrew-earthly-1 ./release.sh
+
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+cd $SCRIPT_DIR
+
+test -n "$RELEASE_TAG" || (echo "ERROR: RELEASE_TAG is not set" && exit 1);
+(echo "$RELEASE_TAG" | grep '^v[0-9]\+.[0-9]\+.[0-9]\+$' > /dev/null) || (echo "ERROR: RELEASE_TAG must be formatted as v1.2.3; instead got \"$RELEASE_TAG\""; exit 1);
+
+# Set default values
+GITHUB_USER=${GITHUB_USER:-earthly}
+DOCKERHUB_USER=${DOCKERHUB_USER:-earthly}
+EARTHLY_REPO=${EARTHLY_REPO:-earthly}
+BREW_REPO=${BREW_REPO:-homebrew-earthly}
+GITHUB_SECRET_PATH=$GITHUB_SECRET_PATH
+
+if [ -n "$GITHUB_SECRET_PATH" ]; then
+    GITHUB_SECRET_PATH_BUILD_ARG="--build-arg GITHUB_SECRET_PATH=$GITHUB_SECRET_PATH"
+fi
+
+../earthly upgrade
+
+../earthly --push --build-arg DOCKERHUB_USER --build-arg RELEASE_TAG +release-dockerhub
+../earthly --push --build-arg GITHUB_USER --build-arg EARTHLY_REPO --build-arg BREW_REPO --build-arg DOCKERHUB_USER --build-arg RELEASE_TAG $GITHUB_SECRET_PATH_BUILD_ARG +release-github
+../earthly --push --build-arg GITHUB_USER --build-arg EARTHLY_REPO --build-arg BREW_REPO --build-arg DOCKERHUB_USER --build-arg RELEASE_TAG $GITHUB_SECRET_PATH_BUILD_ARG +release-homebrew
+
+# TODO pass along a RELEASE_REPO_TEST_SUFFIX which would cause us to host our yum/apt repos under https://test-pkg.earthly.dev/$RELEASE_REPO_TEST_SUFFIX/...
+# and when it is empty, we would use https://pkg.earthly.dev/...
+#../earthly --push --build-arg GITHUB_USER --build-arg EARTHLY_REPO --build-arg BREW_REPO --build-arg DOCKERHUB_USER --build-arg RELEASE_TAG +release-repo
+# until then, we will just print this out:
+echo "TODO: the apt/yum release must be triggered seperately; once we get https://test-pkg.earthly.dev/ setup"

--- a/release/release.sh
+++ b/release/release.sh
@@ -49,4 +49,4 @@ fi
 # and when it is empty, we would use https://pkg.earthly.dev/...
 #../earthly --push --build-arg GITHUB_USER --build-arg EARTHLY_REPO --build-arg BREW_REPO --build-arg DOCKERHUB_USER --build-arg RELEASE_TAG +release-repo
 # until then, we will just print this out:
-echo "TODO: the apt/yum release must be triggered seperately; once we get https://test-pkg.earthly.dev/ setup"
+echo "TODO: the apt/yum release must be triggered seperately; until we get https://test-pkg.earthly.dev/ setup"


### PR DESCRIPTION
This PR introduces a new release target `+all`; which will
build earthly and release it to github and our homebrew repo.

In a follow up PR we will also chain up the apt and yum releases into a
single task.

This PR additionally requires this new task be merged before we perform a new deploy: https://github.com/earthly/homebrew-earthly/pull/12 ; that PR implements the new homebrew automatic build and merge on `release-v...` branches being pushed, without having to create a PR.

Note: This PR has a very ugly hack: the `+all` target is a `LOCALLY` target which calls earthly on the individual targets. This was done as we had to run `+release-github` along with the push, before `+release-homebrew` could begin (otherwise `+release-homebrew` would try to download files which had yet to be uploaded to github).