### PR TITLE
perform linting of CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,16 +148,15 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 ## v0.5.7 - 2021-03-13
 
 - raise error when duplicate target names exists in Earthfile
-- fix zsh autocompletion issue for mac users
 - basic user defined commands (experimental)
 - cleans up console output for saving artifacts (#848)
 - implement support for WORKDIR under LOCALLY targets
-
-If the autocompletion bug persists for anyone (e.g. seeing an error like `command not found: __earthly__`), and the issues persists after upgrading to v0.5.7; it might be necessary to delete the _earthly autocompletion file before re-running earthly bootstrap (or alternatively manually replace `__earthly__` with the full path to the earthly binary).
+- fix zsh autocompletion issue for mac users
+  If the autocompletion bug persists for anyone (e.g. seeing an error like `command not found: __earthly__`), and the issues persists after upgrading to v0.5.7; it might be necessary to delete the _earthly autocompletion file before re-running earthly bootstrap (or alternatively manually replace `__earthly__` with the full path to the earthly binary).
 
 ## v0.5.6 - 2021-03-09
 
-This release removes the `ongoing` updates "Provide intermittent updates on long-running targets (#844)" from the previous release, as it has issues in the interactive mode.
+- This release removes the `ongoing` updates "Provide intermittent updates on long-running targets (#844)" from the previous release, as it has issues in the interactive mode.
 
 ## v0.5.5 - 2021-03-08
 
@@ -223,15 +222,15 @@ This release removes the `ongoing` updates "Provide intermittent updates on long
 
 ## v0.5.0-rc2 - 2021-02-01
 
-No details provided
+- No details provided
 
 ## v0.5.0-rc1 - 2021-02-01
 
-No details provided
+- No details provided
 
 ## v0.4.6 - 2021-01-29
 
-No details provided
+- No details provided
 
 ## v0.4.5 - 2021-01-13
 

--- a/Earthfile
+++ b/Earthfile
@@ -148,6 +148,12 @@ changelog:
     COPY CHANGELOG.md .
     SAVE ARTIFACT CHANGELOG.md
 
+lint-changelog:
+    FROM python:3
+    COPY release/changelogparser.py /usr/bin/changelogparser
+    COPY CHANGELOG.md .
+    RUN changelogparser --changelog CHANGELOG.md
+
 shellrepeater:
     FROM +code
     ARG GOCACHE=/go-cache
@@ -398,6 +404,7 @@ test:
     BUILD +lint
     BUILD +lint-scripts
     BUILD +lint-newline-ending
+    BUILD +lint-changelog
     BUILD +unit-test
     BUILD ./ast/tests+all
     ARG DOCKERHUB_AUTH=true

--- a/release/Earthfile
+++ b/release/Earthfile
@@ -54,7 +54,8 @@ release-notes:
     COPY changelogparser.py /usr/bin/changelogparser
     COPY ..+changelog/CHANGELOG.md .
     ARG RELEASE_TAG
-    RUN changelogparser CHANGELOG.md $RELEASE_TAG > notes.txt
+    RUN test -n "$RELEASE_TAG" || (echo "ERROR: RELEASE_TAG is missing" && exit 1)
+    RUN changelogparser --changelog CHANGELOG.md --version "$RELEASE_TAG" > notes.txt
     SAVE ARTIFACT notes.txt
 
 release-github:

--- a/release/README.md
+++ b/release/README.md
@@ -1,4 +1,4 @@
-# Releasing instructions
+## Releasing instructions
 
 ### earthly
 * Make sure you have access to the `earthly-technologies` organization secrets.

--- a/release/changelogparser.py
+++ b/release/changelogparser.py
@@ -4,23 +4,31 @@ import re
 import sys
 from collections import OrderedDict
 
-class UnexpectedHeaderError(Exception):
+class ChangeLogParseError(Exception):
+    def __init__(self, message, line):
+        super().__init__(message)
+        self.line = line
+
+class UnexpectedHeaderError(ChangeLogParseError):
     pass
 
-class MissingTitleError(Exception):
+class MissingTitleError(ChangeLogParseError):
     pass
 
-class MalformedVersionHeaderError(Exception):
+class MalformedVersionHeaderError(ChangeLogParseError):
     pass
 
-class MalformedHeaderError(Exception):
+class MalformedHeaderError(ChangeLogParseError):
     pass
 
-class DuplicateVersionError(KeyError):
+class MalformedUnorderedItemError(ChangeLogParseError):
+    pass
+
+class DuplicateVersionError(ChangeLogParseError):
     pass
 
 
-def parse_line(line):
+def parse_line(line, line_num):
     '''
     parses lines of the form "# <title>", "## <sub title>", etc.
     if line is not a header, a regular string is returned.
@@ -37,25 +45,18 @@ def parse_line(line):
         return 0, line
     line = line[num_headers:]
     if line == "":
-        raise MalformedHeaderError(line)
+        raise MalformedHeaderError(line, line_num)
     if line[0] != " ":
-        raise MalformedHeaderError(line)
+        raise MalformedHeaderError(line, line_num)
     line = line[1:]
     if line.startswith(" ") or line.endswith(" "):
-        raise MalformedHeaderError(line)
+        raise MalformedHeaderError(line, line_num)
 
     return num_headers, line
 
 version_line_re = re.compile(r'^(v[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?) - ([0-9]{4}-[0-9]{2}-[0-9]{2})$')
 
 def parse_changelog(changelog_data):
-    lines = changelog_data.splitlines()
-    num_headers, title = parse_line(lines[0])
-    if num_headers != 1:
-        raise MissingTitleError
-    if not title.endswith(' Changelog'):
-        raise MissingTitleError
-
     versions = OrderedDict()
     def save_version(version, release_date, body):
         if version in versions:
@@ -65,27 +66,59 @@ def parse_changelog(changelog_data):
             'body': '\n'.join(body),
         }
 
-    lines = lines[1:]
+    line_num = 1
     version = None
-    for line in lines:
-        num_headers, line = parse_line(line)
-        if num_headers == 1:
-            raise UnexpectedHeaderError(line)
+    is_title_body = False
+    dash_found = False
+    body = []
+    for line_num, line in enumerate(changelog_data.splitlines()):
+        num_headers, title = parse_line(line, line_num)
+
+        if line_num == 0:
+            if num_headers != 1:
+                raise MissingTitleError(f'expected title main `# <project-name> Changelog` title; got {line}', line_num)
+            if not title.endswith(' Changelog'):
+                raise MissingTitleError("expected title ending with Changelog", line_num)
+            is_title_body = True
+            continue
+
+        if num_headers == 0:
+            if is_title_body:
+                pass # no linting of title body
+            elif line == '':
+                dash_found = False
+            elif line.startswith('-'):
+                if not line.startswith('- '):
+                    raise MalformedUnorderedItemError(f'expected unordered item of the form `- <text>`; got {line}', line_num)
+                dash_found = True
+            elif not line.startswith(' '):
+                raise MalformedUnorderedItemError(f'expected unordered item of the form `- <text>` (or `- <text>\\n  <more text>`); got {line}', line_num)
+            if line.startswith(' ') and dash_found is False:
+                raise MalformedUnorderedItemError(f'expected unordered item of the form `- <text>` (or `- <text>\\n  <more text>`); got {line}', line_num)
+            body.append(line)
+        elif num_headers == 1:
+            raise UnexpectedHeaderError(line, line_num)
         elif num_headers == 2:
-            if version:
-                save_version(version, release_date, body)
-            if line == 'Unreleased':
-                version = line
+            if is_title_body:
+                if title != 'Unreleased':
+                    raise MissingTitleError(f'expected `## Unreleased` title; got {line}', line_num)
+                is_title_body = False
+                assert version is None
+                version = title
                 release_date = None
             else:
-                m = version_line_re.match(line)
+                if version:
+                    save_version(version, release_date, body)
+                m = version_line_re.match(title)
                 if not m:
-                    raise MalformedVersionHeaderError(line)
+                    raise MalformedVersionHeaderError(line, line_num)
                 version = m.group(1)
                 release_date = m.group(2)
             body = []
-        elif version:
-            body.append(line)
+        elif num_headers == 3:
+            allowed_titles = ('Added', 'Changed', 'Removed', 'Fixed')
+            if title not in allowed_titles:
+                raise UnexpectedHeaderError(f'expected header of {allowed_titles}; but got {title}', line_num)
 
     if version:
         save_version(version, release_date, body)
@@ -94,29 +127,40 @@ def parse_changelog(changelog_data):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('changelog', help='path to change log')
-    parser.add_argument('version', help='version to display')
+    parser.add_argument('--changelog', help='path to change log; if omitted changelog is read from stdin')
+    parser.add_argument('--version', help='version to display; if omitted, changelog is still parsed and any errors are displayed', default=None)
     args = parser.parse_args()
 
-    try:
+    path_str = args.changelog
+    if path_str is None:
+        path_str = 'stdin'
+        changelog_str = sys.stdin.read()
+    else:
         with open(args.changelog, 'rb') as fp:
-            changelog = parse_changelog(fp.read().decode('utf8'))
+            changelog_str = fp.read().decode('utf8')
+
+    try:
+        changelog = parse_changelog(changelog_str)
     except MalformedVersionHeaderError as e:
-        print(f'failed to parse changelog: unable to parse "{e}"; should be of the form "v1.2.3 - YYYY-MM-DD"', file=sys.stderr)
+        print(f'failed to parse {path_str}:{e.line+1}: unable to parse "{e}"; should be of the form "v1.2.3 - YYYY-MM-DD"', file=sys.stderr)
         sys.exit(1)
     except MalformedHeaderError as e:
-        print(f'failed to parse changelog: malformed header found ({e}); should be "#[#[...]] <title>"', file=sys.stderr)
+        print(f'failed to parse {path_str}:{e.line+1}: malformed header found ({e}); should be "#[#[...]] <title>"', file=sys.stderr)
         sys.exit(1)
     except DuplicateVersionError as e:
-        print(f'failed to parse changelog: duplicate titles ({e}) detected', file=sys.stderr)
+        print(f'failed to parse {path_str}:{e.line+1}: duplicate titles ({e}) detected', file=sys.stderr)
         sys.exit(1)
-    except Exception as e:
-        print(f'failed to parse changelog: unhandled exception {e.__class__.__name__}: {e}', file=sys.stderr)
+    except ChangeLogParseError as e:
+        print(f'failed to parse {path_str}:{e.line+1}: unhandled exception {e.__class__.__name__}: {e}', file=sys.stderr)
         sys.exit(1)
+
+    if args.version is None:
+        # running under linting mode
+        sys.exit(0)
 
     try:
         details = changelog[args.version]
     except KeyError:
-        print('No changelog entry exists for {args.version}', file=sys.stderr)
+        print(f'No changelog entry exists for {args.version}', file=sys.stderr)
         sys.exit(1)
     print(details['body'].strip())


### PR DESCRIPTION
- Ensure the CHANGELOG.md file can be correctly parsed
- Changed parser to be more strict in what is accepted:
  - all unordered items must start with `- `,
  - only 'Added', 'Changed', 'Removed', 'Fixed' H3 headers are allowed
    under version releases
  - errors now display the corresponding changelog line number
- Allow changelogparser to read from stdin

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>