### PR TITLE
Small Build Cleanup

### DIFF
--- a/.buildkite/tests.sh
+++ b/.buildkite/tests.sh
@@ -24,11 +24,6 @@ case "$EARTHLY_OS" in
         download_url="https://github.com/earthly/earthly/releases/latest/download/earthly-linux-amd64"
         earthly="./build/linux/amd64/earthly"
         ;;
-
-    windows)
-        download_url="https://github.com/earthly/earthly/releases/latest/download/earthly-windows-amd64.exe"
-        earthly="./build/windows/amd64/earthly.exe"
-        ;;
 esac
 
 echo "The detected architecture of the runner is $(uname -m)"
@@ -67,14 +62,8 @@ export EARTHLY_VERSION_FLAG_OVERRIDES="referenced-save-only"
 
  mirrors = [\"registry-1.docker.io.mirror.corp.earthly.dev\"]'"
 
-if [ "$EARTHLY_OS" != "windows" ]; then
-  # Windows cannot run these tests due to a buildkitd dependency right now.
-  echo "Execute tests"
-  "$earthly" --ci -P +test
+echo "Execute tests"
+"$earthly" --ci -P +test
 
-  echo "Execute fail test"
-  bash -c "! $earthly --ci ./examples/tests/fail+test-fail"
-fi
-
-echo "Build examples"
-"$earthly" --ci -P +examples
+echo "Execute fail test"
+bash -c "! $earthly --ci ./examples/tests/fail+test-fail"

--- a/.buildkite/windows.yml
+++ b/.buildkite/windows.yml
@@ -12,16 +12,3 @@ steps:
     agents:
       os: wsl2
     timeout_in_minutes: 55
-
-  - label: Test Native
-    commands:
-      - ./.buildkite/tests.sh
-    depends_on: wsl
-    env:
-      EARTHLY_INSTALL_ID: "earthly-buildkite-windows"
-      FORCE_COLOR: 1
-      EARTHLY_OS: windows
-      EARTHLY_CONFIG: "./.buildkite/earthly-config-win.yml"
-    agents:
-      os: wsl2
-    timeout_in_minutes: 55


### PR DESCRIPTION
Remove Native Windows Tests in favor of a native Windows build setup in the future. Also only do +test on these.

We will still need to modify the schedule on Buildkite itself AFAICT