### PR TITLE
Fully Qualify Buildkitd Image

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -211,7 +211,7 @@ earthly:
     ARG EARTHLY_TARGET_TAG_DOCKER
     ARG VERSION="dev-$EARTHLY_TARGET_TAG_DOCKER"
     ARG EARTHLY_GIT_HASH
-    ARG DEFAULT_BUILDKITD_IMAGE=earthly/buildkitd:$VERSION
+    ARG DEFAULT_BUILDKITD_IMAGE=docker.io/earthly/buildkitd:$VERSION # The image needs to be fully qualified for alternative frontend support.
     ARG BUILD_TAGS=dfrunmount dfrunsecurity dfsecrets dfssh dfrunnetwork dfheredoc
     ARG GOCACHE=/go-cache
     RUN mkdir -p build


### PR DESCRIPTION
This should lift the requirement to add `docker.io` to the list of registries, or pull the image in advance for `podman` frontends. This should also be compatible with existing `docker` frontends.