### PR TITLE
Implement Required ARGs #904

### DIFF
--- a/earthfile2llb/flags.go
+++ b/earthfile2llb/flags.go
@@ -110,3 +110,7 @@ type doOpts struct {
 type importOpts struct {
 	AllowPrivileged bool `long:"allow-privileged" description:"Allow targets to assume privileged mode"`
 }
+
+type argOpts struct {
+	Required bool `long:"required" description:"Require argument to be non-empty"`
+}

--- a/earthfile2llb/interpreter.go
+++ b/earthfile2llb/interpreter.go
@@ -1028,22 +1028,30 @@ func (i *Interpreter) handleArg(ctx context.Context, cmd spec.Command) error {
 	if i.pushOnlyAllowed {
 		return i.pushOnlyErr(cmd.SourceLocation)
 	}
+	opts := argOpts{}
+	args, err := flagutil.ParseArgs("ARG", &opts, getArgsCopy(cmd))
+	if err != nil {
+		return i.wrapError(err, cmd.SourceLocation, "invalid ARG arguments %v", cmd.Args)
+	}
 	var key, value string
-	switch len(cmd.Args) {
+	switch len(args) {
 	case 3:
-		if cmd.Args[1] != "=" {
+		if args[1] != "=" {
 			return i.errorf(cmd.SourceLocation, "invalid syntax")
 		}
-		value = i.expandArgs(cmd.Args[2], true)
+		value = i.expandArgs(args[2], true)
 		fallthrough
 	case 1:
-		key = cmd.Args[0] // Note: Not expanding args for key.
+		if opts.Required && len(value) == 0 {
+			return i.errorf(cmd.SourceLocation, "required ARG cannot be empty")
+		}
+		key = args[0] // Note: Not expanding args for key.
 	default:
 		return i.errorf(cmd.SourceLocation, "invalid syntax")
 	}
 	// Args declared in the base target are global.
 	global := i.isBase
-	err := i.converter.Arg(ctx, key, value, global)
+	err = i.converter.Arg(ctx, key, value, global)
 	if err != nil {
 		return i.wrapError(err, cmd.SourceLocation, "apply ARG")
 	}


### PR DESCRIPTION
Add optional `--required` flag for Earthfile `ARG`s. Based on implementation description from https://github.com/earthly/earthly/issues/904

Unable to run integration tests using `./build/linux/amd64/earthly -P +test-all` after building with `./build/linux/amd64/earthly +for-linux` due to [dockerhub auth errors](https://hastebin.com/idonahepiy.php). Is there Earthly specific setup I need to do to run these integ tests locally?

I would be more than happy to help update [ARG reference](https://docs.earthly.dev/docs/earthfile#arg) if this implementation is what the maintainers are looking for. Should I create or add to existing unit/integ tests in this repo?

For contacting me directly, my Slack member ID is `U02GHP4SYN7`. Thanks!