### PR TITLE
Add user platform built-in vars

### DIFF
--- a/docs/earthfile/builtin-args.md
+++ b/docs/earthfile/builtin-args.md
@@ -41,6 +41,10 @@ The following builtin args are available
 | `TARGETARCH` | (**experimental**) The target processor architecture the target is being built for. | `arm`, `amd64`, `arm64` |
 | `TARGETVARIANT` | (**experimental**) The target processor architecture variant the target is being built for. | `v7` |
 | `EARTHLY_SOURCE_DATE_EPOCH` | The timestamp, as unix seconds, of the git commit detected within the build context directory. If no git directory is detected, then the value is `0` (the unix epoch) | `1626881847`, `0` |
+| `USERPLATFORM` | (**experimental**) The platform the target is being built on. | `linux/arm/v7`, `linux/amd64`, `linux/arm64` |
+| `USEROS` | (**experimental**) The OS the target is being built on. | `linux` |
+| `USERARCH` | (**experimental**) The processor architecture the target is being built on. | `arm`, `amd64`, `arm64` |
+| `USERVARIANT` | (**experimental**) The processor architecture variant the target is being built on. | `v7` |
 
 {% hint style='info' %}
 ##### Note

--- a/docs/earthfile/builtin-args.md
+++ b/docs/earthfile/builtin-args.md
@@ -41,10 +41,10 @@ The following builtin args are available
 | `TARGETARCH` | (**experimental**) The target processor architecture the target is being built for. | `arm`, `amd64`, `arm64` |
 | `TARGETVARIANT` | (**experimental**) The target processor architecture variant the target is being built for. | `v7` |
 | `EARTHLY_SOURCE_DATE_EPOCH` | The timestamp, as unix seconds, of the git commit detected within the build context directory. If no git directory is detected, then the value is `0` (the unix epoch) | `1626881847`, `0` |
-| `USERPLATFORM` | (**experimental**) The platform the target is being built on. | `linux/arm/v7`, `linux/amd64`, `linux/arm64` |
-| `USEROS` | (**experimental**) The OS the target is being built on. | `linux` |
-| `USERARCH` | (**experimental**) The processor architecture the target is being built on. | `arm`, `amd64`, `arm64` |
-| `USERVARIANT` | (**experimental**) The processor architecture variant the target is being built on. | `v7` |
+| `USERPLATFORM` | (**experimental**) The platform the target is being built from. | `linux/arm/v7`, `linux/amd64`, `linux/arm64` |
+| `USEROS` | (**experimental**) The OS the target is being built from. | `linux` |
+| `USERARCH` | (**experimental**) The processor architecture the target is being built from. | `arm`, `amd64`, `arm64` |
+| `USERVARIANT` | (**experimental**) The processor architecture variant the target is being built from. | `v7` |
 
 {% hint style='info' %}
 ##### Note

--- a/states/dedup/targetinput.go
+++ b/states/dedup/targetinput.go
@@ -161,6 +161,10 @@ var BuiltinVariables = map[string]bool{
 	"TARGETARCH":                      true,
 	"TARGETVARIANT":                   true,
 	"EARTHLY_SOURCE_DATE_EPOCH":       true,
+	"USERPLATFORM":                    true,
+	"USEROS":                          true,
+	"USERARCH":                        true,
+	"USERVARIANT":                     true,
 }
 
 // IsDefaultValue returns whether the value of the BuildArgInput

--- a/util/llbutil/platform.go
+++ b/util/llbutil/platform.go
@@ -32,15 +32,6 @@ func DefaultPlatform() specs.Platform {
 	return platforms.Normalize(p)
 }
 
-// DefaultUserPlatform returns the default platform of the host it is running on.
-func DefaultUserPlatform() specs.Platform {
-	p := platforms.DefaultSpec()
-	if runtime.GOOS == "darwin" {
-		p.OS = "linux"
-	}
-	return platforms.Normalize(p)
-}
-
 // ScratchWithPlatform is the scratch state with the default platform readily set.
 func ScratchWithPlatform() pllb.State {
 	return pllb.Scratch().Platform(DefaultPlatform())

--- a/util/llbutil/platform.go
+++ b/util/llbutil/platform.go
@@ -32,6 +32,15 @@ func DefaultPlatform() specs.Platform {
 	return platforms.Normalize(p)
 }
 
+// DefaultUserPlatform returns the default platform of the host it is running on.
+func DefaultUserPlatform() specs.Platform {
+	p := platforms.DefaultSpec()
+	if runtime.GOOS == "darwin" {
+		p.OS = "linux"
+	}
+	return platforms.Normalize(p)
+}
+
 // ScratchWithPlatform is the scratch state with the default platform readily set.
 func ScratchWithPlatform() pllb.State {
 	return pllb.Scratch().Platform(DefaultPlatform())

--- a/variables/builtin.go
+++ b/variables/builtin.go
@@ -73,7 +73,7 @@ func SetPlatformArgs(s *Scope, platform specs.Platform) {
 
 // SetUserPlatformArgs sets the user's platform-specific built-in args.
 func SetUserPlatformArgs(s *Scope) {
-	platform := platforms.DefaultSpec()
+	platform := llbutil.DefaultUserPlatform()
 	s.AddInactive("USERPLATFORM", platforms.Format(platform))
 	s.AddInactive("USEROS", platform.OS)
 	s.AddInactive("USERARCH", platform.Architecture)

--- a/variables/builtin.go
+++ b/variables/builtin.go
@@ -25,6 +25,7 @@ func BuiltinArgs(target domain.Target, platform specs.Platform, gitMeta *gitutil
 	ret.AddInactive("EARTHLY_TARGET_TAG", target.Tag)
 	ret.AddInactive("EARTHLY_TARGET_TAG_DOCKER", llbutil.DockerTagSafe(target.Tag))
 	SetPlatformArgs(ret, platform)
+	SetUserPlatformArgs(ret)
 
 	if gitMeta != nil {
 		ret.AddInactive("EARTHLY_GIT_HASH", gitMeta.Hash)
@@ -68,6 +69,15 @@ func SetPlatformArgs(s *Scope, platform specs.Platform) {
 	s.AddInactive("TARGETOS", platform.OS)
 	s.AddInactive("TARGETARCH", platform.Architecture)
 	s.AddInactive("TARGETVARIANT", platform.Variant)
+}
+
+// SetUserPlatformArgs sets the user's platform-specific built-in args.
+func SetUserPlatformArgs(s *Scope) {
+	platform := platforms.DefaultSpec()
+	s.AddInactive("USERPLATFORM", platforms.Format(platform))
+	s.AddInactive("USEROS", platform.OS)
+	s.AddInactive("USERARCH", platform.Architecture)
+	s.AddInactive("USERVARIANT", platform.Variant)
 }
 
 // getProjectName returns the depricated PROJECT_NAME value

--- a/variables/builtin.go
+++ b/variables/builtin.go
@@ -73,7 +73,7 @@ func SetPlatformArgs(s *Scope, platform specs.Platform) {
 
 // SetUserPlatformArgs sets the user's platform-specific built-in args.
 func SetUserPlatformArgs(s *Scope) {
-	platform := llbutil.DefaultUserPlatform()
+	platform := platforms.DefaultSpec()
 	s.AddInactive("USERPLATFORM", platforms.Format(platform))
 	s.AddInactive("USEROS", platform.OS)
 	s.AddInactive("USERARCH", platform.Architecture)


### PR DESCRIPTION
resolves #1228 

This adds the built-ins for `USERPLATFORM`, `USEROS`, `USERARCH`, and `USERVARIANT` for the host platform.

Are there any other places that these need to be documented? I added it in the `built-ins.md`, but I'm not sure if there's anywhere else it needs to be added. Also, should these be considered experimental similar to how `TARGET*` are?