### PR TITLE
Fix containerutil Tests on M1

### DIFF
--- a/util/containerutil/frontend_test.go
+++ b/util/containerutil/frontend_test.go
@@ -272,7 +272,7 @@ func TestFrontendContainerRun(t *testing.T) {
 					Privileged:     false,
 					Envs:           containerutil.EnvMap{"test": name},
 					Labels:         containerutil.LabelMap{"test": name},
-					ContainerArgs:  []string{"--text", "create-test"},
+					ContainerArgs:  []string{"nginx-debug", "-g", "daemon off;"},
 					AdditionalArgs: []string{"--rm"},
 					Mounts: containerutil.MountOpt{
 						containerutil.Mount{
@@ -338,13 +338,11 @@ func TestFrontendImagePull(t *testing.T) {
 			fe, err := tC.newFunc(ctx)
 			assert.NoError(t, err)
 
-			refList := []string{"nginx:1.21", "alpine:3.13"}
-
-			err = fe.ImagePull(ctx, refList...)
+			err = fe.ImagePull(ctx, tC.refList...)
 			assert.NoError(t, err)
 
 			defer func() {
-				for _, ref := range refList {
+				for _, ref := range tC.refList {
 					cmd := exec.CommandContext(ctx, "docker", "image", "rm", "-f", ref)
 					cmd.Run()
 				}

--- a/util/containerutil/frontend_test.go
+++ b/util/containerutil/frontend_test.go
@@ -554,7 +554,7 @@ func isBinaryInstalled(ctx context.Context, binary string) bool {
 func spawnTestContainers(ctx context.Context, feBinary string, names ...string) (func(), error) {
 	var err error
 	for _, name := range names {
-		cmd := exec.CommandContext(ctx, feBinary, "run", "-d", "--name", name, "docker.io/hashicorp/http-echo:latest", `-text="test"`)
+		cmd := exec.CommandContext(ctx, feBinary, "run", "-d", "--name", name, "docker.io/nginx:1.21", `-text="test"`)
 		output, createErr := cmd.CombinedOutput()
 		if err != nil {
 			// the frontend exists but is non-functional. This is... not likely to work at all.

--- a/util/containerutil/frontend_test.go
+++ b/util/containerutil/frontend_test.go
@@ -268,7 +268,7 @@ func TestFrontendContainerRun(t *testing.T) {
 			for _, name := range testContainers {
 				runs = append(runs, containerutil.ContainerRun{
 					NameOrID:       name,
-					ImageRef:       "docker.io/hashicorp/http-echo:latest",
+					ImageRef:       "docker.io/nginx:1.21",
 					Privileged:     false,
 					Envs:           containerutil.EnvMap{"test": name},
 					Labels:         containerutil.LabelMap{"test": name},
@@ -327,8 +327,8 @@ func TestFrontendImagePull(t *testing.T) {
 		newFunc func(context.Context) (containerutil.ContainerFrontend, error)
 		refList []string
 	}{
-		{"docker", containerutil.NewDockerShellFrontend, []string{"hello-world", "alpine:3.13"}},
-		{"podman", containerutil.NewPodmanShellFrontend, []string{"docker.io/hello-world", "docker.io/alpine:3.13"}}, // Podman prefers... and exports fully-qualified image tags
+		{"docker", containerutil.NewDockerShellFrontend, []string{"nginx:1.21", "alpine:3.13"}},
+		{"podman", containerutil.NewPodmanShellFrontend, []string{"docker.io/nginx:1.21", "docker.io/alpine:3.13"}}, // Podman prefers... and exports fully-qualified image tags
 	}
 	for _, tC := range testCases {
 		t.Run(tC.binary, func(t *testing.T) {
@@ -338,7 +338,7 @@ func TestFrontendImagePull(t *testing.T) {
 			fe, err := tC.newFunc(ctx)
 			assert.NoError(t, err)
 
-			refList := []string{"hello-world", "alpine:3.13"}
+			refList := []string{"nginx:1.21", "alpine:3.13"}
 
 			err = fe.ImagePull(ctx, refList...)
 			assert.NoError(t, err)
@@ -573,7 +573,7 @@ func spawnTestContainers(ctx context.Context, feBinary string, names ...string) 
 func spawnTestImages(ctx context.Context, feBinary string, refs ...string) (func(), error) {
 	var err error
 	for _, ref := range refs {
-		cmd := exec.CommandContext(ctx, feBinary, "image", "pull", "docker.io/hello-world")
+		cmd := exec.CommandContext(ctx, feBinary, "image", "pull", "docker.io/nginx:1.21")
 		output, createErr := cmd.CombinedOutput()
 		if err != nil {
 			// the frontend exists but is non-functional. This is... not likely to work at all.
@@ -581,7 +581,7 @@ func spawnTestImages(ctx context.Context, feBinary string, refs ...string) (func
 			break
 		}
 
-		cmd = exec.CommandContext(ctx, feBinary, "image", "tag", "docker.io/hello-world", ref)
+		cmd = exec.CommandContext(ctx, feBinary, "image", "tag", "docker.io/nginx:1.21", ref)
 		output, tagErr := cmd.CombinedOutput()
 		if err != nil {
 			// the frontend exists but is non-functional. This is... not likely to work at all.

--- a/util/containerutil/frontend_test.go
+++ b/util/containerutil/frontend_test.go
@@ -131,10 +131,10 @@ func TestFrontendContainerInfo(t *testing.T) {
 			assert.Len(t, info, 3)
 
 			assert.Equal(t, getInfos[0], info[getInfos[0]].Name)
-			assert.Equal(t, "docker.io/hashicorp/http-echo:latest", info[getInfos[0]].Image)
+			assert.Equal(t, "docker.io/nginx:1.21", info[getInfos[0]].Image)
 
 			assert.Equal(t, getInfos[1], info[getInfos[1]].Name)
-			assert.Equal(t, "docker.io/hashicorp/http-echo:latest", info[getInfos[1]].Image)
+			assert.Equal(t, "docker.io/nginx:1.21", info[getInfos[1]].Image)
 
 			assert.Equal(t, getInfos[2], info[getInfos[2]].Name)
 			assert.Equal(t, containerutil.StatusMissing, info[getInfos[2]].Status)

--- a/util/containerutil/frontend_test.go
+++ b/util/containerutil/frontend_test.go
@@ -131,10 +131,10 @@ func TestFrontendContainerInfo(t *testing.T) {
 			assert.Len(t, info, 3)
 
 			assert.Equal(t, getInfos[0], info[getInfos[0]].Name)
-			assert.Equal(t, "docker.io/nginx:1.21", info[getInfos[0]].Image)
+			assert.Equal(t, "docker.io/library/nginx:1.21", info[getInfos[0]].Image)
 
 			assert.Equal(t, getInfos[1], info[getInfos[1]].Name)
-			assert.Equal(t, "docker.io/nginx:1.21", info[getInfos[1]].Image)
+			assert.Equal(t, "docker.io/library/nginx:1.21", info[getInfos[1]].Image)
 
 			assert.Equal(t, getInfos[2], info[getInfos[2]].Name)
 			assert.Equal(t, containerutil.StatusMissing, info[getInfos[2]].Status)
@@ -552,7 +552,7 @@ func isBinaryInstalled(ctx context.Context, binary string) bool {
 func spawnTestContainers(ctx context.Context, feBinary string, names ...string) (func(), error) {
 	var err error
 	for _, name := range names {
-		cmd := exec.CommandContext(ctx, feBinary, "run", "-d", "--name", name, "docker.io/nginx:1.21", `-text="test"`)
+		cmd := exec.CommandContext(ctx, feBinary, "run", "-d", "--name", name, "docker.io/library/nginx:1.21", `-text="test"`)
 		output, createErr := cmd.CombinedOutput()
 		if err != nil {
 			// the frontend exists but is non-functional. This is... not likely to work at all.


### PR DESCRIPTION
The image being used for unit/integration tests was old, and did not have an arm platform image avaliable. This swaps over to an NGINX build, from the official Docker repositories to remedy this.

Tested on an M1 by hand.