### PR TITLE
vale is only available for amd64

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -157,7 +157,7 @@ vale:
     COPY .vale/ .
 
 markdown-spellcheck:
-    FROM +vale
+    FROM --platform=linux/amd64 +vale
     WORKDIR /everything
     COPY . .
     # TODO figure out a way to ignore this pattern in vale (doesn't seem to be working under spelling's filter option)


### PR DESCRIPTION
It is not supported by arm, and produces an error such as:

    ValeLint/vale crit platform linux/arm64 is not supported.

When run from an arm-defice (such as a mac M1).

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>