### PR TITLE
buildkite test job killer

### DIFF
--- a/.buildkite/tests.sh
+++ b/.buildkite/tests.sh
@@ -2,7 +2,16 @@
 
 set -xeu
 
-trap 'kill $(jobs -p); wait' SIGINT SIGTERM
+function cleanup() {
+    jobs="$(jobs -p)"
+    if [ -n "$jobs" ]
+    then
+        # shellcheck disable=SC2086 # Intended splitting of 
+        kill $jobs
+    fi
+    wait
+}
+trap cleanup EXIT
 
 export EARTHLY_CONVERSION_PARALLELISM=5
 


### PR DESCRIPTION
If no jobs are running, we get the errornous error:

    kill: usage: kill [-s sigspec | -n signum | -sigspec] pid | jobspec ... or kill -l [sigspec]

which adds noise to the error logs.

Additionally, we should kill jobs on all exits (including clean), not just sigint and sigterm

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>