### PR TITLE
Use Fork Repo When Running Remote Tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
           fi
           ./build/linux/amd64/earthly --ci -P \
              --build-arg DOCKERHUB_AUTH=false \
-           "github.com/GITHUB_FORK_REPOSITORY:$branch+test"
+           "github.com/$GITHUB_FORK_REPOSITORY:$branch+test"
         if: github.event_name != 'push' && github.event.pull_request.head.repo.full_name != github.repository
       - name: Execute fail test
         run: |


### PR DESCRIPTION
I tested this in a forked CI. Here are the variables that came out of it compared:

```
GITHUB_REPOSITORY=earthly/earthly
GHA_FORK_REPO: dchw/earthly
```

This should let the forked version point at itself instead of our main repo. We may(?) need to do this for the branch too...