### PR TITLE
fixed variable declaration and assignment   -----> buildcontext/provider/provider.go

### DIFF
--- a/buildcontext/provider/provider.go
+++ b/buildcontext/provider/provider.go
@@ -88,7 +88,7 @@ func (bcp *BuildContextProvider) addDir(dirName, dir string) {
 		st.Gid = 0
 		return true
 	}
-	var sd SyncedDir = SyncedDir{
+	sd := SyncedDir{
 		Name: dirName,
 		Dir:  dir,
 		Map:  resetUIDAndGID,


### PR DESCRIPTION
var sd SyncedDir
 sd = SyncedDir{
 Name: dirName,
 Dir:  dir,
 Map:  resetUIDAndGID,

above the variable declaration and assignment is done seperately 

this should be like this 

var sd SyncedDir = SyncedDir{

 Name: dirName,
 Dir:  dir,
 Map:  resetUIDAndGID,