### PR TITLE
autocompletion should suggest base when no other targets

### DIFF
--- a/autocomplete/complete.go
+++ b/autocomplete/complete.go
@@ -96,6 +96,10 @@ func getPotentialPaths(prefix string) ([]string, error) {
 		if err != nil {
 			return nil, err
 		}
+		if len(targets) == 0 {
+			// only suggest when Earthfile has no other targets
+			targets = append(targets, "base")
+		}
 
 		potentials := []string{}
 		for _, target := range targets {

--- a/examples/tests/autocompletion/Earthfile
+++ b/examples/tests/autocompletion/Earthfile
@@ -46,6 +46,12 @@ test-targets:
     RUN COMP_LINE="earthly +m" COMP_POINT=10 earthly > actual
     RUN diff expected actual
 
+test-base-only-target:
+    COPY base.earth ./Earthfile
+    RUN echo "+base " > expected
+    RUN COMP_LINE="earthly +" COMP_POINT=9 earthly > actual
+    RUN diff expected actual
+
 test-relative-dir-targets:
     RUN mkdir -p /test/foo
     COPY fake.earth /test/foo/Earthfile
@@ -62,4 +68,5 @@ test-all:
     BUILD +test-root-commands
     BUILD +test-hidden-root-commands
     BUILD +test-targets
+    BUILD +test-base-only-target
     BUILD +test-relative-dir-targets

--- a/examples/tests/autocompletion/base.earth
+++ b/examples/tests/autocompletion/base.earth
@@ -1,0 +1,3 @@
+FROM alpine:latest
+
+RUN echo "this Earthfile only has a +base target"


### PR DESCRIPTION
If a user has created an Earthfile with no targets, auto completion
only completes to `...+` but doesn't suggest `...+base`. In this case
we will assume the user wants to build base as there's no other options.
In all other cases, we will continue to hide `+base`.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>