### PR TITLE
Test to see if the wrong file is being copied

### DIFF
--- a/examples/tests/dind-auto-install/Earthfile
+++ b/examples/tests/dind-auto-install/Earthfile
@@ -1,4 +1,3 @@
-
 all:
     BUILD \
         --build-arg BASE_IMAGE=docker:dind \
@@ -16,6 +15,7 @@ test:
     ARG BASE_IMAGE
     FROM $BASE_IMAGE
     COPY ./docker-compose.yml ./
+    RUN cat docker-compose.yml && md5sum docker-compose.yml | grep b6626aeca817ea311ae8f1555c01a9cb
     WITH DOCKER --compose docker-compose.yml
         RUN true
     END


### PR DESCRIPTION
I'm seeing an odd error with this test in an unrelated PR.
This is a draft PR to see if the buildkit context is copying the wrong file in.

    ./e/t/dind-auto-install+test *failed* | Docker Compose was missing. It has been installed automatically by Earthly.
    ./e/t/dind-auto-install+test *failed* | /usr/local/bin/***-compose: line 1: syntax error near unexpected token `newline'
    ./e/t/dind-auto-install+test *failed* | /usr/local/bin/***-compose: line 1: `<?xml version="1.0" encoding="UTF-8"?>'

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>