### PR TITLE
Make it obvious when a interactive test timeout occurs

### DIFF
--- a/scripts/tests/interactive-debugger/docker-compose/test-docker-compose.py
+++ b/scripts/tests/interactive-debugger/docker-compose/test-docker-compose.py
@@ -46,17 +46,19 @@ def test_interactive(earthly_path, timeout):
             c.wait()
 
             assert not c.isalive()
+        except pexpect.exceptions.TIMEOUT as e:
+            print('interactive test timedout')
+            exit_code = 2
         except Exception as e:
-            print('interactive test failed')
-            print(f'{e}')
-
-            print('pexpect debug information')
-            print(str(c))
+            print(f'interactive test failed with {e}')
             exit_code = 1
         finally:
             print('earthly output')
             s = ''.join(ch for ch in output.getvalue() if ch.isprintable() or ch == '\n')
             print(s)
+            if exit_code:
+                print('additional pexpect debug information')
+                print(str(c)+'\n')
     finally:
         os.chdir(cwd)
 

--- a/scripts/tests/interactive-debugger/simple/test-simple.py
+++ b/scripts/tests/interactive-debugger/simple/test-simple.py
@@ -40,17 +40,19 @@ def test_interactive(earthly_path, timeout):
             c.wait()
 
             assert not c.isalive()
+        except pexpect.exceptions.TIMEOUT as e:
+            print('interactive test timedout')
+            exit_code = 2
         except Exception as e:
-            print('interactive test failed')
-            print(f'{e}')
-
-            print('pexpect debug information')
-            print(str(c))
+            print(f'interactive test failed with {e}')
             exit_code = 1
         finally:
             print('earthly output')
             s = ''.join(ch for ch in output.getvalue() if ch.isprintable() or ch == '\n')
             print(s)
+            if exit_code:
+                print('additional pexpect debug information')
+                print(str(c)+'\n')
     finally:
         os.chdir(cwd)
 

--- a/scripts/tests/interactive-debugger/test-interactive.py
+++ b/scripts/tests/interactive-debugger/test-interactive.py
@@ -44,7 +44,10 @@ if __name__ == '__main__':
             ):
         print(f'Running {test_name}')
         test_exit_code = test(earthly_path, args.timeout)
-        if test_exit_code:
+        if test_exit_code == 2:
+            print(f'{test_name} timedout')
+            exit_code = test_exit_code
+        elif test_exit_code:
             print(f'{test_name} failed with exit code={test_exit_code}')
             exit_code = test_exit_code
         else:


### PR DESCRIPTION
When a timeout error occurs, it will now print

    test-docker-compose timedout

on a brand new line with a space between it and the previous debug
log.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>