### PR TITLE
remove docs for required build ARGs until next release

### DIFF
--- a/docs/earthfile/earthfile.md
+++ b/docs/earthfile/earthfile.md
@@ -412,7 +412,7 @@ For detailed examples demonstrating how other scenarios may function, please see
 
 #### Synopsis
 
-* `ARG [--required] <name>[=<default-value>]`
+* `ARG <name>[=<default-value>]`
 
 #### Description
 
@@ -445,20 +445,6 @@ FROM --build-arg NAME=john +docker-image
 ```
 
 A number of builtin args are available and are pre-filled by Earthly. For more information see [builtin args](./builtin-args.md).
-
-#### `--required`
-
-A required `ARG` must be provided at build time and can never have a default value. Required args can help eliminate cases where the user has unexpectedly set an `ARG` to "" when declared as `ARG someArg`.
-
-```
-platform-required:
-    # user must supply build arg for target
-    ARG --required PLATFORM
-
-build-linux:
-    # or explicitly supply in build command
-    BUILD --build-arg PLATFORM=linux +platform-required
-```
 
 ## SAVE ARTIFACT
 


### PR DESCRIPTION
The current docs document `--required` flag in the `ARG` command which is not released yet. This PR reverts the doc update to avoid confusion which should be re-merged when we merge the v0.6 doc updates.

Signed-off-by: Andrew Sy Kim <andrew@earthly.dev>