### PR TITLE
#1345 remove premature doc update from main

### DIFF
--- a/docs/earthfile/earthfile.md
+++ b/docs/earthfile/earthfile.md
@@ -412,7 +412,7 @@ For detailed examples demonstrating how other scenarios may function, please see
 
 #### Synopsis
 
-* `ARG [--required] <name>[=<default-value>]`
+* `ARG <name>[=<default-value>]`
 
 #### Description
 
@@ -445,20 +445,6 @@ FROM --build-arg NAME=john +docker-image
 ```
 
 A number of builtin args are available and are pre-filled by Earthly. For more information see [builtin args](./builtin-args.md).
-
-#### `--required`
-
-A required `ARG` must be provided at build time and can never have a default value. Required args can help eliminate cases where the user has unexpectedly set an `ARG` to "" when declared as `ARG someArg`.
-
-```
-platform-required:
-    # user must supply build arg for target
-    ARG --required PLATFORM
-
-build-linux:
-    # or explicitly supply in build command
-    BUILD --build-arg PLATFORM=linux +platform-required
-```
 
 ## SAVE ARTIFACT
 


### PR DESCRIPTION
Saw in this comment I should have added this docs update to `next` branch instead: https://github.com/earthly/earthly/issues/1345#issuecomment-950370394. This PR reverts the `ARG` section of Earthfile docs and can send another one by end of day today for `next` branch.

Sorry for the confusion, I'll send a PR for that branch with this doc update instead.

