### PR TITLE
Silently disable local registry in remote buildkit case

### DIFF
--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -1142,6 +1142,9 @@ func (app *earthlyApp) setupAndValidateAddresses(context *cli.Context) error {
 		app.localRegistryHost = app.cfg.Global.LocalRegistryHost
 	} else {
 		app.localRegistryHost = ""
+		if app.cfg.Global.LocalRegistryHost != "" {
+			app.console.VerbosePrintf("Local registry host is specified while using remote buildkit. Local registry will not be used.")
+		}
 	}
 
 	if bkURL.Scheme == dbURL.Scheme && bkURL.Hostname() != dbURL.Hostname() {


### PR DESCRIPTION
Since the local registry option will be enabled by default from 0.6 onwards, it's better to just ignore the setting in the buildkit remote case. (The warning might cause the user to believe that they are doing something wrong).