### PR TITLE
buildkit module should point to earthly-main branch instead of acb/manual-rebase

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,6 @@ replace (
 
 	github.com/jessevdk/go-flags => github.com/alexcb/go-flags v0.0.0-20210722203016-f11d7ecb5ee5
 
-	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.0-20211028003124-f4a607654bbb
+	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.0-20211028203649-4d51c041a276
 	github.com/tonistiigi/fsutil => github.com/earthly/fsutil v0.0.0-20210609160335-a94814c540b2
 )

--- a/go.sum
+++ b/go.sum
@@ -278,8 +278,8 @@ github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
-github.com/earthly/buildkit v0.0.0-20211028003124-f4a607654bbb h1:d0YZB2pz0HlR0UBhGbcUoLRQmkFgDBZuTaYoXjp2EBc=
-github.com/earthly/buildkit v0.0.0-20211028003124-f4a607654bbb/go.mod h1:0SdY5YeYxYtvXOJ0Eppr9uKnc4yDXe+/5glup9Cthus=
+github.com/earthly/buildkit v0.0.0-20211028203649-4d51c041a276 h1:e+OnvmaNCnpgwTX1sIUd0kM8FGO7pQ3HqkZdAm2H5BY=
+github.com/earthly/buildkit v0.0.0-20211028203649-4d51c041a276/go.mod h1:0SdY5YeYxYtvXOJ0Eppr9uKnc4yDXe+/5glup9Cthus=
 github.com/earthly/fsutil v0.0.0-20210609160335-a94814c540b2 h1:prCu8h270ALmF4U16kSBIJow23/w6NYFeQlr6A1NCbw=
 github.com/earthly/fsutil v0.0.0-20210609160335-a94814c540b2/go.mod h1:4Bcxev2PKmz1bFF6Mg3opy8w4kYQVvEXQGKVkQkP2Ac=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=


### PR DESCRIPTION
This is a minor fix to `go.mod` to point the commit to `earthly-main` instead of the commit in `acb/manual-rebase`. This is just to make it easier to track the commit later, I don't think there are actual code changes involved.

Signed-off-by: Andrew Sy Kim <andrew@earthly.dev>