### PR TITLE
FEAT: Issue 1379 : Upgrade the Issue Template to use GitHub Issue forms

### DIFF
--- a/.github/workflows/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/workflows/ISSUE_TEMPLATE/bug.yaml
@@ -1,0 +1,110 @@
+name: "🐛 Bug Report"
+description: "Submit a bug report to help us improve"
+title: "🐛 Bug Report: "
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out our bug report form 🙏
+  - type: textarea
+    id: description
+    validations:
+      required: true
+    attributes:
+      label: "📜 Description"
+      description: "A clear and concise description of what the bug is."
+      placeholder: "It bugs out when ..."
+  - type: textarea
+    id: steps-to-reproduce
+    validations:
+      required: true
+    attributes:
+      label: "👟 Reproduction steps"
+      description: "How do you trigger this bug? Please walk us through it step by step."
+      placeholder: "1. When I ..."
+  - type: textarea
+    id: expected-behavior
+    validations:
+      required: true
+    attributes:
+      label: "👍 Expected behavior"
+      description: "What did you think would happen?"
+      placeholder: "It should ..."
+  - type: textarea
+    id: actual-behavior
+    validations:
+      required: true
+    attributes:
+      label: "👎 Actual Behavior"
+      description: "What did actually happen? Add screenshots, if applicable."
+      placeholder: "It actually ..."
+  - type: dropdown
+    id: device
+    attributes:
+      label: "💻 Device"
+      description: "Which device running on?"
+      options:
+        - Desktop
+        - Mobile
+    validations:
+      required: true
+  - type: dropdown
+    id: operating-system
+    attributes:
+      label: "💻 Operating system"
+      description: "What OS is your app running on?"
+      options:
+        - Linux
+        - MacOS
+        - Windows
+        - iOS
+        - Android
+        - Something else
+    validations:
+      required: true
+  - type: dropdown
+    id: browser
+    attributes:
+      label: "🌍 Browser"
+      description: "What browser is your app running on?"
+      options:
+        - Chrome
+        - Safari
+        - Firefox
+        - Opera
+        - Edge
+        - Something Else
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    validations:
+      required: false
+    attributes:
+      label: "🧱 Your Environment"
+      description: "Is your environment customized in any way? Provide your Browser version as well."
+      placeholder: "I use XYZ for ..."
+  - type: textarea
+    id: solution
+    validations:
+      required: false
+    attributes:
+      label: "✅ Proposed Solution"
+      description: "Any thoughts as to potential solutions or ideas to go about finding one. Please include links to any research."
+      placeholder: "To fix this, I found ..."
+  - type: checkboxes
+    id: no-duplicate-issues
+    attributes:
+      label: "👀 Have you spent some time to check if this issue has been raised before?"
+      description: "Have you Googled for a similar issue or checked our older issues for a similar bug?"
+      options:
+        - label: "I checked and didn't find similar issue"
+          required: true
+  - type: checkboxes
+    id: read-code-of-conduct
+    attributes:
+      label: "🏢 Have you read the Code of Conduct?"
+      options:
+        - label: "I have read the [Code of Conduct](https://github.com/earthly/earthly/blob/main/code-of-conduct.md)"
+          required: true

--- a/.github/workflows/ISSUE_TEMPLATE/documentation.yaml
+++ b/.github/workflows/ISSUE_TEMPLATE/documentation.yaml
@@ -1,0 +1,32 @@
+name: "📚 Documentation"
+description: "Report an issue related to documentation"
+title: "📚 Documentation: "
+labels: [documentation]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to make our documentation better 🙏
+  - type: textarea
+    id: issue-description
+    validations:
+      required: true
+    attributes:
+      label: "💭 Description"
+      description: "A clear and concise description of what the issue is."
+      placeholder: "Documentation should not ..."
+  - type: checkboxes
+    id: no-duplicate-issues
+    attributes:
+      label: "👀 Have you spent some time to check if this issue has been raised before?"
+      description: "Have you Googled for a similar issue or checked our older issues for a similar bug?"
+      options:
+        - label: "I checked and didn't find similar issue"
+          required: true
+  - type: checkboxes
+    id: read-code-of-conduct
+    attributes:
+      label: "🏢 Have you read the Code of Conduct?"
+      options:
+        - label: "I have read the [Code of Conduct](https://github.com/earthly/earthly/blob/main/code-of-conduct.md)"
+          required: true

--- a/.github/workflows/ISSUE_TEMPLATE/feature.yaml
+++ b/.github/workflows/ISSUE_TEMPLATE/feature.yaml
@@ -1,0 +1,56 @@
+name: 🚀 Feature
+description: "Submit a proposal for a new feature"
+title: "🚀 Feature: "
+labels: [feature]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out our feature request form 🙏
+  - type: textarea
+    id: feature-description
+    validations:
+      required: true
+    attributes:
+      label: "🔖 Feature description"
+      description: "A clear and concise description of what the feature is."
+      placeholder: "You should add ..."
+  - type: textarea
+    id: pitch
+    validations:
+      required: true
+    attributes:
+      label: "🎤 Pitch"
+      description: "Please explain why this feature should be implemented and how it would be used. Add examples, if applicable."
+      placeholder: "In my use-case, ..."
+  - type: textarea
+    id: solution
+    validations:
+      required: true
+    attributes:
+      label: "✌️ Solution"
+      description: "A clear and concise description of what you want to happen."
+      placeholder: "I want this feature to, ..."
+  - type: textarea
+    id: alternative
+    validations:
+      required: true
+    attributes:
+      label: "🔄️ Alternative"
+      description: "A clear and concise description of any alternative solutions or features you've considered."
+      placeholder: "I tried, ..."
+  - type: checkboxes
+    id: no-duplicate-issues
+    attributes:
+      label: "👀 Have you spent some time to check if this issue has been raised before?"
+      description: "Have you Googled for a similar issue or checked our older issues for a similar bug?"
+      options:
+        - label: "I checked and didn't find similar issue"
+          required: true
+  - type: checkboxes
+    id: read-code-of-conduct
+    attributes:
+      label: "🏢 Have you read the Code of Conduct?"
+      options:
+        - label: "I have read the [Code of Conduct](https://github.com/earthly/earthly/blob/main/code-of-conduct.md)"
+          required: true


### PR DESCRIPTION
# Linked Issue
It fixes https://github.com/earthly/earthly/issues/1379

# Description
This PR updates the Issue templates for `Feature`, `Bug`, and `Documentation` requests to use the latest Github Issue forms.

# Methodology
Respective `yaml` files have been added that would be used to provide the newest template for any issue requests.