### PR TITLE
Always display frontend detection errors

### DIFF
--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -1027,8 +1027,7 @@ func (app *earthlyApp) before(context *cli.Context) error {
 
 	fe, err := containerutil.FrontendForSetting(context.Context, app.cfg.Global.ContainerFrontend)
 	if err != nil {
-		app.console.Warnf("%s frontend could not be initialized, but trying anyway", app.cfg.Global.ContainerFrontend)
-		app.console.VerbosePrintf("%s frontend initialization error: %s", app.cfg.Global.ContainerFrontend, err.Error())
+		app.console.Warnf("%s frontend initialization failed due to %s; but will try anyway", app.cfg.Global.ContainerFrontend, err.Error())
 		fe, _ = containerutil.NewStubFrontend(context.Context)
 	}
 	app.containerFrontend = fe


### PR DESCRIPTION
I had an error where `docker` was not on my PATH, and running earthly
displayed `auto frontend could not be initialized, but trying anyway`
without letting me know the issue. It wasn't obvious that a `-V` would
display the error message. Upon adding -V I got:
`auto frontend initialization error: failed to autodetect a supported frontend`.

This PR will now display the reason autodetect failed:

    auto frontend initialization failed due to failed to autodetect a supported frontend: 2 errors occurred:
        * docker-shell frontend failed to initalize: command failed: docker info --format={{.SecurityOptions}}: exec: "docker": executable file not found in $PATH: : exec: "docker": executable file not found in $PATH
        * podman-shell frontend failed to initalize: command failed: podman info --format={{.Host.Security.Rootless}}: exec: "podman": executable file not found in $PATH: : exec: "podman": executable file not found in $PATH
    ; but will try anyway

and in the event either of the frontends are detected, no error will be
displayed.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>