### PR TITLE
v0.6.0rc2 related updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 
 ## Unreleased
 
+## v0.6.0-rc2 - 2021-11-01
+
+### Fixed
+
+- `failed due to failed to autodetect a supported frontend` errors will now include underlying reason for failure
+
+### Changed
+
+- Buildkit was updated to `d47b46cf2a16ca80a958384282e8028285b1866d`.
+
 ## v0.6.0-rc1 - 2021-10-28
 
 This version promotes a number of features that have been previously in Experimental and Beta status. To make use of the features in this version you need to declare `VERSION 0.6` at the top of your Earthfile. If a version is not declared, then Earthly's interpreter will assume `VERSION 0.5`.
@@ -50,8 +60,7 @@ For more information on the individual Earthfile feature flags see the [Earthfil
 - Fixed homebrew installation on macOS 12. [#1370](https://github.com/earthly/earthly/pull/1370), [homebrew/earthly#13](https://github.com/earthly/homebrew-earthly/pull/13)
 ### Changed
 
-<!--changelog-parser-ignore-->
-
+<!--changelog-parser-ignore-start-->
 - What Earthly outputs locally has changed in a way that is not backwards compatible. For an artifact or an image to be produced locally it needs to be part of a `BUILD` chain (or be part of the target being directly built). Artifacts and images introduced through `FROM` or `COPY` are no longer output locally.
   
   To update existing scripts, you may issue a duplicate `BUILD` in addition to a `FROM` (or a `COPY`), should you wish for the referenced target to perform output.
@@ -112,11 +121,12 @@ For more information on the individual Earthfile feature flags see the [Earthfil
   ```
 
   This change is part of the [UDC proposal #581](https://github.com/earthly/earthly/issues/581). The old way of passing args is deprecated and will be removed in a future version (however, it still works in 0.6).
+<!--changelog-parser-ignore-end-->
 - Add builtin args `USERPLATFORM`, `USEROS`, `USERARCH`, and `USERVARIANT` which represent the platform, OS, architecture, and processor variant of the system Earthly is being called from [#1251](https://github.com/earthly/earthly/pull/1251). Thanks to @akrantz01 for the contribution!
 - Support for required ARGs (`ARG --required foo`) [#904](https://github.com/earthly/earthly/issues/904). Thanks to @camerondurham for the contribution!
 - Add a config item for buildkit's `max_parallelism` configuration. Use this to increase parallelism for faster builds or decrease parallelism when resources are constraint. The default is 20. [#1308](https://github.com/earthly/earthly/issues/1308)
 - Extend auto-completion to be build-arg aware. Typing `earthly +my-target --<tab><tab>` now prints possible build-args specific to `+my-target`. [#1330](https://github.com/earthly/earthly/pull/1330).
-- Buildkit was updated to `d47b46cf2a16ca80a958384282e8028285b1866d`. This includes a number of bug fixes, including eliminating crashes due to `panic failed to get edge`.
+- Buildkit was updated to `d429b0b32606b5ea52e6be4a99b69d67b7c722b2`. This includes a number of bug fixes, including eliminating crashes due to `panic failed to get edge`.
 
 ### Fixed
 

--- a/release/changelogparser.py
+++ b/release/changelogparser.py
@@ -71,7 +71,6 @@ def parse_changelog(changelog_data):
     is_title_body = False
     dash_found = False
     body = []
-    is_intro = True
     ignore = False
     for line_num, line in enumerate(changelog_data.splitlines()):
         num_headers, title = parse_line(line, line_num)
@@ -85,8 +84,12 @@ def parse_changelog(changelog_data):
             continue
 
         if num_headers == 0:
-            if line == '<!--changelog-parser-ignore-->':
+            if line == '<!--changelog-parser-ignore-start-->':
                 ignore = True
+                continue
+            if line == '<!--changelog-parser-ignore-end-->':
+                ignore = False
+                continue
             if ignore:
                 pass
             elif is_title_body:
@@ -107,6 +110,7 @@ def parse_changelog(changelog_data):
         elif num_headers == 1:
             raise UnexpectedHeaderError(line, line_num)
         elif num_headers == 2:
+            is_intro = True
             ignore = False
             if is_title_body:
                 if title != 'Unreleased':

--- a/release/release.sh
+++ b/release/release.sh
@@ -23,17 +23,19 @@ set -ex
 # examples
 #
 #  performing a test release to a non-earthly location
-#    env -i RELEASE_TAG=v0.5.10 GITHUB_USER=alexcb DOCKERHUB_USER=alexcb132 EARTHLY_REPO=earthly BREW_REPO=homebrew-earthly-1 ./release.sh
+#    env -i HOME="$HOME" PATH="$PATH" SSH_AUTH_SOCK="$SSH_AUTH_SOCK" RELEASE_TAG=v0.5.10 GITHUB_USER=alexcb DOCKERHUB_USER=alexcb132 EARTHLY_REPO=earthly BREW_REPO=homebrew-earthly-1 ./release.sh
 #
 #  performing a release candidate
-#    env -i RELEASE_TAG=v0.6.0-rc1 PRERELEASE=true ./release.sh
+#    env -i HOME="$HOME" PATH="$PATH" SSH_AUTH_SOCK="$SSH_AUTH_SOCK" RELEASE_TAG=v0.6.0-rc1 PRERELEASE=true ./release.sh
 #
 #  performing a regular release
-#    env -i RELEASE_TAG=v0.6.0 ./release.sh
+#    env -i HOME="$HOME" PATH="$PATH" SSH_AUTH_SOCK="$SSH_AUTH_SOCK" RELEASE_TAG=v0.6.0 ./release.sh
 #
 
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 cd $SCRIPT_DIR
+
+test -n "$HOME" || (echo "ERROR: HOME is not set"; exit 1);
 
 test -n "$RELEASE_TAG" || (echo "ERROR: RELEASE_TAG is not set" && exit 1);
 (echo "$RELEASE_TAG" | grep '^v[0-9]\+.[0-9]\+.[0-9]\+\(-rc[0-9]\+\)\?$' > /dev/null) || (echo "ERROR: RELEASE_TAG must be formatted as v1.2.3 (or v1.2.3-RC1); instead got \"$RELEASE_TAG\""; exit 1);


### PR DESCRIPTION
- changelog entry (previously the updated buildkit version was
incorrectly put under rc1 rather than unreleased; this rollsback that
change and correctly identifies the update being done in rc2)
- fixes changelog parser's is_intro and ignore start/stop handling.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>