### PR TITLE
test docker info works

### DIFF
--- a/util/containerutil/docker.go
+++ b/util/containerutil/docker.go
@@ -29,6 +29,16 @@ func NewDockerShellFrontend(ctx context.Context) (ContainerFrontend, error) {
 		},
 	}
 
+	// running `docker info --format={{.SecurityOptions}}` results in a panic() when docker is not running.
+	// To workaround this issue, first we run `docker info` to test docker is running, then again with the
+	// `--format` option.
+	// This is to prevent displaying panic() errors to our users (even though the panic() occured in the
+	// docker cli binary and not earthly).
+	_, err := fe.commandContextOutput(ctx, "info")
+	if err != nil {
+		return nil, err
+	}
+
 	output, err := fe.commandContextOutput(ctx, "info", "--format={{.SecurityOptions}}")
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
`docker info --format={{.SecurityOptions}}` fails in some cases
and gives a `panic: reflect: indirection through nil pointer to embedded struct`,
lets try to prevent this from happening when the docker process is not
up.

Before, we would get:

```
2021-11-02T20:41:45.3028861Z [36m              +test3[0m | auto frontend initialization failed due to failed to autodetect a supported frontend: 2 errors occurred:
2021-11-02T20:41:45.3031192Z [36m              +test3[0m | 	* docker-shell frontend failed to initalize: command failed: docker info --format={{.SecurityOptions}}: exit status 2: panic: reflect: indirection through nil pointer to embedded struct [recovered]
2021-11-02T20:41:45.3033018Z [36m              +test3[0m | 	panic: reflect: indirection through nil pointer to embedded struct
2021-11-02T20:41:45.3033607Z 
2021-11-02T20:41:45.3034481Z [36m              +test3[0m | goroutine 1 [running]:
2021-11-02T20:41:45.3035537Z [36m              +test3[0m | text/template.errRecover(0xc0005c52e8)
2021-11-02T20:41:45.3036646Z [36m              +test3[0m | 	/usr/lib/go/src/text/template/exec.go:169 +0x1c5
2021-11-02T20:41:45.3037666Z [36m              +test3[0m | panic(0x559ccd4736a0, 0x559ccd76cae8)
2021-11-02T20:41:45.3038669Z [36m              +test3[0m | 	/usr/lib/go/src/runtime/panic.go:965 +0x1b9
2021-11-02T20:41:45.3040180Z [36m              +test3[0m | reflect.Value.FieldByIndex(0x559ccd60aac0, 0xc0002be480, 0x99, 0xc0002e1f60, 0x2, 0x2, 0x0, 0x559ccd7fb968, 0x559ccd43a300)
2021-11-02T20:41:45.3041513Z [36m              +test3[0m | 	/usr/lib/go/src/reflect/value.go:889 +0x325
2021-11-02T20:41:45.3044216Z [36m              +test3[0m | text/template.(*state).evalField(0xc0005c5258, 0x559ccd60aac0, 0xc0002be480, 0x99, 0x7fffd1b82b1c, 0xf, 0x559ccd7e5520, 0xc00014ab40, 0xc0001db1a0, 0x1, ...)
2021-11-02T20:41:45.3045731Z [36m              +test3[0m | 	/usr/lib/go/src/text/template/exec.go:616 +0x4ed
2021-11-02T20:41:45.3048573Z [36m              +test3[0m | text/template.(*state).evalFieldChain(0xc0005c5258, 0x559ccd60aac0, 0xc0002be480, 0x99, 0x559ccd60aac0, 0xc0002be480, 0x99, 0x559ccd7e5520, 0xc00014ab40, 0xc0001db190, ...)
2021-11-02T20:41:45.3050511Z [36m              +test3[0m | 	/usr/lib/go/src/text/template/exec.go:569 +0x225
2021-11-02T20:41:45.3052483Z [36m              +test3[0m | text/template.(*state).evalFieldNode(0xc0005c5258, 0x559ccd60aac0, 0xc0002be480, 0x99, 0xc00014ab40, 0xc0001db1a0, 0x1, 0x1, 0x559ccd501740, 0x559cce595a10, ...)
2021-11-02T20:41:45.3053912Z [36m              +test3[0m | 	/usr/lib/go/src/text/template/exec.go:533 +0x115
2021-11-02T20:41:45.3055555Z [36m              +test3[0m | text/template.(*state).evalCommand(0xc0005c5258, 0x559ccd60aac0, 0xc0002be480, 0x99, 0xc00014ab10, 0x559ccd501740, 0x559cce595a10, 0x99, 0xd0, 0xc00023dba0, ...)
2021-11-02T20:41:45.3056897Z [36m              +test3[0m | 	/usr/lib/go/src/text/template/exec.go:461 +0x8f0
2021-11-02T20:41:45.3058711Z [36m              +test3[0m | text/template.(*state).evalPipeline(0xc0005c5258, 0x559ccd60aac0, 0xc0002be480, 0x99, 0xc000240b40, 0x559ccc103834, 0xc0000a65a8, 0xc0002be400)
2021-11-02T20:41:45.3060037Z [36m              +test3[0m | 	/usr/lib/go/src/text/template/exec.go:435 +0x125
2021-11-02T20:41:45.3061387Z [36m              +test3[0m | text/template.(*state).walk(0xc0005c5258, 0x559ccd60aac0, 0xc0002be480, 0x99, 0x559ccd7e5328, 0xc00014ab70)
2021-11-02T20:41:45.3062581Z [36m              +test3[0m | 	/usr/lib/go/src/text/template/exec.go:254 +0x38a
2021-11-02T20:41:45.3063945Z [36m              +test3[0m | text/template.(*state).walk(0xc0005c5258, 0x559ccd60aac0, 0xc0002be480, 0x99, 0x559ccd7e55f8, 0xc00014aae0)
2021-11-02T20:41:45.3065152Z [36m              +test3[0m | 	/usr/lib/go/src/text/template/exec.go:263 +0x13c
2021-11-02T20:41:45.3066694Z [36m              +test3[0m | text/template.(*Template).execute(0xc0002be400, 0x559ccd78c018, 0xc0000317a0, 0x559ccd60aac0, 0xc0002be480, 0x0, 0x0)
2021-11-02T20:41:45.3068011Z [36m              +test3[0m | 	/usr/lib/go/src/text/template/exec.go:217 +0x1c6
2021-11-02T20:41:45.3069071Z [36m              +test3[0m | text/template.(*Template).Execute(...)
2021-11-02T20:41:45.3070223Z [36m              +test3[0m | 	/usr/lib/go/src/text/template/exec.go:200
2021-11-02T20:41:45.3071744Z [36m              +test3[0m | github.com/docker/cli/cli/command/system.formatInfo(0x559ccd7f8768, 0xc00042f6c0, 0x0, 0xc0001db150, 0x1, 0x1, 0xc0000a6500, 0x0, 0x0, 0x0, ...)
2021-11-02T20:41:45.3073593Z [36m              +test3[0m | 	/home/buildozer/aports/community/docker/src/cli-20.10.9/src/github.com/docker/cli/cli/command/system/info.go:487 +0x1fd
2021-11-02T20:41:45.3076216Z [36m              +test3[0m | github.com/docker/cli/cli/command/system.runInfo(0xc000220b00, 0x559ccd7f8768, 0xc00042f6c0, 0xc0001dac20, 0x0, 0x0)
2021-11-02T20:41:45.3077948Z [36m              +test3[0m | 	/home/buildozer/aports/community/docker/src/cli-20.10.9/src/github.com/docker/cli/cli/command/system/info.go:87 +0x3a5
2021-11-02T20:41:45.3079945Z [36m              +test3[0m | github.com/docker/cli/cli/command/system.NewInfoCommand.func1(0xc000220b00, 0xc0001dac10, 0x0, 0x1, 0x0, 0x0)
2021-11-02T20:41:45.3081727Z [36m              +test3[0m | 	/home/buildozer/aports/community/docker/src/cli-20.10.9/src/github.com/docker/cli/cli/command/system/info.go:53 +0x48
2021-11-02T20:41:45.3096627Z [36m              +test3[0m | github.com/docker/cli/vendor/github.com/spf13/cobra.(*Command).execute(0xc000220b00, 0xc00007f1b0, 0x1, 0x1, 0xc000220b00, 0xc00007f1b0)
2021-11-02T20:41:45.3098669Z [36m              +test3[0m | 	/home/buildozer/aports/community/docker/src/cli-20.10.9/src/github.com/docker/cli/vendor/github.com/spf13/cobra/command.go:850 +0x472
2021-11-02T20:41:45.3100426Z [36m              +test3[0m | github.com/docker/cli/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc000483080, 0xc00007f1a0, 0x2, 0x2)
2021-11-02T20:41:45.3102210Z [36m              +test3[0m | 	/home/buildozer/aports/community/docker/src/cli-20.10.9/src/github.com/docker/cli/vendor/github.com/spf13/cobra/command.go:958 +0x375
2021-11-02T20:41:45.3104032Z [36m              +test3[0m | github.com/docker/cli/vendor/github.com/spf13/cobra.(*Command).Execute(...)
2021-11-02T20:41:45.3108712Z [36m              +test3[0m | 	/home/buildozer/aports/community/docker/src/cli-20.10.9/src/github.com/docker/cli/vendor/github.com/spf13/cobra/command.go:895
2021-11-02T20:41:45.3110197Z [36m              +test3[0m | main.runDocker(0xc00042f6c0, 0x559ccd78e5b8, 0xc000010020)
2021-11-02T20:41:45.3111719Z [36m              +test3[0m | 	/home/buildozer/aports/community/docker/src/cli-20.10.9/src/github.com/docker/cli/cmd/docker/docker.go:287 +0x1eb
2021-11-02T20:41:45.3112857Z [36m              +test3[0m | main.main()
2021-11-02T20:41:45.3114276Z [36m              +test3[0m | 	/home/buildozer/aports/community/docker/src/cli-20.10.9/src/github.com/docker/cli/cmd/docker/docker.go:298 +0xfc: exit status 2
2021-11-02T20:41:45.3117082Z [36m              +test3[0m | 	* podman-shell frontend failed to initalize: command failed: podman info --format={{.Host.Security.Rootless}}: exec: "podman": executable file not found in $PATH: : exec: "podman": executable file not found in $PATH
2021-11-02T20:41:45.3118178Z 
2021-11-02T20:41:45.3118912Z [36m              +test3[0m | ; but will try anyway
```

Now we get:

```
2021-11-02T21:15:34.0257497Z [35m              +test3[0m | auto frontend initialization failed due to failed to autodetect a supported frontend: 2 errors occurred:
2021-11-02T21:15:34.0259134Z [35m              +test3[0m | 	* docker-shell frontend failed to initalize: command failed: docker info: exit status 1: Client:
2021-11-02T21:15:34.0260131Z [35m              +test3[0m |  Context:    default
2021-11-02T21:15:34.0260851Z [35m              +test3[0m |  Debug Mode: false
2021-11-02T21:15:34.0261169Z 
2021-11-02T21:15:34.0261727Z [35m              +test3[0m | Server:
2021-11-02T21:15:34.0262959Z [35m              +test3[0m | ERROR: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
2021-11-02T21:15:34.0264071Z [35m              +test3[0m | errors pretty printing info: exit status 1
2021-11-02T21:15:34.0265763Z [35m              +test3[0m | 	* podman-shell frontend failed to initalize: command failed: podman info --format={{.Host.Security.Rootless}}: exec: "podman": executable file not found in $PATH: : exec: "podman": executable file not found in $PATH
2021-11-02T21:15:34.0267016Z 
2021-11-02T21:15:34.0267666Z [35m              +test3[0m | ; but will try anyway
```

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>