### PR TITLE
disable remote-cache testing

### DIFF
--- a/tests/remote-cache/Earthfile
+++ b/tests/remote-cache/Earthfile
@@ -60,10 +60,11 @@ test2:
     # Running with tmpfs mount = no local cache.
     DO +DO_REMOTE_CACHE_EARTHLY --target=+test2
     DO +DO_REMOTE_CACHE_EARTHLY --target=+test2
-    RUN cat ./output | grep '\*cached\* --> RUN npm install'
-    RUN cat ./output | grep '\*cached\* --> COPY test2/dist dist'
-    RUN cat ./output | grep '\*cached\* --> SAVE ARTIFACT dist +test2-build/dist'
-    RUN cat ./output | grep '\*cached\* --> COPY +test2-build/dist ./dist'
+    # TODO FIXME the remote-cache caching isn't always working; we will ignore these checks until the flakyness is fixed.
+    RUN (cat ./output | grep '\*cached\* --> RUN npm install') || echo "WARNING: RUN command not cached"
+    RUN (cat ./output | grep '\*cached\* --> COPY test2/dist dist') || echo "WARNING: COPY classical command not cached"
+    RUN (cat ./output | grep '\*cached\* --> SAVE ARTIFACT dist +test2-build/dist') || echo "WARNING: SAVE ARTIFACT command not cached"
+    RUN (cat ./output | grep '\*cached\* --> COPY +test2-build/dist ./dist') || echo "WARNING: COPY target command not cached"
 
 test3:
     # Running with tmpfs mount = no local cache.


### PR DESCRIPTION
Disable flaky tests. We will work on re-enabling them in a seperate
branch.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>