### PR TITLE
show hidden help when running dev versions

### DIFF
--- a/autocomplete/complete.go
+++ b/autocomplete/complete.go
@@ -237,10 +237,10 @@ func getCmd(name string, cmds []*cli.Command) *cli.Command {
 	return nil
 }
 
-func getVisibleFlags(flags []cli.Flag, showHidden bool) []string {
+func getVisibleFlags(flags []cli.Flag) []string {
 	visibleFlags := []string{}
 	for _, f := range flags {
-		if isVisibleFlag(f) || showHidden {
+		if isVisibleFlag(f) {
 			for _, n := range f.Names() {
 				if len(n) > 1 {
 					visibleFlags = append(visibleFlags, n)
@@ -291,10 +291,10 @@ func padStrings(flags []string, prefix, suffix string) []string {
 	return padded
 }
 
-func getVisibleCommands(commands []*cli.Command, showHidden bool) []string {
+func getVisibleCommands(commands []*cli.Command) []string {
 	visibleCommands := []string{}
 	for _, cmd := range commands {
-		if !cmd.Hidden || showHidden {
+		if !cmd.Hidden {
 			visibleCommands = append(visibleCommands, cmd.Name)
 		}
 	}
@@ -317,7 +317,7 @@ const (
 // GetPotentials returns a list of potential arguments for shell auto completion
 // NOTE: you can cause earthly to run this command with:
 //       COMP_LINE="earthly -" COMP_POINT=$(echo -n $COMP_LINE | wc -c) go run cmd/earthly/main.go
-func GetPotentials(ctx context.Context, resolver *buildcontext.Resolver, gwClient gwclient.Client, compLine string, compPoint int, app *cli.App, showHidden bool) ([]string, error) {
+func GetPotentials(ctx context.Context, resolver *buildcontext.Resolver, gwClient gwclient.Client, compLine string, compPoint int, app *cli.App) ([]string, error) {
 	compLine = compLine[:compPoint]
 	subCommands := app.Commands
 
@@ -406,9 +406,9 @@ func GetPotentials(ctx context.Context, resolver *buildcontext.Resolver, gwClien
 	switch state {
 	case flagState:
 		if cmd != nil {
-			potentials = getVisibleFlags(cmd.Flags, showHidden)
+			potentials = getVisibleFlags(cmd.Flags)
 		} else {
-			potentials = getVisibleFlags(app.Flags, showHidden)
+			potentials = getVisibleFlags(app.Flags)
 			// append flags that urfav/cli automatically include
 			potentials = append(potentials, "version", "help")
 		}
@@ -416,10 +416,10 @@ func GetPotentials(ctx context.Context, resolver *buildcontext.Resolver, gwClien
 
 	case rootState, commandState:
 		if cmd != nil {
-			potentials = getVisibleCommands(cmd.Subcommands, showHidden)
+			potentials = getVisibleCommands(cmd.Subcommands)
 			potentials = padStrings(potentials, "", " ")
 		} else {
-			potentials = getVisibleCommands(app.Commands, showHidden)
+			potentials = getVisibleCommands(app.Commands)
 			potentials = padStrings(potentials, "", " ")
 			if containsDirectories(".") {
 				potentials = append(potentials, "./")

--- a/autocomplete/complete_test.go
+++ b/autocomplete/complete_test.go
@@ -72,75 +72,69 @@ func getApp() *cli.App {
 	return app
 }
 
-func getPotentials(cmd string, showHidden bool) ([]string, error) {
+func getPotentials(cmd string) ([]string, error) {
 	logger := conslogging.Current(conslogging.NoColor, 0, false)
 	gitLookup := buildcontext.NewGitLookup(logger, "")
 	resolver := buildcontext.NewResolver("", nil, gitLookup, logger, "")
-	return GetPotentials(context.TODO(), resolver, nil, cmd, len(cmd), getApp(), showHidden)
+	return GetPotentials(context.TODO(), resolver, nil, cmd, len(cmd), getApp())
 }
 
 func TestFlagCompletion(t *testing.T) {
-	matches, err := getPotentials("earthly --fl", false)
+	matches, err := getPotentials("earthly --fl")
 	NoError(t, err, "GetPotentials failed")
 	Equal(t, []string{"--flag ", "--fleet "}, matches)
 }
 
 func TestFlagCompletionWithPreviousFlags(t *testing.T) {
-	matches, err := getPotentials("earthly --fig desertking --fla", false)
+	matches, err := getPotentials("earthly --fig desertking --fla")
 	NoError(t, err, "GetPotentials failed")
 	Equal(t, []string{"--flag "}, matches)
 }
 
 func TestFlagCompletionWithPreviousFlags2(t *testing.T) {
-	matches, err := getPotentials("earthly --fig ", false)
+	matches, err := getPotentials("earthly --fig ")
 	NoError(t, err, "GetPotentials failed")
 	Equal(t, []string{}, matches)
 }
 
 func TestFlagCompletionWithPreviousFlagsContainingEqual(t *testing.T) {
-	matches, err := getPotentials("earthly --fig=desertking --fla", false)
+	matches, err := getPotentials("earthly --fig=desertking --fla")
 	NoError(t, err, "GetPotentials failed")
 	Equal(t, []string{"--flag "}, matches)
 }
 
 func TestCommandCompletion(t *testing.T) {
-	matches, err := getPotentials("earthly pru", false)
+	matches, err := getPotentials("earthly pru")
 	NoError(t, err, "GetPotentials failed")
 	Equal(t, []string{"prune "}, matches)
 }
 
 func TestCommandCompletionHidden(t *testing.T) {
-	matches, err := getPotentials("earthly hid", false)
+	matches, err := getPotentials("earthly hid")
 	NoError(t, err, "GetPotentials failed")
 	Equal(t, []string{}, matches)
 }
 
-func TestCommandCompletionShowHidden(t *testing.T) {
-	matches, err := getPotentials("earthly hid", true)
-	NoError(t, err, "GetPotentials failed")
-	Equal(t, []string{"hide "}, matches)
-}
-
 func TestCommandSubCompletion(t *testing.T) {
-	matches, err := getPotentials("earthly sub -", false)
+	matches, err := getPotentials("earthly sub -")
 	NoError(t, err, "GetPotentials failed")
 	Equal(t, []string{"--subflag "}, matches)
 }
 
 func TestCommandSubCompletion2(t *testing.T) {
-	matches, err := getPotentials("earthly sub --subflag abba --s", false)
+	matches, err := getPotentials("earthly sub --subflag abba --s")
 	NoError(t, err, "GetPotentials failed")
 	Equal(t, []string{"--subsubflag ", "--surf-the-internet "}, matches)
 }
 
 func TestCommandSubSubCompletion(t *testing.T) {
-	matches, err := getPotentials("earthly sub --subflag abba --sub", false)
+	matches, err := getPotentials("earthly sub --subflag abba --sub")
 	NoError(t, err, "GetPotentials failed")
 	Equal(t, []string{"--subsubflag "}, matches)
 }
 
 func TestCommandSubSubCompletion2(t *testing.T) {
-	matches, err := getPotentials("earthly sub --subflag abba ", false)
+	matches, err := getPotentials("earthly sub --subflag abba ")
 	NoError(t, err, "GetPotentials failed")
 	Equal(t, []string{"dancing-queen "}, matches)
 }

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -1282,7 +1282,7 @@ func (app *earthlyApp) processDeprecatedCommandOptions(context *cli.Context, cfg
 
 func (app *earthlyApp) unhideFlags(ctx context.Context) error {
 	var err error
-	if os.Getenv("EARTHLY_AUTOCOMPLETE_HIDDEN") != "" && os.Getenv("COMP_POINT") == "" { // TODO delete this check after 2021-03-01
+	if os.Getenv("EARTHLY_AUTOCOMPLETE_HIDDEN") != "" && os.Getenv("COMP_POINT") == "" { // TODO delete this check after 2022-03-01
 		// only display warning when NOT under complete mode (otherwise we break auto completion)
 		app.console.Warnf("Warning: EARTHLY_AUTOCOMPLETE_HIDDEN has been renamed to EARTHLY_SHOW_HIDDEN\n")
 	}

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -1282,15 +1282,14 @@ func (app *earthlyApp) processDeprecatedCommandOptions(context *cli.Context, cfg
 
 func (app *earthlyApp) unhideFlags(ctx context.Context) error {
 	var err error
-	showHidden := strings.HasPrefix(Version, "dev-")
-	oldAutocompleteHidden := os.Getenv("EARTHLY_AUTOCOMPLETE_HIDDEN")
-	if oldAutocompleteHidden != "" && os.Getenv("COMP_POINT") == "" {
+	if os.Getenv("EARTHLY_AUTOCOMPLETE_HIDDEN") != "" && os.Getenv("COMP_POINT") == "" { // TODO delete this check after 2021-03-01
 		// only display warning when NOT under complete mode (otherwise we break auto completion)
 		app.console.Warnf("Warning: EARTHLY_AUTOCOMPLETE_HIDDEN has been renamed to EARTHLY_SHOW_HIDDEN\n")
 	}
-	showHiddenOverride := os.Getenv("EARTHLY_SHOW_HIDDEN")
-	if showHiddenOverride != "" {
-		showHidden, err = strconv.ParseBool(showHiddenOverride)
+	showHidden := false
+	showHiddenStr := os.Getenv("EARTHLY_SHOW_HIDDEN")
+	if showHiddenStr != "" {
+		showHidden, err = strconv.ParseBool(showHiddenStr)
 		if err != nil {
 			return err
 		}

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -119,6 +119,7 @@ ga:
     BUILD +sequential-locally-test
     BUILD +homebrew-test
     BUILD +implicit-ignores
+    BUILD +help
 
 # tests that only run on linux amd64
 # Note: this target is used to validate the USERPLATFORM user arg,
@@ -888,6 +889,13 @@ implicit-ignores:
         echo "test" > ignored/test
     DO +RUN_EARTHLY --earthfile=implicit-ignore.earth
     DO +RUN_EARTHLY --earthfile=no-implicit-ignore.earth
+
+help:
+    # tests the hidden --buildkit-volume-name flag is only displayed in dev mode
+    ENV EARTHLY_SHOW_HIDDEN=0
+    RUN earthly --help | grep -v 'buildkit-volume-name'
+    ENV EARTHLY_SHOW_HIDDEN=1
+    RUN earthly --help | grep 'buildkit-volume-name'
 
 
 RUN_EARTHLY:

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -891,7 +891,7 @@ implicit-ignores:
     DO +RUN_EARTHLY --earthfile=no-implicit-ignore.earth
 
 help:
-    # tests the hidden --buildkit-volume-name flag is only displayed in dev mode
+    # tests the hidden `--buildkit-volume-name` flag is only displayed when EARTHLY_SHOW_HIDDEN is enabled
     ENV EARTHLY_SHOW_HIDDEN=0
     RUN earthly --help | grep -v 'buildkit-volume-name'
     ENV EARTHLY_SHOW_HIDDEN=1

--- a/tests/autocompletion/Earthfile
+++ b/tests/autocompletion/Earthfile
@@ -8,7 +8,7 @@ FROM ../..+earthly-integration-test-base \
     --DOCKERHUB_TOKEN_SECRET=$DOCKERHUB_TOKEN_SECRET \
     --DOCKERHUB_MIRROR=$DOCKERHUB_MIRROR
 
-ENV EARTHLY_AUTOCOMPLETE_HIDDEN=0
+ENV EARTHLY_SHOW_HIDDEN=0
 
 test-root-commands:
     RUN echo "./
@@ -22,7 +22,7 @@ secrets " > expected
     RUN diff expected actual
 
 test-hidden-root-commands:
-    ENV EARTHLY_AUTOCOMPLETE_HIDDEN=1
+    ENV EARTHLY_SHOW_HIDDEN=1
     RUN echo "./
 account 
 bootstrap 

--- a/util/reflectutil/setbool.go
+++ b/util/reflectutil/setbool.go
@@ -1,0 +1,20 @@
+package reflectutil
+
+import (
+	"reflect"
+)
+
+// SetBool looks for a boolean struct value named `structName` in `iface` and sets it to `value`.
+// Upon success a true value is returned, otherwise false.
+func SetBool(iface interface{}, structName string, value bool) bool {
+	rv := reflect.ValueOf(iface)
+	for rv.Kind() == reflect.Ptr {
+		rv = reflect.Indirect(rv)
+	}
+	field := rv.FieldByName(structName)
+	if field.IsValid() && field.Bool() {
+		field.SetBool(value)
+		return true
+	}
+	return false
+}

--- a/util/reflectutil/setbool.go
+++ b/util/reflectutil/setbool.go
@@ -4,14 +4,14 @@ import (
 	"reflect"
 )
 
-// SetBool looks for a boolean struct value named `structName` in `iface` and sets it to `value`.
+// SetBool looks for a boolean field value named `fieldName` in `iface` and sets it to `value`.
 // Upon success a true value is returned, otherwise false.
-func SetBool(iface interface{}, structName string, value bool) bool {
+func SetBool(iface interface{}, fieldName string, value bool) bool {
 	rv := reflect.ValueOf(iface)
 	for rv.Kind() == reflect.Ptr {
 		rv = reflect.Indirect(rv)
 	}
-	field := rv.FieldByName(structName)
+	field := rv.FieldByName(fieldName)
 	if field.IsValid() && field.Bool() {
 		field.SetBool(value)
 		return true


### PR DESCRIPTION
autocomplete already suggests hidden flags; however when running --help
those flags are not displayed. This extends the logic to cover both
autocompletion and help text.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>