### PR TITLE
Allow setting env variables before starting buildkit

### DIFF
--- a/buildkitd/buildkitd.go
+++ b/buildkitd/buildkitd.go
@@ -306,6 +306,10 @@ func Start(ctx context.Context, console conslogging.ConsoleLogger, image, contai
 		envOpts["EARTHLY_ADDITIONAL_BUILDKIT_CONFIG"] = settings.AdditionalConfig
 	}
 
+	if settings.AdditionalEntrypoint != "" {
+		envOpts["EARTHLY_ADDITIONAL_ENTRYPOINT"] = settings.AdditionalEntrypoint
+	}
+
 	if settings.IPTables != "" {
 		envOpts["IP_TABLES"] = settings.IPTables
 	}

--- a/buildkitd/entrypoint.sh
+++ b/buildkitd/entrypoint.sh
@@ -163,6 +163,9 @@ fi
 export TLS_ENABLED
 
 envsubst </etc/buildkitd.toml.template >/etc/buildkitd.toml
+
+eval "$EARTHLY_ADDITIONAL_ENTRYPOINT"
+
 echo "BUILDKIT_ROOT_DIR=$BUILDKIT_ROOT_DIR"
 echo "CACHE_SIZE_MB=$CACHE_SIZE_MB"
 echo "BUILDKIT_MAX_PARALLELISM=$BUILDKIT_MAX_PARALLELISM"

--- a/buildkitd/settings.go
+++ b/buildkitd/settings.go
@@ -19,6 +19,7 @@ type Settings struct {
 	LocalRegistryAddress string
 	AdditionalArgs       []string
 	AdditionalConfig     string
+	AdditionalEntrypoint string
 	CniMtu               uint16
 	Timeout              time.Duration `hash:"ignore"`
 	TLSCA                string

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -1053,6 +1053,7 @@ func (app *earthlyApp) before(context *cli.Context) error {
 
 	app.buildkitdSettings.AdditionalArgs = app.cfg.Global.BuildkitAdditionalArgs
 	app.buildkitdSettings.AdditionalConfig = app.cfg.Global.BuildkitAdditionalConfig
+	app.buildkitdSettings.AdditionalEntrypoint = app.cfg.Global.BuildkitAdditionalEntrypoint
 	app.buildkitdSettings.Timeout = time.Duration(app.cfg.Global.BuildkitRestartTimeoutS) * time.Second
 	app.buildkitdSettings.Debug = app.debug
 	app.buildkitdSettings.BuildkitAddress = app.buildkitHost

--- a/config/config.go
+++ b/config/config.go
@@ -58,26 +58,28 @@ var (
 
 // GlobalConfig contains global config values
 type GlobalConfig struct {
-	DisableAnalytics         bool     `yaml:"disable_analytics"          help:"Controls Earthly telemetry."`
-	BuildkitCacheSizeMb      int      `yaml:"cache_size_mb"              help:"Size of the buildkit cache in Megabytes."`
-	BuildkitImage            string   `yaml:"buildkit_image"             help:"Choose a specific image for your buildkitd."`
-	BuildkitRestartTimeoutS  int      `yaml:"buildkit_restart_timeout_s" help:"How long to wait for buildkit to (re)start, in seconds."`
-	BuildkitAdditionalArgs   []string `yaml:"buildkit_additional_args"   help:"Additional args to pass to buildkit when it starts. Useful for custom/self-signed certs, or user namespace complications."`
-	BuildkitAdditionalConfig string   `yaml:"buildkit_additional_config" help:"Additional config to use when starting the buildkit container; like using custom/self-signed certificates."`
-	BuildkitMaxParallelism   int      `yaml:"buildkit_max_parallelism"   help:"Max parallelism for builtkit workers"`
-	ConversionParallelism    int      `yaml:"conversion_parallelism"     help:"Set the conversion parallelism for speeding up the use of IF, WITH, DOCKER --load, FROMDOCKERFILE and others. A value of 0 disables the feature"`
-	CniMtu                   uint16   `yaml:"cni_mtu"                    help:"Override auto-detection of the default interface MTU, for all containers within buildkit"`
-	BuildkitHost             string   `yaml:"buildkit_host"              help:"The URL of your buildkit, remote or local."`
-	DebuggerHost             string   `yaml:"debugger_host"              help:"The URL of the Earthly debugger, remote or local."`
-	LocalRegistryHost        string   `yaml:"local_registry_host"        help:"The URL of the local registry used for image exports to Docker."`
-	TLSCA                    string   `yaml:"tlsca"                      help:"The path to the CA cert for verification. Relative paths are interpreted as relative to ~/.earthly."`
-	ClientTLSCert            string   `yaml:"tlscert"                    help:"The path to the client cert for verification. Relative paths are interpreted as relative to ~/.earthly."`
-	ClientTLSKey             string   `yaml:"tlskey"                     help:"The path to the client key for verification. Relative paths are interpreted as relative to ~/.earthly."`
-	ServerTLSCert            string   `yaml:"buildkitd_tlscert"          help:"The path to the server cert for verification. Relative paths are interpreted as relative to ~/.earthly. Only used when Earthly manages buildkit."`
-	ServerTLSKey             string   `yaml:"buildkitd_tlskey"           help:"The path to the server key for verification. Relative paths are interpreted as relative to ~/.earthly. Only used when Earthly manages buildkit."`
-	TLSEnabled               bool     `yaml:"tls_enabled"                help:"If TLS should be used to communicate with Buildkit. Only honored when BuildkitScheme is 'tcp'."`
-	ContainerFrontend        string   `yaml:"container_frontend"         help:"What program should be used to start and stop buildkitd, save images. Default is 'docker'. Valid options are 'docker' and 'podman' (experimental)."`
-	IPTables                 string   `yaml:"ip_tables"                  help:"Which iptables binary to use. Valid values are iptables-legacy or iptables-nft. Bypasses any autodetection."`
+	DisableAnalytics             bool     `yaml:"disable_analytics"          help:"Controls Earthly telemetry."`
+	BuildkitCacheSizeMb          int      `yaml:"cache_size_mb"              help:"Size of the buildkit cache in Megabytes."`
+	BuildkitImage                string   `yaml:"buildkit_image"             help:"Choose a specific image for your buildkitd."`
+	BuildkitRestartTimeoutS      int      `yaml:"buildkit_restart_timeout_s" help:"How long to wait for buildkit to (re)start, in seconds."`
+	BuildkitAdditionalArgs       []string `yaml:"buildkit_additional_args"   help:"Additional args to pass to buildkit when it starts. Useful for custom/self-signed certs, or user namespace complications."`
+	BuildkitAdditionalConfig     string   `yaml:"buildkit_additional_config" help:"Additional config to use when starting the buildkit container; like using custom/self-signed certificates."`
+	BuildkitAdditionalEntrypoint string   `yaml:"buildkit_additional_entrypoint" help:"Additional entrypoint commands to evaluate when starting the buildkit container."`
+
+	BuildkitMaxParallelism int    `yaml:"buildkit_max_parallelism"   help:"Max parallelism for builtkit workers"`
+	ConversionParallelism  int    `yaml:"conversion_parallelism"     help:"Set the conversion parallelism for speeding up the use of IF, WITH, DOCKER --load, FROMDOCKERFILE and others. A value of 0 disables the feature"`
+	CniMtu                 uint16 `yaml:"cni_mtu"                    help:"Override auto-detection of the default interface MTU, for all containers within buildkit"`
+	BuildkitHost           string `yaml:"buildkit_host"              help:"The URL of your buildkit, remote or local."`
+	DebuggerHost           string `yaml:"debugger_host"              help:"The URL of the Earthly debugger, remote or local."`
+	LocalRegistryHost      string `yaml:"local_registry_host"        help:"The URL of the local registry used for image exports to Docker."`
+	TLSCA                  string `yaml:"tlsca"                      help:"The path to the CA cert for verification. Relative paths are interpreted as relative to ~/.earthly."`
+	ClientTLSCert          string `yaml:"tlscert"                    help:"The path to the client cert for verification. Relative paths are interpreted as relative to ~/.earthly."`
+	ClientTLSKey           string `yaml:"tlskey"                     help:"The path to the client key for verification. Relative paths are interpreted as relative to ~/.earthly."`
+	ServerTLSCert          string `yaml:"buildkitd_tlscert"          help:"The path to the server cert for verification. Relative paths are interpreted as relative to ~/.earthly. Only used when Earthly manages buildkit."`
+	ServerTLSKey           string `yaml:"buildkitd_tlskey"           help:"The path to the server key for verification. Relative paths are interpreted as relative to ~/.earthly. Only used when Earthly manages buildkit."`
+	TLSEnabled             bool   `yaml:"tls_enabled"                help:"If TLS should be used to communicate with Buildkit. Only honored when BuildkitScheme is 'tcp'."`
+	ContainerFrontend      string `yaml:"container_frontend"         help:"What program should be used to start and stop buildkitd, save images. Default is 'docker'. Valid options are 'docker' and 'podman' (experimental)."`
+	IPTables               string `yaml:"ip_tables"                  help:"Which iptables binary to use. Valid values are iptables-legacy or iptables-nft. Bypasses any autodetection."`
 
 	// Obsolete.
 	CachePath      string `yaml:"cache_path"         help:" *Deprecated* The path to keep Earthly's cache."`


### PR DESCRIPTION
Introduces a new `buildkit_additional_entrypoint` global argument that
can be configured in `~/.earthly/config.yml`, which is evaluated before
running buildkit. This allows a user to pass arbitratry commands to the
entrypoint.sh script, e.g.

    buildkit_additional_entrypoint: 'export BUILDKIT_SCHEDULER_DEBUG=1'

or it can be extended to help with debugging, for example displaying all
environment variables containing the string debug:

    buildkit_additional_entrypoint: 'echo ---start---; env | grep -i debug; echo ---end---'

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>