### PR TITLE
fix cache export when using --max-remote-cache

### DIFF
--- a/builder/solver.go
+++ b/builder/solver.go
@@ -205,7 +205,7 @@ func (s *solver) newSolveOptMulti(ctx context.Context, eg *errgroup.Group, onIma
 		cacheExports = append(cacheExports, newCacheExportOpt(s.cacheExport, false))
 	}
 	if s.maxCacheExport != "" {
-		cacheExports = append(cacheExports, newCacheExportOpt(s.cacheExport, true))
+		cacheExports = append(cacheExports, newCacheExportOpt(s.maxCacheExport, true))
 	}
 	if s.saveInlineCache {
 		cacheExports = append(cacheExports, newInlineCacheOpt())


### PR DESCRIPTION
In `cmd/earthly/main.go`, we set either the `cacheExport` or the `maxCacheExport` field into the Builder. But when generating cache export options for buildkit, we we're always using cacheExport even when `--max-remote-cache` is set.

Signed-off-by: Andrew Sy Kim <andrew@earthly.dev>