### PR TITLE
Update buildkit to fix logging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,6 +284,8 @@ jobs:
               --build-arg DOCKERHUB_AUTH=false \
           ./tests+experimental
         if: github.event_name != 'push' && github.event.pull_request.head.repo.full_name != github.repository
+      - name: Test buildkit info-level logging
+        run: docker logs earthly-buildkitd 2>&1 | grep 'running server on'
       - name: Buildkit logs (runs on failure)
         run: docker logs earthly-buildkitd
         if: ${{ failure() }}

--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -11,7 +11,7 @@ buildkitd:
             ARG BUILDKIT_BASE_IMAGE=$BUILDKIT_PROJECT+build
         END
     ELSE
-        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:d8349d68bca7da065b9c51a159d983cb7d5cdbe4+build
+        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:902721127522a48918c2da97e9ab50cee3f62a58+build
     END
     FROM $BUILDKIT_BASE_IMAGE
     RUN echo "@edge-community http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,6 @@ replace (
 
 	github.com/jessevdk/go-flags => github.com/alexcb/go-flags v0.0.0-20210722203016-f11d7ecb5ee5
 
-	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.1-0.20211029211110-d8349d68bca7
+	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.1-0.20211110195712-902721127522
 	github.com/tonistiigi/fsutil => github.com/earthly/fsutil v0.0.0-20211029185157-9f87c4e70cf0
 )

--- a/go.sum
+++ b/go.sum
@@ -317,8 +317,8 @@ github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
-github.com/earthly/buildkit v0.0.1-0.20211029211110-d8349d68bca7 h1:MV6U5dYY4L10BJSyPeJQKpcUQUW2Sqhh6BIF9XhMqn4=
-github.com/earthly/buildkit v0.0.1-0.20211029211110-d8349d68bca7/go.mod h1:xVzArlNtSY2T0lx781v4QKjeGEI+StJYWdJHKd/vlmw=
+github.com/earthly/buildkit v0.0.1-0.20211110195712-902721127522 h1:ZiNj+5jeeQlY7Zw8egTdJEM49+ouHy4EXnh1XJKYM+s=
+github.com/earthly/buildkit v0.0.1-0.20211110195712-902721127522/go.mod h1:xVzArlNtSY2T0lx781v4QKjeGEI+StJYWdJHKd/vlmw=
 github.com/earthly/fsutil v0.0.0-20211029185157-9f87c4e70cf0 h1:AnKSLuPyEB7ZLDhapjkypj+eJohCBvTKdcCYLxvLcPA=
 github.com/earthly/fsutil v0.0.0-20211029185157-9f87c4e70cf0/go.mod h1:E6osHKls9ix67jofYQ61RQKwlJhqJOZM2hintp+49iI=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=


### PR DESCRIPTION
Additionally creates a new test to validate the buildkit info log
"running server on ..." is found in the earthly-buildkitd logs.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>