### PR TITLE
update changelog for v0.6.0-rc3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 
 ## Unreleased
 
+## v0.6.0-rc3 - 2021-11-15
+
+### Fixed
+
+- cache export was not honoring `EARTHLY_MAX_REMOTE_CACHE` setting
+- buildkit logs were not being sent to `earthly-buildkitd` container's output.
+- kind required permissions were not available in earthly-buildkitd.
+
+### Changed
+
+- docker and fsutils versions were set to match versions defined in earthly's buildkit fork.
+
 ## v0.6.0-rc2 - 2021-11-01
 
 ### Fixed

--- a/release/release.sh
+++ b/release/release.sh
@@ -63,6 +63,9 @@ fi
 
 ../earthly upgrade
 
+# fail-fast if release-notes do not exist
+../earthly --build-arg DOCKERHUB_USER --build-arg RELEASE_TAG +release-notes
+
 if [ -n "$GITHUB_SECRET_PATH" ]; then
     GITHUB_SECRET_PATH_BUILD_ARG="--build-arg GITHUB_SECRET_PATH=$GITHUB_SECRET_PATH"
 else


### PR DESCRIPTION
Additionally make release.sh fail-fast when changelog is missing.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>