### PR TITLE
update buildkit version used for earthly v0.6.0

### DIFF
--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -11,7 +11,7 @@ buildkitd:
             ARG BUILDKIT_BASE_IMAGE=$BUILDKIT_PROJECT+build
         END
     ELSE
-        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:b18e94b75d79364f37a8c27bf6017856d8e20b28+build
+        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:5ee328821a2b2b3cbb84ef6290ba8d1abc910e44+build
     END
     FROM $BUILDKIT_BASE_IMAGE
     RUN echo "@edge-community http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,6 @@ replace (
 
 	github.com/jessevdk/go-flags => github.com/alexcb/go-flags v0.0.0-20210722203016-f11d7ecb5ee5
 
-	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.0-20211118181317-b18e94b75d79
+	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.0-20211120012956-5ee328821a2b
 	github.com/tonistiigi/fsutil => github.com/earthly/fsutil v0.0.0-20211029185157-9f87c4e70cf0
 )

--- a/go.sum
+++ b/go.sum
@@ -316,8 +316,8 @@ github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
-github.com/earthly/buildkit v0.0.0-20211118181317-b18e94b75d79 h1:hohmwLJdWJ9DKI/uM3AtVwZGJMYYH1n2Jnk6sBeujFQ=
-github.com/earthly/buildkit v0.0.0-20211118181317-b18e94b75d79/go.mod h1:0SdY5YeYxYtvXOJ0Eppr9uKnc4yDXe+/5glup9Cthus=
+github.com/earthly/buildkit v0.0.0-20211120012956-5ee328821a2b h1:c2CftoOyCSaoWwUI1ZgQU9S2c+3Hh2CBXLHxo9wrMDk=
+github.com/earthly/buildkit v0.0.0-20211120012956-5ee328821a2b/go.mod h1:0SdY5YeYxYtvXOJ0Eppr9uKnc4yDXe+/5glup9Cthus=
 github.com/earthly/fsutil v0.0.0-20211029185157-9f87c4e70cf0 h1:AnKSLuPyEB7ZLDhapjkypj+eJohCBvTKdcCYLxvLcPA=
 github.com/earthly/fsutil v0.0.0-20211029185157-9f87c4e70cf0/go.mod h1:E6osHKls9ix67jofYQ61RQKwlJhqJOZM2hintp+49iI=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=


### PR DESCRIPTION
This sets us to use https://github.com/earthly/buildkit/tree/version-for-earthly-v0.6

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>