### PR TITLE
update homebrew release to use griswoldthecat ssh key

### DIFF
--- a/release/Earthfile
+++ b/release/Earthfile
@@ -177,10 +177,15 @@ release-homebrew:
 
     RUN git config --global user.name "$GIT_NAME" && \
         git config --global user.email "$GIT_EMAIL"
-    COPY ./envcredhelper.sh /usr/bin/envcredhelper.sh
-    RUN git config --global credential.helper "/bin/sh /usr/bin/envcredhelper.sh"
-    RUN --secret GIT_PASSWORD="$GITHUB_TOKEN_SECRET_PATH" --no-cache \
-        git clone "https://$GITHUB_USER@github.com/$GITHUB_USER/$BREW_REPO.git" .
+
+    # load in github.com's public key (fetched by running: ssh-keyscan -H github.com)
+    RUN mkdir -p /root/.ssh
+    RUN echo "|1|M66Uwae8fx9M5JFDd+WyVi3dERM=|LKfAmECF1kHoZ6epHR5jtPhJgic= ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==" > /root/.ssh/known_hosts
+
+    RUN --mount type=secret,id=+secrets/earthly-technologies/github/griswoldthecat/id_rsa,target=/root/id_rsa --no-cache \
+        eval $(ssh-agent) && \
+        cat /root/id_rsa | ssh-add - && \
+        git clone "git@github.com:$GITHUB_USER/$BREW_REPO.git" .
     # Make the change in a new branch.
     ARG RELEASE_BRANCH="release-$RELEASE_TAG"
     RUN git switch -c "$RELEASE_BRANCH"
@@ -204,9 +209,12 @@ release-homebrew:
     RUN version=${RELEASE_TAG#v} ;\
         echo version=$version ;\
         git commit -a --allow-empty -m "earthly $version"
-    RUN --secret GIT_PASSWORD="$GITHUB_TOKEN_SECRET_PATH" \
+
+    RUN --mount type=secret,id=+secrets/earthly-technologies/github/griswoldthecat/id_rsa,target=/root/id_rsa \
         --secret SLACK_WEBHOOK_URL=+secrets/earthly-technologies/slack/release-webhook \
         --push \
+        eval $(ssh-agent) && \
+        cat /root/id_rsa | ssh-add - && \
         git push --force --set-upstream origin "$RELEASE_BRANCH" && \
         curl -s -X POST -H 'Content-type: application/json' --data '{"text":"Successfully pushed release branch: https://github.com/earthly/homebrew-earthly/tree/'$RELEASE_BRANCH'"}' "$SLACK_WEBHOOK_URL"
 


### PR DESCRIPTION
github disabled password-based login; this changes the homebrew release
to use a ssh key to push up changes.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>