### PR TITLE
surface last connection error from buildkitd client

### DIFF
--- a/buildkitd/buildkitd.go
+++ b/buildkitd/buildkitd.go
@@ -550,7 +550,7 @@ func waitForConnection(ctx context.Context, containerName, address string, opTim
 			err := checkConnection(ctx, address, opts...)
 			if err != nil {
 				// We give up.
-				return errors.Wrapf(ErrBuildkitStartFailure, "timeout %s: buildkitd did not make connection available after start", opTimeout)
+				return errors.Wrapf(ErrBuildkitStartFailure, "timeout %s: buildkitd did not make connection available after start with error: %s", opTimeout, err.Error())
 			}
 			return nil
 		}


### PR DESCRIPTION
While troubleshooting another issue, I noticed that the last error when buildkit client tries to connect is not logged which made it hard to troubleshoot the issue. This PR includes the error message in the error. 

Signed-off-by: Andrew Sy Kim <andrew@earthly.dev>