### PR TITLE
earthly wrapper should check for symlink

### DIFF
--- a/earthly
+++ b/earthly
@@ -7,7 +7,8 @@ if [ ! -d "$bindir" ]; then
 fi
 
 scriptname=$(basename "$0")
-script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+scriptpath=$(readlink -f "$0")
+script_dir="$( cd "$( dirname "$scriptpath" )" &> /dev/null && pwd )"
 
 last_check_state_path=/tmp/last-earthly-prerelease-check
 


### PR DESCRIPTION
if `./earthly` is executed via a symlink, this fixes the following error

    /home/alex/bin/earthly: line 99: /home/alex/bin/.earthly_version_flag_overrides: No such file or directory

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>