### PR TITLE
If port 22 is open, default to ssh

### DIFF
--- a/buildcontext/gitlookup.go
+++ b/buildcontext/gitlookup.go
@@ -235,13 +235,13 @@ func (gl *GitLookup) detectProtocol(host string) (protocol gitProtocol, err erro
 
 	client, err := ssh.Dial("tcp", fmt.Sprintf("%s:22", host), config)
 	if err != nil {
-		protocol = httpsProtocol
+		protocol = sshProtocol
 		err = nil
 		return
 	}
 	defer client.Close()
 
-	protocol = sshProtocol
+	protocol = httpsProtocol
 	err = nil
 	return
 }


### PR DESCRIPTION
Fixes a bug where auto heuristic set git auth to use https
rather than ssh when port 22 is open.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>