### PR TITLE
Perform apt+yum deploy under ./release.sh

### DIFF
--- a/release/Earthfile
+++ b/release/Earthfile
@@ -216,7 +216,7 @@ release-homebrew:
         eval $(ssh-agent) && \
         cat /root/id_rsa | ssh-add - && \
         git push --force --set-upstream origin "$RELEASE_BRANCH" && \
-        curl -s -X POST -H 'Content-type: application/json' --data '{"text":"Successfully pushed release branch: https://github.com/earthly/homebrew-earthly/tree/'$RELEASE_BRANCH'"}' "$SLACK_WEBHOOK_URL"
+        curl -s -X POST -H 'Content-type: application/json' --data '{"text":"Successfully pushed release branch: https://github.com/earthly/homebrew-earthly/tree/'$RELEASE_BRANCH' (this branch will be automatically deleted via GHA once GHA deploy task finishes)"}' "$SLACK_WEBHOOK_URL"
 
 release-vscode-syntax-highlighting:
     ARG VSCODE_RELEASE_TAG

--- a/release/README.md
+++ b/release/README.md
@@ -33,13 +33,8 @@
   | Windows (WSL) | [![Build status](https://badge.buildkite.com/19d9cf7fcfb3e0ee45adcb29abb5ef3cfcd994fba2d6dc148c.svg)](https://buildkite.com/earthly-technologies/earthly-windows-scheduled)
 * Run
   ```bash
-  ./release.sh
+  env -i HOME="$HOME" PATH="$PATH" SSH_AUTH_SOCK="$SSH_AUTH_SOCK" RELEASE_TAG="$RELEASE_TAG" ./release.sh
   ```
-* Run
-  ```bash
-  ./earthly --push ./release+release-repo --RELEASE_TAG="$RELEASE_TAG"
-  ```
-  TODO: This step will be merged into the release.sh command once our staging environment is setup
 * Merge branch `main` into `next`, then merge branch `next` into `main`.
 * Update the version for the installation command in the following places:
 <!-- vale HouseStyle.Spelling = NO -->

--- a/release/apt-repo/Earthfile
+++ b/release/apt-repo/Earthfile
@@ -173,7 +173,7 @@ upload:
     # upload signed repo
     RUN --push \
         --mount type=secret,id=+secrets/user/earthly-technologies/aws/credentials,target=/root/.aws/credentials \
-        aws s3 cp --recursive --acl public-read /repo s3://staging-pkg/deb/
+        aws s3 sync --acl public-read /repo s3://staging-pkg/deb/
 
 build-and-release:
     BUILD --build-arg USE_OUTPUT_COPY=false +upload

--- a/release/release.sh
+++ b/release/release.sh
@@ -95,3 +95,10 @@ fi
 #../earthly --push --build-arg GITHUB_USER --build-arg EARTHLY_REPO --build-arg BREW_REPO --build-arg DOCKERHUB_USER --build-arg RELEASE_TAG +release-repo
 # until then, we will just print this out:
 echo "TODO: the apt/yum release must be triggered seperately; until we get https://test-pkg.earthly.dev/ setup"
+
+if [ "$GITHUB_USER" = "earthly" ] && [ "$EARTHLY_REPO" = "earthly" ]; then
+    ../earthly --push --build-arg RELEASE_TAG ./apt-repo+build-and-release
+    ../earthly --push --build-arg RELEASE_TAG ./yum-repo+build-and-release
+else
+    echo "WARNING: there is no staging environment for apt or yum repos"
+fi

--- a/release/yum-repo/Earthfile
+++ b/release/yum-repo/Earthfile
@@ -138,7 +138,7 @@ upload:
     # upload signed repo
     RUN --push \
         --mount type=secret,id=+secrets/user/earthly-technologies/aws/credentials,target=/root/.aws/credentials \
-        aws s3 cp --recursive --acl public-read /repo s3://staging-pkg/rpm/stable
+        aws s3 sync --acl public-read /repo s3://staging-pkg/rpm/stable
 
 build-and-release:
     BUILD --build-arg USE_OUTPUT_COPY=false +upload


### PR DESCRIPTION
Move apt and yum repo deployment under ./release.sh script
so we only have to run a single command.

Update the homebrew release message to point out the URL's branch will
be deleted by GHA (under https://github.com/earthly/homebrew-earthly/blob/main/.github/workflows/test-and-publish.yml#L86)

Update the readme to suggest using `env -i`, to make it obvious which
environment variables are being passed to `release.sh`.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>