### PR TITLE
earthly ls: lists targets under an Earthfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 - Earthly now provides the following [builtin ARGs](https://docs.earthly.dev/docs/earthfile/builtin-args): `EARTHLY_VERSION` and `EARTHLY_BUILD_SHA`. These will be generally available in Earthly version 0.7+, however, they can be enabled earlier by using the `--earthly-version-arg` [feature flag](https://docs.earthly.dev/docs/earthfile/features#feature-flags) [#1452](https://github.com/earthly/earthly/issues/1452).
 - Config option to disable `known_host` checking for specific git hosts by setting `strict_host_key_checking ` to `false` under the `git` section of `earthly/config.yml` (defaults to `true`).
 - Error check for using both `--interactive` and `--buildkit-host` (which are not currently supported together) [#1492](https://github.com/earthly/earthly/issues/1492).
+- `earthly ls [<project-ref>]` to list Earthfile targets
 
 ### Fixed
 

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -133,6 +133,8 @@ ga:
     BUILD +homebrew-test
     BUILD +implicit-ignores
     BUILD +help
+    BUILD +ls
+    BUILD +ls-subdir
 
 # tests that only run on linux amd64
 # Note: this target is used to validate the USERPLATFORM user arg,
@@ -888,6 +890,18 @@ help:
     RUN earthly --help | grep -v 'buildkit-volume-name'
     ENV EARTHLY_SHOW_HIDDEN=1
     RUN earthly --help | grep 'buildkit-volume-name'
+
+ls:
+    COPY ls.earth Earthfile
+    RUN earthly ls 2>/dev/null | tee actual
+    RUN echo -e "+alpha\n+base\n+bravo\n+charlie" > expected
+    RUN diff expected actual
+
+ls-subdir:
+    COPY ls.earth subdir/Earthfile
+    RUN earthly ls ./subdir 2>/dev/null | tee actual
+    RUN echo -e "+alpha\n+base\n+bravo\n+charlie" > expected
+    RUN diff expected actual
 
 
 RUN_EARTHLY:

--- a/tests/autocompletion/Earthfile
+++ b/tests/autocompletion/Earthfile
@@ -16,6 +16,7 @@ test-root-commands:
 account 
 bootstrap 
 config 
+ls 
 org 
 prune 
 secrets " > expected
@@ -31,6 +32,7 @@ config
 debug 
 docker 
 docker2earthly 
+ls 
 org 
 prune 
 secrets " > expected

--- a/tests/ls.earth
+++ b/tests/ls.earth
@@ -1,0 +1,10 @@
+FROM alpine:
+
+alpha:
+    RUN echo "a"
+
+charlie:
+    RUN echo "c"
+
+bravo:
+    RUN echo "b"


### PR DESCRIPTION
Displays a list of all targets under an Earthfile.

usage:

    earthly ls

    earthly ls ./sub-dir-containing-an-earthfile

This commit is dedicated to jazzdan.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>