### PR TITLE
Update GitLab Integration Guide

### DIFF
--- a/docs/ci-integration/guides/gitlab-integration.md
+++ b/docs/ci-integration/guides/gitlab-integration.md
@@ -13,8 +13,9 @@ services:
 
 before_script:
     - apk update && apk add git
-    - wget https://github.com/earthly/earthly/releases/download/v0.6.1/earthly-linux-amd64 -O /usr/local/bin/earthly
+    - wget https://github.com/earthly/earthly/releases/download/v0.6.2/earthly-linux-amd64 -O /usr/local/bin/earthly
     - chmod +x /usr/local/bin/earthly
+    - export FORCE_COLOR=1
     - /usr/local/bin/earthly bootstrap
     - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
 
@@ -24,6 +25,6 @@ earthly:
     - earthly --ci --push -P +build
 ```
 
-A full example is available [on GitLab](https://gitlab.com/brandon176/earthly-demo/-/tree/main).
+A full example is available [on GitLab](https://gitlab.com/earthly-technologies/earthly-demo).
 
 For a complete guide on CI integration see the [CI integration guide](../overview.md).

--- a/release/README.md
+++ b/release/README.md
@@ -42,6 +42,7 @@
   * [circle-integration.md](../docs/ci-integration/guides/circle-integration.md)
   * [gh-actions-integration.md](../docs/ci-integration/guides/gh-actions-integration.md)
   * [codebuild-integration.md](../docs/ci-integration/guides/codebuild-integration.md)
+  * [gitlab-integration.md](../docs/ci-integration/guides/gitlab-integration.md)
   * [build-an-earthly-ci-image.md](../docs/ci-integration/build-an-earthly-ci-image.md)
 <!-- vale HouseStyle.Spelling = YES -->
   * you can try doing that with:


### PR DESCRIPTION
Some minor adjustments based on feedback after this PR was merged: https://github.com/earthly/earthly/pull/1471

One outstanding question that was asked on Slack: "Does the GitLab integration work on the [Earthly image](https://hub.docker.com/r/earthly/earthly)?" 
- I was not able to get it working, however, some more testing could be done. For example:
  - Does it work locally or elsewhere within the Earthly image? 
  - Maybe I was missing something in my GitLab config? 
  - Can we get a copy of the `.gitlab-ca.yml` from the user who was having issues with it?
- Nonetheless, I think the current guide showing Docker's own image is still appropriate, as it's what is [suggested by GitLab](https://docs.gitlab.com/ee/ci/docker/using_docker_build.html) to run Docker commands in their CI.