### PR TITLE
Error out if interactive and buildkit-host flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 
 - Earthly now provides the following [builtin ARGs](https://docs.earthly.dev/docs/earthfile/builtin-args): `EARTHLY_VERSION` and `EARTHLY_BUILD_SHA`. These will be generally available in Earthly version 0.7+, however, they can be enabled earlier by using the `--earthly-version-arg` [feature flag](https://docs.earthly.dev/docs/earthfile/features#feature-flags) [#1452](https://github.com/earthly/earthly/issues/1452).
 - Config option to disable `known_host` checking for specific git hosts by setting `strict_host_key_checking ` to `false` under the `git` section of `earthly/config.yml` (defaults to `true`).
+- Error check for using both `--interactive` and `--buildkit-host` (which are not currently supported together) [#1492](https://github.com/earthly/earthly/issues/1492).
 
 ### Fixed
 

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -2606,9 +2606,15 @@ func (app *earthlyApp) actionBuild(c *cli.Context) error {
 			return errors.New("unable to use --ci flag in combination with --interactive flag")
 		}
 	}
-	if !termutil.IsTTY() && app.interactiveDebugging {
-		return errors.New("A tty-terminal must be present in order to the --interactive flag")
+	if app.interactiveDebugging {
+		if !termutil.IsTTY() {
+			return errors.New("A tty-terminal must be present in order to the --interactive flag")
+		}
+		if !buildkitd.IsLocal(app.buildkitHost) {
+			return errors.New("the --interactive flag is not currently supported with non-local buildkit servers")
+		}
 	}
+
 	if app.imageMode && app.artifactMode {
 		return errors.New("both image and artifact modes cannot be active at the same time")
 	}


### PR DESCRIPTION
Currently --interactive does not work with a remote buildkit instance,
until this is implemented, we should display a more clear error message.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>