### PR TITLE
Document Issues with FROM Dockerfile

### DIFF
--- a/docs/earthfile/earthfile.md
+++ b/docs/earthfile/earthfile.md
@@ -731,6 +731,8 @@ The `FROM DOCKERFILE` command initializes a new build environment, inheriting fr
 
 The `<context-path>` is the path where the Dockerfile build context exists. By default, it is assumed that a file named `Dockerfile` exists in that directory. The context path can be either a path on the host system, or an [artifact reference](../guides/target-ref.md#artifact-reference), pointing to a directory containing a `Dockerfile`.
 
+Transfer of the build context when using [artifact references](../guides/target-ref.md#artifact-reference) can be achieved by specifying the -f flag manually and appending a /* to the context-path argument. For example `FROM DOCKERFILE -f +target/dir/Dockerfile +target/dir`. Other specifications may currently face issues as documented in [#1410](https://github.com/earthly/earthly/issues/1410).
+
 #### Options
 
 ##### `-f <dockerfile-path>`


### PR DESCRIPTION
Hi!

Issue #1410 is not intuitive for a user. Besides a reference in the documentation that "WITH DOCKER" and "docker build" should not be used together, the documentation currently lacks any direction in allowing the generation of a Dockerfile (e.g. in combination with GIT CLONE and RUN git apply <patch>).

Without the Workaround discussed in the above issues, users would be forced to work around earthly rather than utilize it correctly. Usability wise i'd argue FROM DOCKERFILE +target/repo should automatically imply or at the very least should be functionally identical to FROM DOCKERFILE -f +target/repo/Dockerfile +target/repo/*.

In case you disagree with that interpretation, the documentation should be adapted accordingly.

Thanks

PS: Otherwise been using earthly in some production-ish workloads and it's now been a breeze.