### PR TITLE
fix autocompletion of ARGs containing flags

### DIFF
--- a/earthfile2llb/earthfile2llb.go
+++ b/earthfile2llb/earthfile2llb.go
@@ -191,8 +191,12 @@ func GetTargetArgs(ctx context.Context, resolver *buildcontext.Resolver, gwClien
 	}
 	var args []string
 	for _, stmt := range t.Recipe {
-		if stmt.Command.Name == "ARG" {
-			args = append(args, stmt.Command.Args[0])
+		if stmt.Command != nil && stmt.Command.Name == "ARG" {
+			_, argName, _, err := parseArgArgs(ctx, *stmt.Command)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to parse ARG arguments %v", stmt.Command.Args)
+			}
+			args = append(args, argName)
 		}
 	}
 	return args, nil

--- a/tests/autocompletion/Earthfile
+++ b/tests/autocompletion/Earthfile
@@ -42,7 +42,8 @@ test-targets:
 
     RUN echo "+mytarget 
 +othertarget 
-+othertargetwithargs " > expected
++othertargetwithargs 
++targetwithrequiredarg " > expected
     RUN COMP_LINE="earthly +" COMP_POINT=9 earthly > actual
     RUN diff expected actual
 
@@ -50,7 +51,7 @@ test-targets:
     RUN COMP_LINE="earthly +m" COMP_POINT=10 earthly > actual
     RUN diff expected actual
 
-test-targets-with-build-args:
+test-target-with-build-args:
     COPY fake.earth ./Earthfile
 
     RUN echo "--city=
@@ -81,7 +82,8 @@ test-targets-from-other-dir:
 
     RUN echo "./child/dir+mytarget 
 ./child/dir+othertarget 
-./child/dir+othertargetwithargs " > expected
+./child/dir+othertargetwithargs 
+./child/dir+targetwithrequiredarg " > expected
     RUN COMP_LINE="earthly ./child/dir+" COMP_POINT=20 earthly > actual
     RUN diff expected actual
 
@@ -89,7 +91,7 @@ test-targets-from-other-dir:
     RUN COMP_LINE="earthly ./child/dir+m" COMP_POINT=21 earthly > actual
     RUN diff expected actual
 
-test-targets-with-build-args-from-other-dir:
+test-target-with-build-args-from-other-dir:
     RUN mkdir -p child/dir
     COPY fake.earth child/dir/Earthfile
 
@@ -105,6 +107,13 @@ test-targets-with-build-args-from-other-dir:
 
     RUN echo "--city=" > expected
     RUN COMP_LINE="earthly ./child/dir+othertargetwithargs --ci" COMP_POINT=44 earthly > actual
+    RUN diff expected actual
+
+test-target-with-required-arg:
+    COPY fake.earth Earthfile
+
+    RUN echo "--musthave=" > expected
+    RUN COMP_LINE="earthly +targetwithrequiredarg -" COMP_POINT=32 earthly > actual
     RUN diff expected actual
 
 test-base-only-target:
@@ -143,7 +152,8 @@ test-relative-dir-targets:
     RUN diff expected actual
     RUN echo "./foo+mytarget 
 ./foo+othertarget 
-./foo+othertargetwithargs " > expected
+./foo+othertargetwithargs 
+./foo+targetwithrequiredarg " > expected
     RUN COMP_LINE="earthly ./foo+" COMP_POINT=14 earthly > actual
     RUN diff expected actual
 
@@ -152,8 +162,9 @@ test-all:
     BUILD +test-hidden-root-commands
     BUILD +test-targets
     BUILD +test-targets-from-other-dir
-    BUILD +test-targets-with-build-args
-    BUILD +test-targets-with-build-args-from-other-dir
+    BUILD +test-target-with-build-args
+    BUILD +test-target-with-build-args-from-other-dir
+    BUILD +test-target-with-required-arg
     BUILD +test-base-only-target
     BUILD +test-relative-dir-targets
     BUILD +test-no-parent-at-root

--- a/tests/autocompletion/fake.earth
+++ b/tests/autocompletion/fake.earth
@@ -13,3 +13,7 @@ othertargetwithargs:
     ARG city
     ARG country
     RUN echo "we will test that +othertargetwithargs --c<tab><tab> suggests --city and --country"
+
+targetwithrequiredarg:
+    ARG --required musthave
+    RUN echo "this is a $musthave feature"


### PR DESCRIPTION
autocompletion for ARGS with flags (e.g. ARG --required FOO)
was incorrectly suggesting

    +target ----required

rather than

    +target --FOO`.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>