### PR TITLE
allow overriding .env with --env-flag

### DIFF
--- a/earthfile2llb/interpreter.go
+++ b/earthfile2llb/interpreter.go
@@ -14,6 +14,7 @@ import (
 	"github.com/earthly/earthly/domain"
 	"github.com/earthly/earthly/util/flagutil"
 	"github.com/earthly/earthly/util/llbutil"
+	"github.com/earthly/earthly/util/parseutil"
 	"github.com/earthly/earthly/variables"
 
 	flags "github.com/jessevdk/go-flags"
@@ -1586,7 +1587,7 @@ func parseParans(str string) (string, []string, error) {
 // isSafeAsyncBuildArgsDeprecatedStyle is used for "BUILD --build-arg key=value +target" style buildargs
 func isSafeAsyncBuildArgsDeprecatedStyle(args []string) bool {
 	for _, arg := range args {
-		_, v, _ := variables.ParseKeyValue(arg)
+		_, v, _ := parseutil.ParseKeyValue(arg)
 		if strings.HasPrefix(v, "$(") || strings.HasPrefix(v, "\"$(") {
 			return false
 		}
@@ -1600,7 +1601,7 @@ func isSafeAsyncBuildArgs(args []string) bool {
 		if !strings.HasPrefix(arg, "--") {
 			return false // malformed build arg
 		}
-		_, v, _ := variables.ParseKeyValue(arg[2:])
+		_, v, _ := parseutil.ParseKeyValue(arg[2:])
 		if strings.HasPrefix(v, "$(") || strings.HasPrefix(v, "\"$(") {
 			return false
 		}

--- a/util/parseutil/key_value.go
+++ b/util/parseutil/key_value.go
@@ -1,0 +1,58 @@
+package parseutil
+
+import (
+	"strings"
+)
+
+// ParseArgsForKey parses a list of args and returns the value
+// of the first found key
+func ParseArgsForKey(key string, args []string) (string, bool) {
+	wantNextVal := false
+	for _, s := range args {
+		if wantNextVal {
+			return s, true
+		}
+
+		k, v, keyOnly := ParseKeyValue(s)
+		if k == key {
+			if keyOnly {
+				wantNextVal = true
+				continue
+			}
+			return v, true
+		}
+	}
+	return "", false
+}
+
+// ParseKeyValue pases a key-value type into its parts
+// if a key value needs to contain a = or \, it must be escapped using '\=', and '\\' respectively
+// once an unescaped '=' is found, all remaining chars will be used as-is without the need to be escaped.
+// the key and value are returned, along with a bool that is true if a value was defined (i.e. an equal was found)
+//
+// e.g. ParseKeyValue("foo")       -> `foo`,  ``,       false
+//      ParseKeyValue("foo=")      -> `foo`,  ``,       true
+//      ParseKeyValue("foo=bar")   -> `foo`,  `bar`,    true
+//      ParseKeyValue(`f\=oo=bar`) -> `f=oo`, `bar`,    true
+//      ParseKeyValue(`foo=bar=`)  -> `foo",  `bar=`,   true
+//      ParseKeyValue(`foo=bar\=`) -> `foo",  `bar\=`,  true
+func ParseKeyValue(s string) (string, string, bool) {
+	key := []string{}
+	var escaped bool
+	for i, c := range s {
+		if escaped {
+			key = append(key, string(c))
+			escaped = false
+			continue
+		}
+		if c == '\\' {
+			escaped = true
+			continue
+		}
+		if c == '=' {
+			return strings.Join(key, ""), s[i+1:], true
+		}
+		key = append(key, string(c))
+	}
+	return strings.Join(key, ""), "", false
+}

--- a/util/parseutil/key_value_test.go
+++ b/util/parseutil/key_value_test.go
@@ -1,4 +1,4 @@
-package variables
+package parseutil
 
 import (
 	"testing"

--- a/variables/parse.go
+++ b/variables/parse.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/earthly/earthly/util/parseutil"
+
 	"github.com/pkg/errors"
 )
 
@@ -99,7 +101,7 @@ func parseArgValue(name string, value string, pncvf ProcessNonConstantVariableFu
 func ParseEnvVars(envVars []string) *Scope {
 	ret := NewScope()
 	for _, envVar := range envVars {
-		k, v, _ := ParseKeyValue(envVar)
+		k, v, _ := parseutil.ParseKeyValue(envVar)
 		ret.AddActive(k, v)
 	}
 	return ret

--- a/variables/parsenew.go
+++ b/variables/parsenew.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/earthly/earthly/util/parseutil"
+
 	"github.com/pkg/errors"
 )
 
@@ -44,7 +46,7 @@ func ParseFlagArgsWithNonFlags(args []string) ([]string, []string, error) {
 				continue
 			}
 			var hasValue bool
-			k, v, hasValue = ParseKeyValue(trimmedArg)
+			k, v, hasValue = parseutil.ParseKeyValue(trimmedArg)
 			if !hasValue {
 				keyFromPrev = k
 				continue

--- a/variables/util.go
+++ b/variables/util.go
@@ -2,40 +2,9 @@ package variables
 
 import (
 	"fmt"
-	"strings"
-)
 
-// ParseKeyValue pases a key-value type into its parts
-// if a key value needs to contain a = or \, it must be escapped using '\=', and '\\' respectively
-// once an unescaped '=' is found, all remaining chars will be used as-is without the need to be escaped.
-// the key and value are returned, along with a bool that is true if a value was defined (i.e. an equal was found)
-//
-// e.g. ParseKeyValue("foo")       -> `foo`,  ``,       false
-//      ParseKeyValue("foo=")      -> `foo`,  ``,       true
-//      ParseKeyValue("foo=bar")   -> `foo`,  `bar`,    true
-//      ParseKeyValue(`f\=oo=bar`) -> `f=oo`, `bar`,    true
-//      ParseKeyValue(`foo=bar=`)  -> `foo",  `bar=`,   true
-//      ParseKeyValue(`foo=bar\=`) -> `foo",  `bar\=`,  true
-func ParseKeyValue(s string) (string, string, bool) {
-	key := []string{}
-	var escaped bool
-	for i, c := range s {
-		if escaped {
-			key = append(key, string(c))
-			escaped = false
-			continue
-		}
-		if c == '\\' {
-			escaped = true
-			continue
-		}
-		if c == '=' {
-			return strings.Join(key, ""), s[i+1:], true
-		}
-		key = append(key, string(c))
-	}
-	return strings.Join(key, ""), "", false
-}
+	"github.com/earthly/earthly/util/parseutil"
+)
 
 // AddEnv takes in a slice of env vars in key-value format and a new key-value
 // string to it, taking care of possible overrides.
@@ -43,7 +12,7 @@ func AddEnv(envVars []string, key, value string) []string {
 	// Note that this mutates the original slice.
 	found := false
 	for i, envVar := range envVars {
-		k, _, _ := ParseKeyValue(envVar)
+		k, _, _ := parseutil.ParseKeyValue(envVar)
 		if k == key {
 			envVars[i] = fmt.Sprintf("%s=%s", key, value)
 			found = true


### PR DESCRIPTION
Allow users to change which .env file is loaded by earthly; defaults
to .env in current directory.

To make this work, we need to get the value of --env-flag before
urfav/cli is initialized, as we must load in environment variables
into the global scope before parsing them with urfav/cli.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>