### PR TITLE
use ubuntu 20.04 rather than 20.10

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -390,7 +390,7 @@ dind-alpine:
     SAVE IMAGE --push --cache-from=earthly/dind:main $DOCKERHUB_USER/dind:$DIND_ALPINE_TAG
 
 dind-ubuntu:
-    FROM ubuntu:20.10
+    FROM ubuntu:20.04
     COPY ./buildkitd/docker-auto-install.sh /usr/local/bin/docker-auto-install.sh
     RUN docker-auto-install.sh
     ARG DIND_UBUNTU_TAG=ubuntu-$EARTHLY_TARGET_TAG_DOCKER

--- a/docs/earthfile/earthfile.md
+++ b/docs/earthfile/earthfile.md
@@ -897,7 +897,7 @@ ARG base=alpine
 IF [ "$base" = "alpine" ]
     FROM alpine:3.13
 ELSE
-    FROM ubuntu:20.10
+    FROM ubuntu:20.04
 END
 ```
 
@@ -911,7 +911,7 @@ FROM busybox
 IF [ "$base" = "alpine" ]
     FROM alpine:3.13
 ELSE
-    FROM ubuntu:20.10
+    FROM ubuntu:20.04
 END
 ```
 

--- a/examples/cobol/Earthfile
+++ b/examples/cobol/Earthfile
@@ -1,5 +1,5 @@
 VERSION 0.6
-FROM ubuntu:20.10
+FROM ubuntu:20.04
 
 ## for apt to be noninteractive
 ENV DEBIAN_FRONTEND noninteractive

--- a/examples/cpp/Earthfile
+++ b/examples/cpp/Earthfile
@@ -1,5 +1,5 @@
 VERSION 0.6
-FROM ubuntu:20.10
+FROM ubuntu:20.04
 
 ## for apt to be noninteractive
 ENV DEBIAN_FRONTEND noninteractive

--- a/release/apt-repo/Earthfile
+++ b/release/apt-repo/Earthfile
@@ -1,7 +1,10 @@
 FROM alpine:3.13
 
 deps:
-    FROM ubuntu:20.10
+    FROM ubuntu:20.04
+    # for apt to be noninteractive
+    ENV DEBIAN_FRONTEND noninteractive
+    ENV DEBCONF_NONINTERACTIVE_SEEN true
     RUN apt-get update && apt-get install -y dpkg-dev wget dpkg-sig
 
 deb:

--- a/release/msi/Earthfile
+++ b/release/msi/Earthfile
@@ -1,6 +1,6 @@
 
 build-msi:
-    FROM ubuntu:20.10
+    FROM ubuntu:20.04
     ENV TZ=Etc/UTC
     RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
     RUN dpkg --add-architecture i386 && \

--- a/scripts/tests/auth/test-with-git-url-instead-of.sh
+++ b/scripts/tests/auth/test-with-git-url-instead-of.sh
@@ -3,9 +3,22 @@ set -eu # don't use -x as it will leak the private key
 # shellcheck source=./setup.sh
 source "$(dirname "$0")/setup.sh"
 
-gitsha=$(git rev-parse HEAD)
+if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
+    # GHA does a pre-merge before running tests, this per-merge is not pushed to the repo
+    # until after the PR is merged. Therefore running it against this pre-merged, non-pushed
+    # commit will fail and should be avoided.
+    gitsha=$(jq -r .pull_request.head.sha < "$GITHUB_EVENT_PATH")
+else
+    gitsha=$(git rev-parse HEAD)
+fi
 test -n "$gitsha"
 
+GITHUB_SERVER_URL="${VARIABLE:-https://github.com}"
+GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-earthly/earthly}"
+github_server_without_protocol=$(echo "$GITHUB_SERVER_URL" | sed -e 's#^https\?://##; s#//$##')
+earthly_ref="$github_server_without_protocol/$GITHUB_REPOSITORY/examples/cpp:$gitsha+docker"
+
 docker image rm -f earthly/examples:cpp
-GIT_URL_INSTEAD_OF="https://github.com/=git@github.com:" "$earthly" -VD "github.com/earthly/earthly/examples/cpp:$gitsha+docker"
+echo "running $earthly -VD $earthly_ref"
+GIT_URL_INSTEAD_OF="https://github.com/=git@github.com:" "$earthly" -VD "$earthly_ref"
 docker run --rm earthly/examples:cpp | grep fib


### PR DESCRIPTION
Ubuntu 20.04 has long-term-support; 20.10 does not.
20.10 deb repos are no longer maintained and some mirrors are now
returning 404s which are causing builds to break.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>