### PR TITLE
test against current branch rather than main

### DIFF
--- a/scripts/tests/auth/test-with-git-url-instead-of.sh
+++ b/scripts/tests/auth/test-with-git-url-instead-of.sh
@@ -3,6 +3,9 @@ set -eu # don't use -x as it will leak the private key
 # shellcheck source=./setup.sh
 source "$(dirname "$0")/setup.sh"
 
+gitsha=$(git rev-parse HEAD)
+test -n "$gitsha"
+
 docker image rm -f earthly/examples:cpp
-GIT_URL_INSTEAD_OF="https://github.com/=git@github.com:" $earthly -VD github.com/earthly/earthly/examples/cpp:main+docker
+GIT_URL_INSTEAD_OF="https://github.com/=git@github.com:" "$earthly" -VD "github.com/earthly/earthly/examples/cpp:$gitsha+docker"
 docker run --rm earthly/examples:cpp | grep fib


### PR DESCRIPTION
Currently if main is broken, and fixed in a PR,
this test will fail until main is fixed. This makes it impossible
to submit a PR and validate the PR fixes main until after it gets
merged to main.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>