### PR TITLE
use tinyurl to reference Earthfile due to gitbook bug

### DIFF
--- a/docs/best-practices/best-practices.md
+++ b/docs/best-practices/best-practices.md
@@ -843,12 +843,15 @@ As one example, you might find the [monorepo example](https://github.com/earthly
 
 For a real-world example, you can also take a look at Earthly's own build, where several Earthfiles are scattered across the repository to help organize build logic across modules, very much like regular code. Here are some examples:
 
+<!-- GitBook currently has a bug where any references to an "Earthfile" gets confused with "docs/Earthfile" and somehow appends a /README.md
+https://github.com/earthly/earthly/blob/main/Earthfile was changed to https://tinyurl.com/yt3d3cx6 -->
+
 * [`ast/parser`](https://github.com/earthly/earthly/tree/main/ast/parser) - Earthfile contains the logic for generating Go source code based on an ANTLR grammar.
 * [`ast/parser/tests`](https://github.com/earthly/earthly/tree/main/ast/tests) - Earthfile contains logic for running AST-specific tests.
 * [`buildkitd`](https://github.com/earthly/earthly/tree/main/buildkitd) - Earthfile contains the logic for building the Earthly buildkit image.
 * [`tests`](https://github.com/earthly/earthly/tree/main/tests) - Earthfile contains logic for executing e2e tests.
 * [`release/**/`](https://github.com/earthly/earthly/tree/main/release) - Multiple Earthfiles contain logic used for the release of Earthly.
-* [The main Earthfile](https://github.com/earthly/earthly/blob/main/Earthfile) - ties everything together, referencing the various targets across the sub-directories.
+* [The main Earthfile](https://tinyurl.com/yt3d3cx6) - ties everything together, referencing the various targets across the sub-directories.
 
 ### Pattern: Pass-through artifacts or images
 

--- a/docs/examples/examples.md
+++ b/docs/examples/examples.md
@@ -78,11 +78,49 @@ Please note that these examples, although similar, are distinct from the ones us
 
 As a distinct example of a complete build, you can take a look at Earthly's own build. Earthly builds itself, and the build files are available on GitHub:
 
+<!--
+
+GitBook currently has a bug where any references to an "Earthfile" gets confused with "docs/Earthfile" and somehow appends a /README.md
+
+e.g. https://github.com/earthly/earthly/blob/main/Earthfile is changed to https://github.com/earthly/earthly/blob/main/Earthfile/README.md
+
+Here's a snip from an support request with gitbook:
+
+    On Thu, Dec 23, 2021 at 7:15:12 UTC, GitBook Support <support@gitbook.com> wrote:
+
+    There is a file:
+
+    https://github.com/earthly/earthly/blob/main/Earthfile
+
+    And you want to reference it directly in your GitBook space as a link.
+
+    The problem here is that GitBook is thrown off by the fact it has a folder under the docs root. Remember you documentation root is set to /docs.
+
+    So when it sees that reference, it assumes you are referencing a default README.md file under that folder. The folder I am talking about is this one:
+
+    https://github.com/earthly/earthly/tree/main/docs/earthfile
+
+    Now, the question is, if there's an easy way out of this.
+
+    On Thu, Dec 23, 2021 at 11:41:41 UTC, GitBook Support <support@gitbook.com> wrote:
+
+    I can't confirm it yet, but this might be an edge case that we could patch.
+
+    One not very ideal workaround I thought of is to temporarily switch to shortened URLs for those that fail because of this scenario.
+
+
 * [Earthfile](https://github.com/earthly/earthly/blob/main/Earthfile) - the root build file
 * [buildkitd/Earthfile](https://github.com/earthly/earthly/blob/main/buildkitd/Earthfile) - the build of the Buildkit daemon
 * [AST/parser/Earthfile](https://github.com/earthly/earthly/blob/main/ast/parser/Earthfile) - the build of the parser, which generates .go files
 * [tests/Earthfile](https://github.com/earthly/earthly/blob/main/tests/Earthfile) - system and smoke tests
 * [contrib/earthfile-syntax-highlighting/Earthfile](https://github.com/earthly/earthly/blob/main/contrib/earthfile-syntax-highlighting/Earthfile) - the build of the VS Code extension
+-->
+
+* [Earthfile](https://tinyurl.com/yt3d3cx6) - the root build file
+* [buildkitd/Earthfile](https://tinyurl.com/yvnpuru7) - the build of the Buildkit daemon
+* [AST/parser/Earthfile](https://tinyurl.com/2k3u4vty) - the build of the parser, which generates .go files
+* [tests/Earthfile](https://tinyurl.com/2p8ws579) - system and smoke tests
+* [contrib/earthfile-syntax-highlighting/Earthfile](https://tinyurl.com/yp4y6byn) - the build of the VS Code extension
 
 To invoke Earthly's build, check out the code and then run the following in the root of the repository
 

--- a/docs/guides/integration.md
+++ b/docs/guides/integration.md
@@ -171,7 +171,9 @@ project-files:
     RUN touch a.scala && sbt compile && rm a.scala
 ```
 
-[Full file](https://github.com/earthly/earthly/blob/main/examples/integration-test/Earthfile)
+<!-- due to gitbook bug, https://github.com/earthly/earthly/blob/main/examples/integration-test/Earthfile changed to https://tinyurl.com/4m6hbd6a -->
+
+[Full file](https://tinyurl.com/4m6hbd6a)
 
 {% sample lang="Compile" %}
 
@@ -182,7 +184,7 @@ build:
     COPY src src
     RUN sbt compile
 ```
-[Full file](https://github.com/earthly/earthly/blob/main/examples/integration-test/Earthfile)
+[Full file](https://tinyurl.com/4m6hbd6a)
 
 {% sample lang="Unit Test" %}
 
@@ -196,7 +198,7 @@ unit-test:
     RUN sbt test
 
 ```
-[Full file](https://github.com/earthly/earthly/blob/main/examples/integration-test/Earthfile)
+[Full file](https://tinyurl.com/4m6hbd6a)
 
 {% sample lang="Docker" %}
 


### PR DESCRIPTION
GitBook currently has a bug where any references to an "Earthfile" gets confused with "docs/Earthfile" and somehow appends a /README.md

e.g. https://github.com/earthly/earthly/blob/main/Earthfile is changed to https://github.com/earthly/earthly/blob/main/Earthfile/README.md

This is a workaround they suggested we could use until they fix the
issue.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>