### PR TITLE
Add a retry for starting `dockerd` when using `WITH DOCKER`

### DIFF
--- a/buildkitd/dockerd-wrapper.sh
+++ b/buildkitd/dockerd-wrapper.sh
@@ -32,7 +32,7 @@ execute() {
             break
         else
             sleep 5
-      fi
+        fi
     done
 
     load_images

--- a/buildkitd/dockerd-wrapper.sh
+++ b/buildkitd/dockerd-wrapper.sh
@@ -67,7 +67,7 @@ EOF
     # Start with a rm -rf to make sure a previous interrupted build did not leave its state around.
     rm -rf "$EARTHLY_DOCKERD_DATA_ROOT"
     mkdir -p "$EARTHLY_DOCKERD_DATA_ROOT"
-    dockerd --data-root="$EARTHLY_DOCKERD_DATA_ROOT" --bip=172.20.0.1/16 >/var/log/docker.log 2>&1 &
+    dockerd --data-root="$EARTHLY_DOCKERD_DATA_ROOT" --bip=172.20.0.1/16 --log-level debug >/var/log/docker.log 2>&1 &
     dockerd_pid="$!"
     i=1
     timeout=300

--- a/buildkitd/dockerd-wrapper.sh
+++ b/buildkitd/dockerd-wrapper.sh
@@ -24,6 +24,7 @@ execute() {
         exit 1
     fi
 
+    # shellcheck disable=SC2015
     for i in 1 2 3 4 5; do start_dockerd && break || sleep 15; done
     load_images
     if [ "$EARTHLY_START_COMPOSE" = "true" ]; then

--- a/buildkitd/dockerd-wrapper.sh
+++ b/buildkitd/dockerd-wrapper.sh
@@ -31,6 +31,10 @@ execute() {
         if start_dockerd; then
             break
         else
+            if [ "$i" = 5 ]; then
+                # Exiting here on the last retry maintains prior behavior of exiting when this cant start.
+                exit 1
+            fi
             sleep 5
         fi
     done

--- a/buildkitd/dockerd-wrapper.sh
+++ b/buildkitd/dockerd-wrapper.sh
@@ -35,7 +35,15 @@ execute() {
                 # Exiting here on the last retry maintains prior behavior of exiting when this cant start.
                 exit 1
             fi
-            sleep 5
+
+            if grep -q "^failed to start containerd: timeout waiting for containerd to start$" /var/log/docker.log; then
+                # This error is the sentinel string for retrying to start dockerd.
+                echo "Attempting to restart dockerd (attempt $i), since the error may be transient..."
+                sleep 5
+            else
+                # If the logs do not contain this, then fail fast to maintain prior behavior.
+                exit 1
+            fi
         fi
     done
 

--- a/buildkitd/dockerd-wrapper.sh
+++ b/buildkitd/dockerd-wrapper.sh
@@ -24,7 +24,7 @@ execute() {
         exit 1
     fi
 
-    start_dockerd
+    for i in 1 2 3 4 5; do start_dockerd && break || sleep 15; done
     load_images
     if [ "$EARTHLY_START_COMPOSE" = "true" ]; then
         # shellcheck disable=SC2086

--- a/buildkitd/dockerd-wrapper.sh
+++ b/buildkitd/dockerd-wrapper.sh
@@ -88,7 +88,7 @@ EOF
             cat /var/log/docker.log
             echo "==== End dockerd logs ===="
             echo "If you are having trouble running docker, try using the official earthly/dind image instead"
-            exit 1
+            return 1
         fi
         i=$((i+1))
     done

--- a/buildkitd/dockerd-wrapper.sh
+++ b/buildkitd/dockerd-wrapper.sh
@@ -24,8 +24,17 @@ execute() {
         exit 1
     fi
 
-    # shellcheck disable=SC2015
-    for i in 1 2 3 4 5; do start_dockerd && break || sleep 15; done
+    # Sometimes, when dockerd starts containerd, it doesn't come up in time. This timeout is not configurable from
+    # dockerd, therefore we retry... since most instances of this timeout seem to be related to networking or scheculing
+    # when many WITH DOCKER commands are also running. Logs are printed for each failure.
+    for i in 1 2 3 4 5; do
+      if start_dockerd; then
+        break
+       else
+         sleep 5
+      fi
+    done
+
     load_images
     if [ "$EARTHLY_START_COMPOSE" = "true" ]; then
         # shellcheck disable=SC2086

--- a/buildkitd/dockerd-wrapper.sh
+++ b/buildkitd/dockerd-wrapper.sh
@@ -28,10 +28,10 @@ execute() {
     # dockerd, therefore we retry... since most instances of this timeout seem to be related to networking or scheduling
     # when many WITH DOCKER commands are also running. Logs are printed for each failure.
     for i in 1 2 3 4 5; do
-      if start_dockerd; then
-        break
-       else
-         sleep 5
+        if start_dockerd; then
+            break
+        else
+            sleep 5
       fi
     done
 

--- a/buildkitd/dockerd-wrapper.sh
+++ b/buildkitd/dockerd-wrapper.sh
@@ -25,7 +25,7 @@ execute() {
     fi
 
     # Sometimes, when dockerd starts containerd, it doesn't come up in time. This timeout is not configurable from
-    # dockerd, therefore we retry... since most instances of this timeout seem to be related to networking or scheculing
+    # dockerd, therefore we retry... since most instances of this timeout seem to be related to networking or scheduling
     # when many WITH DOCKER commands are also running. Logs are printed for each failure.
     for i in 1 2 3 4 5; do
       if start_dockerd; then

--- a/buildkitd/dockerd-wrapper.sh
+++ b/buildkitd/dockerd-wrapper.sh
@@ -77,7 +77,7 @@ EOF
     # Start with a rm -rf to make sure a previous interrupted build did not leave its state around.
     rm -rf "$EARTHLY_DOCKERD_DATA_ROOT"
     mkdir -p "$EARTHLY_DOCKERD_DATA_ROOT"
-    dockerd --data-root="$EARTHLY_DOCKERD_DATA_ROOT" --bip=172.20.0.1/16 --log-level debug >/var/log/docker.log 2>&1 &
+    dockerd --data-root="$EARTHLY_DOCKERD_DATA_ROOT" --bip=172.20.0.1/16 >/var/log/docker.log 2>&1 &
     dockerd_pid="$!"
     i=1
     timeout=300


### PR DESCRIPTION
Under heavy load, `dockerd` can't start `containerd` in time. The timeout is not configurable, so retries to catch it under lesser load seem simple enough.

The alternative would be to start `containerd` ourselves. We can go there and make sure its compatible... but it seems easier to let the dependency manage itself if we can get away with it.