### PR TITLE
Fix race condition caused by UDC args incorrectly causing the same target to look like a different one

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -247,7 +247,7 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 				}
 
 				if !isMultiPlatform[saveImage.DockerTag] {
-					if singPlatImgNames[saveImage.DockerTag] {
+					if _, found := singPlatImgNames[saveImage.DockerTag]; found {
 						return nil, errors.Errorf(
 							"image %s is defined multiple times for the same default platform",
 							saveImage.DockerTag)
@@ -284,7 +284,7 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 					if err != nil {
 						return nil, err
 					}
-					if platformImgNames[platformImgName] {
+					if _, found := platformImgNames[platformImgName]; found {
 						return nil, errors.Errorf(
 							"image %s is defined multiple times for the same platform (%s)",
 							saveImage.DockerTag, platformImgName)

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -145,6 +145,8 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 
 	destPathWhitelist := make(map[string]bool)
 	manifestLists := make(map[string][]manifest) // parent image -> child images
+	platformImgNames := make(map[string]bool)    // ensure that these are unique
+	singPlatImgNames := make(map[string]bool)    // ensure that these are unique
 	var mts *states.MultiTarget
 	depIndex := 0
 	imageIndex := 0
@@ -245,6 +247,13 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 				}
 
 				if !isMultiPlatform[saveImage.DockerTag] {
+					if singPlatImgNames[saveImage.DockerTag] {
+						return nil, errors.Errorf(
+							"image %s is defined multiple times for the same default platform",
+							saveImage.DockerTag)
+					}
+					singPlatImgNames[saveImage.DockerTag] = true
+
 					refKey := fmt.Sprintf("image-%d", imageIndex)
 					refPrefix := fmt.Sprintf("ref/%s", refKey)
 					imageIndex++
@@ -271,6 +280,16 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 				} else {
 					platform := llbutil.PlatformWithDefault(sts.Platform)
 					platformStr := llbutil.PlatformWithDefaultToString(sts.Platform)
+					platformImgName, err := platformSpecificImageName(saveImage.DockerTag, platform)
+					if err != nil {
+						return nil, err
+					}
+					if platformImgNames[platformImgName] {
+						return nil, errors.Errorf(
+							"image %s is defined multiple times for the same platform (%s)",
+							saveImage.DockerTag, platformImgName)
+					}
+					platformImgNames[platformImgName] = true
 					// Image has platform set - need to use manifest lists.
 					// Need to push as a single multi-manifest image, but output locally as
 					// separate images.
@@ -299,10 +318,6 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 						refPrefix := fmt.Sprintf("ref/%s", refKey)
 						imageIndex++
 
-						platformImgName, err := platformSpecificImageName(saveImage.DockerTag, platform)
-						if err != nil {
-							return nil, err
-						}
 						localRegPullID, err := platformSpecificImageName(
 							fmt.Sprintf("sess-%s/mp:img%d", gwClient.BuildOpts().SessionID, imageIndex), platform)
 						if err != nil {

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -1019,11 +1019,13 @@ func (c *Converter) Arg(ctx context.Context, argKey string, defaultArgValue stri
 	} else if opts.Required && len(effective) == 0 {
 		return errors.New("build-arg not supplied for required ARG")
 	}
-	c.mts.Final.AddBuildArgInput(dedup.BuildArgInput{
-		Name:          argKey,
-		DefaultValue:  defaultArgValue,
-		ConstantValue: effective,
-	})
+	if c.varCollection.IsStackAtBase() { // Only when outside of UDC.
+		c.mts.Final.AddBuildArgInput(dedup.BuildArgInput{
+			Name:          argKey,
+			DefaultValue:  defaultArgValue,
+			ConstantValue: effective,
+		})
+	}
 	return nil
 }
 


### PR DESCRIPTION
Fixes https://github.com/earthly/earthly/issues/1543

Also, improve the error message when the same image is attempted to be pushed from more than one target
