### PR TITLE
fixes IF statements not working as non-root

### DIFF
--- a/ast/tests/build-arg.ast.json
+++ b/ast/tests/build-arg.ast.json
@@ -104,6 +104,14 @@
             ],
             "name": "BUILD"
           }
+        },
+        {
+          "command": {
+            "args": [
+              "+test-non-root"
+            ],
+            "name": "BUILD"
+          }
         }
       ]
     },
@@ -499,6 +507,50 @@
               "\"$global2\"",
               "==",
               "\"def\""
+            ],
+            "name": "RUN"
+          }
+        }
+      ]
+    },
+    {
+      "name": "test-non-root",
+      "recipe": [
+        {
+          "command": {
+            "args": [
+              "adduser",
+              "--system",
+              "weeheavy"
+            ],
+            "name": "RUN"
+          }
+        },
+        {
+          "command": {
+            "args": [
+              "weeheavy"
+            ],
+            "name": "USER"
+          }
+        },
+        {
+          "command": {
+            "args": [
+              "foo",
+              "=",
+              "$(echo bar)"
+            ],
+            "name": "ARG"
+          }
+        },
+        {
+          "command": {
+            "args": [
+              "test",
+              "\"$foo\"",
+              "==",
+              "\"bar\""
             ],
             "name": "RUN"
           }

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -592,7 +592,7 @@ func (c *Converter) RunExpression(ctx context.Context, expressionName string, op
 		outputFile = path.Join(srcBuildArgDir, expressionName)
 		opts.statePrep = func(ctx context.Context, state pllb.State) (pllb.State, error) {
 			return state.File(
-				pllb.Mkdir(srcBuildArgDir, 0755, llb.WithParents(true)),
+				pllb.Mkdir(srcBuildArgDir, 0777, llb.WithParents(true)), // Mkdir is performed as root even when USER is set; we must use 0777
 				llb.WithCustomNamef("[internal] mkdir %s", srcBuildArgDir)), nil
 		}
 	}

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -527,7 +527,7 @@ func (c *Converter) RunExitCode(ctx context.Context, opts ConvertRunOpts) (int, 
 			return os.RemoveAll(exitCodeDir)
 		})
 	} else {
-		exitCodeFile = "/run/exit_code"
+		exitCodeFile = "/tmp/earthly_if_statement_exit_code"
 		opts.statePrep = func(ctx context.Context, state pllb.State) (pllb.State, error) {
 			return state.File(
 				pllb.Mkdir("/run", 0755, llb.WithParents(true)),

--- a/tests/build-arg.earth
+++ b/tests/build-arg.earth
@@ -14,6 +14,7 @@ all:
     BUILD +test-global1
     BUILD +test-global2
     BUILD +test-global3
+    BUILD +test-non-root
 
 file-exists:
     ARG VAR1=nope.txt
@@ -70,3 +71,9 @@ test-global3:
     FROM +dummy
     RUN test "$global1" == "abc"
     RUN test "$global2" == "def"
+
+test-non-root:
+    RUN adduser --system weeheavy
+    USER weeheavy
+    ARG foo=$(echo bar)
+    RUN test "$foo" == "bar"

--- a/tests/if.earth
+++ b/tests/if.earth
@@ -47,6 +47,7 @@ all:
     BUILD +test-empty
     BUILD +test-complex
     BUILD +test-else-if
+    BUILD +test-non-root-user
 
 test-build:
     IF [ "true" = "false" ]
@@ -182,6 +183,15 @@ test-else-if:
     ELSE
         RUN false
     END
+
+test-non-root-user:
+    RUN adduser --system weeheavy
+    USER weeheavy
+    RUN ! test -f /tmp/exists
+    IF [ "true" = "true" ]
+        RUN touch /tmp/exists
+    END
+    RUN test -f /tmp/exists
 
 fail:
     RUN false


### PR DESCRIPTION
The IF command stores the exit code to a file.
This file must be writable by the current user.
/run is only writable by root; however /tmp
should be writable by all users (unless an earthly user goes out of
their way to change the permissions of /tmp).

Fixes #1547

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>