### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/analytics/analytics.go
+++ b/analytics/analytics.go
@@ -6,7 +6,6 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -144,14 +143,14 @@ func getInstallID() (string, error) {
 			}
 		}
 		ID := u.String()
-		err = ioutil.WriteFile(path, []byte(ID), 0644)
+		err = os.WriteFile(path, []byte(ID), 0644)
 		if err != nil {
 			return "", errors.Wrapf(err, "failed to write %q", path)
 		}
 		return ID, nil
 	}
 
-	s, err := ioutil.ReadFile(path)
+	s, err := os.ReadFile(path)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to read %q", path)
 	}

--- a/autocomplete/complete.go
+++ b/autocomplete/complete.go
@@ -2,7 +2,6 @@ package autocomplete
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"path"
@@ -48,7 +47,7 @@ func isCWDRoot() bool {
 }
 
 func containsDirectories(path string) bool {
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	if err != nil {
 		return false
 	}
@@ -165,7 +164,7 @@ func getPotentialPaths(ctx context.Context, resolver *buildcontext.Resolver, gwC
 		dir, f = path.Split(prefix)
 	}
 
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, err
 	}
@@ -465,7 +464,7 @@ func hasEarthfile(dirPath string) bool {
 }
 
 func hasSubDirs(dirPath string) bool {
-	files, err := ioutil.ReadDir(dirPath)
+	files, err := os.ReadDir(dirPath)
 	if err != nil {
 		return false
 	}

--- a/buildcontext/excludes_test.go
+++ b/buildcontext/excludes_test.go
@@ -1,7 +1,6 @@
 package buildcontext
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -59,11 +58,7 @@ func Test_readExcludes(t *testing.T) {
 
 	for _, testcase := range testcases {
 		t.Run(testcase.name, func(t *testing.T) {
-			dir, err := ioutil.TempDir("", "earthly-test-read-excludes")
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer os.RemoveAll(dir)
+			dir := t.TempDir()
 
 			if testcase.earthIgnoreContents != "" {
 				earthIgnoreFile, err := os.Create(filepath.Join(dir, earthIgnoreFile))

--- a/buildcontext/git.go
+++ b/buildcontext/git.go
@@ -3,7 +3,6 @@ package buildcontext
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -79,7 +78,7 @@ func (gr *gitResolver) resolveEarthProject(ctx context.Context, gwClient gwclien
 		key = ref.StringCanonical()
 	}
 	localBuildFilePathValue, err := gr.buildFileCache.Do(ctx, key, func(ctx context.Context, _ interface{}) (interface{}, error) {
-		earthfileTmpDir, err := ioutil.TempDir(os.TempDir(), "earthly-git")
+		earthfileTmpDir, err := os.MkdirTemp(os.TempDir(), "earthly-git")
 		if err != nil {
 			return nil, errors.Wrap(err, "create temp dir for Earthfile")
 		}
@@ -101,7 +100,7 @@ func (gr *gitResolver) resolveEarthProject(ctx context.Context, gwClient gwclien
 			return nil, errors.Wrap(err, "read build file")
 		}
 		localBuildFilePath := filepath.Join(earthfileTmpDir, path.Base(buildFile))
-		err = ioutil.WriteFile(localBuildFilePath, buildFileBytes, 0700)
+		err = os.WriteFile(localBuildFilePath, buildFileBytes, 0700)
 		if err != nil {
 			return nil, errors.Wrapf(err, "write build file to tmp dir at %s", localBuildFilePath)
 		}

--- a/buildcontext/gitlookup.go
+++ b/buildcontext/gitlookup.go
@@ -6,7 +6,6 @@ import (
 	"crypto/sha1"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/url"
 	"os"
@@ -599,7 +598,7 @@ func loadKnownHosts() ([]string, error) {
 		return nil, nil
 	}
 
-	b, err := ioutil.ReadFile(knownHosts)
+	b, err := os.ReadFile(knownHosts)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to read %s", knownHosts)
 	}

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -784,7 +783,7 @@ func (b *Builder) tempEarthlyOutDir() (string, error) {
 			err = errors.Wrapf(err, "unable to create dir %s", tmpParentDir)
 			return
 		}
-		b.outDir, err = ioutil.TempDir(tmpParentDir, "tmp")
+		b.outDir, err = os.MkdirTemp(tmpParentDir, "tmp")
 		if err != nil {
 			err = errors.Wrap(err, "mk temp dir for artifacts")
 			return

--- a/cmd/debugger/main.go
+++ b/cmd/debugger/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -172,7 +171,7 @@ func interactiveMode(ctx context.Context, remoteConsoleAddr string, cmdBuilder f
 }
 
 func getSettings(path string) (*common.DebuggerSettings, error) {
-	s, err := ioutil.ReadFile(path)
+	s, err := os.ReadFile(path)
 	if err != nil {
 		return nil, errors.Wrap(err, fmt.Sprintf("failed to read %s", path))
 	}

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -8,7 +8,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	_ "net/http/pprof" // enable pprof handlers on net/http listener
@@ -211,7 +211,7 @@ func main() {
 		}
 	}()
 	// Occasional spurious warnings show up - these are coming from imported libraries. Discard them.
-	logrus.StandardLogger().Out = ioutil.Discard
+	logrus.StandardLogger().Out = io.Discard
 
 	// Load .env into current global env's. This is mainly for applying Earthly settings.
 	// Separate call is made for build args and secrets.
@@ -1454,7 +1454,7 @@ func (app *earthlyApp) deleteZcompdump() error {
 		}
 		homeDir = currentUser.HomeDir
 	}
-	files, err := ioutil.ReadDir(homeDir)
+	files, err := os.ReadDir(homeDir)
 	if err != nil {
 		return errors.Wrapf(err, "failed to read dir %s", homeDir)
 	}
@@ -1643,7 +1643,7 @@ func (app *earthlyApp) printCrashLogs(ctx context.Context) {
 
 func isEarthlyBinary(path string) bool {
 	// apply heuristics to see if binary is a version of earthly
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return false
 	}
@@ -1995,7 +1995,7 @@ func (app *earthlyApp) actionSecretsSet(c *cli.Context) error {
 			return errors.New("invalid number of arguments provided")
 		}
 		path = c.Args().Get(0)
-		data, err := ioutil.ReadAll(os.Stdin)
+		data, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return errors.Wrap(err, "failed to read from stdin")
 		}
@@ -2005,7 +2005,7 @@ func (app *earthlyApp) actionSecretsSet(c *cli.Context) error {
 			return errors.New("invalid number of arguments provided")
 		}
 		path = c.Args().Get(0)
-		data, err := ioutil.ReadFile(app.secretFile)
+		data, err := os.ReadFile(app.secretFile)
 		if err != nil {
 			return errors.Wrapf(err, "failed to read secret from %s", app.secretFile)
 		}
@@ -2815,7 +2815,7 @@ func (app *earthlyApp) actionBuildImp(c *cli.Context, flagArgs, nonFlagArgs []st
 		return errors.Wrap(err, "failed to create localhostprovider")
 	}
 
-	cacheLocalDir, err := ioutil.TempDir("", "earthly-cache")
+	cacheLocalDir, err := os.MkdirTemp("", "earthly-cache")
 	if err != nil {
 		return errors.Wrap(err, "make temp dir for cache")
 	}
@@ -3119,7 +3119,7 @@ func processSecrets(secrets, secretFiles []string, dotEnvMap map[string]string) 
 		}
 		k := parts[0]
 		path := fileutil.ExpandPath(parts[1])
-		data, err := ioutil.ReadFile(path)
+		data, err := os.ReadFile(path)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to open %q", path)
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -435,7 +434,7 @@ func deleteYamlValue(node *yaml.Node, path []string) []string {
 
 // ReadConfigFile reads in the config file from the disk, into a byte slice.
 func ReadConfigFile(configPath string, contextSet bool) ([]byte, error) {
-	yamlData, err := ioutil.ReadFile(configPath)
+	yamlData, err := os.ReadFile(configPath)
 	if os.IsNotExist(err) && !contextSet {
 		return []byte{}, nil
 	} else if err != nil {
@@ -452,5 +451,5 @@ func WriteConfigFile(configPath string, data []byte) error {
 		return err
 	}
 
-	return ioutil.WriteFile(configPath, data, 0644)
+	return os.WriteFile(configPath, data, 0644)
 }

--- a/debugger/common/common.go
+++ b/debugger/common/common.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"io"
-	"io/ioutil"
 )
 
 //******************************************************************************************
@@ -48,7 +47,7 @@ func readUint16PrefixedData(r io.Reader) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return ioutil.ReadAll(io.LimitReader(r, int64(l)))
+	return io.ReadAll(io.LimitReader(r, int64(l)))
 }
 
 // ReadDataPacket decodes a data packet from the reader

--- a/dockertar/dockertar.go
+++ b/dockertar/dockertar.go
@@ -5,7 +5,6 @@ import (
 	"bufio"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -30,7 +29,7 @@ func GetID(tarFilePath string) (string, error) {
 			return "", errors.Wrapf(err, "reading tar %s", tarFilePath)
 		}
 		if header.Name == "manifest.json" && !header.FileInfo().IsDir() {
-			dt, err := ioutil.ReadAll(tarR)
+			dt, err := io.ReadAll(tarR)
 			if err != nil {
 				return "", errors.Wrapf(err, "read manifest.json from tar %s", tarFilePath)
 			}

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"hash/fnv"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -243,7 +242,7 @@ func (c *Converter) FromDockerfile(ctx context.Context, contextPath string, dfPa
 				return errors.Wrap(err, "resolve build context for dockerfile")
 			}
 			c.opt.BuildContextProvider.AddDirs(data.LocalDirs)
-			dfData, err = ioutil.ReadFile(data.BuildFilePath)
+			dfData, err = os.ReadFile(data.BuildFilePath)
 			if err != nil {
 				return errors.Wrapf(err, "read file %s", data.BuildFilePath)
 			}
@@ -298,7 +297,7 @@ func (c *Converter) FromDockerfile(ctx context.Context, contextPath string, dfPa
 		c.opt.BuildContextProvider.AddDirs(data.LocalDirs)
 		if dfPath == "" {
 			// Imply dockerfile as being ./Dockerfile in the root of the build context.
-			dfData, err = ioutil.ReadFile(data.BuildFilePath)
+			dfData, err = os.ReadFile(data.BuildFilePath)
 			if err != nil {
 				return errors.Wrapf(err, "read file %s", data.BuildFilePath)
 			}
@@ -533,7 +532,7 @@ func (c *Converter) RunExitCode(ctx context.Context, opts ConvertRunOpts) (int, 
 
 	var exitCodeFile string
 	if opts.Locally {
-		exitCodeDir, err := ioutil.TempDir(os.TempDir(), "earthlyexitcode")
+		exitCodeDir, err := os.MkdirTemp(os.TempDir(), "earthlyexitcode")
 		if err != nil {
 			return 0, errors.Wrap(err, "create temp dir")
 		}
@@ -560,7 +559,7 @@ func (c *Converter) RunExitCode(ctx context.Context, opts ConvertRunOpts) (int, 
 	}
 	var codeDt []byte
 	if opts.Locally {
-		codeDt, err = ioutil.ReadFile(exitCodeFile)
+		codeDt, err = os.ReadFile(exitCodeFile)
 		if err != nil {
 			return 0, errors.Wrap(err, "read exit code file")
 		}
@@ -594,7 +593,7 @@ func (c *Converter) RunExpression(ctx context.Context, expressionName string, op
 
 	var outputFile string
 	if opts.Locally {
-		outputDir, err := ioutil.TempDir(os.TempDir(), "earthlyexproutput")
+		outputDir, err := os.MkdirTemp(os.TempDir(), "earthlyexproutput")
 		if err != nil {
 			return "", errors.Wrap(err, "create temp dir")
 		}
@@ -623,7 +622,7 @@ func (c *Converter) RunExpression(ctx context.Context, expressionName string, op
 
 	var outputDt []byte
 	if opts.Locally {
-		outputDt, err = ioutil.ReadFile(outputFile)
+		outputDt, err = os.ReadFile(outputFile)
 		if err != nil {
 			return "", errors.Wrap(err, "read exit code file")
 		}

--- a/earthfile2llb/withdockerrun.go
+++ b/earthfile2llb/withdockerrun.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"sort"
@@ -306,7 +305,7 @@ func (wdr *withDockerRun) solveImage(ctx context.Context, mts *states.MultiTarge
 	tarContext, err := wdr.c.opt.SolveCache.Do(ctx, solveID, func(ctx context.Context, _ states.StateKey) (pllb.State, error) {
 		// Use a builder to create docker .tar file, mount it via a local build context,
 		// then docker load it within the current side effects state.
-		outDir, err := ioutil.TempDir(os.TempDir(), "earthly-docker-load")
+		outDir, err := os.MkdirTemp(os.TempDir(), "earthly-docker-load")
 		if err != nil {
 			return pllb.State{}, errors.Wrap(err, "mk temp dir for docker load")
 		}

--- a/earthfile2llb/withdockerrunlocal.go
+++ b/earthfile2llb/withdockerrunlocal.go
@@ -3,7 +3,6 @@ package earthfile2llb
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 
@@ -89,7 +88,7 @@ func (wdrl *withDockerRunLocal) load(ctx context.Context, opt DockerLoadOpt) (st
 }
 
 func (wdrl *withDockerRunLocal) solveImage(ctx context.Context, mts *states.MultiTarget, opName string, dockerTag string, opts ...llb.RunOption) (string, error) {
-	outDir, err := ioutil.TempDir(os.TempDir(), "earthly-docker-load")
+	outDir, err := os.MkdirTemp(os.TempDir(), "earthly-docker-load")
 	if err != nil {
 		return "", errors.Wrap(err, "mk temp dir for docker load")
 	}

--- a/secretsclient/client.go
+++ b/secretsclient/client.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -202,7 +201,7 @@ func (c *client) doCallImp(r request, method, url string, opts ...requestOpt) (i
 		return 0, "", err
 	}
 
-	respBody, err := ioutil.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return 0, "", err
 	}
@@ -309,7 +308,7 @@ func getMessageFromJSON(r io.Reader) (string, error) {
 }
 
 func (c *client) getLastUsedPublicKey() (string, error) {
-	data, err := ioutil.ReadFile(path.Join(os.TempDir(), "last-used-public-key"))
+	data, err := os.ReadFile(path.Join(os.TempDir(), "last-used-public-key"))
 	if err != nil {
 		return "", errors.Wrap(err, "failed to read file")
 	}
@@ -897,7 +896,7 @@ func (c *client) loadAuthToken() error {
 	if !fileutil.FileExists(tokenPath) {
 		return nil
 	}
-	data, err := ioutil.ReadFile(tokenPath)
+	data, err := os.ReadFile(tokenPath)
 	if err != nil {
 		return errors.Wrap(err, "failed to read file")
 	}
@@ -954,7 +953,7 @@ func (c *client) saveToken(email, tokenType, tokenValue string) error {
 	}
 
 	data := []byte(email + " " + tokenType + " " + tokenValue)
-	err = ioutil.WriteFile(tokenPath, []byte(data), 0600)
+	err = os.WriteFile(tokenPath, []byte(data), 0600)
 	if err != nil {
 		return errors.Wrapf(err, "failed to store auth token")
 	}

--- a/tests/docker2earth/app.go
+++ b/tests/docker2earth/app.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 )
 
 func main() {
-	hello, err := ioutil.ReadFile("/root/hello.txt")
+	hello, err := os.ReadFile("/root/hello.txt")
 	if err != nil {
 		panic(err)
 	}

--- a/util/fileutil/homedirs.go
+++ b/util/fileutil/homedirs.go
@@ -3,7 +3,6 @@ package fileutil
 import (
 	"bufio"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"path"
@@ -23,7 +22,7 @@ func GetUserHomeDirs() (map[string]string, error) {
 			return nil, errors.Wrap(err, "failed to get current user")
 		}
 		home := filepath.Dir(currentUser.HomeDir)
-		directoryList, err := ioutil.ReadDir(home)
+		directoryList, err := os.ReadDir(home)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to read dir")
 		}


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.