### PR TITLE
build: update docker2earth Dockerfile2 to Go 1.16

### DIFF
--- a/tests/docker2earth/Dockerfile2
+++ b/tests/docker2earth/Dockerfile2
@@ -1,4 +1,4 @@
-FROM golang:1.7.3
+FROM golang:1.16
 WORKDIR /go/src/github.com/alexellis/href-counter/
 RUN go get -d -v golang.org/x/net/html
 COPY app.go .


### PR DESCRIPTION
@alexcb The minimum required Go version is now 1.16 for `docker2earth` tests after #1560 is merged. Sorry for not noticing this early on.