### PR TITLE
lint: ioutil is deprecated

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -115,6 +115,7 @@ lint:
             echo "$output" ; \
             exit 1 ; \
         fi
+    RUN if find . -type f -name \*.go | xargs grep '"io/ioutil"'; then echo "io/ioutil is deprecated: https://go.dev/doc/go1.16#ioutil"; exit 1; fi
 
 lint-newline-ending:
     FROM alpine:3.13

--- a/tests/docker2earth/Dockerfile2
+++ b/tests/docker2earth/Dockerfile2
@@ -1,7 +1,8 @@
-FROM golang:1.7.3
+FROM golang:1.16
 WORKDIR /go/src/github.com/alexellis/href-counter/
 RUN go get -d -v golang.org/x/net/html
 COPY app.go .
+RUN go mod init
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
 
 FROM alpine:latest as greet


### PR DESCRIPTION
io/ioutil is deprecated and no longer used in our codebase. This is to
keep it that way.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>