### PR TITLE
Fix a bug causing some targets to execute twice

### DIFF
--- a/states/states.go
+++ b/states/states.go
@@ -131,9 +131,6 @@ func (sts *SingleTarget) TargetInput() dedup.TargetInput {
 // SetPlatform sets the sts platform.
 func (sts *SingleTarget) SetPlatform(platform *specs.Platform) {
 	sts.Platform = platform
-	sts.tiMu.Lock()
-	defer sts.tiMu.Unlock()
-	sts.targetInput.Platform = llbutil.PlatformWithDefaultToString(platform)
 }
 
 // AddBuildArgInput adds a bai to the sts's target input.


### PR DESCRIPTION
Fixes #1565 

Turns out that when comparing two targets to figure out if they are the same (to understand whether the target has already run or not), the platform that needs to be compared should be the initial platform with which the target was originally invoked as, and not the final platform that the target ends up becoming.

CC @adamgordonbell 