### PR TITLE
update docs to include git as sample user

### DIFF
--- a/docs/earthly-command/earthly-command.md
+++ b/docs/earthly-command/earthly-command.md
@@ -355,7 +355,7 @@ Set up a whole custom git repository for a server called example.com, using a si
 * is recognized to earthly as example.com/name-of-repo
 
 ```
-config git "{example: {pattern: 'example.com/([^/]+)', substitute: 'ssh://git@example.com:2222/var/git/repos/\$1.git', auth: ssh}}"
+config git "{example: {pattern: 'example.com/([^/]+)', substitute: 'ssh://git@example.com:2222/var/git/repos/\$1.git', auth: ssh, user: git}}"
 ```
 
 The above command yields the following config file:
@@ -366,6 +366,7 @@ git:
         pattern: example.com/([^/]+)
         substitute: ssh://git@example.com:2222/var/git/repos/$1.git
         auth: ssh
+        user: git
 ```
 
 ## earthly account

--- a/docs/guides/auth.md
+++ b/docs/guides/auth.md
@@ -36,11 +36,12 @@ Sites can be explicitly added to the [earthly config file](../earthly-config/ear
 git:
     git.example.com:
         auth: ssh
+        user: git
 ```
 
 #### Username-password authentication
 
-Username-password based authentication can be configured in the [earthly config file](../earthly-config/earthly-config.md) under the git section: 
+Username-password based authentication can be configured in the [earthly config file](../earthly-config/earthly-config.md) under the git section:
 
 ```yaml
 git:


### PR DESCRIPTION
Without a user, earthly will use the current username.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>