### PR TITLE
Raise error if builtin ARG has value set by user

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -109,7 +109,11 @@ lint:
             echo "$output" ; \
             exit 1 ; \
         fi
+    # names.go defines some very obvious consts that to not need comments; however golint doesn't support disabling rules: https://github.com/golang/lint/issues/263
+    # therefore, we will hide this file from golint, and restore it after.
+    RUN mv variables/reserved/names.go variables/reserved/names.skip-go-lint && echo "package reserved" > variables/reserved/names.go
     RUN golint -set_exit_status ./...
+    RUN mv variables/reserved/names.skip-go-lint variables/reserved/names.go
     RUN output="$(go vet ./... 2>&1)" ; \
         if [ -n "$output" ]; then \
             echo "$output" ; \

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -2355,7 +2355,7 @@ func (app *earthlyApp) actionAccountLogin(c *cli.Context) error {
 	}
 
 	if token != "" && (email != "" || pass != "") {
-		return errors.New("--token can not be used in conjuction with --email or --password")
+		return errors.New("--token cannot be used in conjuction with --email or --password")
 	}
 	sc, err := secretsclient.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
@@ -3036,7 +3036,7 @@ func (app *earthlyApp) actionListTargets(c *cli.Context) error {
 			return errors.New("remote-paths are not currently supported; local paths must start with \"/\" or \".\"")
 		}
 		if strings.Contains(targetToParse, "+") {
-			return errors.New("path can not contain a +")
+			return errors.New("path cannot contain a +")
 		}
 		targetToParse = strings.TrimSuffix(targetToParse, "/Earthfile")
 	}

--- a/docs/guides/cloud-secrets.md
+++ b/docs/guides/cloud-secrets.md
@@ -98,7 +98,7 @@ earthly +build
 
 The only difference between the naming of locally-supplied and cloud-based secrets is that cloud secrets will contain
 two or more slashes since all cloud secrets must start with a `+secrets/<user or organization>/` prefix, whereas locally-defined secrets
-will only start with the `+secrets/` suffix, followed by a single name which can not contain slashes.
+will only start with the `+secrets/` suffix, followed by a single name which cannot contain slashes.
 {% endhint %}
 
 

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -29,6 +29,7 @@ import (
 	"github.com/earthly/earthly/util/llbutil/pllb"
 	"github.com/earthly/earthly/util/stringutil"
 	"github.com/earthly/earthly/variables"
+	"github.com/earthly/earthly/variables/reserved"
 
 	"github.com/alessio/shellescape"
 	"github.com/docker/distribution/reference"
@@ -1057,8 +1058,12 @@ func (c *Converter) Arg(ctx context.Context, argKey string, defaultArgValue stri
 	effective, err := c.varCollection.DeclareArg(argKey, defaultArgValue, global, c.processNonConstantBuildArgFunc((ctx)))
 	if err != nil {
 		return err
-	} else if opts.Required && len(effective) == 0 {
+	}
+	if opts.Required && len(effective) == 0 {
 		return errors.New("build-arg not supplied for required ARG")
+	}
+	if len(defaultArgValue) > 0 && reserved.IsBuiltIn(argKey) {
+		return errors.New("build-arg default value supplied for built-in ARG")
 	}
 	if c.varCollection.IsStackAtBase() { // Only when outside of UDC.
 		c.mts.Final.AddBuildArgInput(dedup.BuildArgInput{

--- a/scripts/tests/auth/README.md
+++ b/scripts/tests/auth/README.md
@@ -1,4 +1,4 @@
-These tests are for tests that can not run via earthly-in-earthly.
+These tests are for tests that cannot run via earthly-in-earthly.
 
 If you add or remote any tests from this directory, the corresponding entry in `.github/workflows/ci.yml`
 must also be updated by running:

--- a/states/dedup/targetinput.go
+++ b/states/dedup/targetinput.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 
 	"github.com/earthly/earthly/domain"
+	"github.com/earthly/earthly/variables/reserved"
+
 	"github.com/pkg/errors"
 )
 
@@ -140,39 +142,10 @@ type BuildArgInput struct {
 	DefaultValue string `json:"defaultConstant"`
 }
 
-// BuiltinVariables is a set of all the builtin variable names.
-var BuiltinVariables = map[string]bool{
-	"EARTHLY_TARGET":                  true,
-	"EARTHLY_TARGET_PROJECT":          true,
-	"EARTHLY_TARGET_PROJECT_NO_TAG":   true,
-	"EARTHLY_TARGET_NAME":             true,
-	"EARTHLY_TARGET_TAG":              true,
-	"EARTHLY_TARGET_TAG_DOCKER":       true,
-	"EARTHLY_VERSION":                 true,
-	"EARTHLY_BUILD_SHA":               true,
-	"EARTHLY_GIT_HASH":                true,
-	"EARTHLY_GIT_SHORT_HASH":          true,
-	"EARTHLY_GIT_BRANCH":              true,
-	"EARTHLY_GIT_TAG":                 true,
-	"EARTHLY_GIT_ORIGIN_URL":          true,
-	"EARTHLY_GIT_ORIGIN_URL_SCRUBBED": true,
-	"EARTHLY_GIT_PROJECT_NAME":        true,
-	"EARTHLY_GIT_COMMIT_TIMESTAMP":    true,
-	"TARGETPLATFORM":                  true,
-	"TARGETOS":                        true,
-	"TARGETARCH":                      true,
-	"TARGETVARIANT":                   true,
-	"EARTHLY_SOURCE_DATE_EPOCH":       true,
-	"USERPLATFORM":                    true,
-	"USEROS":                          true,
-	"USERARCH":                        true,
-	"USERVARIANT":                     true,
-}
-
 // IsDefaultValue returns whether the value of the BuildArgInput
 // is set as the same as the default.
 func (bai BuildArgInput) IsDefaultValue() bool {
-	if BuiltinVariables[bai.Name] {
+	if reserved.IsBuiltIn(bai.Name) {
 		return true
 	}
 	return bai.ConstantValue == bai.DefaultValue

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -62,6 +62,9 @@ ga:
         --DOCKERHUB_TOKEN_SECRET=$DOCKERHUB_TOKEN_SECRET \
         --DOCKERHUB_MIRROR=$DOCKERHUB_MIRROR
     BUILD +builtin-args-test
+    BUILD +builtin-args-invalid-default-test
+    BUILD +builtin-args-invalid-pass-test
+    BUILD +builtin-args-cli-tests
     BUILD +smoke-test
     BUILD ./config+test \
         --DOCKERHUB_AUTH=$DOCKERHUB_AUTH \
@@ -222,6 +225,16 @@ git-clone-test:
 
 builtin-args-test:
     DO +RUN_EARTHLY --earthfile=builtin-args.earth --target=+builtin-args-test
+
+builtin-args-invalid-default-test:
+    DO +RUN_EARTHLY --earthfile=builtin-args-invalid-default.earth --should_fail=true --target=+test --output_contains="build-arg default value supplied for built-in ARG"
+
+builtin-args-invalid-pass-test:
+    DO +RUN_EARTHLY --earthfile=builtin-args-invalid-pass.earth --should_fail=true --target=+test --output_contains="value cannot be specified for built-in build arg EARTHLY_VERSION"
+
+builtin-args-cli-tests:
+    DO +RUN_EARTHLY --earthfile=builtin-args.earth --should_fail=true --extra_args="--build-arg EARTHLY_VERSION=123" --target=+builtin-args-test \
+        --output_contains="cannot be passed on the command line"
 
 smoke-test:
     DO +RUN_EARTHLY --earthfile=smoke.earth --target=+test

--- a/tests/builtin-args-invalid-default.earth
+++ b/tests/builtin-args-invalid-default.earth
@@ -1,0 +1,6 @@
+VERSION --earthly-version-arg 0.6
+FROM alpine:3.13
+
+test:
+    ARG EARTHLY_VERSION="this is not possible"
+    RUN echo "$EARTHLY_VERSION"

--- a/tests/builtin-args-invalid-pass.earth
+++ b/tests/builtin-args-invalid-pass.earth
@@ -1,0 +1,9 @@
+VERSION --earthly-version-arg 0.6
+FROM alpine:3.13
+
+mytarget:
+    ARG EARTHLY_VERSION
+    RUN echo "$EARTHLY_VERSION"
+
+test:
+    BUILD +mytarget --EARTHLY_VERSION="this is not possible"

--- a/variables/parse.go
+++ b/variables/parse.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/earthly/earthly/variables/reserved"
+
 	"github.com/pkg/errors"
 )
 
@@ -26,6 +28,9 @@ func ParseCommandLineArgs(args []string) (*Scope, error) {
 		if len(splitArg) == 2 {
 			value = splitArg[1]
 			hasValue = true
+		}
+		if reserved.IsBuiltIn(key) {
+			return nil, errors.Errorf("built-in arg %s cannot be passed on the command line", key)
 		}
 		if !hasValue {
 			var found bool
@@ -66,6 +71,10 @@ func parseArg(arg string, pncvf ProcessNonConstantVariableFunc, current *Collect
 		hasValue = true
 	}
 	if hasValue {
+		if reserved.IsBuiltIn(name) {
+			return "", "", errors.Errorf("value cannot be specified for built-in build arg %s", name)
+		}
+
 		v, err := parseArgValue(name, value, pncvf)
 		if err != nil {
 			return "", "", err

--- a/variables/reserved/names.go
+++ b/variables/reserved/names.go
@@ -1,0 +1,67 @@
+package reserved
+
+const (
+	EarthlyBuildSha             = "EARTHLY_BUILD_SHA"
+	EarthlyGitBranch            = "EARTHLY_GIT_BRANCH"
+	EarthlyGitCommitTimestamp   = "EARTHLY_GIT_COMMIT_TIMESTAMP"
+	EarthlyGitHash              = "EARTHLY_GIT_HASH"
+	EarthlyGitOriginURL         = "EARTHLY_GIT_ORIGIN_URL"
+	EarthlyGitOriginURLScrubbed = "EARTHLY_GIT_ORIGIN_URL_SCRUBBED"
+	EarthlyGitProjectName       = "EARTHLY_GIT_PROJECT_NAME"
+	EarthlyGitShortHash         = "EARTHLY_GIT_SHORT_HASH"
+	EarthlyGitTag               = "EARTHLY_GIT_TAG"
+	EarthlySourceDateEpoch      = "EARTHLY_SOURCE_DATE_EPOCH"
+	EarthlyTarget               = "EARTHLY_TARGET"
+	EarthlyTargetName           = "EARTHLY_TARGET_NAME"
+	EarthlyTargetProject        = "EARTHLY_TARGET_PROJECT"
+	EarthlyTargetProjectNoTag   = "EARTHLY_TARGET_PROJECT_NO_TAG"
+	EarthlyTargetTag            = "EARTHLY_TARGET_TAG"
+	EarthlyTargetTagDocker      = "EARTHLY_TARGET_TAG_DOCKER"
+	EarthlyVersion              = "EARTHLY_VERSION"
+	TargetArch                  = "TARGETARCH"
+	TargetOS                    = "TARGETOS"
+	TargetPlatform              = "TARGETPLATFORM"
+	TargetVariant               = "TARGETVARIANT"
+	UserArch                    = "USERARCH"
+	UserOS                      = "USEROS"
+	UserPlatform                = "USERPLATFORM"
+	UserVariant                 = "USERVARIANT"
+)
+
+var args map[string]struct{}
+
+func init() {
+	args = map[string]struct{}{
+		EarthlyBuildSha:             struct{}{},
+		EarthlyGitBranch:            struct{}{},
+		EarthlyGitCommitTimestamp:   struct{}{},
+		EarthlyGitHash:              struct{}{},
+		EarthlyGitOriginURL:         struct{}{},
+		EarthlyGitOriginURLScrubbed: struct{}{},
+		EarthlyGitProjectName:       struct{}{},
+		EarthlyGitShortHash:         struct{}{},
+		EarthlyGitTag:               struct{}{},
+		EarthlySourceDateEpoch:      struct{}{},
+		EarthlyTarget:               struct{}{},
+		EarthlyTargetName:           struct{}{},
+		EarthlyTargetProject:        struct{}{},
+		EarthlyTargetProjectNoTag:   struct{}{},
+		EarthlyTargetTag:            struct{}{},
+		EarthlyTargetTagDocker:      struct{}{},
+		EarthlyVersion:              struct{}{},
+		TargetArch:                  struct{}{},
+		TargetOS:                    struct{}{},
+		TargetPlatform:              struct{}{},
+		TargetVariant:               struct{}{},
+		UserArch:                    struct{}{},
+		UserOS:                      struct{}{},
+		UserPlatform:                struct{}{},
+		UserVariant:                 struct{}{},
+	}
+}
+
+// IsBuiltIn returns true if s is the name of a builtin arg
+func IsBuiltIn(s string) bool {
+	_, exists := args[s]
+	return exists
+}

--- a/variables/reserved/names_test.go
+++ b/variables/reserved/names_test.go
@@ -1,0 +1,94 @@
+package reserved
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path"
+	"runtime"
+	"strings"
+	"testing"
+
+	. "github.com/stretchr/testify/assert"
+)
+
+// getConsts parses names.go and returns all constants.
+// Unfortunately reflect is unable to work on the package level.
+func getConsts() (map[string]string, error) {
+	_, filename, _, _ := runtime.Caller(0)
+	namesPath := path.Join(path.Dir(filename), "names.go")
+	namesSrc, err := os.ReadFile(namesPath)
+	if err != nil {
+		return nil, err
+	}
+
+	fset := token.NewFileSet()
+
+	f, err := parser.ParseFile(fset, "", namesSrc, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	consts := map[string]string{}
+	for name, obj := range f.Scope.Objects {
+		if obj.Kind == ast.Con {
+			val := obj.Decl.(*ast.ValueSpec).Values[0].(*ast.BasicLit).Value
+			parsedVal, ok := trimeDoubleQuotes(val)
+			if !ok {
+				return nil, fmt.Errorf("failed to parse %s", val)
+			}
+			consts[name] = parsedVal
+		}
+	}
+	return consts, nil
+}
+
+// trimeDoubleQuotes takes a string such as "abc" and returns abc
+// this is a hack due to the ast ast.BasicLit returning the literal go source code.
+// There is probably a better way to do this, but Alex couldn't quickly figure it out.
+// This function should not be used outside of testing the very-specific use-case,
+// it is very fragile, and is only designed to work with basic strings that are only ever
+// defined on a single line in the go source code (which works fine for builtin ARG names).
+func trimeDoubleQuotes(s string) (string, bool) {
+	n := len(s)
+	if n < 2 {
+		return "", false
+	}
+	if s[0] != '"' || s[n-1] != '"' {
+		return "", false
+	}
+	return s[1:(n - 1)], true
+}
+
+func isUpper(s string) bool {
+	return strings.ToUpper(s) == s
+}
+
+// TestAllConstsInMap tests that this package only defines constants
+// that represent reserved ARG names, and that they exist in the map that IsBuiltIn
+// relies on.
+func TestAllConstsInMap(t *testing.T) {
+	consts, err := getConsts()
+	Nil(t, err)
+
+	constsValues := map[string]struct{}{}
+
+	// tests all consts return true for IsBuiltIn (i.e. all consts are in args map)
+	for _, v := range consts {
+		t.Run(v, func(t *testing.T) {
+			True(t, IsBuiltIn(v))
+			True(t, isUpper(v))
+		})
+		constsValues[v] = struct{}{}
+	}
+
+	// tests all values in args are defined as consts
+	for k := range args {
+		t.Run(k, func(t *testing.T) {
+			_, exists := constsValues[k]
+			True(t, exists)
+		})
+	}
+}


### PR DESCRIPTION
builtin ARGs can not be overridden. This introduces
an explicit check and raises an error. Previously
the overridden value was simply ignored.
    
Signed-off-by: Alex Couture-Beil <alex@earthly.dev>
