### PR TITLE
test for duplicate with docker load failure

### DIFF
--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -32,6 +32,7 @@ ga:
         --DOCKERHUB_MIRROR=$DOCKERHUB_MIRROR
     BUILD ./with-docker+all
     BUILD ./with-docker-compose+all
+    BUILD ./with-docker-via-command+test
     BUILD ./dockerfile+test
     BUILD ./dockerfile2/subdir+test
     BUILD ./version+test-all \

--- a/tests/with-docker-via-command/Earthfile
+++ b/tests/with-docker-via-command/Earthfile
@@ -1,0 +1,15 @@
+my-image:
+    FROM alpine
+    SAVE IMAGE my/image:test
+
+MY_COMMAND_WITH_DOCKER:
+    COMMAND
+    ARG MY_ARG="default"
+    WITH DOCKER --load +my-image
+        RUN echo "got $MY_ARG"
+    END
+
+test:
+    FROM earthly/dind:alpine
+    DO +MY_COMMAND_WITH_DOCKER --MY_ARG="myvalue"
+    DO +MY_COMMAND_WITH_DOCKER


### PR DESCRIPTION
This test replicates the issue reported in https://github.com/earthly/earthly/issues/1582
which produces the error:

    Error: build target: build main: bkClient.Build: failed to solve: image my/image:test is defined multiple times for the same default platform

This issue is in earthly v0.6.3; however was fixed in https://github.com/earthly/earthly/pull/1577

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>