### PR TITLE
Fix error if multiple images with the same name are output in `VERSION 0.5`

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -246,12 +246,14 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 				}
 
 				if !isMultiPlatform[saveImage.DockerTag] {
-					if _, found := singPlatImgNames[saveImage.DockerTag]; found {
-						return nil, errors.Errorf(
-							"image %s is defined multiple times for the same default platform",
-							saveImage.DockerTag)
+					if saveImage.CheckDuplicate {
+						if _, found := singPlatImgNames[saveImage.DockerTag]; found {
+							return nil, errors.Errorf(
+								"image %s is defined multiple times for the same default platform",
+								saveImage.DockerTag)
+						}
+						singPlatImgNames[saveImage.DockerTag] = true
 					}
-					singPlatImgNames[saveImage.DockerTag] = true
 
 					refKey := fmt.Sprintf("image-%d", imageIndex)
 					refPrefix := fmt.Sprintf("ref/%s", refKey)
@@ -283,12 +285,14 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 					if err != nil {
 						return nil, err
 					}
-					if _, found := platformImgNames[platformImgName]; found {
-						return nil, errors.Errorf(
-							"image %s is defined multiple times for the same platform (%s)",
-							saveImage.DockerTag, platformImgName)
+					if saveImage.CheckDuplicate {
+						if _, found := platformImgNames[platformImgName]; found {
+							return nil, errors.Errorf(
+								"image %s is defined multiple times for the same platform (%s)",
+								saveImage.DockerTag, platformImgName)
+						}
+						platformImgNames[platformImgName] = true
 					}
-					platformImgNames[platformImgName] = true
 					// Image has platform set - need to use manifest lists.
 					// Need to push as a single multi-manifest image, but output locally as
 					// separate images.

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -872,6 +872,7 @@ func (c *Converter) SaveImage(ctx context.Context, imageNames []string, pushImag
 					CacheHint:           cacheHint,
 					HasPushDependencies: true,
 					DoSave:              c.opt.DoSaves || c.opt.ForceSaveImage,
+					CheckDuplicate:      c.ftrs.CheckDuplicateImages,
 				})
 		} else {
 			pcState := persistCache(
@@ -889,6 +890,7 @@ func (c *Converter) SaveImage(ctx context.Context, imageNames []string, pushImag
 					CacheHint:           cacheHint,
 					HasPushDependencies: false,
 					DoSave:              c.opt.DoSaves || c.opt.ForceSaveImage,
+					CheckDuplicate:      c.ftrs.CheckDuplicateImages,
 				})
 		}
 

--- a/earthfile2llb/interpreter.go
+++ b/earthfile2llb/interpreter.go
@@ -1373,7 +1373,7 @@ func (i *Interpreter) handleDoUserCommand(ctx context.Context, command domain.Co
 	if allowPrivileged && !i.allowPrivileged {
 		return i.errorf(uc.SourceLocation, "invalid privileged in COMMAND") // this shouldn't happen, but check just in case
 	}
-	if len(uc.Recipe) == 0 || uc.Recipe[0].Command.Name != "COMMAND" {
+	if len(uc.Recipe) == 0 || uc.Recipe[0].Command == nil || uc.Recipe[0].Command.Name != "COMMAND" {
 		return i.errorf(uc.SourceLocation, "command recipes must start with COMMAND")
 	}
 	if len(uc.Recipe[0].Command.Args) > 0 {

--- a/features/features.go
+++ b/features/features.go
@@ -23,6 +23,7 @@ type Features struct {
 	ForIn                      bool `long:"for-in" description:"allow the use of the FOR command"`
 	RequireForceForUnsafeSaves bool `long:"require-force-for-unsafe-saves" description:"require the --force flag when saving to path outside of current path"`
 	NoImplicitIgnore           bool `long:"no-implicit-ignore" description:"disable implicit ignore rules to exclude .tmp-earthly-out/, build.earth, Earthfile, .earthignore and .earthlyignore when resolving local context"`
+	CheckDuplicateImages       bool `long:"check-duplicate-images" description:"check for duplicate images during output"`
 	EarthlyVersionArg          bool `long:"earthly-version-arg" description:"includes EARTHLY_VERSION and EARTHLY_BUILD_SHA ARGs"`
 	UseCacheCommand            bool `long:"use-cache-command" description:"allow use of CACHE command in Earthfiles"`
 
@@ -168,6 +169,7 @@ func GetFeatures(version *spec.Version) (*Features, error) {
 		ftrs.ForIn = true
 		ftrs.RequireForceForUnsafeSaves = true
 		ftrs.NoImplicitIgnore = true
+		ftrs.CheckDuplicateImages = true
 	case versionAtLeast(ftrs, 0, 7):
 		ftrs.EarthlyVersionArg = true
 		ftrs.UseCacheCommand = true

--- a/states/states.go
+++ b/states/states.go
@@ -241,6 +241,9 @@ type SaveImage struct {
 	HasPushDependencies bool
 	// DoSave indicates whether the image should be saved and (possibly pushed).
 	DoSave bool
+	// CheckDuplicate indicates whether to check if the image name shows up
+	// multiple times during output.
+	CheckDuplicate bool
 }
 
 // RunPush is a series of RUN --push commands to be run after the build has been deemed as


### PR DESCRIPTION
Fixes https://github.com/earthly/earthly/issues/1582

For the most part, in #1582, Earthly is behaving as intended. The additional `ARG` passed to the UDC actually propagates through to the image, causing Earthly to believe that they are two different images (it doesn't know that the arg is actually not used anywhere), that happen to have the same name.

What is perhaps surprising is that some users may have been relying on this behavior before we introduced the duplicate-image check. So this PR makes that check a feature flag that is enabled in 0.6 onwards.

FWIW, this isn't reproducing in 0.6, because the image is not output automatically as a result of a `WITH DOCKER --load`. Version 0.6 makes the control of which image is output a bit more fine-grained for the user. I couldn't reproduce this via simply `BUILD` in v0.6, unless the `ARG` was actually declared in the image target - but that would be obviously an error (it would actually output two different images with the same name) - so working as intended.