### PR TITLE
Use docker images rm -f when removing docker image

### DIFF
--- a/builder/docker.go
+++ b/builder/docker.go
@@ -110,7 +110,8 @@ func dockerPullLocalImage(ctx context.Context, fe containerutil.ContainerFronten
 	if err != nil {
 		return errors.Wrap(err, "image tag after pull")
 	}
-	err = fe.ImageRemove(ctx, false, fullPullName)
+	force := true // Sometime Docker GCs images automatically (force prevents an error).
+	err = fe.ImageRemove(ctx, force, fullPullName)
 	if err != nil {
 		return errors.Wrap(err, "image rmi after pull and retag")
 	}

--- a/builder/docker.go
+++ b/builder/docker.go
@@ -110,7 +110,7 @@ func dockerPullLocalImage(ctx context.Context, fe containerutil.ContainerFronten
 	if err != nil {
 		return errors.Wrap(err, "image tag after pull")
 	}
-	force := true // Sometime Docker GCs images automatically (force prevents an error).
+	force := true // Sometimes Docker GCs images automatically (force prevents an error).
 	err = fe.ImageRemove(ctx, force, fullPullName)
 	if err != nil {
 		return errors.Wrap(err, "image rmi after pull and retag")


### PR DESCRIPTION
Fixes #1590 

I'm seeing random reports that Docker GC's some images if there is little space left on the device: https://support.capiot.com/support/solutions/articles/42000074528-docker-images-automatically-getting-deleted. This (or some manual parallel user-issued prune) could be the cause of this.

Using `docker images rm -f` should help in these cases. (`-f` prevents the command from returning exit code 1 if the image is not found).