### PR TITLE
--env-file arg to support different .env file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 
 ## Unreleased
 
+### Added
+
+- Ability to load a different `.env` file via the `--env-file` flag.
+
 ### Changed
 
 - updated buildkit to include changes up to 17c237d69a46d61653746c03bcbe6953014b41a5

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -7,6 +7,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
+	"flag"
 	"fmt"
 	"io"
 	"net"
@@ -84,9 +85,10 @@ const (
 	DefaultBuildkitdContainerName = "earthly-buildkitd"
 	// DefaultBuildkitdVolumeName is the name of the docker volume used for storing the cache.
 	DefaultBuildkitdVolumeName = "earthly-cache"
-)
 
-var dotEnvPath = ".env"
+	defaultEnvFile = ".env"
+	envFileFlag    = "env-file"
+)
 
 type earthlyApp struct {
 	cliApp      *cli.App
@@ -159,6 +161,7 @@ type cliFlags struct {
 	disableAnalytics          bool
 	featureFlagOverrides      string
 	localRegistryHost         string
+	envFile                   string
 	lsShowLong                bool
 	lsShowArgs                bool
 	containerFrontend         containerutil.ContainerFrontend
@@ -215,10 +218,33 @@ func main() {
 
 	// Load .env into current global env's. This is mainly for applying Earthly settings.
 	// Separate call is made for build args and secrets.
-	if fileutil.FileExists(dotEnvPath) {
-		err := godotenv.Load(dotEnvPath)
-		if err != nil {
-			fmt.Printf("Error loading dot-env file %s: %s\n", dotEnvPath, err.Error())
+	envFile := defaultEnvFile
+	envFileOverride := false
+	if envFileFromEnv, ok := os.LookupEnv("EARTHLY_ENV_FILE"); ok {
+		envFile = envFileFromEnv
+		envFileOverride = true
+	}
+	envFileFromArgOK := true
+	flagSet := flag.NewFlagSet(getBinaryName(), flag.ContinueOnError)
+	for _, f := range newEarthlyApp(ctx, conslogging.ConsoleLogger{}).cliApp.Flags {
+		if err := f.Apply(flagSet); err != nil {
+			envFileFromArgOK = false
+			break
+		}
+	}
+	if envFileFromArgOK {
+		if err := flagSet.Parse(os.Args[1:]); err == nil {
+			if envFileFlag := flagSet.Lookup(envFileFlag); envFileFlag != nil {
+				envFile = envFileFlag.Value.String()
+				envFileOverride = envFile != defaultEnvFile // flag lib doesn't expose if a value was set or not
+			}
+		}
+	}
+	err := godotenv.Load(envFile)
+	if err != nil {
+		// ignore ErrNotExist when using default .env file
+		if envFileOverride || !errors.Is(err, os.ErrNotExist) {
+			fmt.Printf("Error loading dot-env file %s: %s\n", envFile, err.Error())
 			os.Exit(1)
 		}
 	}
@@ -590,6 +616,13 @@ func newEarthlyApp(ctx context.Context, console conslogging.ConsoleLogger) *eart
 			Usage:       "Apply additional flags after each VERSION command across all Earthfiles, multiple flags can be seperated by commas",
 			Destination: &app.featureFlagOverrides,
 			Hidden:      true, // used for feature-flipping from ./earthly dev script
+		},
+		&cli.StringFlag{
+			Name:        envFileFlag,
+			EnvVars:     []string{"EARTHLY_ENV_FILE"},
+			Usage:       "Use values from this file as earthly environment variables, buildargs, or secrets",
+			Value:       defaultEnvFile,
+			Destination: &app.envFile,
 		},
 	}
 
@@ -2777,13 +2810,14 @@ func (app *earthlyApp) actionBuildImp(c *cli.Context, flagArgs, nonFlagArgs []st
 		platformsSlice = []*specs.Platform{nil}
 	}
 
-	dotEnvMap := make(map[string]string)
-	if fileutil.FileExists(dotEnvPath) {
-		dotEnvMap, err = godotenv.Read(dotEnvPath)
-		if err != nil {
-			return errors.Wrapf(err, "read %s", dotEnvPath)
+	dotEnvMap, err := godotenv.Read(app.envFile)
+	if err != nil {
+		// ignore ErrNotExist when using default .env file
+		if app.envFile != defaultEnvFile || !errors.Is(err, os.ErrNotExist) {
+			return errors.Wrapf(err, "read %s", app.envFile)
 		}
 	}
+
 	secretsMap, err := processSecrets(app.secrets.Value(), app.secretFiles.Value(), dotEnvMap)
 	if err != nil {
 		return err

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -452,8 +452,16 @@ dotenv-test:
     RUN echo "TEST_ENV_3=bar" >>.env
     DO +RUN_EARTHLY --earthfile=dotenv.earth --extra_args="--no-output" --target=+test
     # Smoke test that no .env file does not result in an error.
-    RUN rm .env
+    RUN mv .env .some-other-env
     DO +RUN_EARTHLY --earthfile=dotenv.earth --extra_args="--no-output" --target=+test-no-dotenv
+    DO +RUN_EARTHLY --earthfile=dotenv.earth --extra_args="--no-output --env-file .some-other-env" --target=+test
+    DO +RUN_EARTHLY --earthfile=dotenv.earth --extra_args="--no-output" --pre_command="export EARTHLY_ENV_FILE=.some-other-env" --target=+test
+    DO +RUN_EARTHLY --earthfile=dotenv.earth --extra_args="--no-output --env-file .this-should-fail" --should_fail="true" --target=+test
+    DO +RUN_EARTHLY --earthfile=dotenv.earth --extra_args="--no-output" --pre_command="export EARTHLY_ENV_FILE=.this-too-should-fail" --should_fail="true" --target=+test
+
+    # --env-file takes preceddence
+    DO +RUN_EARTHLY --earthfile=dotenv.earth --extra_args="--no-output --env-file .some-other-env" --pre_command="export EARTHLY_ENV_FILE=.this-should-be-ignored" --target=+test
+
 
 env-test:
     DO +RUN_EARTHLY --earthfile=env.earth --extra_args="--no-output" --target=+test


### PR DESCRIPTION
Allow a user to specify an alternative `.env` file to source
environment variables from.

A user may load multiple `.env` files using process
substitution. For example, if a user has `.env` committed to git
containing:

    PUBLIC_VALUE=this-is-public-information
    MY_TOKEN=

And a second `.env.local` which is not committed to git:

    MY_TOKEN=secretvalue

A user can then have earthly combine these two files using:

    earthly --env-file <(cat .env && cat .env.local) +some-target

When multiple values are defined, the last one takes precedence.
