### PR TITLE
Move duplicate images check to 0.7. Fix SAVE IMAGE --cache-hint

### DIFF
--- a/.earthly_version_flag_overrides
+++ b/.earthly_version_flag_overrides
@@ -1,1 +1,1 @@
-referenced-save-only,use-copy-include-patterns,earthly-version-arg,use-cache-command
+referenced-save-only,use-copy-include-patterns,earthly-version-arg,use-cache-command,check-duplicate-images

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -246,7 +246,7 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 				}
 
 				if !isMultiPlatform[saveImage.DockerTag] {
-					if saveImage.CheckDuplicate {
+					if saveImage.CheckDuplicate && saveImage.DockerTag != "" {
 						if _, found := singPlatImgNames[saveImage.DockerTag]; found {
 							return nil, errors.Errorf(
 								"image %s is defined multiple times for the same default platform",
@@ -285,7 +285,7 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 					if err != nil {
 						return nil, err
 					}
-					if saveImage.CheckDuplicate {
+					if saveImage.CheckDuplicate && saveImage.DockerTag != "" {
 						if _, found := platformImgNames[platformImgName]; found {
 							return nil, errors.Errorf(
 								"image %s is defined multiple times for the same platform (%s)",

--- a/features/features.go
+++ b/features/features.go
@@ -169,8 +169,8 @@ func GetFeatures(version *spec.Version) (*Features, error) {
 		ftrs.ForIn = true
 		ftrs.RequireForceForUnsafeSaves = true
 		ftrs.NoImplicitIgnore = true
-		ftrs.CheckDuplicateImages = true
 	case versionAtLeast(ftrs, 0, 7):
+		ftrs.CheckDuplicateImages = true
 		ftrs.EarthlyVersionArg = true
 		ftrs.UseCacheCommand = true
 	}


### PR DESCRIPTION
Fixes https://github.com/earthly/earthly/issues/1594

I've also decided to move check-duplicate-images feature to 0.7, given that it has created problems so far.