### PR TITLE
fix --version and --help text output

### DIFF
--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -226,6 +226,7 @@ func main() {
 	}
 	envFileFromArgOK := true
 	flagSet := flag.NewFlagSet(getBinaryName(), flag.ContinueOnError)
+	flagSet.SetOutput(io.Discard)
 	for _, f := range newEarthlyApp(ctx, conslogging.ConsoleLogger{}).cliApp.Flags {
 		if err := f.Apply(flagSet); err != nil {
 			envFileFromArgOK = false

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -144,7 +144,7 @@ ga:
     BUILD +true-false-flag-invalid
     BUILD +dont-save-indirect-remote-artifact
     BUILD +sequential-locally-test
-    BUILD +homebrew-test
+    BUILD +version-flag-test
     BUILD +implicit-ignores
     BUILD +help
     BUILD +cache-cmd
@@ -906,9 +906,11 @@ echo test passed: RUNs were sequentially grouped
 " > test-output.sh && chmod +x test-output.sh
     RUN cat output-filtered.txt | ./test-output.sh
 
-homebrew-test:
-    # This is to ensure the assert in https://github.com/earthly/homebrew-earthly/blob/main/Formula/earthly.rb continues to work
+version-flag-test:
+    # In addition to testing the --version flag works; this flag is critical for the homebrew deployment test, which
+    # performs an assert in https://github.com/earthly/homebrew-earthly/blob/main/Formula/earthly.rb
     RUN earthly --version | grep '^earthly version'
+    RUN test "$(earthly --version | wc -l)" = "1"
 
 implicit-ignores:
     RUN mkdir -p ignored notignored && \


### PR DESCRIPTION
This fixes a bug that was introduced in c056afc75f6daeb25cd1f7144acaa958dfcbbea4
which caused help text to be output when --version was run, and
duplicated help text for --help.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>