### PR TITLE
Use force execution after parallel build conversion

### DIFF
--- a/.earthly_version_flag_overrides
+++ b/.earthly_version_flag_overrides
@@ -1,1 +1,1 @@
-referenced-save-only,use-copy-include-patterns,earthly-version-arg,use-cache-command,check-duplicate-images
+referenced-save-only,use-copy-include-patterns,earthly-version-arg,use-cache-command,check-duplicate-images,exec-after-parallel

--- a/Earthfile
+++ b/Earthfile
@@ -457,8 +457,7 @@ test:
     BUILD +lint-scripts
     BUILD +lint-newline-ending
     BUILD +lint-changelog
-    # BUILD +unit-test
-    # @#
+    BUILD +unit-test
     ARG DOCKERHUB_MIRROR
     ARG DOCKERHUB_AUTH=true
     ARG DOCKERHUB_USER_SECRET=+secrets/DOCKERHUB_USER

--- a/Earthfile
+++ b/Earthfile
@@ -457,7 +457,8 @@ test:
     BUILD +lint-scripts
     BUILD +lint-newline-ending
     BUILD +lint-changelog
-    BUILD +unit-test
+    # BUILD +unit-test
+    # @#
     ARG DOCKERHUB_MIRROR
     ARG DOCKERHUB_AUTH=true
     ARG DOCKERHUB_USER_SECRET=+secrets/DOCKERHUB_USER

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -938,7 +938,7 @@ func (c *Converter) BuildAsync(ctx context.Context, fullTargetName string, platf
 				return errors.Wrapf(err, "async earthfile2llb for %s", fullTargetName)
 			})
 		}
-		if c.ftrs.ExecAfterParallel {
+		if c.ftrs.ExecAfterParallel && mts != nil && mts.Final != nil {
 			eg.Go(func() error {
 				err = c.forceExecution(ctx, mts.Final.MainState)
 				if err != nil {

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -929,7 +929,6 @@ func (c *Converter) BuildAsync(ctx context.Context, fullTargetName string, platf
 			eg.Go(func() error {
 				return errors.Wrapf(err, "acquiring parallelism semaphore for %s", fullTargetName)
 			})
-			return
 		}
 		defer c.opt.Parallelism.Release(1)
 		mts, err := Earthfile2LLB(ctx, target, opt, false)
@@ -938,7 +937,6 @@ func (c *Converter) BuildAsync(ctx context.Context, fullTargetName string, platf
 			eg.Go(func() error {
 				return errors.Wrapf(err, "async earthfile2llb for %s", fullTargetName)
 			})
-			return
 		}
 		if c.ftrs.ExecAfterParallel && mts != nil && mts.Final != nil {
 			eg.Go(func() error {

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -922,32 +922,24 @@ func (c *Converter) BuildAsync(ctx context.Context, fullTargetName string, platf
 	if err != nil {
 		return err
 	}
-	go func() {
+	eg.Go(func() error {
 		err := c.opt.Parallelism.Acquire(ctx, 1)
 		if err != nil {
-			// Bubble up errors as part of the error group.
-			eg.Go(func() error {
-				return errors.Wrapf(err, "acquiring parallelism semaphore for %s", fullTargetName)
-			})
+			return errors.Wrapf(err, "acquiring parallelism semaphore for %s", fullTargetName)
 		}
 		defer c.opt.Parallelism.Release(1)
 		mts, err := Earthfile2LLB(ctx, target, opt, false)
 		if err != nil {
-			// Bubble up errors as part of the error group.
-			eg.Go(func() error {
-				return errors.Wrapf(err, "async earthfile2llb for %s", fullTargetName)
-			})
+			return errors.Wrapf(err, "async earthfile2llb for %s", fullTargetName)
 		}
-		if c.ftrs.ExecAfterParallel {
-			eg.Go(func() error {
-				err = c.forceExecution(ctx, mts.Final.MainState)
-				if err != nil {
-					return errors.Wrapf(err, "async force execution for %s", fullTargetName)
-				}
-				return nil
-			})
+		if c.ftrs.ExecAfterParallel && mts != nil && mts.Final != nil {
+			err = c.forceExecution(ctx, mts.Final.MainState)
+			if err != nil {
+				return errors.Wrapf(err, "async force execution for %s", fullTargetName)
+			}
 		}
-	}()
+		return nil
+	})
 	return nil
 }
 

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -1612,9 +1612,16 @@ func (c *Converter) parseSecretFlag(secretKeyValue string) (secretID string, env
 }
 
 func (c *Converter) forceExecution(ctx context.Context, state pllb.State) error {
+	if state.Output() != nil {
+		// Scratch - no need to execute.
+		return nil
+	}
 	ref, err := llbutil.StateToRef(ctx, c.opt.GwClient, state, c.opt.NoCache, c.opt.Platform, c.opt.CacheImports.AsMap())
 	if err != nil {
 		return errors.Wrap(err, "force execution state to ref")
+	}
+	if ref == nil {
+		return nil
 	}
 	// We're not really interested in reading the dir - we just
 	// want to un-lazy the ref so that the commands have executed.

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -28,9 +28,9 @@ import (
 	"github.com/earthly/earthly/util/llbutil/llbfactory"
 	"github.com/earthly/earthly/util/llbutil/pllb"
 	"github.com/earthly/earthly/util/stringutil"
+	"github.com/earthly/earthly/util/syncutil/serrgroup"
 	"github.com/earthly/earthly/variables"
 	"github.com/earthly/earthly/variables/reserved"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/alessio/shellescape"
 	"github.com/docker/distribution/reference"
@@ -917,7 +917,7 @@ func (c *Converter) Build(ctx context.Context, fullTargetName string, platform *
 }
 
 // BuildAsync applies the earthly BUILD command asynchronously.
-func (c *Converter) BuildAsync(ctx context.Context, fullTargetName string, platform *specs.Platform, allowPrivileged bool, buildArgs []string, cmdT cmdType, eg *errgroup.Group) error {
+func (c *Converter) BuildAsync(ctx context.Context, fullTargetName string, platform *specs.Platform, allowPrivileged bool, buildArgs []string, cmdT cmdType, eg *serrgroup.Group) error {
 	target, opt, _, err := c.prepBuildTarget(ctx, fullTargetName, platform, allowPrivileged, buildArgs, true, cmdT)
 	if err != nil {
 		return err

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -937,7 +937,7 @@ func (c *Converter) BuildAsync(ctx context.Context, fullTargetName string, platf
 			errChan <- errors.Wrapf(err, "async earthfile2llb for %s", fullTargetName)
 			return
 		}
-		if c.ftrs.ExecAfterParallel {
+		if c.ftrs.ExecAfterParallel && mts != nil && mts.Final != nil {
 			err = c.forceExecution(ctx, mts.Final.MainState)
 			if err != nil {
 				errChan <- errors.Wrapf(err, "async force execution for %s", fullTargetName)
@@ -1614,7 +1614,7 @@ func (c *Converter) parseSecretFlag(secretKeyValue string) (secretID string, env
 }
 
 func (c *Converter) forceExecution(ctx context.Context, state pllb.State) error {
-	if state.Output() != nil {
+	if state.Output() == nil {
 		// Scratch - no need to execute.
 		return nil
 	}

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -929,6 +929,7 @@ func (c *Converter) BuildAsync(ctx context.Context, fullTargetName string, platf
 			eg.Go(func() error {
 				return errors.Wrapf(err, "acquiring parallelism semaphore for %s", fullTargetName)
 			})
+			return
 		}
 		defer c.opt.Parallelism.Release(1)
 		mts, err := Earthfile2LLB(ctx, target, opt, false)
@@ -937,6 +938,7 @@ func (c *Converter) BuildAsync(ctx context.Context, fullTargetName string, platf
 			eg.Go(func() error {
 				return errors.Wrapf(err, "async earthfile2llb for %s", fullTargetName)
 			})
+			return
 		}
 		if c.ftrs.ExecAfterParallel && mts != nil && mts.Final != nil {
 			eg.Go(func() error {

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -937,10 +937,12 @@ func (c *Converter) BuildAsync(ctx context.Context, fullTargetName string, platf
 			errChan <- errors.Wrapf(err, "async earthfile2llb for %s", fullTargetName)
 			return
 		}
-		err = c.forceExecution(ctx, mts.Final.MainState)
-		if err != nil {
-			errChan <- errors.Wrapf(err, "async force execution for %s", fullTargetName)
-			return
+		if c.ftrs.ExecAfterParallel {
+			err = c.forceExecution(ctx, mts.Final.MainState)
+			if err != nil {
+				errChan <- errors.Wrapf(err, "async force execution for %s", fullTargetName)
+				return
+			}
 		}
 		errChan <- nil
 	}()

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -938,7 +938,7 @@ func (c *Converter) BuildAsync(ctx context.Context, fullTargetName string, platf
 				return errors.Wrapf(err, "async earthfile2llb for %s", fullTargetName)
 			})
 		}
-		if c.ftrs.ExecAfterParallel && mts != nil && mts.Final != nil {
+		if c.ftrs.ExecAfterParallel {
 			eg.Go(func() error {
 				err = c.forceExecution(ctx, mts.Final.MainState)
 				if err != nil {

--- a/earthfile2llb/earthfile2llb.go
+++ b/earthfile2llb/earthfile2llb.go
@@ -18,6 +18,7 @@ import (
 	"github.com/earthly/earthly/domain"
 	"github.com/earthly/earthly/features"
 	"github.com/earthly/earthly/states"
+	"github.com/earthly/earthly/util/syncutil/serrgroup"
 	"github.com/earthly/earthly/variables"
 )
 
@@ -91,18 +92,18 @@ type ConvertOpt struct {
 	ParallelConversion bool
 	// Parallelism is a semaphore controlling the maximum parallelism.
 	Parallelism *semaphore.Weighted
-
-	// parentDepSub is a channel informing of any new dependencies from the parent.
-	parentDepSub chan string // chan of sts IDs.
+	// ErrorGroup is a serrgroup used to submit parallel conversion jobs.
+	ErrorGroup *serrgroup.Group
 
 	// FeatureFlagOverride is used to override feature flags that are defined in specific Earthfiles
 	FeatureFlagOverrides string
-
 	// Default set of ARGs to make available in Earthfile.
 	BuiltinArgs variables.DefaultArgs
-
 	// NoCache sets llb.IgnoreCache before calling StateToRef
 	NoCache bool
+
+	// parentDepSub is a channel informing of any new dependencies from the parent.
+	parentDepSub chan string // chan of sts IDs.
 }
 
 // Earthfile2LLB parses a earthfile and executes the statements for a given target.
@@ -115,6 +116,11 @@ func Earthfile2LLB(ctx context.Context, target domain.Target, opt ConvertOpt, in
 	}
 	if opt.MetaResolver == nil {
 		opt.MetaResolver = NewCachedMetaResolver(opt.GwClient)
+	}
+	egWait := false
+	if opt.ErrorGroup == nil {
+		opt.ErrorGroup, ctx = serrgroup.WithContext(ctx)
+		egWait = true
 	}
 	// Resolve build context.
 	bc, err := opt.Resolver.Resolve(ctx, opt.GwClient, target)
@@ -151,12 +157,22 @@ func Earthfile2LLB(ctx context.Context, target domain.Target, opt ConvertOpt, in
 	if err != nil {
 		return nil, err
 	}
-	interpreter := newInterpreter(converter, targetWithMetadata, opt.AllowPrivileged, opt.ParallelConversion, opt.Parallelism, opt.Console, opt.GitLookup)
+	interpreter := newInterpreter(converter, targetWithMetadata, opt.AllowPrivileged, opt.ParallelConversion, opt.Parallelism, opt.ErrorGroup, opt.Console, opt.GitLookup)
 	err = interpreter.Run(ctx, bc.Earthfile)
 	if err != nil {
 		return nil, err
 	}
-	return converter.FinalizeStates(ctx)
+	mts, err = converter.FinalizeStates(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if egWait {
+		err := opt.ErrorGroup.Wait()
+		if err != nil {
+			return nil, err
+		}
+	}
+	return mts, nil
 }
 
 // GetTargets returns a list of targets from an Earthfile.

--- a/earthfile2llb/interpreter.go
+++ b/earthfile2llb/interpreter.go
@@ -14,12 +14,12 @@ import (
 	"github.com/earthly/earthly/domain"
 	"github.com/earthly/earthly/util/flagutil"
 	"github.com/earthly/earthly/util/llbutil"
+	"github.com/earthly/earthly/util/syncutil/serrgroup"
 	"github.com/earthly/earthly/variables"
 
 	flags "github.com/jessevdk/go-flags"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
-	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
 )
 
@@ -44,12 +44,12 @@ type Interpreter struct {
 
 	parallelConversion bool
 	parallelism        *semaphore.Weighted
-	eg                 *errgroup.Group
+	eg                 *serrgroup.Group
 	console            conslogging.ConsoleLogger
 	gitLookup          *buildcontext.GitLookup
 }
 
-func newInterpreter(c *Converter, t domain.Target, allowPrivileged, parallelConversion bool, parallelism *semaphore.Weighted, console conslogging.ConsoleLogger, gitLookup *buildcontext.GitLookup) *Interpreter {
+func newInterpreter(c *Converter, t domain.Target, allowPrivileged, parallelConversion bool, parallelism *semaphore.Weighted, eg *serrgroup.Group, console conslogging.ConsoleLogger, gitLookup *buildcontext.GitLookup) *Interpreter {
 	return &Interpreter{
 		converter:          c,
 		target:             t,
@@ -57,6 +57,7 @@ func newInterpreter(c *Converter, t domain.Target, allowPrivileged, parallelConv
 		allowPrivileged:    allowPrivileged,
 		parallelism:        parallelism,
 		parallelConversion: parallelConversion,
+		eg:                 eg,
 		console:            console,
 		gitLookup:          gitLookup,
 	}
@@ -64,26 +65,18 @@ func newInterpreter(c *Converter, t domain.Target, allowPrivileged, parallelConv
 
 // Run interprets the commands in the given Earthfile AST, for a specific target.
 func (i *Interpreter) Run(ctx context.Context, ef spec.Earthfile) (err error) {
-	if i.eg != nil {
-		return errors.New("cannot run an interpreter twice")
+	if i.target.Target == "base" {
+		i.isBase = true
+		err := i.handleBlock(ctx, ef.BaseRecipe)
+		i.isBase = false
+		return err
 	}
-	eg, ctx := errgroup.WithContext(ctx)
-	i.eg = eg
-	eg.Go(func() error {
-		if i.target.Target == "base" {
-			i.isBase = true
-			err := i.handleBlock(ctx, ef.BaseRecipe)
-			i.isBase = false
-			return err
+	for _, t := range ef.Targets {
+		if t.Name == i.target.Target {
+			return i.handleTarget(ctx, t)
 		}
-		for _, t := range ef.Targets {
-			if t.Name == i.target.Target {
-				return i.handleTarget(ctx, t)
-			}
-		}
-		return i.errorf(ef.SourceLocation, "target %s not found", i.target.Target)
-	})
-	return eg.Wait() // Waits for any parallel execution to finish too.
+	}
+	return i.errorf(ef.SourceLocation, "target %s not found", i.target.Target)
 }
 
 func (i *Interpreter) handleTarget(ctx context.Context, t spec.Target) error {

--- a/features/features.go
+++ b/features/features.go
@@ -26,6 +26,7 @@ type Features struct {
 	CheckDuplicateImages       bool `long:"check-duplicate-images" description:"check for duplicate images during output"`
 	EarthlyVersionArg          bool `long:"earthly-version-arg" description:"includes EARTHLY_VERSION and EARTHLY_BUILD_SHA ARGs"`
 	UseCacheCommand            bool `long:"use-cache-command" description:"allow use of CACHE command in Earthfiles"`
+	ExecAfterParallel          bool `long:"exec-after-parallel" description:"force execution after parallel conversion"`
 
 	Major int
 	Minor int
@@ -173,6 +174,7 @@ func GetFeatures(version *spec.Version) (*Features, error) {
 		ftrs.CheckDuplicateImages = true
 		ftrs.EarthlyVersionArg = true
 		ftrs.UseCacheCommand = true
+		ftrs.ExecAfterParallel = true
 	}
 
 	return &ftrs, nil

--- a/util/syncutil/serrgroup/serrgroup.go
+++ b/util/syncutil/serrgroup/serrgroup.go
@@ -1,0 +1,77 @@
+// Package serrgroup is an error group that does not crash if work is added after
+// Wait has returned after an error. This is based on
+// https://cs.opensource.google/go/x/sync/+/036812b2:errgroup/errgroup.go
+// with some modifications.
+package serrgroup
+
+import (
+	"context"
+	"sync"
+)
+
+// A Group is a collection of goroutines working on subtasks that are part of
+// the same overall task.
+//
+// A zero Group is valid and does not cancel on error.
+type Group struct {
+	cancel func()
+
+	wg sync.WaitGroup
+
+	errOnce sync.Once
+	err     error
+	errMu   sync.Mutex
+}
+
+// WithContext returns a new Group and an associated Context derived from ctx.
+//
+// The derived Context is canceled the first time a function passed to Go
+// returns a non-nil error or the first time Wait returns, whichever occurs
+// first.
+func WithContext(ctx context.Context) (*Group, context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	return &Group{cancel: cancel}, ctx
+}
+
+// Wait blocks until all function calls from the Go method have returned, then
+// returns the first non-nil error (if any) from them.
+func (g *Group) Wait() error {
+	g.wg.Wait()
+	if g.cancel != nil {
+		g.cancel()
+	}
+	g.errMu.Lock()
+	defer g.errMu.Unlock()
+	return g.err
+}
+
+// Go calls the given function in a new goroutine.
+//
+// The first call to return a non-nil error cancels the group; its error will be
+// returned by Wait.
+func (g *Group) Go(f func() error) {
+	g.errMu.Lock()
+	if g.err != nil {
+		g.errMu.Unlock()
+		// Don't add more work if there has been an error.
+		return
+	}
+	g.errMu.Unlock()
+
+	g.wg.Add(1)
+
+	go func() {
+		defer g.wg.Done()
+
+		if err := f(); err != nil {
+			g.errOnce.Do(func() {
+				g.errMu.Lock()
+				defer g.errMu.Unlock()
+				g.err = err
+				if g.cancel != nil {
+					g.cancel()
+				}
+			})
+		}
+	}()
+}


### PR DESCRIPTION
Fixes https://github.com/earthly/earthly/issues/1589

In the original repro script, it seems that `+slow` and `+fast` do actually convert in parallel, but there is nothing triggering the execution for `+slow` after the conversion, which leads to limited parallelism.

This change forces execution after each parallel conversion, to encourage more parallelism. This seems to address the problem in #1589. The parallel workers are now also started via a global error group and the top-most earthfile2llb will wait for all children to finish before returning control.