### PR TITLE
./earthly should print to stderr

### DIFF
--- a/earthly
+++ b/earthly
@@ -30,10 +30,10 @@ last_check_state_path=/tmp/last-earthly-prerelease-check
 last_flag_hash_path=/tmp/last-earthly-flag-hash
 
 get_latest_binary() {
-    docker rm --force earthly_binary 2>/dev/null || true
+    docker rm --force earthly_binary 2>/dev/null >&2 || true
 
-    docker pull earthly/earthlybinaries:prerelease
-    docker create --name earthly_binary earthly/earthlybinaries:prerelease
+    docker pull earthly/earthlybinaries:prerelease >&2
+    docker create --name earthly_binary earthly/earthlybinaries:prerelease >&2
 
     earth_bin_path=/earthly-linux-amd64
     bk_platform=linux/amd64
@@ -46,9 +46,9 @@ get_latest_binary() {
         fi
     fi
 
-    docker pull --platform="$bk_platform" earthly/buildkitd:prerelease
-    docker cp earthly_binary:"$earth_bin_path" "$bindir/earthly-prerelease"
-    docker rm earthly_binary
+    docker pull --platform="$bk_platform" earthly/buildkitd:prerelease >&2
+    docker cp earthly_binary:"$earth_bin_path" "$bindir/earthly-prerelease" >&2
+    docker rm earthly_binary >&2
 }
 
 do_reset() {
@@ -100,7 +100,7 @@ case "$1" in
     --help)
         do_help
         ;;
-    
+
     *)
         last=$(cat "$last_check_state_path" 2>/dev/null || echo 0)
         now=$(date +%s)
@@ -115,17 +115,17 @@ case "$1" in
             if [ "$last_flag_hash" != "$flagoverride_hash" ]; then
                 echo ".earthly_version_flag_overrides has changed since last run, checking for prerelease binaries" \
                      "If you see an \"unable to set <flag-name>: invalid flag\" error, you may have to wait for the" \
-                     "prerelease binary to be built by GHA on the main branch, before re-attempting a ./earthly upgrade" | fold
+                     "prerelease binary to be built by GHA on the main branch, before re-attempting a ./earthly upgrade" | fold >&2
                 update="true"
             elif [ "$since" -ge 3600 ]; then
-                echo checking for latest earthly prerelease binaries
+                echo "checking for latest earthly prerelease binaries" >&2
                 update="true"
             fi
 
             if [ "$update" = "true" ]; then
                 get_latest_binary
-                echo "Updated prerelease binary. Version:"
-                "$bindir/earthly-prerelease" --version
+                echo "Updated prerelease binary. Version:" >&2
+                "$bindir/earthly-prerelease" --version >&2
                 echo "$now" >"$last_check_state_path"
                 echo "$flagoverride_hash" >"$last_flag_hash_path"
             fi


### PR DESCRIPTION
This fixes issues where periodic update text ends up clobbering secrets,
e.g.

    export token="$(secrets get -n /path/...)"

would contain text such as "updating earthly...".

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>