### PR TITLE
remove SUDO_USER from circleci test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,14 @@ jobs:
           command: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/latest/download/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly'"
       - run:
           name: Build latest earthly
-          command: earthly --use-inline-cache +for-linux
+          # earthly v0.6.5 has a bug that causes a panic when SUDO_USER is set to a user that the current user does not have read permission to. To Work-around this,
+          # we need to set SUDO_USER to "".
+          #
+          # This is due to circle CI running under the user "circleci" with SUDO_USER="root"; however the circleci user does not have access to /root/.earthly/config.yml
+          # therefore, we must unset the SUDO_USER; otherwise we will get this error: "open /root/.earthly/config.yml: permission denied"
+          #
+          # Once this bugfix is released, this can be undone.
+          command: SUDO_USER="" earthly --use-inline-cache +for-linux
       - run:
           name: Bootstrap
           command: sudo ./build/linux/amd64/earthly bootstrap

--- a/tests/git-ssh-server/setup/Earthfile
+++ b/tests/git-ssh-server/setup/Earthfile
@@ -68,6 +68,7 @@ fi
 
     RUN --privileged start-sshd && \
         mkdir -p ~/.ssh && \
+        timeout 5 sh -c 'until nc -z $0 $1; do sleep 1; done' git.example.com 22 && \
         ssh-keyscan -H git.example.com > ~/.ssh/known_hosts && \
         echo done setup.
 
@@ -76,6 +77,7 @@ fi
         if [ "$USER_RSA" = "true" ]; then ssh-add /root/self-hosted-rsa-key; fi && \
         if [ "$USER_ED25519" = "true" ]; then ssh-add /root/self-hosted-ed25519-key; fi && \
         ssh-add -l && \
+        timeout 5 sh -c 'until nc -z $0 $1; do sleep 1; done' git.example.com 22 && \
         ssh-keyscan -H git.example.com && \
         mkdir -p /test/repo && \
         cd /test/repo && \

--- a/util/fileutil/homedir.go
+++ b/util/fileutil/homedir.go
@@ -21,7 +21,6 @@ func getHomeFromSudoUser() (string, *user.User, bool) {
 	if !writable {
 		return "", nil, false
 	}
-
 	return u.HomeDir, u, true
 }
 

--- a/util/fileutil/iswritable_other.go
+++ b/util/fileutil/iswritable_other.go
@@ -5,7 +5,11 @@ package fileutil
 
 import (
 	"os"
+	"os/user"
+	"strconv"
 	"syscall"
+
+	"github.com/pkg/errors"
 )
 
 // IsDirWritable returns if the path is a directory that the user can write to
@@ -26,6 +30,20 @@ func IsDirWritable(path string) (bool, error) {
 
 	var stat syscall.Stat_t
 	if err = syscall.Stat(path, &stat); err != nil {
+		return false, err
+	}
+
+	u, err := user.Current()
+	if err != nil {
+		return false, err
+	}
+
+	uid, err := strconv.Atoi(u.Uid)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to convert uid %s to int", u.Uid)
+	}
+
+	if int(stat.Uid) != uid && uid != 0 {
 		return false, err
 	}
 


### PR DESCRIPTION
circle CI is being run as user `circleci` with `SUDO_USER="root"`; however the circleci user does not have access to `/root/.earthly/config.yml` therefore, we must unset the `SUDO_USER`; otherwise we will get this error: `open /root/.earthly/config.yml: permission denied`


Signed-off-by: Alex Couture-Beil <alex@earthly.dev>