### PR TITLE
Don't re-authenticate requests which don't have a JWT

### DIFF
--- a/cloud/client.go
+++ b/cloud/client.go
@@ -169,6 +169,9 @@ func (c *client) doCall(method, url string, opts ...requestOpt) (int, string, er
 		}
 
 		if status == http.StatusUnauthorized {
+			if !r.hasAuth {
+				return status, body, ErrUnauthorized
+			}
 			if alreadyReAuthed {
 				return status, body, err
 			}

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -2442,7 +2442,7 @@ func (app *earthlyApp) actionAccountLogin(c *cli.Context) error {
 
 	loggedInEmail, authType, writeAccess, err := cc.WhoAmI()
 	switch errors.Cause(err) {
-	case cloud.ErrNoAuthorizedPublicKeys, cloud.ErrNoSSHAgent:
+	case cloud.ErrUnauthorized:
 		break
 	case nil:
 		if email != "" && email != loggedInEmail {


### PR DESCRIPTION
Edge case where this can cause an infinite recursive loop. 

Basically, an authenticated request would 401 (e.g. list secrets but not logged in) which would trigger a login request  (re-auth) -> which would 401 and trigger SSH discovery -> which would request an "auth challenge" -> which would 401, and trigger another login request (re-auth) -> which would trigger SSH discovery again -> ... etc

The solution here prevents the 401 on a login request from retrying.