### PR TITLE
verify ssh git@git.example.com works

### DIFF
--- a/tests/git-ssh-server/Earthfile
+++ b/tests/git-ssh-server/Earthfile
@@ -27,6 +27,10 @@ eval \$(ssh-agent)
 ssh-add /root/self-hosted-rsa-key
 ssh-add -l
 
+# next validate ssh is working
+ssh git@git.example.com | grep \"Hi git! You've successfully authenticated, but you get no shellz\"
+
+# finally perform earthly tests
 earthly --config \$earthly_config --verbose -D +test
 earthly --config \$earthly_config --verbose -D git.example.com/testuser/repo:main+hello
 " >/tmp/test-earthly-script && chmod +x /tmp/test-earthly-script
@@ -54,6 +58,10 @@ eval \$(ssh-agent)
 ssh-add /root/self-hosted-ed25519-key
 ssh-add -l
 
+# next validate ssh is working
+ssh git@git.example.com | grep \"Hi git! You've successfully authenticated, but you get no shellz\"
+
+# finally perform earthly tests
 earthly --config \$earthly_config --verbose -D +test
 earthly --config \$earthly_config --verbose -D git.example.com/testuser/repo:main+hello
 " >/tmp/test-earthly-script && chmod +x /tmp/test-earthly-script
@@ -81,6 +89,10 @@ eval \$(ssh-agent)
 ssh-add /root/self-hosted-rsa-key
 ssh-add -l
 
+# next validate ssh is working
+ssh git@git.example.com | grep \"Hi git! You've successfully authenticated, but you get no shellz\"
+
+# finally perform earthly tests
 earthly --config \$earthly_config --verbose -D +test
 earthly --config \$earthly_config --verbose -D git.example.com/testuser/repo:main+hello
 " >/tmp/test-earthly-script && chmod +x /tmp/test-earthly-script

--- a/tests/git-ssh-server/setup/Earthfile
+++ b/tests/git-ssh-server/setup/Earthfile
@@ -40,6 +40,7 @@ server:
         sed -i 's/\(git:.*\):\/bin\/ash/\1:\/usr\/bin\/git-shell/g' /etc/passwd && \
         cat /etc/passwd | grep git && \
         passwd git -u
+    COPY no-interactive-login /home/git/git-shell-commands/no-interactive-login
     RUN mkdir /home/git/testuser && \
         git init --bar /home/git/testuser/repo.git && \
         chown -R git:git /home/git/testuser

--- a/tests/git-ssh-server/setup/no-interactive-login
+++ b/tests/git-ssh-server/setup/no-interactive-login
@@ -1,0 +1,4 @@
+#!/bin/sh
+printf '%s\n' "Hi $USER! You've successfully authenticated, but you get no shellz"
+exit 128
+EOF


### PR DESCRIPTION
Perform a sanity-check to validate the sshd server and ssh-agent
work together before moving on to testing earthly;

This it to make it easier to debug

    earthly -P ./tests/git-ssh-server+test-rsa-only

which is failing in a development-branch I am currently working on.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>