### PR TITLE
explicitly allow sshd to accept ssh-rsa

### DIFF
--- a/tests/git-ssh-server/setup/Earthfile
+++ b/tests/git-ssh-server/setup/Earthfile
@@ -64,6 +64,7 @@ cp /tmp/hosts /etc/hosts
 if ! grep git.example.com /etc/hosts 2>/dev/null; then
     echo -e \"127.0.0.1\tgit.example.com\" >> /etc/hosts
 fi
+/sbin/syslogd # required to have sshd log to /var/log/messages
 /usr/sbin/sshd
 " > /bin/start-sshd && chmod +x /bin/start-sshd
 

--- a/tests/git-ssh-server/setup/sshd_config
+++ b/tests/git-ssh-server/setup/sshd_config
@@ -3,5 +3,7 @@ AllowTcpForwarding no
 GatewayPorts no
 X11Forwarding no
 PasswordAuthentication no
+LogLevel DEBUG3
+pubkeyacceptedkeytypes ssh-ed25519,rsa-sha2-512,rsa-sha2-256,ssh-rsa # we need to allow ssh-rsa due to https://github.com/golang/go/issues/39885
 
 Subsystem	sftp	/usr/lib/ssh/sftp-server


### PR DESCRIPTION
Due to https://github.com/golang/go/issues/39885
if we only allow rsa-sha2-256,rsa-sha2-512 golang/x/crypto
doesn't work as it presents the key as a regular ssh-rsa (which
fallsback to using sha1 hashes which are insecure)

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>