### PR TITLE
Display GitSha with --version

### DIFF
--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -306,7 +306,7 @@ func getVersionPlatform() string {
 	if !isRelease.MatchString(Version) {
 		v = fmt.Sprintf("%s-%s", Version, GitSha)
 	}
-	return fmt.Sprintf("%s %s", v, getPlatform())
+	return fmt.Sprintf("%s %s %s", v, GitSha, getPlatform())
 }
 
 func getPlatform() string {


### PR DESCRIPTION
Currently when you run: earthly --version
on a released version of earthly, you get:

    earthly-v0.6.3 version v0.6.3 linux/amd64; Ubuntu 20.04

This changes it to print out

    earthly-v0.6.3 version v0.6.3 40ac00a17b4174f3b332ee8be3df441d493a9013 linux/amd64; Ubuntu 20.04

Pre-released / built from source builds will remain unchanged and will
display

    earthly version prerelease-40ac00a17b4174f3b332ee8be3df441d493a9013 linux/amd64; Ubuntu 20.04

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>