### PR TITLE
Capture missing phase output in `_full`.

### DIFF
--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -2756,8 +2756,6 @@ func (app *earthlyApp) combineVariables(dotEnvMap map[string]string, flagArgs []
 }
 
 func (app *earthlyApp) actionBuildImp(c *cli.Context, flagArgs, nonFlagArgs []string) error {
-	app.console.PrintPhaseHeader(builder.PhaseInit, false, "")
-	app.warnIfArgContainsBuildArg(flagArgs)
 	var target domain.Target
 	var artifact domain.Artifact
 	destPath := "./"
@@ -2855,6 +2853,9 @@ func (app *earthlyApp) actionBuildImp(c *cli.Context, flagArgs, nonFlagArgs []st
 			}()
 		}
 	}
+
+	app.console.PrintPhaseHeader(builder.PhaseInit, false, "")
+	app.warnIfArgContainsBuildArg(flagArgs)
 
 	bkClient, err := buildkitd.NewClient(c.Context, app.console, app.buildkitdImage, app.containerName, app.containerFrontend, app.buildkitdSettings)
 	if err != nil {

--- a/conslogging/conslogging.go
+++ b/conslogging/conslogging.go
@@ -155,6 +155,7 @@ func (cl ConsoleLogger) WithLogBundleWriter(entrypoint string, collection *clean
 	ret.bb = NewBundleBuilder(entrypoint, collection)
 	fullW := ret.bb.PrefixWriter(fullLog)
 	ret.consoleErrW = io.MultiWriter(ret.consoleErrW, fullW)
+	ret.errW = ret.consoleErrW
 	return ret
 }
 


### PR DESCRIPTION
Had to reorder some things, and make sure that when using the bundler, it gets put in as the root `io.Reader`. Sample output: https://ci.earthly.dev/logs?logId=07ed7d96-cec5-4d31-ae12-4ee2ce26dbe3