### PR TITLE
autocompletion bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 
 ## Unreleased
 
+### Fixed
+
+- Autocompletion bug when directory has both an Earthfile and subdir containing an earthfile.
+- Autocompletion bug when directory has two subdirectories where one is a prefix of the other.
+
 ## v0.6.6 - 2022-01-26
 
 ### Added

--- a/autocomplete/complete.go
+++ b/autocomplete/complete.go
@@ -157,13 +157,31 @@ func getPotentialPaths(ctx context.Context, resolver *buildcontext.Resolver, gwC
 		return potentials, nil
 	}
 
-	prefixDirExists, err := fileutil.DirExists(prefix)
+	usePrefixAsDir, err := fileutil.DirExists(prefix)
 	if err != nil {
 		return nil, err
 	}
 
+	if usePrefixAsDir && !strings.HasSuffix(prefix, "/") {
+		p, f := path.Split(prefix)
+		if hasEarthfile(f) {
+			usePrefixAsDir = false
+		}
+		files, err := os.ReadDir(p)
+		if err != nil {
+			return nil, err
+		}
+		for _, file := range files {
+			fileName := file.Name()
+			if strings.HasPrefix(fileName, f) && fileName != f {
+				usePrefixAsDir = false
+				break
+			}
+		}
+	}
+
 	var f, dir string
-	if prefixDirExists {
+	if usePrefixAsDir {
 		dir = prefix
 	} else {
 		dir, f = path.Split(prefix)

--- a/tests/autocompletion/Earthfile
+++ b/tests/autocompletion/Earthfile
@@ -159,6 +159,39 @@ test-relative-dir-targets:
     RUN COMP_LINE="earthly ./foo+" COMP_POINT=14 earthly > actual
     RUN diff expected actual
 
+test-targets-in-dir-and-subdir:
+    RUN mkdir -p /test/foo/subdir
+    COPY fake.earth /test/foo/Earthfile
+    COPY fake.earth /test/foo/subdir/Earthfile
+
+    WORKDIR /test/
+    RUN echo "./foo+
+./foo/" > expected
+    RUN COMP_LINE="earthly ./" COMP_POINT=10 earthly > actual
+    RUN diff expected actual
+
+    RUN COMP_LINE="earthly ./f" COMP_POINT=11 earthly > actual
+    RUN diff expected actual
+
+    RUN COMP_LINE="earthly ./foo" COMP_POINT=13 earthly > actual
+    RUN diff expected actual
+
+test-targets-in-two-subdirs-that-are-similar:
+    COPY fake.earth /test/foo/subdir/Earthfile
+    COPY fake.earth /test/food/subdir/Earthfile
+
+    WORKDIR /test/
+    RUN echo "./foo/
+./food/" > expected
+    RUN COMP_LINE="earthly ./" COMP_POINT=10 earthly > actual
+    RUN diff expected actual
+
+    RUN COMP_LINE="earthly ./f" COMP_POINT=11 earthly > actual
+    RUN diff expected actual
+
+    RUN COMP_LINE="earthly ./foo" COMP_POINT=13 earthly > actual
+    RUN diff expected actual
+
 test-all:
     BUILD +test-root-commands
     BUILD +test-hidden-root-commands
@@ -171,3 +204,5 @@ test-all:
     BUILD +test-relative-dir-targets
     BUILD +test-no-parent-at-root
     BUILD +test-no-parent-at-root-from-home
+    BUILD +test-targets-in-dir-and-subdir
+    BUILD +test-targets-in-two-subdirs-that-are-similar


### PR DESCRIPTION
fixes two autocompletion bugs
- when directory has both an Earthfile and subdir containing an earthfile.
- when directory has two subdirectories where one is a prefix of the other.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>