### PR TITLE
Fix some remote log manifest data

### DIFF
--- a/conslogging/bundle.go
+++ b/conslogging/bundle.go
@@ -156,7 +156,7 @@ func (bb *BundleBuilder) WriteToDisk() (string, error) {
 func (bb *BundleBuilder) buildManifest(targetManifests []TargetManifest) *Manifest {
 	manifest := &Manifest{
 		Version:    1,
-		Duration:   int(time.Since(bb.started).Seconds()),
+		Duration:   int(time.Since(bb.started).Milliseconds()),
 		Status:     StatusComplete,
 		Result:     ResultSuccess,
 		CreatedAt:  time.Now().In(time.UTC),
@@ -165,6 +165,13 @@ func (bb *BundleBuilder) buildManifest(targetManifests []TargetManifest) *Manife
 	}
 
 	for _, tm := range targetManifests {
+		if tm.Name == fullLog {
+			// Full Log reserved name should not determine whole build status.
+			// Really, we could go back through after determining whole build status to set _full result & status to the
+			// values for the whole build; but it doesn't (yet) affect or mean anything to us. So leave it as is.
+			continue
+		}
+
 		if tm.Result != ResultSuccess {
 			manifest.Result = tm.Result
 		}
@@ -203,7 +210,7 @@ func (tl *targetLogger) toManifestTarget() (TargetManifest, error) {
 		Name:     tl.prefix,
 		Status:   tl.status,
 		Result:   tl.result,
-		Duration: int(time.Since(tl.started).Seconds()),
+		Duration: int(time.Since(tl.started).Milliseconds()),
 		Size:     tl.writer.Len(),
 		Command:  command,
 		Summary:  summary,


### PR DESCRIPTION
Report timing in milliseconds, and exempt _full from affecting whole-build status.

cc @mirho - this should fix some builds showing as cancelled when they were really completed successfully.