### PR TITLE
Use JWT in Analytics Request

### DIFF
--- a/cloud/client.go
+++ b/cloud/client.go
@@ -970,6 +970,9 @@ func (c *client) WhoAmI() (string, string, bool, error) {
 	return email, authType, writeAccess, nil
 }
 
+// EarthlyAnalytics is the payload used in SendAnalytics.
+// It contains information about the command that was run,
+// the environment it was run in, and the result of the command.
 type EarthlyAnalytics struct {
 	Key              string                    `json:"key"`
 	InstallID        string                    `json:"install_id"`
@@ -984,6 +987,7 @@ type EarthlyAnalytics struct {
 	Counts           map[string]map[string]int `json:"counts"`
 }
 
+// SendAnalytics send an analytics event to the Cloud server.
 func (c *client) SendAnalytics(data *EarthlyAnalytics) error {
 	payload, err := json.Marshal(data)
 	if err != nil {

--- a/cloud/client.go
+++ b/cloud/client.go
@@ -89,6 +89,7 @@ type Client interface {
 	DeleteCachedToken() error
 	DisableSSHKeyGuessing()
 	SetAuthTokenDir(path string)
+	SendAnalytics(data *EarthlyAnalytics) error
 }
 
 type request struct {
@@ -967,6 +968,42 @@ func (c *client) WhoAmI() (string, string, bool, error) {
 	}
 
 	return email, authType, writeAccess, nil
+}
+
+type EarthlyAnalytics struct {
+	Key              string                    `json:"key"`
+	InstallID        string                    `json:"install_id"`
+	Version          string                    `json:"version"`
+	Platform         string                    `json:"platform"`
+	GitSHA           string                    `json:"git_sha"`
+	ExitCode         int                       `json:"exit_code"`
+	CI               string                    `json:"ci_name"`
+	RepoHash         string                    `json:"repo_hash"`
+	ExecutionSeconds float64                   `json:"execution_seconds"`
+	Terminal         bool                      `json:"terminal"`
+	Counts           map[string]map[string]int `json:"counts"`
+}
+
+func (c *client) SendAnalytics(data *EarthlyAnalytics) error {
+	payload, err := json.Marshal(data)
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal data")
+	}
+	opts := []requestOpt{
+		withBody(string(payload)),
+		withHeader("Content-Type", "application/json; charset=utf-8"),
+	}
+	if c.authToken != "" {
+		opts = append(opts, withAuth())
+	}
+	status, _, err := c.doCall("PUT", "/analytics", opts...)
+	if err != nil {
+		return errors.Wrap(err, "failed sending analytics")
+	}
+	if status != http.StatusAccepted {
+		return errors.Errorf("unexpected response from analytics server: %d", status)
+	}
+	return nil
 }
 
 func (c *client) migrateOldToken() error {

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -298,7 +298,7 @@ func main() {
 		cc, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
 		if err != nil && displayErrors {
 			app.console.Warnf("unable to start cloud client: %s", err)
-		} else {
+		} else if err == nil {
 			analytics.CollectAnalytics(
 				ctxTimeout, cc, displayErrors, Version, getPlatform(),
 				GitSha, app.commandName, exitCode, time.Since(startTime),

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -295,7 +295,15 @@ func main() {
 		ctxTimeout, cancel := context.WithTimeout(ctx, time.Millisecond*500)
 		defer cancel()
 		displayErrors := app.verbose
-		analytics.CollectAnalytics(ctxTimeout, app.apiServer, displayErrors, Version, getPlatform(), GitSha, app.commandName, exitCode, time.Since(startTime))
+		cc, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+		if err != nil && displayErrors {
+			app.console.Warnf("unable to start cloud client: %s", err)
+		} else {
+			analytics.CollectAnalytics(
+				ctxTimeout, cc, displayErrors, Version, getPlatform(),
+				GitSha, app.commandName, exitCode, time.Since(startTime),
+			)
+		}
 	}
 	os.Exit(exitCode)
 }
@@ -3127,6 +3135,8 @@ func ifNilBoolDefault(ptr *bool, defaultValue bool) bool {
 }
 
 func (app *earthlyApp) actionListTargets(c *cli.Context) error {
+	app.commandName = "listTargets"
+
 	if c.NArg() > 1 {
 		return errors.New("invalid number of arguments provided")
 	}


### PR DESCRIPTION
When the JWT is set, send it in the analytics request, so the server can record the user's ID with the event.