### PR TITLE
fix mirrors required for yum release

### DIFF
--- a/release/yum-repo/Earthfile
+++ b/release/yum-repo/Earthfile
@@ -2,6 +2,8 @@ FROM alpine:3.15
 
 deps:
     FROM centos:8.3.2011
+    RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-*
+    RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
     RUN yum install -y createrepo rpm-build rpm-sign wget
 
 rpm:


### PR DESCRIPTION
Centos 8 has reached end-of-life, and mirror URLs need to be changed
to continue working.

We should update our yum repo release process to use a newer version of
centos in a follow-up PR.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>