### PR TITLE
Display GitHub OAuth account registration in help

### DIFF
--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -832,11 +832,19 @@ func newEarthlyApp(ctx context.Context, console conslogging.ConsoleLogger) *eart
 					Name:        "register",
 					Usage:       "Register for an Earthly account",
 					Description: "Register for an Earthly account",
-					UsageText: "first, request a token with:\n" +
-						"     earthly [options] account register --email <email>\n" +
+					UsageText: "You may register using GitHub OAuth, by visiting https://ci.earthly.dev\n" +
+						"   Once authenticated, a login token will be displayed which can be used to login:\n" +
 						"\n" +
-						"   then check your email to retrieve the token, then continue by running:\n" +
-						"     earthly [options] account register --email <email> --token <token> [options]",
+						"       earthly [options] account login --token <token>\n" +
+						"\n" +
+						"   Alternatively, you can register using an email:\n" +
+						"       first, request a token with:\n" +
+						"\n" +
+						"           earthly [options] account register --email <email>\n" +
+						"\n" +
+						"       then check your email to retrieve the token, then continue by running:\n" +
+						"\n" +
+						"           earthly [options] account register --token <token>\n",
 					Action: app.actionRegister,
 					Flags: []cli.Flag{
 						&cli.StringFlag{


### PR DESCRIPTION
Let users know they can sign up for an account using github OAuth.
Here's what the updated `--help` looks like:

    earthly account register --help
    NAME:
       earthly account register - Register for an Earthly account

    USAGE:
       You may register using GitHub OAuth, by visiting https://ci.earthly.dev
       Once authenticated, a login token will be displayed which can be used to login:

           earthly [options] account login --token <token>

       Alternatively, you can register using an email:
           first, request a token with:

               earthly [options] account register --email <email>

           then check your email to retrieve the token, then continue by running:

               earthly [options] account register --token <token>

    DESCRIPTION:
       Register for an Earthly account

    OPTIONS:
       --email value                      Email address
       --token value                      Email verification token
       --password value                   Specify password on the command line instead of interactively being asked [$EARTHLY_PASSWORD]
       --public-key value                 Path to public key to register [$EARTHLY_PUBLIC_KEY]
       --accept-terms-of-service-privacy  Accept the Terms & Conditions, and Privacy Policy (default: false) [$EARTHLY_ACCEPT_TERMS_OF_SERVICE_PRIVACY]
       --help, -h                         show help (default: false)

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>