### PR TITLE
include git sha in semver

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'main'
+      - '**-staging-test'
     paths-ignore:
       - 'docs/**'
 
@@ -48,13 +49,15 @@ jobs:
       - name: staging releases
         run: |-
             set -euo pipefail
-            export RELEASE_TAG="v0.0.$(date +%s)"
+            export SHA_DEC="$(echo "ibase=16; $(git rev-parse --short HEAD | tr '[:lower:]' '[:upper:]')" | bc)"
+            export RELEASE_TAG="v0.$(date +%s).$SHA_DEC"
             export earthly="./build/linux/amd64/earthly"
+            echo "attempting staging-release version: $RELEASE_TAG"
             eval "$(ssh-agent -s)"
             "$earthly" secrets get -n /earthly-technologies/github/griswoldthecat/id_rsa | ssh-add -
             git remote add staging git@github.com:earthly/earthly-staging.git
             git push staging HEAD:pre-release-$RELEASE_TAG
-            echo -e "# Earthly Changelog\n\nAll notable changes to [Earthly](https://github.com/earthly/earthly) will be documented in this file.\n\n## Unreleased\n\n## $RELEASE_TAG - $(date +%Y-%m-%d)\n\nThis is a pre-release" > CHANGELOG.md
+            echo -e "# Earthly Changelog\n\nAll notable changes to [Earthly](https://github.com/earthly/earthly) will be documented in this file.\n\n## Unreleased\n\n## $RELEASE_TAG - $(date +%Y-%m-%d)\n\nThis pre-release was built from $(git rev-parse HEAD)" > CHANGELOG.md
             ./release/release.sh
       - name: Buildkit logs (runs on failure)
         run: docker logs earthly-buildkitd


### PR DESCRIPTION
This changes staging releases to be of the form

    0.<unix-timestamp>.<git-sha-in-decimal>

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>