### PR TITLE
Better handle cancellation of builds in bundle creation

### DIFF
--- a/builder/solver_monitor.go
+++ b/builder/solver_monitor.go
@@ -44,6 +44,7 @@ type vertexMonitor struct {
 	headerPrinted  bool
 	isInternal     bool
 	isError        bool
+	isCanceled     bool
 	tailOutput     *circbuf.Buffer
 	// Line of output that has not yet been terminated with a \n.
 	openLine            []byte
@@ -210,11 +211,11 @@ func (vm *vertexMonitor) isOngoing() bool {
 }
 
 func (vm *vertexMonitor) reportStatusToConsole() {
-	vm.console.MarkBundleBuilderStatus(vm.vertex.Started != nil, vm.vertex.Completed != nil)
+	vm.console.MarkBundleBuilderStatus(vm.vertex.Started != nil, vm.vertex.Completed != nil, vm.isCanceled)
 }
 
 func (vm *vertexMonitor) reportResultToConsole() {
-	vm.console.MarkBundleBuilderResult(vm.isError)
+	vm.console.MarkBundleBuilderResult(vm.isError, vm.isCanceled)
 }
 
 type solverMonitor struct {
@@ -338,6 +339,7 @@ func (sm *solverMonitor) processStatus(ss *client.SolveStatus) error {
 			if strings.Contains(vertex.Error, "context canceled") {
 				if !vm.isInternal {
 					vm.console.Printf("WARN: Canceled\n")
+					vm.isCanceled = true
 					sm.noOutputTicker.Reset(sm.noOutputTick)
 				}
 			} else {

--- a/conslogging/conslogging.go
+++ b/conslogging/conslogging.go
@@ -419,36 +419,44 @@ func (cl ConsoleLogger) WriteBundleToDisk() (string, error) {
 }
 
 // MarkBundleBuilderResult marks the current targets result in a log bundle for a given prefix with the current result.
-func (cl ConsoleLogger) MarkBundleBuilderResult(error bool) {
+func (cl ConsoleLogger) MarkBundleBuilderResult(isError, isCanceled bool) {
 	if cl.bb == nil {
 		return
 	}
 
 	var result string
-	if error {
-		result = ResultFailure
+	if isCanceled {
+		result = ResultCancelled
 	} else {
-		result = ResultSuccess
+		if isError {
+			result = ResultFailure
+		} else {
+			result = ResultSuccess
+		}
 	}
 
 	cl.bb.PrefixResult(cl.Prefix(), result)
 }
 
 // MarkBundleBuilderStatus marks the current targets status in a log bundle for a given prefix with the current status.
-func (cl ConsoleLogger) MarkBundleBuilderStatus(isStarted, isFinished bool) {
+func (cl ConsoleLogger) MarkBundleBuilderStatus(isStarted, isFinished, isCanceled bool) {
 	if cl.bb == nil {
 		return
 	}
 
 	var status string
-	if isStarted {
-		if isFinished {
-			status = StatusComplete
-		} else {
-			status = StatusInProgress
-		}
+	if isCanceled {
+		status = StatusCancelled
 	} else {
-		status = StatusWaiting
+		if isStarted {
+			if isFinished {
+				status = StatusComplete
+			} else {
+				status = StatusInProgress
+			}
+		} else {
+			status = StatusWaiting
+		}
 	}
 
 	cl.bb.PrefixStatus(cl.Prefix(), status)


### PR DESCRIPTION
Better accounting for build cancellation in log bundles. Cancellation is the most precedent of all statuses or results, when determining what to do.