### PR TITLE
Rename build_arg to build-arg

### DIFF
--- a/examples/terraform/README.md
+++ b/examples/terraform/README.md
@@ -16,13 +16,13 @@ Saves the `.tfstate` to show how it can work with Earthly. It will not work on t
 
 ## +plan
 
-`earthly --build_arg AWS_ACCESS_KEY_ID --build_arg AWS_SECRET_ACCESS_KEY +plan`
+`earthly --build-arg AWS_ACCESS_KEY_ID --build-arg AWS_SECRET_ACCESS_KEY +plan`
 
 This target actually plans the Terraform against your cloud, if you pass in valid credentials. The region is optional, and can be overridden. Defaults to `us-east-1`.
 
 ## +apply
 
-`earthly --push --build_arg AWS_ACCESS_KEY_ID --build_arg AWS_SECRET_ACCESS_KEY +apply`
+`earthly --push --build-arg AWS_ACCESS_KEY_ID --build-arg AWS_SECRET_ACCESS_KEY +apply`
 
 This target actually applies the Terraform against your cloud, if you pass in valid credentials. Like in `+plan`, the region is optional, and can be overridden.
 


### PR DESCRIPTION
When trying the example `build_arg` failed and after looking closer at the output I realised the earthly cli help menu describes it as `build-arg`.

```
   --build-arg value               A build arg override, specified as <key>=[<value>] [$EARTHLY_BUILD_ARGS]
```