### PR TITLE
force apt release to always upload metadata

### DIFF
--- a/release/apt-repo/Earthfile
+++ b/release/apt-repo/Earthfile
@@ -174,8 +174,18 @@ upload:
         grep PUBLIC /release-key/earthly-public.pgp >/dev/null && \
         aws s3 cp --acl public-read /release-key/earthly-public.pgp s3://staging-pkg/earthly.pgp
     # upload signed repo
+    # Note: aws s3 sync doesn't always pickup changes to Release and Packages files, so force a cp to ensure they are uploaded
     RUN --push \
         --mount type=secret,id=+secrets/user/earthly-technologies/aws/credentials,target=/root/.aws/credentials \
+        aws s3 cp --acl public-read /repo/dists/stable/Release s3://staging-pkg/deb/dists/stable/Release && \
+        aws s3 cp --acl public-read /repo/dists/stable/Release.gpg s3://staging-pkg/deb/dists/stable/Release.gpg && \
+        aws s3 cp --acl public-read /repo/dists/stable/InRelease s3://staging-pkg/deb/dists/stable/InRelease && \
+        aws s3 cp --acl public-read /repo/dists/stable/main/binary-amd64/Packages s3://staging-pkg/deb/dists/stable/main/binary-amd64/Packages && \
+        aws s3 cp --acl public-read /repo/dists/stable/main/binary-arm64/Packages s3://staging-pkg/deb/dists/stable/main/binary-arm64/Packages && \
+        aws s3 cp --acl public-read /repo/dists/stable/main/binary-arm7/Packages s3://staging-pkg/deb/dists/stable/main/binary-arm7/Packages && \
+        aws s3 cp --acl public-read /repo/dists/stable/main/binary-amd64/Packages.gz s3://staging-pkg/deb/dists/stable/main/binary-amd64/Packages.gz && \
+        aws s3 cp --acl public-read /repo/dists/stable/main/binary-arm64/Packages.gz s3://staging-pkg/deb/dists/stable/main/binary-arm64/Packages.gz && \
+        aws s3 cp --acl public-read /repo/dists/stable/main/binary-arm7/Packages.gz s3://staging-pkg/deb/dists/stable/main/binary-arm7/Packages.gz && \
         aws s3 sync --acl public-read /repo s3://staging-pkg/deb/
 
 build-and-release:


### PR DESCRIPTION
The aws s3 sync command was sometimes failing to pickup changes to
Release or Package files which resulted in hashes no longer matching.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>