### PR TITLE
force upload of yum repomd.xml data

### DIFF
--- a/release/yum-repo/Earthfile
+++ b/release/yum-repo/Earthfile
@@ -140,6 +140,8 @@ upload:
     # upload signed repo
     RUN --push \
         --mount type=secret,id=+secrets/user/earthly-technologies/aws/credentials,target=/root/.aws/credentials \
+        aws s3 cp --acl public-read /repo/repodata/repomd.xml s3://staging-pkg/rpm/stable/repodata/repomd.xml && \
+        aws s3 cp --acl public-read /repo/repodata/repomd.xml.asc s3://staging-pkg/rpm/stable/repodata/repomd.xml.asc && \
         aws s3 sync --acl public-read /repo s3://staging-pkg/rpm/stable
 
 build-and-release:


### PR DESCRIPTION
aws s3 sync doesn't always detect changes in repomd.xml
which results it a stale repo, force a cp of this file.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>