### PR TITLE
circleci is deprecating 16.04 image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   build:
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-2004:202201-02
     steps:
       - checkout
       - run:


### PR DESCRIPTION
This updates the circle CI image from 16.04 to 20.04

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>