### PR TITLE
fix RUN --ssh WITH DOCKER

### DIFF
--- a/earthfile2llb/interpreter.go
+++ b/earthfile2llb/interpreter.go
@@ -554,6 +554,7 @@ func (i *Interpreter) handleRun(ctx context.Context, cmd spec.Command) error {
 		i.withDocker.Secrets = opts.Secrets
 		i.withDocker.WithShell = withShell
 		i.withDocker.WithEntrypoint = opts.WithEntrypoint
+		i.withDocker.WithSSH = opts.WithSSH
 		i.withDocker.NoCache = opts.NoCache
 		i.withDocker.Interactive = opts.Interactive
 		i.withDocker.interactiveKeep = opts.InteractiveKeep

--- a/earthfile2llb/withdockerrun.go
+++ b/earthfile2llb/withdockerrun.go
@@ -50,6 +50,7 @@ type WithDockerOpt struct {
 	Secrets         []string
 	WithShell       bool
 	WithEntrypoint  bool
+	WithSSH         bool
 	NoCache         bool
 	Interactive     bool
 	interactiveKeep bool
@@ -137,6 +138,7 @@ func (wdr *withDockerRun) Run(ctx context.Context, args []string, opt WithDocker
 		WithEntrypoint:  opt.WithEntrypoint,
 		WithShell:       opt.WithShell,
 		Privileged:      true, // needed for dockerd
+		WithSSH:         opt.WithSSH,
 		NoCache:         opt.NoCache,
 		Interactive:     opt.Interactive,
 		InteractiveKeep: opt.interactiveKeep,

--- a/earthly-entrypoint.sh
+++ b/earthly-entrypoint.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-
 set -e
 
 earthly_config="/etc/.earthly/config.yml"

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -152,6 +152,7 @@ ga:
     BUILD +cache-cmd
     BUILD +ls
     BUILD +ls-subdir
+    BUILD +ssh
 
 # tests that only run on linux amd64
 # Note: this target is used to validate the USERPLATFORM user arg,
@@ -957,6 +958,22 @@ ls-subdir:
     RUN earthly ls ./subdir 2>/dev/null | tee actual
     RUN echo -e "+alpha\n+base\n+bravo\n+charlie" > expected
     RUN diff expected actual
+
+ssh:
+    COPY ssh.earth ./Earthfile
+    RUN ssh-keygen -b 3072 -t rsa -f /root/rsa-key -q -N '' -C 'rsa-key-from-earthly-tests'
+    RUN echo "#!/bin/sh
+set -e
+eval \"\$(ssh-agent)\"
+ssh-add /root/rsa-key
+earthly --config \$earthly_config +test
+earthly --config \$earthly_config -P +test-with-docker
+" >/tmp/test-earthly-script && chmod +x /tmp/test-earthly-script
+    ENV EARTHLY_EXEC_CMD="/tmp/test-earthly-script"
+    RUN --privileged \
+    --entrypoint \
+    --mount=type=tmpfs,target=/tmp/earthly \
+    -- -P
 
 RUN_EARTHLY:
     COMMAND

--- a/tests/ssh.earth
+++ b/tests/ssh.earth
@@ -1,0 +1,13 @@
+VERSION 0.6
+
+test:
+    FROM alpine:3.15
+    RUN apk --update add openssh-client
+    RUN test -z "$SSH_AUTH_SOCK"
+    RUN --ssh test -n "$SSH_AUTH_SOCK" && ssh-add -l | grep 'rsa-key-from-earthly-tests'
+
+test-with-docker:
+    FROM earthly/dind:alpine
+    WITH DOCKER
+        RUN --ssh test -n "$SSH_AUTH_SOCK" && ssh-add -l | grep 'rsa-key-from-earthly-tests'
+    END


### PR DESCRIPTION
This fixes an issue where `--ssh` was not correctly passed to the `WITH
DOCKER` handler.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>