### PR TITLE
Add language sections to tutorial

### DIFF
--- a/docs/basics/part-1-a-simple-earthfile.md
+++ b/docs/basics/part-1-a-simple-earthfile.md
@@ -1,10 +1,17 @@
 # A simple Earthfile
 
-Earthfiles are always named `Earthfile`, regardless of their location in the codebase.
+All the magic of Earthly happens in the Earthfile. Earthfiles are always named `Earthfile`, regardless of their location in the codebase. Below you'll find several example Earthfiles. 
+
+- [Go](#go) 
+- [JavaScript](#javascript) 
+- [Java](#java)
+- [Python](#python)
+
+
+### Go
 
 {% method %}
 {% sample lang="Go" %}
-Here is a sample Earthfile of a Go app
 
 `./Earthfile`
 
@@ -53,7 +60,8 @@ earthly --artifact github.com/earthly/earthly/examples/tutorial/go:main+part1/pa
 {% endhint %}
 
 {% sample lang="JavaScript" %}
-Here is a sample Earthfile of a JS app
+
+### JavaScript
 
 `./Earthfile`
 
@@ -97,7 +105,8 @@ earthly --artifact github.com/earthly/earthly/examples/tutorial/js:main+part1/pa
 {% endhint %}
 
 {% sample lang="Java" %}
-Here is a sample Earthfile of a Java app
+
+### Java
 
 `./Earthfile`
 
@@ -168,7 +177,8 @@ earthly --artifact github.com/earthly/earthly/examples/tutorial/java:main+part1/
 {% endhint %}
 
 {% sample lang="Python" %}
-Here is a sample Earthfile of a Python app
+
+### Python
 
 `./Earthfile`
 

--- a/docs/basics/part-1-a-simple-earthfile.md
+++ b/docs/basics/part-1-a-simple-earthfile.md
@@ -10,9 +10,6 @@ All the magic of Earthly happens in the Earthfile. Earthfiles are always named `
 
 ### Go
 
-{% method %}
-{% sample lang="Go" %}
-
 `./Earthfile`
 
 ```Dockerfile
@@ -59,8 +56,6 @@ earthly --artifact github.com/earthly/earthly/examples/tutorial/go:main+part1/pa
 
 {% endhint %}
 
-{% sample lang="JavaScript" %}
-
 ### JavaScript
 
 `./Earthfile`
@@ -103,8 +98,6 @@ earthly --artifact github.com/earthly/earthly/examples/tutorial/js:main+part1/pa
 ```
 
 {% endhint %}
-
-{% sample lang="Java" %}
 
 ### Java
 
@@ -176,8 +169,6 @@ earthly --artifact github.com/earthly/earthly/examples/tutorial/java:main+part1/
 
 {% endhint %}
 
-{% sample lang="Python" %}
-
 ### Python
 
 `./Earthfile`
@@ -219,8 +210,6 @@ earthly --artifact github.com/earthly/earthly/examples/tutorial/python:main+part
 ```
 
 {% endhint %}
-
-{% endmethod %}
 
 From the example above, you may notice that an Earthfile is very similar to a Dockerfile. This is an intentional design decision. Existing Dockerfiles can easily be ported to Earthly by copying them to an Earthfile and tweaking them slightly.
 

--- a/docs/basics/part-1b-detailed-explanation.md
+++ b/docs/basics/part-1b-detailed-explanation.md
@@ -1,10 +1,17 @@
 
 # Detailed explanation
 
+- [Go](#go) 
+- [JavaScript](#javascript) 
+- [Java](#java)
+- [Python](#python)
+
 Going back to the example Earthfile definition, here is what each command does:
 
 {% method %}
 {% sample lang="Go" %}
+
+### Go
 The Earthfile starts off with a version defintion. This will tell Earthly which features to enable and which ones not to, so that the build script maintains compatibility over time, even if Earthly itself is updated.
 
 ```Dockerfile
@@ -76,7 +83,7 @@ Save the current state as a docker image, which will have the docker tag `go-exa
 ```Dockerfile
 SAVE IMAGE go-example:latest
 ```
-
+### JavaScript
 {% sample lang="JavaScript" %}
 The Earthfile starts off with a version defintion. This will tell Earthly which features to enable and which ones not to, so that the build script maintains compatibility over time, even if Earthly itself is updated.
 
@@ -149,7 +156,7 @@ if the entire build succeeds.
 ```
     SAVE IMAGE js-example:latest
 ```
-
+### Java
 {% sample lang="Java" %}
 The Earthfile starts off with a version defintion. This will tell Earthly which features to enable and which ones not to, so that the build script maintains compatibility over time, even if Earthly itself is updated.
 
@@ -240,6 +247,8 @@ docker if the entire build succeeds.
 ```
     SAVE IMAGE java-example:latest
 ```
+
+### Python
 {% sample lang="Python" %}
 The Earthfile starts off with a version defintion. This will tell Earthly which features to enable and which ones not to, so that the build script maintains compatibility over time, even if Earthly itself is updated.
 

--- a/docs/basics/part-1b-detailed-explanation.md
+++ b/docs/basics/part-1b-detailed-explanation.md
@@ -8,9 +8,6 @@
 
 Going back to the example Earthfile definition, here is what each command does:
 
-{% method %}
-{% sample lang="Go" %}
-
 ### Go
 The Earthfile starts off with a version defintion. This will tell Earthly which features to enable and which ones not to, so that the build script maintains compatibility over time, even if Earthly itself is updated.
 
@@ -157,7 +154,6 @@ if the entire build succeeds.
     SAVE IMAGE js-example:latest
 ```
 ### Java
-{% sample lang="Java" %}
 The Earthfile starts off with a version defintion. This will tell Earthly which features to enable and which ones not to, so that the build script maintains compatibility over time, even if Earthly itself is updated.
 
 ```Dockerfile
@@ -249,7 +245,6 @@ docker if the entire build succeeds.
 ```
 
 ### Python
-{% sample lang="Python" %}
 The Earthfile starts off with a version defintion. This will tell Earthly which features to enable and which ones not to, so that the build script maintains compatibility over time, even if Earthly itself is updated.
 
 ```Dockerfile
@@ -317,7 +312,6 @@ if the entire build succeeds.
 ```
     SAVE IMAGE python-example:latest
 ```
-{% endmethod %}
 
 {% hint style='info' %}
 ##### Note

--- a/docs/basics/part-2-running-the-build.md
+++ b/docs/basics/part-2-running-the-build.md
@@ -1,6 +1,6 @@
 # Running the build
 
-In this example, we can see two explicit targets: `build` and `docker`. In order to execute the build, we can run, for example:
+In the example `Earthfile` we have defined two explicit targets: `+build` and `+docker`. When we run Earthly, we can tell it to execute either target by passing the target name. In this case our docker target calls on our build target, so we can run both with:
 
 ```bash
 earthly +docker

--- a/docs/basics/part-2-running-the-build.md
+++ b/docs/basics/part-2-running-the-build.md
@@ -20,29 +20,20 @@ Finally, notice how the output of the build (the docker image and the files) are
 
 Once the build has executed, we can run the resulting docker image to try it out:
 
-{% method %}
-{% sample lang="Go" %}
+
 
 ```
 docker run --rm go-example:latest
 ```
 
-{% sample lang="JavaScript" %}
-
 ```
 docker run --rm js-example:latest
 ```
-
-{% sample lang="Java" %}
 
 ```
 docker run --rm java-example:latest
 ```
 
-{% sample lang="Python" %}
-
 ```
 docker run --rm python-example:latest
 ```
-
-{% endmethod %}

--- a/docs/basics/part-3-adding-dependencies.md
+++ b/docs/basics/part-3-adding-dependencies.md
@@ -10,9 +10,6 @@ Now Let's imagine that we want to add some dependancies to our app. Here's how o
 
 ### Go
 
-{% method %}
-{% sample lang="Go" %}
-
 `./go.mod`
 
 ```go.mod
@@ -74,7 +71,7 @@ earthly --artifact github.com/earthly/earthly/examples/tutorial/go:main+part3/pa
 {% endhint %}
 
 ### Javascript
-{% sample lang="JavaScript" %}
+
 `./package.json`
 
 ```json
@@ -171,7 +168,6 @@ earthly --artifact github.com/earthly/earthly/examples/tutorial/js:main+part3/pa
 {% endhint %}
 
 ### Java
-{% sample lang="Java" %}
 
 `./build.gradle`
 
@@ -252,7 +248,7 @@ earthly --artifact github.com/earthly/earthly/examples/tutorial/java:main+part3/
 {% endhint %}
 
 ### Python
-{% sample lang="Python" %}
+
 `./requirements.txt`
 
 ```
@@ -306,8 +302,6 @@ To copy the files for [this example ( Part 3 )](https://github.com/earthly/earth
 earthly --artifact github.com/earthly/earthly/examples/tutorial/python:main+part3/part3 ./part3
 ```
 {% endhint %}
-
-{% endmethod %}
 
 However, as we build this new setup and make changes to the main source code, we notice that the dependencies are downloaded every single time we change the source code. While the build is not necessarily incorrect, it is inefficient for proper development speed.
 

--- a/docs/basics/part-3-adding-dependencies.md
+++ b/docs/basics/part-3-adding-dependencies.md
@@ -1,7 +1,14 @@
 
 # Adding dependencies
 
-Let's imagine now that in our simple app, we now want to add a programming language dependency. Here's how our build might look like as a result
+Now Let's imagine that we want to add some dependancies to our app. Here's how our build might look as a result.
+
+- [Go](#go) 
+- [JavaScript](#javascript) 
+- [Java](#java)
+- [Python](#python)
+
+### Go
 
 {% method %}
 {% sample lang="Go" %}
@@ -66,6 +73,7 @@ earthly --artifact github.com/earthly/earthly/examples/tutorial/go:main+part3/pa
 ```
 {% endhint %}
 
+### Javascript
 {% sample lang="JavaScript" %}
 `./package.json`
 
@@ -162,6 +170,7 @@ earthly --artifact github.com/earthly/earthly/examples/tutorial/js:main+part3/pa
 ```
 {% endhint %}
 
+### Java
 {% sample lang="Java" %}
 
 `./build.gradle`
@@ -242,6 +251,7 @@ earthly --artifact github.com/earthly/earthly/examples/tutorial/java:main+part3/
 ```
 {% endhint %}
 
+### Python
 {% sample lang="Python" %}
 `./requirements.txt`
 

--- a/docs/basics/part-4-caching-dependencies.md
+++ b/docs/basics/part-4-caching-dependencies.md
@@ -1,9 +1,16 @@
 # Caching dependencies
 
-The reason the build is inefficient is because we have not made proper use of caching. When a file changes, the corresponding `COPY` command is re-executed without cache, causing all commands after it to also re-execute without cache.
+In the previous step we added some dependancies to our Earthfile. This works, but it is inefficient because we have not made proper use of caching. In the current setup, when a file changes, the corresponding `COPY` command is re-executed without cache, causing all commands after it to also re-execute without cache.
 
 If, however, we could first download the dependencies and only afterwards copy and build the code, then the cache would be reused every time we changed the code.
 
+- [Go](#go) 
+- [JavaScript](#javascript) 
+- [Java](#java)
+- [Python](#python)
+
+
+### Go
 {% method %}
 {% sample lang="Go" %}
 `./Earthfile`
@@ -38,6 +45,7 @@ earthly --artifact github.com/earthly/earthly/examples/tutorial/go:main+part4/pa
 ```
 {% endhint %}
 
+### JavaScript
 {% sample lang="JavaScript" %}
 `./Earthfile`
 
@@ -75,6 +83,7 @@ earthly --artifact github.com/earthly/earthly/examples/tutorial/js:main+part4/pa
 ```
 {% endhint %}
 
+### Java
 {% sample lang="Java" %}
 `./Earthfile`
 
@@ -112,6 +121,7 @@ earthly --artifact github.com/earthly/earthly/examples/tutorial/java:main+part4/
 ```
 {% endhint %}
 
+### Python
 {% sample lang="Python" %}
 
 `./Earthfile`

--- a/docs/basics/part-4-caching-dependencies.md
+++ b/docs/basics/part-4-caching-dependencies.md
@@ -11,8 +11,7 @@ If, however, we could first download the dependencies and only afterwards copy a
 
 
 ### Go
-{% method %}
-{% sample lang="Go" %}
+
 `./Earthfile`
 
 ```Dockerfile
@@ -46,7 +45,7 @@ earthly --artifact github.com/earthly/earthly/examples/tutorial/go:main+part4/pa
 {% endhint %}
 
 ### JavaScript
-{% sample lang="JavaScript" %}
+
 `./Earthfile`
 
 ```Dockerfile
@@ -84,7 +83,7 @@ earthly --artifact github.com/earthly/earthly/examples/tutorial/js:main+part4/pa
 {% endhint %}
 
 ### Java
-{% sample lang="Java" %}
+
 `./Earthfile`
 
 ```Dockerfile
@@ -122,7 +121,6 @@ earthly --artifact github.com/earthly/earthly/examples/tutorial/java:main+part4/
 {% endhint %}
 
 ### Python
-{% sample lang="Python" %}
 
 `./Earthfile`
 
@@ -159,6 +157,5 @@ To copy the files for [this example ( Part 4 )](https://github.com/earthly/earth
 earthly --artifact github.com/earthly/earthly/examples/tutorial/python:main+part4/part4 ./part4
 ```
 {% endhint %}
-{% endmethod %}
 
 For a primer into Dockerfile layer caching see [this article](https://pythonspeed.com/articles/docker-caching-model/). The same principles apply to Earthfiles.

--- a/docs/basics/part-5-reducing-code-duplication.md
+++ b/docs/basics/part-5-reducing-code-duplication.md
@@ -11,8 +11,7 @@ Note that in our case, only the JavaScript version has an example where `FROM +d
 
 
 ### Go
-{% method %}
-{% sample lang="Go" %}
+
 `./Earthfile`
 
 ```Dockerfile
@@ -50,7 +49,7 @@ earthly --artifact github.com/earthly/earthly/examples/tutorial/go:main+part5/pa
 {% endhint %}
 
 ### JavaScript
-{% sample lang="JavaScript" %}
+
 `./Earthfile`
 
 ```Dockerfile
@@ -92,7 +91,7 @@ earthly --artifact github.com/earthly/earthly/examples/tutorial/js:main+part5/pa
 {% endhint %}
 
 ### Java
-{% sample lang="Java" %}
+
 `./Earthfile`
 
 ```Dockerfile
@@ -131,7 +130,7 @@ earthly --artifact github.com/earthly/earthly/examples/tutorial/java:main+part5/
 {% endhint %}
 
 ### Python
-{% sample lang="Python" %}
+
 `./Earthfile`
 
 ```Dockerfile
@@ -168,5 +167,3 @@ To copy the files for [this example ( Part 5 )](https://github.com/earthly/earth
 earthly --artifact github.com/earthly/earthly/examples/tutorial/python:main+part5/part5 ./part5
 ```
 {% endhint %}
-
-{% endmethod %}

--- a/docs/basics/part-5-reducing-code-duplication.md
+++ b/docs/basics/part-5-reducing-code-duplication.md
@@ -4,6 +4,13 @@ In some cases, the dependencies might be used in more than one build target. For
 
 Note that in our case, only the JavaScript version has an example where `FROM +deps` is used in more than one place: both in `build` and in `docker`. Nevertheless, all versions show how dependencies may be separated.
 
+- [Go](#go) 
+- [JavaScript](#javascript) 
+- [Java](#java)
+- [Python](#python)
+
+
+### Go
 {% method %}
 {% sample lang="Go" %}
 `./Earthfile`
@@ -42,6 +49,7 @@ earthly --artifact github.com/earthly/earthly/examples/tutorial/go:main+part5/pa
 ```
 {% endhint %}
 
+### JavaScript
 {% sample lang="JavaScript" %}
 `./Earthfile`
 
@@ -83,6 +91,7 @@ earthly --artifact github.com/earthly/earthly/examples/tutorial/js:main+part5/pa
 ```
 {% endhint %}
 
+### Java
 {% sample lang="Java" %}
 `./Earthfile`
 
@@ -121,6 +130,7 @@ earthly --artifact github.com/earthly/earthly/examples/tutorial/java:main+part5/
 ```
 {% endhint %}
 
+### Python
 {% sample lang="Python" %}
 `./Earthfile`
 


### PR DESCRIPTION
[Gitbook link](https://docs.earthly.dev/~/revisions/rrmLhAaanneYk5ykOWnh/)

Biggest change was to make it easier to differentiate between examples based on programming language. It was particularly difficult to pick out the beginning and end of say, the Javascript section, in Part1b: Detailed Explanation, but thought this would be beneficial on all pages. 

It would have been cool to do this with [tabs](https://docs.gitbook.com/editing-content/rich-content/with-command-palette#tabs) but I could not figure out how to do that outside of the Gitbook UI. Do changes made in the UI re sync with this repo? Wasn't sure how much we wanted to stick to standard markdown for now.

Other than that I made a couple small changes to wording to add a little context. 