### PR TITLE
Fix inferring WITH DOCKER --load image name doesn't work well in combination with compose

### DIFF
--- a/ast/tests/with-docker-compose.ast.json
+++ b/ast/tests/with-docker-compose.ast.json
@@ -56,6 +56,14 @@
             "execMode": true,
             "name": "CMD"
           }
+        },
+        {
+          "command": {
+            "args": [
+              "print-countries:latest"
+            ],
+            "name": "SAVE IMAGE"
+          }
         }
       ]
     },
@@ -128,7 +136,7 @@
                 "--service",
                 "postgres",
                 "--load",
-                "print-countries:latest=+print-countries"
+                "+print-countries"
               ],
               "name": "DOCKER"
             }

--- a/tests/with-docker-compose/Earthfile
+++ b/tests/with-docker-compose/Earthfile
@@ -13,6 +13,7 @@ all:
 print-countries:
     FROM jbergknoff/postgresql-client:latest
     CMD ["-c", "SELECT * FROM country WHERE country_id = '76'"]
+    SAVE IMAGE print-countries:latest
 
 test:
     RUN apk add postgresql-client
@@ -22,7 +23,7 @@ test:
     WITH DOCKER \
             --compose docker-compose.yml \
             --service postgres \
-            --load print-countries:latest=+print-countries
+            --load +print-countries
         RUN while ! pg_isready --host=localhost --port=5432 --dbname=iso3166 --username=postgres; do sleep 1; done ;\
             docker-compose up --exit-code-from print-countries print-countries | grep Brazil
     END


### PR DESCRIPTION
In the following, `earthly/redis:main` is not detected properly when used in `WITH DOCKER --load`. This PR fixes that.

```Earthly
redis:
    FROM redis:6.2
    SAVE IMAGE earthly/redis:main

integration-test:
    FROM earthly/dind:alpine
    WORKDIR /workspace
    COPY ./docker-compose.yml ./
    WITH DOCKER \
            --compose docker-compose.yml \
            --service=redis \
            --load=+redis \
            --load=+logstream-integration
        RUN docker-compose up --exit-code-from=integration integration
    END
```