### PR TITLE
Try to fallback to CNI gateway when regular address fails.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 - Podman can now use credentials from the default location [#1644](https://github.com/earthly/earthly/issues/1644)
 - Podman can now use the local registry cache without modifying `registries.conf` [#1675](https://github.com/earthly/earthly/pull/1675)
 - Podman can now use `WITH DOCKER --load` inside a target marked as `LOCALLY` [#1675](https://github.com/earthly/earthly/pull/1675)
+- Interactive sessions should now work with rootless configurations that have no apparent external IP address [#1573](https://github.com/earthly/earthly/issues/1573), [#1689](https://github.com/earthly/earthly/pull/1689)
 
 ## v0.6.8 - 2022-02-16
 

--- a/cmd/debugger/main.go
+++ b/cmd/debugger/main.go
@@ -21,7 +21,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const cniFallbackHost = "172.30.0.1:8373"
+const cniGateway = "172.30.0.1:8373"
 
 var (
 	// Version is the version of the debugger
@@ -89,14 +89,14 @@ func populateShellHistory(cmd string) error {
 func interactiveMode(ctx context.Context, remoteConsoleAddr string, cmdBuilder func() (*exec.Cmd, error)) error {
 	log := slog.GetLogger(ctx)
 
-	conn, err := net.Dial("tcp", remoteConsoleAddr)
+	conn, err := net.Dial("tcp", cniGateway)
 	if err != nil {
 		// If the IP we derived at start fails, try the reserved gateway address for our internal CNI network.
 		// The CIDR range for this can be found in buildkitd/cni-conf.json.template, so if that ever changes, we need to change it here, too.
 		// Relevant CNI docs for the host-local ipam module: https://www.cni.dev/plugins/current/ipam/host-local/
 		// tl;dr we can assume the gateway is at .1 in the subnet.
-		log.Debug(fmt.Sprintf("failed to connect to %q", trying internal CNI fallback \"%s\".", remoteConsoleAddr, cniFallbackHost))
-		conn, err = net.Dial("tcp", cniFallbackHost)
+		log.Debug(fmt.Sprintf("failed to connect internal CNI %q, trying configured address %q.", cniGateway, remoteConsoleAddr))
+		conn, err = net.Dial("tcp", remoteConsoleAddr)
 		if err != nil {
 			return errors.Wrap(err, "failed to connect to remote debugger")
 		}

--- a/cmd/debugger/main.go
+++ b/cmd/debugger/main.go
@@ -89,12 +89,12 @@ func populateShellHistory(cmd string) error {
 func interactiveMode(ctx context.Context, remoteConsoleAddr string, cmdBuilder func() (*exec.Cmd, error)) error {
 	log := slog.GetLogger(ctx)
 
+	// If the IP we derived at start fails, try the reserved gateway address for our internal CNI network.
+	// The CIDR range for this can be found in buildkitd/cni-conf.json.template, so if that ever changes, we need to change it here, too.
+	// Relevant CNI docs for the host-local ipam module: https://www.cni.dev/plugins/current/ipam/host-local/
+	// tl;dr we can assume the gateway is at .1 in the subnet.
 	conn, err := net.Dial("tcp", cniGateway)
 	if err != nil {
-		// If the IP we derived at start fails, try the reserved gateway address for our internal CNI network.
-		// The CIDR range for this can be found in buildkitd/cni-conf.json.template, so if that ever changes, we need to change it here, too.
-		// Relevant CNI docs for the host-local ipam module: https://www.cni.dev/plugins/current/ipam/host-local/
-		// tl;dr we can assume the gateway is at .1 in the subnet.
 		log.Debug(fmt.Sprintf("failed to connect internal CNI %q, trying configured address %q.", cniGateway, remoteConsoleAddr))
 		conn, err = net.Dial("tcp", remoteConsoleAddr)
 		if err != nil {

--- a/cmd/debugger/main.go
+++ b/cmd/debugger/main.go
@@ -95,7 +95,7 @@ func interactiveMode(ctx context.Context, remoteConsoleAddr string, cmdBuilder f
 		// The CIDR range for this can be found in buildkitd/cni-conf.json.template, so if that ever changes, we need to change it here, too.
 		// Relevant CNI docs for the host-local ipam module: https://www.cni.dev/plugins/current/ipam/host-local/
 		// tl;dr we can assume the gateway is at .1 in the subnet.
-		log.Debug(fmt.Sprintf("Failed to connect to \"%s\", trying internal CNI fallback \"%s\".", remoteConsoleAddr, cniFallbackHost))
+		log.Debug(fmt.Sprintf("failed to connect to %q", trying internal CNI fallback \"%s\".", remoteConsoleAddr, cniFallbackHost))
 		conn, err = net.Dial("tcp", cniFallbackHost)
 		if err != nil {
 			return errors.Wrap(err, "failed to connect to remote debugger")


### PR DESCRIPTION
According to the CNI spec, our `host-local` ipam module will always put the gateway at `.1` inside our subnet. If the derived address from the config fails to connect, fallback and try the internal CNI gateway. Should improve compatibility when the container does not have an IP, such as rootless configurations.

Fixes #1573.
