### PR TITLE
Flip on exec-after-parallel feature flag

### DIFF
--- a/.earthly_version_flag_overrides
+++ b/.earthly_version_flag_overrides
@@ -1,1 +1,1 @@
-referenced-save-only,use-copy-include-patterns,earthly-version-arg,use-cache-command,use-host-command,check-duplicate-images,exec-after-parallel
+referenced-save-only,use-copy-include-patterns,earthly-version-arg,use-cache-command,use-host-command,check-duplicate-images

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 
 ### Added
 
+- Earthly is now 15-30% faster when executing large builds [#1589](https://github.com/earthly/earthly/issues/1589)
 - Experimental `HOST` command, which can be used like this: `HOST <domain> <ip>` to add additional hosts during the execution of your build. To enable this feature, use `VERSION --use-host-command 0.6`. [#1168](https://github.com/earthly/earthly/issues/1168)
 
 ### Fixed

--- a/config/config.go
+++ b/config/config.go
@@ -23,7 +23,7 @@ const (
 	DefaultBuildkitScheme = "docker-container"
 
 	// DefaultConversionParallelism is the default conversion parallelism that Earthly uses internally to generate LLB for BuildKit to consume.
-	DefaultConversionParallelism = 4
+	DefaultConversionParallelism = 10
 
 	// DefaultBuildkitMaxParallelism is the default max parallelism for buildkit workers.
 	DefaultBuildkitMaxParallelism = 20

--- a/features/features.go
+++ b/features/features.go
@@ -172,12 +172,12 @@ func GetFeatures(version *spec.Version) (*Features, error) {
 		ftrs.ForIn = true
 		ftrs.RequireForceForUnsafeSaves = true
 		ftrs.NoImplicitIgnore = true
+		ftrs.ExecAfterParallel = true
 	case versionAtLeast(ftrs, 0, 7):
 		ftrs.ExplicitGlobal = true
 		ftrs.CheckDuplicateImages = true
 		ftrs.EarthlyVersionArg = true
 		ftrs.UseCacheCommand = true
-		ftrs.ExecAfterParallel = true
 		ftrs.UseHostCommand = true
 	}
 


### PR DESCRIPTION
This is a flag that does not affect compatibility (so it can be safely turned on in 0.6). It has been turned off so far, to help with rolling out gradually. We've used this internally for a few weeks without any issues and it's now time for this feature to see the light of day.

The flip of this switch will make Earthly 15-30% faster for large builds.

Original PR: https://github.com/earthly/earthly/pull/1602.

Re #1589.