### PR TITLE
Use the equivalent of `COPY --link`, which is based on an LLB MergeOp

### DIFF
--- a/.earthly_version_flag_overrides
+++ b/.earthly_version_flag_overrides
@@ -1,1 +1,1 @@
-referenced-save-only,use-copy-include-patterns,earthly-version-arg,use-cache-command,use-host-command,check-duplicate-images
+referenced-save-only,use-copy-include-patterns,earthly-version-arg,use-cache-command,use-host-command,check-duplicate-images,use-copy-link

--- a/buildcontext/git.go
+++ b/buildcontext/git.go
@@ -65,7 +65,7 @@ func (gr *gitResolver) resolveEarthProject(ctx context.Context, gwClient gwclien
 			buildContextFactory = llbfactory.PreconstructedState(rgp.state)
 		} else {
 			buildContextFactory = llbfactory.PreconstructedState(llbutil.CopyOp(
-				rgp.state, []string{subDir}, llbutil.ScratchWithPlatform(), "./", false, false, false, "root:root", false, false,
+				rgp.state, []string{subDir}, llbutil.ScratchWithPlatform(), "./", false, false, false, "root:root", false, false, false,
 				llb.WithCustomNamef("[internal] COPY git context %s", ref.String())))
 		}
 	} else {

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -275,6 +275,7 @@ func (c *Converter) FromDockerfile(ctx context.Context, contextPath string, dfPa
 		BuildContextFactory = llbfactory.PreconstructedState(llbutil.CopyOp(
 			mts.Final.ArtifactsState, []string{contextArtifact.Artifact},
 			llbutil.ScratchWithPlatform(), "/", true, true, false, "", false, false,
+			c.ftrs.UseCopyLink,
 			llb.WithCustomNamef(
 				"[internal] FROM DOCKERFILE (copy build context from) %s%s",
 				joinWrap(buildArgs, "(", " ", ") "), contextArtifact.String())))
@@ -446,6 +447,7 @@ func (c *Converter) CopyArtifact(ctx context.Context, artifactName string, dest 
 	c.mts.Final.MainState = llbutil.CopyOp(
 		relevantDepState.ArtifactsState, []string{artifact.Artifact},
 		c.mts.Final.MainState, dest, true, isDir, keepTs, c.copyOwner(keepOwn, chown), ifExists, symlinkNoFollow,
+		c.ftrs.UseCopyLink,
 		llb.WithCustomNamef(
 			"%sCOPY %s%s%s%s%s %s",
 			c.vertexPrefix(false, false),
@@ -479,6 +481,7 @@ func (c *Converter) CopyClassical(ctx context.Context, srcs []string, dest strin
 		srcState,
 		srcs,
 		c.mts.Final.MainState, dest, true, isDir, keepTs, c.copyOwner(keepOwn, chown), ifExists, false,
+		c.ftrs.UseCopyLink,
 		llb.WithCustomNamef(
 			"%sCOPY %s%s%s %s",
 			c.vertexPrefix(false, false),
@@ -694,6 +697,7 @@ func (c *Converter) SaveArtifact(ctx context.Context, saveFrom string, saveTo st
 	c.mts.Final.ArtifactsState = llbutil.CopyOp(
 		pcState, []string{saveFrom}, c.mts.Final.ArtifactsState,
 		saveToAdjusted, true, true, keepTs, own, ifExists, symlinkNoFollow,
+		c.ftrs.UseCopyLink,
 		llb.WithCustomNamef(
 			"%sSAVE ARTIFACT %s%s%s %s",
 			c.vertexPrefix(false, false),
@@ -712,6 +716,7 @@ func (c *Converter) SaveArtifact(ctx context.Context, saveFrom string, saveTo st
 			separateArtifactsState = llbutil.CopyOp(
 				pushState, []string{saveFrom}, separateArtifactsState,
 				saveToAdjusted, true, true, keepTs, "root:root", ifExists, symlinkNoFollow,
+				c.ftrs.UseCopyLink,
 				llb.WithCustomNamef(
 					"%sSAVE ARTIFACT %s%s%s %s AS LOCAL %s",
 					c.vertexPrefix(false, false),
@@ -724,6 +729,7 @@ func (c *Converter) SaveArtifact(ctx context.Context, saveFrom string, saveTo st
 			separateArtifactsState = llbutil.CopyOp(
 				pcState, []string{saveFrom}, separateArtifactsState,
 				saveToAdjusted, true, true, keepTs, "root:root", ifExists, symlinkNoFollow,
+				c.ftrs.UseCopyLink,
 				llb.WithCustomNamef(
 					"%sSAVE ARTIFACT %s%s%s %s AS LOCAL %s",
 					c.vertexPrefix(false, false),
@@ -836,6 +842,7 @@ func (c *Converter) SaveArtifactFromLocal(ctx context.Context, saveFrom, saveTo 
 	c.mts.Final.ArtifactsState = llbutil.CopyOp(
 		c.mts.Final.MainState, []string{absSaveTo}, c.mts.Final.ArtifactsState,
 		absSaveTo, true, true, keepTs, own, ifExists, false,
+		c.ftrs.UseCopyLink,
 	)
 	err = c.forceExecution(ctx, c.mts.Final.ArtifactsState)
 	if err != nil {
@@ -1139,7 +1146,7 @@ func (c *Converter) GitClone(ctx context.Context, gitURL string, branch string, 
 	gitState := pllb.Git(gitURL, branch, gitOpts...)
 	c.mts.Final.MainState = llbutil.CopyOp(
 		gitState, []string{"."}, c.mts.Final.MainState, dest, false, false, keepTs,
-		c.mts.Final.MainImage.Config.User, false, false,
+		c.mts.Final.MainImage.Config.User, false, false, c.ftrs.UseCopyLink,
 		llb.WithCustomNamef(
 			"%sCOPY GIT CLONE (--branch %s) %s TO %s", c.vertexPrefix(false, false),
 			branch, gitURLScrubbed, dest))

--- a/features/features.go
+++ b/features/features.go
@@ -29,6 +29,7 @@ type Features struct {
 	UseCacheCommand            bool `long:"use-cache-command" description:"allow use of CACHE command in Earthfiles"`
 	UseHostCommand             bool `long:"use-host-command" description:"allow use of HOST command in Earthfiles"`
 	ExecAfterParallel          bool `long:"exec-after-parallel" description:"force execution after parallel conversion"`
+	UseCopyLink                bool `long:"use-copy-link" description:"use the equivalent of COPY --link for all copy-like operations"`
 
 	Major int
 	Minor int
@@ -179,6 +180,7 @@ func GetFeatures(version *spec.Version) (*Features, error) {
 		ftrs.EarthlyVersionArg = true
 		ftrs.UseCacheCommand = true
 		ftrs.UseHostCommand = true
+		ftrs.UseCopyLink = true
 	}
 
 	return &ftrs, nil

--- a/util/llbutil/copyop.go
+++ b/util/llbutil/copyop.go
@@ -15,7 +15,7 @@ import (
 )
 
 // CopyOp is a simplified llb copy operation.
-func CopyOp(srcState pllb.State, srcs []string, destState pllb.State, dest string, allowWildcard bool, isDir bool, keepTs bool, chown string, ifExists, symlinkNoFollow bool, opts ...llb.ConstraintsOpt) pllb.State {
+func CopyOp(srcState pllb.State, srcs []string, destState pllb.State, dest string, allowWildcard bool, isDir bool, keepTs bool, chown string, ifExists, symlinkNoFollow, merge bool, opts ...llb.ConstraintsOpt) pllb.State {
 	destAdjusted := dest
 	if dest == "." || dest == "" || len(srcs) > 1 {
 		destAdjusted += string("/") // TODO: needs to be the containers platform, not the earthly hosts platform. For now, this is always Linux.
@@ -58,6 +58,9 @@ func CopyOp(srcState pllb.State, srcs []string, destState pllb.State, dest strin
 	}
 	if fa == nil {
 		return destState
+	}
+	if merge && chown == "" {
+		return pllb.Merge([]pllb.State{destState, pllb.Scratch().File(fa)}, opts...)
 	}
 	return destState.File(fa, opts...)
 }

--- a/util/llbutil/pllb/state.go
+++ b/util/llbutil/pllb/state.go
@@ -56,6 +56,17 @@ func Git(remote, ref string, opts ...llb.GitOption) State {
 	return State{st: llb.Git(remote, ref, opts...)}
 }
 
+// Merge is a wrapper around llb.Merge.
+func Merge(sts []State, opts ...llb.ConstraintsOpt) State {
+	sts2 := make([]llb.State, len(sts))
+	for i, st := range sts {
+		sts2[i] = st.st
+	}
+	gmu.Lock()
+	defer gmu.Unlock()
+	return State{st: llb.Merge(sts2, opts...)}
+}
+
 // RawState returns the wrapped llb.State, but requires an unlock from the caller.
 func (s State) RawState() (llb.State, func()) {
 	gmu.Lock()


### PR DESCRIPTION
This helps with slightly improved cache reuse in a series of consecutive COPY operations.