### PR TITLE
Change ARG shell-execution

### DIFF
--- a/.earthly_version_flag_overrides
+++ b/.earthly_version_flag_overrides
@@ -1,1 +1,1 @@
-referenced-save-only,use-copy-include-patterns,earthly-version-arg,use-cache-command,use-host-command,check-duplicate-images,use-copy-link,parallel-load
+referenced-save-only,use-copy-include-patterns,earthly-version-arg,use-cache-command,use-host-command,check-duplicate-images,use-copy-link,parallel-load,shell-out-anywhere

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 
 - Earthly is now 15-30% faster when executing large builds [#1589](https://github.com/earthly/earthly/issues/1589)
 - Experimental `HOST` command, which can be used like this: `HOST <domain> <ip>` to add additional hosts during the execution of your build. To enable this feature, use `VERSION --use-host-command 0.6`. [#1168](https://github.com/earthly/earthly/issues/1168)
+- Ability to shell-out in any Earthly command, (e.g. `SAVE IMAGE myimage:$(cat version)`), as well as in the middle of ARG strings. To enable this feature, use `VERSION --shell-out-anywhere 0.6`.
 
 ### Fixed
 

--- a/ast/tests/with-docker.ast.json
+++ b/ast/tests/with-docker.ast.json
@@ -24,6 +24,14 @@
         {
           "command": {
             "args": [
+              "+docker-load-shellout-test"
+            ],
+            "name": "BUILD"
+          }
+        },
+        {
+          "command": {
+            "args": [
               "+docker-load-arg-test"
             ],
             "name": "BUILD"
@@ -209,6 +217,58 @@
       ]
     },
     {
+      "name": "a-test-image-with-shell-out",
+      "recipe": [
+        {
+          "command": {
+            "args": [
+              "alpine:3.15"
+            ],
+            "name": "FROM"
+          }
+        },
+        {
+          "command": {
+            "args": [
+              "echo",
+              "c2hlbGxvdXQ=",
+              ">",
+              "data"
+            ],
+            "name": "RUN"
+          }
+        },
+        {
+          "command": {
+            "args": [
+              "echo",
+              "myver",
+              ">",
+              "version"
+            ],
+            "name": "RUN"
+          }
+        },
+        {
+          "command": {
+            "args": [
+              "echo",
+              "\"you found me\""
+            ],
+            "name": "ENTRYPOINT"
+          }
+        },
+        {
+          "command": {
+            "args": [
+              "\"test-img-with-$(cat data | base64 -d)\":\"$(cat version)\""
+            ],
+            "name": "SAVE IMAGE"
+          }
+        }
+      ]
+    },
+    {
       "name": "docker-load-test",
       "recipe": [
         {
@@ -254,6 +314,36 @@
                 "hello-world",
                 "--load",
                 "+a-test-image"
+              ],
+              "name": "DOCKER"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "docker-load-shellout-test",
+      "recipe": [
+        {
+          "with": {
+            "body": [
+              {
+                "command": {
+                  "args": [
+                    "docker",
+                    "run",
+                    "test-img-with-shellout:myver",
+                    "|",
+                    "grep",
+                    "\"you found me\""
+                  ],
+                  "name": "RUN"
+                }
+              }
+            ],
+            "command": {
+              "args": [
+                "--load=+a-test-image-with-shell-out"
               ],
               "name": "DOCKER"
             }
@@ -702,6 +792,7 @@
   "version": {
     "args": [
       "--parallel-load",
+      "--shell-out-anywhere",
       "0.6"
     ]
   }

--- a/earthfile2llb/withdockerrun.go
+++ b/earthfile2llb/withdockerrun.go
@@ -444,7 +444,7 @@ func makeWithDockerdWrapFun(dindID string, tarPaths []string, opt WithDockerOpt)
 		envVars2 := append(params, envVars...)
 		return []string{
 			"/bin/sh", "-c",
-			strWithEnvVarsAndDocker(args, envVars2, isWithShell, withDebugger, forceDebugger, true, "", ""),
+			strWithEnvVarsAndDocker(args, envVars2, isWithShell, withDebugger, forceDebugger, true, false, "", ""),
 		}
 	}
 }

--- a/features/features.go
+++ b/features/features.go
@@ -31,6 +31,7 @@ type Features struct {
 	ExecAfterParallel          bool `long:"exec-after-parallel" description:"force execution after parallel conversion"`
 	UseCopyLink                bool `long:"use-copy-link" description:"use the equivalent of COPY --link for all copy-like operations"`
 	ParallelLoad               bool `long:"parallel-load" description:"perform parallel loading of images into WITH DOCKER"`
+	ShellOutAnywhere           bool `long:"shell-out-anywhere" description:"allow shelling-out in the middle of ARGs, or any other command"`
 
 	Major int
 	Minor int
@@ -127,9 +128,9 @@ func ApplyFlagOverrides(ftrs *Features, envOverrides string) error {
 
 var errUnexpectedArgs = fmt.Errorf("unexpected VERSION arguments; should be VERSION [flags] <major-version>.<minor-version>")
 
-func instrumentVersion(_ string, opt *goflags.Option, s *string) *string {
+func instrumentVersion(_ string, opt *goflags.Option, s *string) (*string, error) {
 	analytics.Count("version-feature-flags", opt.LongName)
-	return s // don't modify the flag, just pass it back.
+	return s, nil // don't modify the flag, just pass it back.
 }
 
 // GetFeatures returns a features struct for a particular version

--- a/tests/shell-out/Earthfile
+++ b/tests/shell-out/Earthfile
@@ -16,16 +16,33 @@ WORKDIR /test
 
 test-all:
     BUILD +test-old
+    BUILD +test-old2
+    BUILD +test-old-works-with-new
+    BUILD +test-new
+    BUILD +test-new-shellout-errors-are-detected
 
-# TODO shelling-out functionality will change in a follow-up PR;
-# for now, we will test the current behaviour (which will become the old behaviour)
 test-old:
     DO +RUN_EARTHLY_ARGS --earthfile=old.earth --target=+test
     DO +RUN_EARTHLY_ARGS --earthfile=old-no-middle-shell-out.earth --target=+test
     DO +RUN_EARTHLY_ARGS --earthfile=old-ignore-shellout-errors.earth --target=+test
     DO +RUN_EARTHLY_ARGS --earthfile=old-fail1.earth --target=+test --should_fail=true --output_contains="/valid-\$.echo file..: not found"
     DO +RUN_EARTHLY_ARGS --earthfile=old-fail2.earth --target=+test --should_fail=true --output_contains="invalid env key definition \$key"
+
+test-old2:
     DO +RUN_EARTHLY_ARGS --earthfile=old2.earth --target=+test
+
+test-old-works-with-new:
+    COPY old.earth Earthfile
+    RUN sed -i "1s/VERSION .*/VERSION --shell-out-anywhere 0.6/" Earthfile
+    DO +RUN_EARTHLY_ARGS --target=+test
+
+test-new-shellout-errors-are-detected:
+    COPY old-ignore-shellout-errors.earth Earthfile
+    RUN sed -i "1s/VERSION .*/VERSION --shell-out-anywhere 0.6/" Earthfile
+    DO +RUN_EARTHLY_ARGS --target=+test --should_fail=true
+
+test-new:
+    DO +RUN_EARTHLY_ARGS --earthfile=new.earth --target=+test
 
 RUN_EARTHLY_ARGS:
     COMMAND

--- a/tests/shell-out/new.earth
+++ b/tests/shell-out/new.earth
@@ -1,0 +1,61 @@
+VERSION --shell-out-anywhere 0.6
+
+test-all:
+    BUILD +test-copyfile
+    BUILD +test
+    BUILD +test2
+    BUILD +test3
+    BUILD +test4
+    BUILD +test5
+    BUILD +test6
+
+hasfile:
+    FROM +test
+    RUN touch valid-file
+    SAVE ARTIFACT "valid-$(echo file)"
+
+test-copyfile:
+    FROM alpine:3.15
+    COPY "+hasfile/$(echo dmFsaWQtZmlsZQ== | base64 -d)" .
+    RUN test -f valid-file
+
+test:
+    FROM alpine:3.15
+    RUN echo "world" > data
+    ARG key="hello$(cat /data)"
+    RUN env | grep -w key | grep 'helloworld$'
+
+test2:
+    FROM alpine:3.15
+    RUN echo alpha > a
+    RUN echo "bravo" > b
+    RUN echo 'charlie' > c
+    ENV d "delta"
+    ARG VAR1="a is $(cat a) and b is $(dd if=b 2>/dev/null) and c is $(cat <c) and d is $d."
+    RUN test "$VAR1" == "a is alpha and b is bravo and c is charlie and d is delta."
+
+test3:
+    FROM alpine:3.15
+    RUN echo world > data
+    ARG VAR1="hello$(cat ./data)"
+    RUN test "$VAR1" == "helloworld"
+
+test4:
+    FROM scratch
+    ARG VAR1="literal\$(string)"
+    FROM alpine:3.15
+    RUN test "$VAR1" == "literal\$(string)"
+    RUN echo -n $VAR1 | base64
+    RUN echo -n $VAR1 | base64 | grep bGl0ZXJhbCQoc3RyaW5nKQ==
+
+test5:
+    FROM scratch
+    ARG VAR1='literal$(whoami)string'
+    FROM alpine:3.15
+    RUN test "$VAR1" == 'literal$(whoami)string'
+    RUN echo -n $VAR1 | base64 | grep bGl0ZXJhbCQod2hvYW1pKXN0cmluZw==
+
+test6:
+    FROM alpine:3.15
+    ARG mystr="hello $(echo -n one && echo -n two >/dev/null && echo -n three)."
+    RUN test "$mystr" = "hello onethree."

--- a/tests/with-docker/Earthfile
+++ b/tests/with-docker/Earthfile
@@ -1,8 +1,9 @@
-VERSION --parallel-load 0.6
+VERSION --parallel-load --shell-out-anywhere 0.6
 FROM earthly/dind:alpine
 
 all:
     BUILD +docker-load-test
+    BUILD +docker-load-shellout-test
     BUILD +docker-load-arg-test
     BUILD +docker-load-multi-test
     BUILD +docker-pull-test
@@ -28,6 +29,13 @@ another-test-image:
     ENTRYPOINT cat /work/file.txt
     SAVE IMAGE another-test-img:i${INDEX}
 
+a-test-image-with-shell-out:
+    FROM alpine:3.15
+    RUN echo c2hlbGxvdXQ= > data # decodes into "shellout"
+    RUN echo myver > version
+    ENTRYPOINT echo "you found me"
+    SAVE IMAGE "test-img-with-$(cat data | base64 -d)":"$(cat version)"
+
 docker-load-test:
     # Index is used to create parallel tests.
     ARG INDEX=0
@@ -37,6 +45,11 @@ docker-load-test:
             --load +a-test-image
         RUN docker run test-abc-img:xyz && \
             docker run hello-world
+    END
+
+docker-load-shellout-test:
+    WITH DOCKER --load=+a-test-image-with-shell-out
+        RUN docker run test-img-with-shellout:myver | grep "you found me"
     END
 
 docker-load-arg-test:

--- a/util/shell/envVarTest
+++ b/util/shell/envVarTest
@@ -1,0 +1,238 @@
+A|hello                    |     hello
+A|he'll'o                  |     hello
+A|he'llo                   |     error
+A|he\'llo                  |     he'llo
+A|he\\'llo                 |     error
+A|abc\tdef                 |     abctdef
+A|"abc\tdef"               |     abc\tdef
+A|"abc\\tdef"              |     abc\tdef
+A|'abc\tdef'               |     abc\tdef
+A|hello\                   |     hello
+A|hello\\                  |     hello\
+A|"hello                   |     error
+A|"hello\"                 |     error
+A|"hel'lo"                 |     hel'lo
+A|'hello                   |     error
+A|'hello\'                 |     hello\
+A|'hello\there'            |     hello\there
+A|'hello\\there'           |     hello\\there
+A|"''"                     |     ''
+A|$.                       |     $.
+A|he$1x                    |     hex
+A|he$.x                    |     he$.x
+# Next one is different on Windows as $pwd==$PWD
+U|he$pwd.                  |     he.
+W|he$pwd.                  |     he/home.
+A|he$PWD                   |     he/home
+A|he\$PWD                  |     he$PWD
+A|he\\$PWD                 |     he\/home
+A|"he\$PWD"                |     he$PWD
+A|"he\\$PWD"               |     he\/home
+A|\${}                     |     ${}
+A|\${}aaa                  |     ${}aaa
+A|he\${}                   |     he${}
+A|he\${}xx                 |     he${}xx
+A|${}                      |     error
+A|${}aaa                   |     error
+A|he${}                    |     error
+A|he${}xx                  |     error
+A|he${hi}                  |     he
+A|he${hi}xx                |     hexx
+A|he${PWD}                 |     he/home
+A|he${.}                   |     error
+A|he${XXX:-000}xx          |     he000xx
+A|he${PWD:-000}xx          |     he/homexx
+A|he${XXX:-$PWD}xx         |     he/homexx
+A|he${XXX:-${PWD:-yyy}}xx  |     he/homexx
+A|he${XXX:-${YYY:-yyy}}xx  |     heyyyxx
+A|he${XXX:YYY}             |     error
+A|he${XXX?}                |     error
+A|he${XXX:?}               |     error
+A|he${PWD?}                |     he/home
+A|he${PWD:?}               |     he/home
+A|he${NULL?}               |     he
+A|he${NULL:?}              |     error
+A|he${XXX:+${PWD}}xx       |     hexx
+A|he${PWD:+${XXX}}xx       |     hexx
+A|he${PWD:+${SHELL}}xx     |     hebashxx
+A|he${XXX:+000}xx          |     hexx
+A|he${PWD:+000}xx          |     he000xx
+A|'he${XX}'                |     he${XX}
+A|"he${PWD}"               |     he/home
+A|"he'$PWD'"               |     he'/home'
+A|"$PWD"                   |     /home
+A|'$PWD'                   |     $PWD
+A|'\$PWD'                  |     \$PWD
+A|'"hello"'                |     "hello"
+A|he\$PWD                  |     he$PWD
+A|"he\$PWD"                |     he$PWD
+A|'he\$PWD'                |     he\$PWD
+A|he${PWD                  |     error
+A|he${PWD:=000}xx          |     error
+A|he${PWD:+${PWD}:}xx      |     he/home:xx
+A|he${XXX:-\$PWD:}xx       |     he$PWD:xx
+A|he${XXX:-\${PWD}z}xx     |     he${PWDz}xx
+A|안녕하세요                 |     안녕하세요
+A|안'녕'하세요               |     안녕하세요
+A|안'녕하세요                |     error
+A|안녕\'하세요               |     안녕'하세요
+A|안\\'녕하세요              |     error
+A|안녕\t하세요               |     안녕t하세요
+A|"안녕\t하세요"             |     안녕\t하세요
+A|'안녕\t하세요              |     error
+A|안녕하세요\                |     안녕하세요
+A|안녕하세요\\               |     안녕하세요\
+A|"안녕하세요                |     error
+A|"안녕하세요\"              |     error
+A|"안녕'하세요"              |     안녕'하세요
+A|'안녕하세요                |     error
+A|'안녕하세요\'              |     안녕하세요\
+A|안녕$1x                    |     안녕x
+A|안녕$.x                    |     안녕$.x
+# Next one is different on Windows as $pwd==$PWD
+U|안녕$pwd.                  |     안녕.
+W|안녕$pwd.                  |     안녕/home.
+A|안녕$PWD                   |     안녕/home
+A|안녕\$PWD                  |     안녕$PWD
+A|안녕\\$PWD                 |     안녕\/home
+A|안녕\${}                   |     안녕${}
+A|안녕\${}xx                 |     안녕${}xx
+A|안녕${}                    |     error
+A|안녕${}xx                  |     error
+A|안녕${hi}                  |     안녕
+A|안녕${hi}xx                |     안녕xx
+A|안녕${PWD}                 |     안녕/home
+A|안녕${.}                   |     error
+A|안녕${XXX:-000}xx          |     안녕000xx
+A|안녕${PWD:-000}xx          |     안녕/homexx
+A|안녕${XXX:-$PWD}xx         |     안녕/homexx
+A|안녕${XXX:-${PWD:-yyy}}xx  |     안녕/homexx
+A|안녕${XXX:-${YYY:-yyy}}xx  |     안녕yyyxx
+A|안녕${XXX:YYY}             |     error
+A|안녕${XXX:+${PWD}}xx       |     안녕xx
+A|안녕${PWD:+${XXX}}xx       |     안녕xx
+A|안녕${PWD:+${SHELL}}xx     |     안녕bashxx
+A|안녕${XXX:+000}xx          |     안녕xx
+A|안녕${PWD:+000}xx          |     안녕000xx
+A|'안녕${XX}'                |     안녕${XX}
+A|"안녕${PWD}"               |     안녕/home
+A|"안녕'$PWD'"               |     안녕'/home'
+A|'"안녕"'                   |     "안녕"
+A|안녕\$PWD                  |     안녕$PWD
+A|"안녕\$PWD"                |     안녕$PWD
+A|'안녕\$PWD'                |     안녕\$PWD
+A|안녕${PWD                  |     error
+A|안녕${PWD:=000}xx          |     error
+A|안녕${PWD:+${PWD}:}xx      |     안녕/home:xx
+A|안녕${XXX:-\$PWD:}xx       |     안녕$PWD:xx
+A|안녕${XXX:-\${PWD}z}xx     |     안녕${PWDz}xx
+A|$KOREAN                    |     한국어
+A|안녕$KOREAN                |     안녕한국어
+A|${{aaa}                   |     error
+A|${aaa}}                   |     }
+A|${aaa                     |     error
+A|${{aaa:-bbb}              |     error
+A|${aaa:-bbb}}              |     bbb}
+A|${aaa:-bbb                |     error
+A|${aaa:-bbb}               |     bbb
+A|${aaa:-${bbb:-ccc}}       |     ccc
+A|${aaa:-bbb ${foo}         |     error
+A|${aaa:-bbb {foo}          |     bbb {foo
+A|${:}                      |     error
+A|${:-bbb}                  |     error
+A|${:+bbb}                  |     error
+
+# Positional parameters won't be set:
+# http://pubs.opengroup.org/onlinepubs/009695399/utilities/xcu_chap02.html#tag_02_05_01
+A|$1                        |
+A|${1}                      |
+A|${1:+bbb}                 |
+A|${1:-bbb}                 |     bbb
+A|$2                        |
+A|${2}                      |
+A|${2:+bbb}                 |
+A|${2:-bbb}                 |     bbb
+A|$3                        |
+A|${3}                      |
+A|${3:+bbb}                 |
+A|${3:-bbb}                 |     bbb
+A|$4                        |
+A|${4}                      |
+A|${4:+bbb}                 |
+A|${4:-bbb}                 |     bbb
+A|$5                        |
+A|${5}                      |
+A|${5:+bbb}                 |
+A|${5:-bbb}                 |     bbb
+A|$6                        |
+A|${6}                      |
+A|${6:+bbb}                 |
+A|${6:-bbb}                 |     bbb
+A|$7                        |
+A|${7}                      |
+A|${7:+bbb}                 |
+A|${7:-bbb}                 |     bbb
+A|$8                        |
+A|${8}                      |
+A|${8:+bbb}                 |
+A|${8:-bbb}                 |     bbb
+A|$9                        |
+A|${9}                      |
+A|${9:+bbb}                 |
+A|${9:-bbb}                 |     bbb
+A|$999                      |
+A|${999}                    |
+A|${999:+bbb}               |
+A|${999:-bbb}               |     bbb
+A|$999aaa                   |     aaa
+A|${999}aaa                 |     aaa
+A|${999:+bbb}aaa            |     aaa
+A|${999:-bbb}aaa            |     bbbaaa
+A|$001                      |
+A|${001}                    |
+A|${001:+bbb}               |
+A|${001:-bbb}               |     bbb
+A|$001aaa                   |     aaa
+A|${001}aaa                 |     aaa
+A|${001:+bbb}aaa            |     aaa
+A|${001:-bbb}aaa            |     bbbaaa
+
+# Special parameters won't be set in the Dockerfile:
+# http://pubs.opengroup.org/onlinepubs/009695399/utilities/xcu_chap02.html#tag_02_05_02
+A|$@                        |
+A|${@}                      |
+A|${@:+bbb}                 |
+A|${@:-bbb}                 |     bbb
+A|$@@@                      |     @@
+A|$@aaa                     |     aaa
+A|${@}aaa                   |     aaa
+A|${@:+bbb}aaa              |     aaa
+A|${@:-bbb}aaa              |     bbbaaa
+A|$*                        |
+A|${*}                      |
+A|${*:+bbb}                 |
+A|${*:-bbb}                 |     bbb
+A|$#                        |
+A|${#}                      |
+A|${#:+bbb}                 |
+A|${#:-bbb}                 |     bbb
+A|$?                        |
+A|${?}                      |
+A|${?:+bbb}                 |
+A|${?:-bbb}                 |     bbb
+A|$-                        |
+A|${-}                      |
+A|${-:+bbb}                 |
+A|${-:-bbb}                 |     bbb
+A|$$                        |
+A|${$}                      |
+A|${$:+bbb}                 |
+A|${$:-bbb}                 |     bbb
+A|$!                        |
+A|${!}                      |
+A|${!:+bbb}                 |
+A|${!:-bbb}                 |     bbb
+A|$0                        |
+A|${0}                      |
+A|${0:+bbb}                 |
+A|${0:-bbb}                 |     bbb

--- a/util/shell/equal_env_unix.go
+++ b/util/shell/equal_env_unix.go
@@ -1,0 +1,11 @@
+//go:build !windows
+// +build !windows
+
+package shell
+
+// EqualEnvKeys compare two strings and returns true if they are equal.
+// On Unix this comparison is case sensitive.
+// On Windows this comparison is case insensitive.
+func EqualEnvKeys(from, to string) bool {
+	return from == to
+}

--- a/util/shell/equal_env_windows.go
+++ b/util/shell/equal_env_windows.go
@@ -1,0 +1,10 @@
+package shell
+
+import "strings"
+
+// EqualEnvKeys compare two strings and returns true if they are equal.
+// On Unix this comparison is case sensitive.
+// On Windows this comparison is case insensitive.
+func EqualEnvKeys(from, to string) bool {
+	return strings.ToUpper(from) == strings.ToUpper(to)
+}

--- a/util/shell/lex.go
+++ b/util/shell/lex.go
@@ -1,0 +1,598 @@
+// Package shell was forked from buildkit/frontend/dockerfile/shell in order to allow shelling-out.
+// This package is distributed under the original file's license, The Apache License, which is defined under
+// https://github.com/moby/buildkit/blob/7c3e9fdd48c867f48a07a80cde64cc2d578cb332/LICENSE
+package shell
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"text/scanner"
+	"unicode"
+
+	"github.com/pkg/errors"
+)
+
+// Lex performs shell word splitting and variable expansion.
+//
+// Lex takes a string and an array of env variables and
+// process all quotes (" and ') as well as $xxx and ${xxx} env variable
+// tokens.  Tries to mimic bash shell process.
+// It doesn't support all flavors of ${xx:...} formats but new ones can
+// be added by adding code to the "special ${} format processing" section
+type Lex struct {
+	escapeToken       rune
+	RawQuotes         bool
+	RawEscapes        bool
+	SkipProcessQuotes bool
+	SkipUnsetEnv      bool
+	ShellOut          EvalShellOutFn
+}
+
+// NewLex creates a new Lex which uses escapeToken to escape quotes.
+func NewLex(escapeToken rune) *Lex {
+	return &Lex{escapeToken: escapeToken}
+}
+
+// ProcessWord will use the 'env' list of environment variables,
+// and replace any env var references in 'word'.
+func (s *Lex) ProcessWord(word string, env []string) (string, error) {
+	word, _, err := s.process(word, BuildEnvs(env))
+	return word, err
+}
+
+// ProcessWords will use the 'env' list of environment variables,
+// and replace any env var references in 'word' then it will also
+// return a slice of strings which represents the 'word'
+// split up based on spaces - taking into account quotes.  Note that
+// this splitting is done **after** the env var substitutions are done.
+// Note, each one is trimmed to remove leading and trailing spaces (unless
+// they are quoted", but ProcessWord retains spaces between words.
+func (s *Lex) ProcessWords(word string, env []string) ([]string, error) {
+	_, words, err := s.process(word, BuildEnvs(env))
+	return words, err
+}
+
+// ProcessWordWithMap will use the 'env' list of environment variables,
+// and replace any env var references in 'word'.
+func (s *Lex) ProcessWordWithMap(word string, env map[string]string) (string, error) {
+	word, _, err := s.process(word, env)
+	return word, err
+}
+
+// ProcessWordsWithMap will use the 'env' list of environment variables,
+// and replace any env var references in 'word'.
+func (s *Lex) ProcessWordsWithMap(word string, env map[string]string) ([]string, error) {
+	_, words, err := s.process(word, env)
+	return words, err
+}
+
+func (s *Lex) process(word string, env map[string]string) (string, []string, error) {
+	sw := &shellWord{
+		envs:              env,
+		escapeToken:       s.escapeToken,
+		skipUnsetEnv:      s.SkipUnsetEnv,
+		skipProcessQuotes: s.SkipProcessQuotes,
+		rawQuotes:         s.RawQuotes,
+		rawEscapes:        s.RawEscapes,
+		shellOut:          s.ShellOut,
+	}
+	sw.scanner.Init(strings.NewReader(word))
+	return sw.process(word)
+}
+
+// EvalShellOutFn is a supplied callback function which is called whenever a shell-out command needs to be evaluated
+type EvalShellOutFn func(cmd string) (string, error)
+
+// ErrNoShellOut occurs when the EvalShellOutFn was not set
+var ErrNoShellOut = errors.New("shelling out is not available")
+
+type shellWord struct {
+	scanner           scanner.Scanner
+	envs              map[string]string
+	escapeToken       rune
+	rawQuotes         bool
+	rawEscapes        bool
+	skipUnsetEnv      bool
+	skipProcessQuotes bool
+	shellOut          EvalShellOutFn
+}
+
+func (sw *shellWord) process(source string) (string, []string, error) {
+	word, words, err := sw.processStopOn(scanner.EOF)
+	if err != nil {
+		err = errors.Wrapf(err, "failed to process %q", source)
+	}
+	return word, words, err
+}
+
+type wordsStruct struct {
+	word   string
+	words  []string
+	inWord bool
+}
+
+func (w *wordsStruct) addChar(ch rune) {
+	if unicode.IsSpace(ch) && w.inWord {
+		if len(w.word) != 0 {
+			w.words = append(w.words, w.word)
+			w.word = ""
+			w.inWord = false
+		}
+	} else if !unicode.IsSpace(ch) {
+		w.addRawChar(ch)
+	}
+}
+
+func (w *wordsStruct) addRawChar(ch rune) {
+	w.word += string(ch)
+	w.inWord = true
+}
+
+func (w *wordsStruct) addString(str string) {
+	for _, ch := range str {
+		w.addChar(ch)
+	}
+}
+
+func (w *wordsStruct) addRawString(str string) {
+	w.word += str
+	w.inWord = true
+}
+
+func (w *wordsStruct) getWords() []string {
+	if len(w.word) > 0 {
+		w.words = append(w.words, w.word)
+
+		// Just in case we're called again by mistake
+		w.word = ""
+		w.inWord = false
+	}
+	return w.words
+}
+
+// Process the word, starting at 'pos', and stop when we get to the
+// end of the word or the 'stopChar' character
+func (sw *shellWord) processStopOn(stopChar rune) (string, []string, error) {
+	var result bytes.Buffer
+	var words wordsStruct
+
+	var charFuncMapping = map[rune]func() (string, error){
+		'$': sw.processDollar,
+	}
+	if !sw.skipProcessQuotes {
+		charFuncMapping['\''] = sw.processSingleQuote
+		charFuncMapping['"'] = sw.processDoubleQuote
+	}
+
+	for sw.scanner.Peek() != scanner.EOF {
+		ch := sw.scanner.Peek()
+
+		if stopChar != scanner.EOF && ch == stopChar {
+			sw.scanner.Next()
+			return result.String(), words.getWords(), nil
+		}
+		if fn, ok := charFuncMapping[ch]; ok {
+			// Call special processing func for certain chars
+			tmp, err := fn()
+			if err != nil {
+				return "", []string{}, err
+			}
+			result.WriteString(tmp)
+
+			if ch == rune('$') {
+				words.addString(tmp)
+			} else {
+				words.addRawString(tmp)
+			}
+		} else {
+			// Not special, just add it to the result
+			ch = sw.scanner.Next()
+
+			if ch == sw.escapeToken {
+				if sw.rawEscapes {
+					words.addRawChar(ch)
+					result.WriteRune(ch)
+				}
+
+				// '\' (default escape token, but ` allowed) escapes, except end of line
+				ch = sw.scanner.Next()
+
+				if ch == scanner.EOF {
+					break
+				}
+
+				words.addRawChar(ch)
+			} else {
+				words.addChar(ch)
+			}
+
+			result.WriteRune(ch)
+		}
+	}
+	if stopChar != scanner.EOF {
+		return "", []string{}, errors.Errorf("unexpected end of statement while looking for matching %s", string(stopChar))
+	}
+	return result.String(), words.getWords(), nil
+}
+
+func (sw *shellWord) processSingleQuote() (string, error) {
+	// All chars between single quotes are taken as-is
+	// Note, you can't escape '
+	//
+	// From the "sh" man page:
+	// Single Quotes
+	//   Enclosing characters in single quotes preserves the literal meaning of
+	//   all the characters (except single quotes, making it impossible to put
+	//   single-quotes in a single-quoted string).
+
+	var result bytes.Buffer
+
+	ch := sw.scanner.Next()
+	if sw.rawQuotes {
+		result.WriteRune(ch)
+	}
+
+	for {
+		ch = sw.scanner.Next()
+		switch ch {
+		case scanner.EOF:
+			return "", errors.New("unexpected end of statement while looking for matching single-quote")
+		case '\'':
+			if sw.rawQuotes {
+				result.WriteRune(ch)
+			}
+			return result.String(), nil
+		}
+		result.WriteRune(ch)
+	}
+}
+
+func (sw *shellWord) processDoubleQuote() (string, error) {
+	// All chars up to the next " are taken as-is, even ', except any $ chars
+	// But you can escape " with a \ (or ` if escape token set accordingly)
+	//
+	// From the "sh" man page:
+	// Double Quotes
+	//  Enclosing characters within double quotes preserves the literal meaning
+	//  of all characters except dollarsign ($), backquote (`), and backslash
+	//  (\).  The backslash inside double quotes is historically weird, and
+	//  serves to quote only the following characters:
+	//    $ ` " \ <newline>.
+	//  Otherwise it remains literal.
+
+	var result bytes.Buffer
+
+	ch := sw.scanner.Next()
+	if sw.rawQuotes {
+		result.WriteRune(ch)
+	}
+
+	for {
+		switch sw.scanner.Peek() {
+		case scanner.EOF:
+			return "", errors.New("unexpected end of statement while looking for matching double-quote")
+		case '"':
+			ch := sw.scanner.Next()
+			if sw.rawQuotes {
+				result.WriteRune(ch)
+			}
+			return result.String(), nil
+		case '$':
+			value, err := sw.processDollar()
+			if err != nil {
+				return "", err
+			}
+			result.WriteString(value)
+		default:
+			ch := sw.scanner.Next()
+			if ch == sw.escapeToken {
+				if sw.rawEscapes {
+					result.WriteRune(ch)
+				}
+
+				switch sw.scanner.Peek() {
+				case scanner.EOF:
+					// Ignore \ at end of word
+					continue
+				case '"', '$', sw.escapeToken:
+					// These chars can be escaped, all other \'s are left as-is
+					// Note: for now don't do anything special with ` chars.
+					// Not sure what to do with them anyway since we're not going
+					// to execute the text in there (not now anyway).
+					ch = sw.scanner.Next()
+				}
+			}
+			result.WriteRune(ch)
+		}
+	}
+}
+
+func (sw *shellWord) processDoubleQuoteIgnoringDollar() (string, error) {
+	// like processDoubleQuote except no variable substitution is done (as we are in the shell-out)
+
+	var result bytes.Buffer
+
+	result.WriteRune('"')
+
+	for {
+		switch sw.scanner.Peek() {
+		case scanner.EOF:
+			return "", errors.New("unexpected end of statement while looking for matching double-quote")
+		case '"':
+			ch := sw.scanner.Next()
+			result.WriteRune(ch)
+			return result.String(), nil
+		default:
+			ch := sw.scanner.Next()
+			if ch == sw.escapeToken {
+				if sw.rawEscapes {
+					result.WriteRune(ch)
+				}
+
+				switch sw.scanner.Peek() {
+				case scanner.EOF:
+					// Ignore \ at end of word
+					continue
+				case '"', '$', sw.escapeToken:
+					// These chars can be escaped, all other \'s are left as-is
+					// Note: for now don't do anything special with ` chars.
+					// Not sure what to do with them anyway since we're not going
+					// to execute the text in there (not now anyway).
+					ch = sw.scanner.Next()
+				}
+			}
+			result.WriteRune(ch)
+		}
+	}
+}
+
+func (sw *shellWord) processDollar() (string, error) {
+	sw.scanner.Next()
+
+	// $(...) case
+	peek := sw.scanner.Peek()
+	switch peek {
+	case '(':
+		sw.scanner.Next()
+		//return sw.processDollarShellOut()
+		shout, err := sw.processDollarShellOut()
+		return shout, err
+	case '{':
+		sw.scanner.Next()
+		return sw.processDollarCurlyBracket()
+	default:
+		// $xxx case
+		name := sw.processName()
+		if name == "" {
+			return "$", nil
+		}
+		value, found := sw.getEnv(name)
+		if !found && sw.skipUnsetEnv {
+			return "$" + name, nil
+		}
+		return value, nil
+	}
+}
+func (sw *shellWord) processDollarShellOut() (string, error) {
+	var result bytes.Buffer
+
+	seenParentheses := 1
+	escaped := false
+	for {
+		ch := sw.scanner.Next()
+		if ch == scanner.EOF {
+			return "", errors.New("syntax error: missing ')'")
+		}
+		if escaped {
+			escaped = false
+			result.WriteRune(ch)
+			continue
+		}
+		switch ch {
+		case '\\':
+			escaped = true
+			continue
+		case ')':
+			seenParentheses--
+			if seenParentheses == 0 {
+				command := result.String()
+				if sw.shellOut == nil {
+					return "", ErrNoShellOut
+				}
+				return sw.shellOut(command)
+			}
+			result.WriteRune(ch)
+		case '(':
+			seenParentheses++
+			result.WriteRune(ch)
+		case '\'':
+			s, err := sw.processSingleQuote()
+			if err != nil {
+				return "", err
+			}
+			result.WriteString(s)
+		case '"':
+			s, err := sw.processDoubleQuoteIgnoringDollar()
+			if err != nil {
+				return "", err
+			}
+			result.WriteString(s)
+		default:
+			result.WriteRune(ch)
+		}
+	}
+}
+
+func (sw *shellWord) processDollarCurlyBracket() (string, error) {
+	switch sw.scanner.Peek() {
+	case scanner.EOF:
+		return "", errors.New("syntax error: missing '}'")
+	case '{', '}', ':':
+		// Invalid ${{xx}, ${:xx}, ${:}. ${} case
+		return "", errors.New("syntax error: bad substitution")
+	}
+	name := sw.processName()
+	ch := sw.scanner.Next()
+	switch ch {
+	case '}':
+		// Normal ${xx} case
+		value, found := sw.getEnv(name)
+		if !found && sw.skipUnsetEnv {
+			return fmt.Sprintf("${%s}", name), nil
+		}
+		return value, nil
+	case '?':
+		word, _, err := sw.processStopOn('}')
+		if err != nil {
+			if sw.scanner.Peek() == scanner.EOF {
+				return "", errors.New("syntax error: missing '}'")
+			}
+			return "", err
+		}
+		newValue, found := sw.getEnv(name)
+		if !found {
+			if sw.skipUnsetEnv {
+				return fmt.Sprintf("${%s?%s}", name, word), nil
+			}
+			message := "is not allowed to be unset"
+			if word != "" {
+				message = word
+			}
+			return "", errors.Errorf("%s: %s", name, message)
+		}
+		return newValue, nil
+	case ':':
+		// Special ${xx:...} format processing
+		// Yes it allows for recursive $'s in the ... spot
+		modifier := sw.scanner.Next()
+
+		word, _, err := sw.processStopOn('}')
+		if err != nil {
+			if sw.scanner.Peek() == scanner.EOF {
+				return "", errors.New("syntax error: missing '}'")
+			}
+			return "", err
+		}
+
+		// Grab the current value of the variable in question so we
+		// can use to to determine what to do based on the modifier
+		newValue, found := sw.getEnv(name)
+
+		switch modifier {
+		case '+':
+			if newValue != "" {
+				newValue = word
+			}
+			if !found && sw.skipUnsetEnv {
+				return fmt.Sprintf("${%s:%s%s}", name, string(modifier), word), nil
+			}
+			return newValue, nil
+
+		case '-':
+			if newValue == "" {
+				newValue = word
+			}
+			if !found && sw.skipUnsetEnv {
+				return fmt.Sprintf("${%s:%s%s}", name, string(modifier), word), nil
+			}
+
+			return newValue, nil
+
+		case '?':
+			if !found {
+				if sw.skipUnsetEnv {
+					return fmt.Sprintf("${%s:%s%s}", name, string(modifier), word), nil
+				}
+				message := "is not allowed to be unset"
+				if word != "" {
+					message = word
+				}
+				return "", errors.Errorf("%s: %s", name, message)
+			}
+			if newValue == "" {
+				message := "is not allowed to be empty"
+				if word != "" {
+					message = word
+				}
+				return "", errors.Errorf("%s: %s", name, message)
+			}
+			return newValue, nil
+
+		default:
+			return "", errors.Errorf("unsupported modifier (%c) in substitution", modifier)
+		}
+	}
+	return "", errors.Errorf("missing ':' in substitution")
+}
+
+func (sw *shellWord) processName() string {
+	// Read in a name (alphanumeric or _)
+	// If it starts with a numeric then just return $#
+	var name bytes.Buffer
+
+	for sw.scanner.Peek() != scanner.EOF {
+		ch := sw.scanner.Peek()
+		if name.Len() == 0 && unicode.IsDigit(ch) {
+			for sw.scanner.Peek() != scanner.EOF && unicode.IsDigit(sw.scanner.Peek()) {
+				// Keep reading until the first non-digit character, or EOF
+				ch = sw.scanner.Next()
+				name.WriteRune(ch)
+			}
+			return name.String()
+		}
+		if name.Len() == 0 && isSpecialParam(ch) {
+			ch = sw.scanner.Next()
+			return string(ch)
+		}
+		if !unicode.IsLetter(ch) && !unicode.IsDigit(ch) && ch != '_' {
+			break
+		}
+		ch = sw.scanner.Next()
+		name.WriteRune(ch)
+	}
+
+	return name.String()
+}
+
+// isSpecialParam checks if the provided character is a special parameters,
+// as defined in http://pubs.opengroup.org/onlinepubs/009695399/utilities/xcu_chap02.html#tag_02_05_02
+func isSpecialParam(char rune) bool {
+	switch char {
+	case '@', '*', '#', '?', '-', '$', '!', '0':
+		// Special parameters
+		// http://pubs.opengroup.org/onlinepubs/009695399/utilities/xcu_chap02.html#tag_02_05_02
+		return true
+	}
+	return false
+}
+
+func (sw *shellWord) getEnv(name string) (string, bool) {
+	for key, value := range sw.envs {
+		if EqualEnvKeys(name, key) {
+			return value, true
+		}
+	}
+	return "", false
+}
+
+// BuildEnvs takes a list of envs and converts it to a map
+func BuildEnvs(env []string) map[string]string {
+	envs := map[string]string{}
+
+	for _, e := range env {
+		i := strings.Index(e, "=")
+
+		if i < 0 {
+			envs[e] = ""
+		} else {
+			k := e[:i]
+			v := e[i+1:]
+
+			// overwrite value if key already exists
+			envs[k] = v
+		}
+	}
+
+	return envs
+}

--- a/util/shell/lex_test.go
+++ b/util/shell/lex_test.go
@@ -1,0 +1,227 @@
+package shell
+
+import (
+	"bufio"
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestShellParserMandatoryEnvVars(t *testing.T) {
+	var newWord string
+	var err error
+	shlex := NewLex('\\')
+	setEnvs := []string{"VAR=plain", "ARG=x"}
+	emptyEnvs := []string{"VAR=", "ARG=x"}
+	unsetEnvs := []string{"ARG=x"}
+
+	noEmpty := "${VAR:?message here$ARG}"
+	noUnset := "${VAR?message here$ARG}"
+
+	// disallow empty
+	newWord, err = shlex.ProcessWord(noEmpty, setEnvs)
+	require.NoError(t, err)
+	require.Equal(t, "plain", newWord)
+
+	_, err = shlex.ProcessWord(noEmpty, emptyEnvs)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "message herex")
+
+	_, err = shlex.ProcessWord(noEmpty, unsetEnvs)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "message herex")
+
+	// disallow unset
+	newWord, err = shlex.ProcessWord(noUnset, setEnvs)
+	require.NoError(t, err)
+	require.Equal(t, "plain", newWord)
+
+	newWord, err = shlex.ProcessWord(noUnset, emptyEnvs)
+	require.NoError(t, err)
+	require.Equal(t, "", newWord)
+
+	_, err = shlex.ProcessWord(noUnset, unsetEnvs)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "message herex")
+}
+
+func TestShellParser4EnvVars(t *testing.T) {
+	fn := "envVarTest"
+	lineCount := 0
+
+	file, err := os.Open(fn)
+	require.NoError(t, err)
+	defer file.Close()
+
+	shlex := NewLex('\\')
+	scanner := bufio.NewScanner(file)
+	envs := []string{"PWD=/home", "SHELL=bash", "KOREAN=한국어", "NULL="}
+	envsMap := BuildEnvs(envs)
+	for scanner.Scan() {
+		line := scanner.Text()
+		lineCount++
+
+		// Skip comments and blank lines
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		words := strings.Split(line, "|")
+		require.Equal(t, 3, len(words))
+
+		platform := strings.TrimSpace(words[0])
+		source := strings.TrimSpace(words[1])
+		expected := strings.TrimSpace(words[2])
+
+		// Key W=Windows; A=All; U=Unix
+		if platform != "W" && platform != "A" && platform != "U" {
+			t.Fatalf("Invalid tag %s at line %d of %s. Must be W, A or U", platform, lineCount, fn)
+		}
+
+		if ((platform == "W" || platform == "A") && runtime.GOOS == "windows") ||
+			((platform == "U" || platform == "A") && runtime.GOOS != "windows") {
+			newWord, err := shlex.ProcessWord(source, envs)
+			if expected == "error" {
+				require.Errorf(t, err, "input: %q, result: %q", source, newWord)
+			} else {
+				require.NoError(t, err, "at line %d of %s", lineCount, fn)
+				require.Equal(t, expected, newWord, "at line %d of %s", lineCount, fn)
+			}
+
+			newWord, err = shlex.ProcessWordWithMap(source, envsMap)
+			if expected == "error" {
+				require.Errorf(t, err, "input: %q, result: %q", source, newWord)
+			} else {
+				require.NoError(t, err, "at line %d of %s", lineCount, fn)
+				require.Equal(t, expected, newWord, "at line %d of %s", lineCount, fn)
+			}
+		}
+	}
+}
+
+func TestShellParser4Words(t *testing.T) {
+	fn := "wordsTest"
+
+	file, err := os.Open(fn)
+	if err != nil {
+		t.Fatalf("Can't open '%s': %s", err, fn)
+	}
+	defer file.Close()
+
+	const (
+		modeNormal = iota
+		modeOnlySetEnv
+	)
+	for _, mode := range []int{modeNormal, modeOnlySetEnv} {
+		var envs []string
+		shlex := NewLex('\\')
+		if mode == modeOnlySetEnv {
+			shlex.RawQuotes = true
+			shlex.SkipUnsetEnv = true
+		}
+		scanner := bufio.NewScanner(file)
+		lineNum := 0
+		for scanner.Scan() {
+			line := scanner.Text()
+			lineNum = lineNum + 1
+
+			if strings.HasPrefix(line, "#") {
+				continue
+			}
+
+			if strings.HasPrefix(line, "ENV ") {
+				line = strings.TrimLeft(line[3:], " ")
+				envs = append(envs, line)
+				continue
+			}
+
+			words := strings.Split(line, "|")
+			if len(words) != 2 {
+				t.Fatalf("Error in '%s'(line %d) - should be exactly one | in: %q", fn, lineNum, line)
+			}
+			test := strings.TrimSpace(words[0])
+			expected := strings.Split(strings.TrimLeft(words[1], " "), ",")
+
+			// test for ProcessWords
+			result, err := shlex.ProcessWords(test, envs)
+
+			if err != nil {
+				result = []string{"error"}
+			}
+
+			if len(result) != len(expected) {
+				t.Fatalf("Error on line %d. %q was suppose to result in %q, but got %q instead", lineNum, test, expected, result)
+			}
+			for i, w := range expected {
+				if w != result[i] {
+					t.Fatalf("Error on line %d. %q was suppose to result in %q, but got %q instead", lineNum, test, expected, result)
+				}
+			}
+
+			// test for ProcessWordsWithMap
+			result, err = shlex.ProcessWordsWithMap(test, BuildEnvs(envs))
+
+			if err != nil {
+				result = []string{"error"}
+			}
+
+			if len(result) != len(expected) {
+				t.Fatalf("Error on line %d. %q was suppose to result in %q, but got %q instead", lineNum, test, expected, result)
+			}
+			for i, w := range expected {
+				if w != result[i] {
+					t.Fatalf("Error on line %d. %q was suppose to result in %q, but got %q instead", lineNum, test, expected, result)
+				}
+			}
+		}
+	}
+}
+
+func TestGetEnv(t *testing.T) {
+	sw := &shellWord{envs: nil}
+
+	getEnv := func(name string) string {
+		value, _ := sw.getEnv(name)
+		return value
+	}
+	sw.envs = BuildEnvs([]string{})
+	if getEnv("foo") != "" {
+		t.Fatal("2 - 'foo' should map to ''")
+	}
+
+	sw.envs = BuildEnvs([]string{"foo"})
+	if getEnv("foo") != "" {
+		t.Fatal("3 - 'foo' should map to ''")
+	}
+
+	sw.envs = BuildEnvs([]string{"foo="})
+	if getEnv("foo") != "" {
+		t.Fatal("4 - 'foo' should map to ''")
+	}
+
+	sw.envs = BuildEnvs([]string{"foo=bar"})
+	if getEnv("foo") != "bar" {
+		t.Fatal("5 - 'foo' should map to 'bar'")
+	}
+
+	sw.envs = BuildEnvs([]string{"foo=bar", "car=hat"})
+	if getEnv("foo") != "bar" {
+		t.Fatal("6 - 'foo' should map to 'bar'")
+	}
+	if getEnv("car") != "hat" {
+		t.Fatal("7 - 'car' should map to 'hat'")
+	}
+
+	// Make sure we grab the last 'car' in the list
+	sw.envs = BuildEnvs([]string{"foo=bar", "car=hat", "car=bike"})
+	if getEnv("car") != "bike" {
+		t.Fatal("8 - 'car' should map to 'bike'")
+	}
+}

--- a/util/shell/wordsTest
+++ b/util/shell/wordsTest
@@ -1,0 +1,30 @@
+hello | hello
+hello${hi}bye | hellobye
+ENV hi=hi
+hello${hi}bye | hellohibye
+ENV space=abc  def
+hello${space}bye | helloabc,defbye
+hello"${space}"bye | helloabc  defbye
+hello "${space}"bye | hello,abc  defbye
+ENV leading=  ab c
+hello${leading}def | hello,ab,cdef
+hello"${leading}" def | hello  ab c,def
+hello"${leading}" | hello  ab c
+hello${leading} | hello,ab,c
+# next line MUST have 3 trailing spaces, don't erase them!
+ENV trailing=ab c   
+hello${trailing} | helloab,c
+hello${trailing}d | helloab,c,d
+hello"${trailing}"d | helloab c   d
+# next line MUST have 3 trailing spaces, don't erase them!
+hel"lo${trailing}" | helloab c   
+hello" there  " | hello there  
+hello there     | hello,there
+hello\ there | hello there
+hello" there | error
+hello\" there | hello",there
+hello"\\there" | hello\there
+hello"\there" | hello\there
+hello'\\there' | hello\\there
+hello'\there' | hello\there
+hello'$there' | hello$there

--- a/variables/collection.go
+++ b/variables/collection.go
@@ -8,6 +8,7 @@ import (
 	"github.com/earthly/earthly/domain"
 	"github.com/earthly/earthly/features"
 	"github.com/earthly/earthly/util/gitutil"
+	"github.com/earthly/earthly/util/shell"
 
 	dfShell "github.com/moby/buildkit/frontend/dockerfile/shell"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
@@ -131,8 +132,9 @@ func (c *Collection) SortedOverridingVariables() []string {
 	return c.overriding().SortedAny()
 }
 
-// Expand expands variables within the given word.
-func (c *Collection) Expand(word string) string {
+// ExpandOld expands variables within the given word, it does not peform shelling-out.
+// it will eventually be removed when the ShellOutAnywhere feature is fully-adopted
+func (c *Collection) ExpandOld(word string) string {
 	shlex := dfShell.NewLex('\\')
 	varMap := c.effective().ActiveValueMap()
 	ret, err := shlex.ProcessWordWithMap(word, varMap)
@@ -141,6 +143,14 @@ func (c *Collection) Expand(word string) string {
 		return word
 	}
 	return ret
+}
+
+// Expand expands variables within the given word.
+func (c *Collection) Expand(word string, shellOut shell.EvalShellOutFn) (string, error) {
+	shlex := shell.NewLex('\\')
+	shlex.ShellOut = shellOut
+	varMap := c.effective().ActiveValueMap()
+	return shlex.ProcessWordWithMap(word, varMap)
 }
 
 // DeclareArg declares an arg. The effective value may be

--- a/variables/parse.go
+++ b/variables/parse.go
@@ -74,7 +74,6 @@ func parseArg(arg string, pncvf ProcessNonConstantVariableFunc, current *Collect
 		if reserved.IsBuiltIn(name) {
 			return "", "", errors.Errorf("value cannot be specified for built-in build arg %s", name)
 		}
-
 		v, err := parseArgValue(name, value, pncvf)
 		if err != nil {
 			return "", "", err
@@ -100,7 +99,6 @@ func parseArgValue(name string, value string, pncvf ProcessNonConstantVariableFu
 			return "", err
 		}
 	}
-
 	return value, nil
 }
 


### PR DESCRIPTION
ARG values such as `foo$(cat data)` were not being expanded.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>