### PR TITLE
Update Rust Example

### DIFF
--- a/examples/rust/Earthfile
+++ b/examples/rust/Earthfile
@@ -1,5 +1,5 @@
 VERSION 0.6
-FROM rust:1.51
+FROM rust:1.59
 WORKDIR /rustexample
 
 install-chef:


### PR DESCRIPTION
I lost a game of rock-paper-scissors so I'm fixing the Rust example that seems to have broken the `+examples2` target recently.