### PR TITLE
Revert "Use the zero time for the timestamp used when flattening file metadata"

### DIFF
--- a/util/llbutil/copyop.go
+++ b/util/llbutil/copyop.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/earthly/earthly/util/llbutil/pllb"
@@ -12,8 +13,6 @@ import (
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
-
-var defaultFlatTs = time.Time{} // the zero time
 
 // CopyOp is a simplified llb copy operation.
 func CopyOp(srcState pllb.State, srcs []string, destState pllb.State, dest string, allowWildcard bool, isDir bool, keepTs bool, chown string, ifExists, symlinkNoFollow, merge bool, opts ...llb.ConstraintsOpt) pllb.State {
@@ -27,7 +26,7 @@ func CopyOp(srcState pllb.State, srcs []string, destState pllb.State, dest strin
 	}
 	var fa *pllb.FileAction
 	if !keepTs {
-		baseCopyOpts = append(baseCopyOpts, llb.WithCreatedTime(defaultFlatTs))
+		baseCopyOpts = append(baseCopyOpts, llb.WithCreatedTime(*defaultTs()))
 	}
 	for _, src := range srcs {
 		if ifExists {
@@ -108,4 +107,18 @@ func Abs(ctx context.Context, s pllb.State, p string) (string, error) {
 		return "", errors.Wrap(err, "get dir")
 	}
 	return path.Join(dir, p), nil
+}
+
+var defaultTsValue time.Time
+var defaultTsParse sync.Once
+
+func defaultTs() *time.Time {
+	defaultTsParse.Do(func() {
+		var err error
+		defaultTsValue, err = time.Parse(time.RFC3339, "2020-04-16T12:00:00+00:00")
+		if err != nil {
+			panic(err)
+		}
+	})
+	return &defaultTsValue
 }


### PR DESCRIPTION
Reverts earthly/earthly#1705

Fixes https://github.com/earthly/earthly/issues/1712