### PR TITLE
Parallel conversion for `WITH DOCKER --load`

### DIFF
--- a/.earthly_version_flag_overrides
+++ b/.earthly_version_flag_overrides
@@ -1,1 +1,1 @@
-referenced-save-only,use-copy-include-patterns,earthly-version-arg,use-cache-command,use-host-command,check-duplicate-images,use-copy-link
+referenced-save-only,use-copy-include-patterns,earthly-version-arg,use-cache-command,use-host-command,check-duplicate-images,use-copy-link,parallel-load

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 
 ## Unreleased
 
+### Added
+
+- An experimental feature whereby `WITH DOCKER` parallelizes building of the
+  images to be loaded has been added. To enable this feature use
+  `VERSION --parallel-load 0.6`. [#1725](https://github.com/earthly/earthly/pull/1725)
+
+### Fixed
+
+- Fixed a duplicate build issue when using `IF` together with `WITH DOCKER` [#1724](https://github.com/earthly/earthly/issues/1724)
+
 ## v0.6.10 - 2022-03-03
 
 ### Changed

--- a/ast/tests/with-docker.ast.json
+++ b/ast/tests/with-docker.ast.json
@@ -32,6 +32,14 @@
         {
           "command": {
             "args": [
+              "+docker-load-multi-test"
+            ],
+            "name": "BUILD"
+          }
+        },
+        {
+          "command": {
+            "args": [
               "+docker-pull-test"
             ],
             "name": "BUILD"
@@ -136,6 +144,64 @@
           "command": {
             "args": [
               "test-${name}-img:xyz"
+            ],
+            "name": "SAVE IMAGE"
+          }
+        }
+      ]
+    },
+    {
+      "name": "another-test-image",
+      "recipe": [
+        {
+          "command": {
+            "args": [
+              "alpine:3.15"
+            ],
+            "name": "FROM"
+          }
+        },
+        {
+          "command": {
+            "args": [
+              "/work"
+            ],
+            "name": "WORKDIR"
+          }
+        },
+        {
+          "command": {
+            "args": [
+              "INDEX",
+              "=",
+              "0"
+            ],
+            "name": "ARG"
+          }
+        },
+        {
+          "command": {
+            "args": [
+              "echo",
+              "\"hello another test img $INDEX\"",
+              ">file.txt"
+            ],
+            "name": "RUN"
+          }
+        },
+        {
+          "command": {
+            "args": [
+              "cat",
+              "/work/file.txt"
+            ],
+            "name": "ENTRYPOINT"
+          }
+        },
+        {
+          "command": {
+            "args": [
+              "another-test-img:i${INDEX}"
             ],
             "name": "SAVE IMAGE"
           }
@@ -388,6 +454,63 @@
       ]
     },
     {
+      "name": "docker-load-multi-test",
+      "recipe": [
+        {
+          "with": {
+            "body": [
+              {
+                "command": {
+                  "args": [
+                    "docker",
+                    "run",
+                    "--rm",
+                    "another-test-img:i1",
+                    "&&",
+                    "docker",
+                    "run",
+                    "--rm",
+                    "another-test-img:i2",
+                    "&&",
+                    "docker",
+                    "run",
+                    "--rm",
+                    "another-test-img:i3",
+                    "&&",
+                    "docker",
+                    "run",
+                    "--rm",
+                    "another-test-img:i4",
+                    "&&",
+                    "docker",
+                    "run",
+                    "--rm",
+                    "another-test-img:i5"
+                  ],
+                  "name": "RUN"
+                }
+              }
+            ],
+            "command": {
+              "args": [
+                "--load=(+another-test-image",
+                "--INDEX=1)",
+                "--load=(+another-test-image",
+                "--INDEX=2)",
+                "--load=(+another-test-image",
+                "--INDEX=3)",
+                "--load=(+another-test-image",
+                "--INDEX=4)",
+                "--load=(+another-test-image",
+                "--INDEX=5)"
+              ],
+              "name": "DOCKER"
+            }
+          }
+        }
+      ]
+    },
+    {
       "name": "docker-pull-test",
       "recipe": [
         {
@@ -578,6 +701,7 @@
   ],
   "version": {
     "args": [
+      "--parallel-load",
       "0.6"
     ]
   }

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -22,6 +22,7 @@ import (
 	"github.com/earthly/earthly/util/gwclientlogger"
 	"github.com/earthly/earthly/util/llbutil"
 	"github.com/earthly/earthly/util/llbutil/pllb"
+	"github.com/earthly/earthly/util/syncutil/semutil"
 	"github.com/earthly/earthly/variables"
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/client/llb"
@@ -33,7 +34,6 @@ import (
 	reccopy "github.com/otiai10/copy"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
-	"golang.org/x/sync/semaphore"
 )
 
 const (
@@ -70,7 +70,7 @@ type Opt struct {
 	Strict                 bool
 	DisableNoOutputUpdates bool
 	ParallelConversion     bool
-	Parallelism            *semaphore.Weighted
+	Parallelism            semutil.Semaphore
 	LocalRegistryAddr      string
 	FeatureFlagOverrides   string
 	ContainerFrontend      containerutil.ContainerFrontend
@@ -639,43 +639,13 @@ func (b *Builder) artifactStateToRef(ctx context.Context, gwClient gwclient.Clie
 }
 
 func (b *Builder) buildOnlyLastImageAsTar(ctx context.Context, mts *states.MultiTarget, dockerTag string, outFile string, opt BuildOpt) error {
+	platform, err := llbutil.ResolvePlatform(mts.Final.Platform, opt.Platform)
+	if err != nil {
+		platform = mts.Final.Platform
+	}
+	plat := llbutil.PlatformWithDefault(platform)
 	saveImage := mts.Final.LastSaveImage()
-	err := b.buildMain(ctx, mts, opt)
-	if err != nil {
-		return err
-	}
-
-	platform, err := llbutil.ResolvePlatform(mts.Final.Platform, opt.Platform)
-	if err != nil {
-		platform = mts.Final.Platform
-	}
-	plat := llbutil.PlatformWithDefault(platform)
-	err = b.outputImageTar(ctx, saveImage, plat, dockerTag, outFile)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func (b *Builder) buildMain(ctx context.Context, mts *states.MultiTarget, opt BuildOpt) error {
-	state := mts.Final.MainState
-	if b.opt.NoCache {
-		state = state.SetMarshalDefaults(llb.IgnoreCache)
-	}
-	platform, err := llbutil.ResolvePlatform(mts.Final.Platform, opt.Platform)
-	if err != nil {
-		platform = mts.Final.Platform
-	}
-	plat := llbutil.PlatformWithDefault(platform)
-	err = b.s.solveMain(ctx, state, plat)
-	if err != nil {
-		return errors.Wrapf(err, "solve side effects")
-	}
-	return nil
-}
-
-func (b *Builder) outputImageTar(ctx context.Context, saveImage states.SaveImage, platform specs.Platform, dockerTag string, outFile string) error {
-	err := b.s.solveDockerTar(ctx, saveImage.State, platform, saveImage.Image, dockerTag, outFile)
+	err = b.s.solveDockerTar(ctx, saveImage.State, plat, saveImage.Image, dockerTag, outFile)
 	if err != nil {
 		return errors.Wrapf(err, "solve image tar %s", outFile)
 	}

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -49,7 +49,6 @@ import (
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
 	"golang.org/x/sync/errgroup"
-	"golang.org/x/sync/semaphore"
 	"golang.org/x/term"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -76,6 +75,7 @@ import (
 	"github.com/earthly/earthly/util/fileutil"
 	"github.com/earthly/earthly/util/llbutil"
 	"github.com/earthly/earthly/util/reflectutil"
+	"github.com/earthly/earthly/util/syncutil/semutil"
 	"github.com/earthly/earthly/util/termutil"
 	"github.com/earthly/earthly/variables"
 )
@@ -2955,9 +2955,9 @@ func (app *earthlyApp) actionBuildImp(c *cli.Context, flagArgs, nonFlagArgs []st
 			cacheExport = app.remoteCache
 		}
 	}
-	var parallelism *semaphore.Weighted
+	var parallelism semutil.Semaphore
 	if app.cfg.Global.ConversionParallelism != 0 {
-		parallelism = semaphore.NewWeighted(int64(app.cfg.Global.ConversionParallelism))
+		parallelism = semutil.NewWeighted(int64(app.cfg.Global.ConversionParallelism))
 	}
 	localRegistryAddr := ""
 	if isLocal && app.localRegistryHost != "" {

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -1165,27 +1165,29 @@ func (c *Converter) GitClone(ctx context.Context, gitURL string, branch string, 
 }
 
 // WithDockerRun applies an entire WITH DOCKER ... RUN ... END clause.
-func (c *Converter) WithDockerRun(ctx context.Context, args []string, opt WithDockerOpt) error {
+func (c *Converter) WithDockerRun(ctx context.Context, args []string, opt WithDockerOpt, allowParallel bool) error {
 	err := c.checkAllowed(runCmd)
 	if err != nil {
 		return err
 	}
 	c.nonSaveCommand()
 	wdr := &withDockerRun{
-		c: c,
+		c:              c,
+		enableParallel: allowParallel && c.opt.ParallelConversion && c.ftrs.ParallelLoad,
 	}
 	return wdr.Run(ctx, args, opt)
 }
 
 // WithDockerRunLocal applies an entire WITH DOCKER ... RUN ... END clause.
-func (c *Converter) WithDockerRunLocal(ctx context.Context, args []string, opt WithDockerOpt) error {
+func (c *Converter) WithDockerRunLocal(ctx context.Context, args []string, opt WithDockerOpt, allowParallel bool) error {
 	err := c.checkAllowed(runCmd)
 	if err != nil {
 		return err
 	}
 	c.nonSaveCommand()
 	wdrl := &withDockerRunLocal{
-		c: c,
+		c:              c,
+		enableParallel: allowParallel && c.opt.ParallelConversion && c.ftrs.ParallelLoad,
 	}
 	return wdrl.Run(ctx, args, opt)
 }

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -30,7 +30,7 @@ import (
 	"github.com/earthly/earthly/util/llbutil/llbfactory"
 	"github.com/earthly/earthly/util/llbutil/pllb"
 	"github.com/earthly/earthly/util/stringutil"
-	"github.com/earthly/earthly/util/syncutil/serrgroup"
+	"github.com/earthly/earthly/util/syncutil/semutil"
 	"github.com/earthly/earthly/variables"
 	"github.com/earthly/earthly/variables/reserved"
 
@@ -932,18 +932,23 @@ func (c *Converter) Build(ctx context.Context, fullTargetName string, platform *
 	return err
 }
 
+type afterParallelFunc func(context.Context, *states.MultiTarget) error
+
 // BuildAsync applies the earthly BUILD command asynchronously.
-func (c *Converter) BuildAsync(ctx context.Context, fullTargetName string, platform *specs.Platform, allowPrivileged bool, buildArgs []string, cmdT cmdType, eg *serrgroup.Group) error {
+func (c *Converter) BuildAsync(ctx context.Context, fullTargetName string, platform *specs.Platform, allowPrivileged bool, buildArgs []string, cmdT cmdType, apf afterParallelFunc, sem semutil.Semaphore) error {
 	target, opt, _, err := c.prepBuildTarget(ctx, fullTargetName, platform, allowPrivileged, buildArgs, true, cmdT)
 	if err != nil {
 		return err
 	}
-	eg.Go(func() error {
-		err := c.opt.Parallelism.Acquire(ctx, 1)
+	c.opt.ErrorGroup.Go(func() error {
+		if sem == nil {
+			sem = c.opt.Parallelism
+		}
+		rel, err := sem.Acquire(ctx, 1)
 		if err != nil {
 			return errors.Wrapf(err, "acquiring parallelism semaphore for %s", fullTargetName)
 		}
-		defer c.opt.Parallelism.Release(1)
+		defer rel()
 		mts, err := Earthfile2LLB(ctx, target, opt, false)
 		if err != nil {
 			return errors.Wrapf(err, "async earthfile2llb for %s", fullTargetName)
@@ -952,6 +957,12 @@ func (c *Converter) BuildAsync(ctx context.Context, fullTargetName string, platf
 			err = c.forceExecution(ctx, mts.Final.MainState)
 			if err != nil {
 				return errors.Wrapf(err, "async force execution for %s", fullTargetName)
+			}
+		}
+		if apf != nil {
+			err = apf(ctx, mts)
+			if err != nil {
+				return err
 			}
 		}
 		return nil

--- a/earthfile2llb/earthfile2llb.go
+++ b/earthfile2llb/earthfile2llb.go
@@ -9,7 +9,6 @@ import (
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
-	"golang.org/x/sync/semaphore"
 
 	"github.com/earthly/earthly/ast/spec"
 	"github.com/earthly/earthly/buildcontext"
@@ -19,6 +18,7 @@ import (
 	"github.com/earthly/earthly/domain"
 	"github.com/earthly/earthly/features"
 	"github.com/earthly/earthly/states"
+	"github.com/earthly/earthly/util/syncutil/semutil"
 	"github.com/earthly/earthly/util/syncutil/serrgroup"
 	"github.com/earthly/earthly/variables"
 )
@@ -92,7 +92,7 @@ type ConvertOpt struct {
 	// ParallelConversion is a feature flag enabling the parallel conversion algorithm.
 	ParallelConversion bool
 	// Parallelism is a semaphore controlling the maximum parallelism.
-	Parallelism *semaphore.Weighted
+	Parallelism semutil.Semaphore
 	// ErrorGroup is a serrgroup used to submit parallel conversion jobs.
 	ErrorGroup *serrgroup.Group
 
@@ -176,7 +176,7 @@ func Earthfile2LLB(ctx context.Context, target domain.Target, opt ConvertOpt, in
 	if err != nil {
 		return nil, err
 	}
-	interpreter := newInterpreter(converter, targetWithMetadata, opt.AllowPrivileged, opt.ParallelConversion, opt.Parallelism, opt.ErrorGroup, opt.Console, opt.GitLookup)
+	interpreter := newInterpreter(converter, targetWithMetadata, opt.AllowPrivileged, opt.ParallelConversion, opt.Console, opt.GitLookup)
 	err = interpreter.Run(ctx, bc.Earthfile)
 	if err != nil {
 		return nil, err

--- a/earthfile2llb/withdockerrunlocal.go
+++ b/earthfile2llb/withdockerrunlocal.go
@@ -4,16 +4,30 @@ import (
 	"context"
 	"os"
 	"path"
+	"sort"
+	"sync"
 
 	"github.com/earthly/earthly/domain"
 	"github.com/earthly/earthly/states"
+	"github.com/earthly/earthly/util/syncutil/semutil"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/session/localhost"
 	"github.com/pkg/errors"
 )
 
 type withDockerRunLocal struct {
-	c *Converter
+	c   *Converter
+	sem semutil.Semaphore
+
+	enableParallel bool
+
+	mu       sync.Mutex
+	tarLoads []tarLoadLocal
+}
+
+type tarLoadLocal struct {
+	imgName string
+	imgFile string
 }
 
 func (wdrl *withDockerRunLocal) Run(ctx context.Context, args []string, opt WithDockerOpt) error {
@@ -22,17 +36,35 @@ func (wdrl *withDockerRunLocal) Run(ctx context.Context, args []string, opt With
 		return err
 	}
 	wdrl.c.nonSaveCommand()
+	// This semaphore ensures that there is at least one thread allowed to progress,
+	// even if parallelism is completely starved.
+	wdrl.sem = semutil.NewMultiSem(wdrl.c.opt.Parallelism, semutil.NewWeighted(1))
 
+	// Build and solve images to be loaded.
+	loadPromises := make([]chan DockerLoadOpt, 0, len(opt.Loads))
 	for _, loadOpt := range opt.Loads {
-		// Load.
-		localImageTarPath, err := wdrl.load(ctx, loadOpt)
+		lp, err := wdrl.load(ctx, loadOpt)
 		if err != nil {
 			return errors.Wrap(err, "load")
 		}
-		// then issue docker load
+		loadPromises = append(loadPromises, lp)
+	}
+	for _, lp := range loadPromises {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-lp:
+		}
+	}
+	// Sort the tar list, to make the operation consistent.
+	sort.Slice(wdrl.tarLoads, func(i, j int) bool {
+		return wdrl.tarLoads[i].imgName < wdrl.tarLoads[j].imgName
+	})
+	// Issue docker load.
+	for _, tl := range wdrl.tarLoads {
 		runOpts := []llb.RunOption{
 			llb.IgnoreCache,
-			llb.Args([]string{localhost.RunOnLocalHostMagicStr, "/bin/sh", "-c", wdrl.c.containerFrontend.ImageLoadFromFileCommand(localImageTarPath)}),
+			llb.Args([]string{localhost.RunOnLocalHostMagicStr, "/bin/sh", "-c", wdrl.c.containerFrontend.ImageLoadFromFileCommand(tl.imgFile)}),
 		}
 		wdrl.c.mts.Final.MainState = wdrl.c.mts.Final.MainState.Run(runOpts...).Root()
 	}
@@ -58,38 +90,58 @@ func (wdrl *withDockerRunLocal) Run(ctx context.Context, args []string, opt With
 	return nil
 }
 
-func (wdrl *withDockerRunLocal) load(ctx context.Context, opt DockerLoadOpt) (string, error) {
+func (wdrl *withDockerRunLocal) load(ctx context.Context, opt DockerLoadOpt) (chan DockerLoadOpt, error) {
+	optPromise := make(chan DockerLoadOpt, 1)
 	depTarget, err := domain.ParseTarget(opt.Target)
 	if err != nil {
-		return "", errors.Wrapf(err, "parse target %s", opt.Target)
+		return nil, errors.Wrapf(err, "parse target %s", opt.Target)
 	}
-	mts, err := wdrl.c.buildTarget(ctx, depTarget.String(), opt.Platform, opt.AllowPrivileged, opt.BuildArgs, false, loadCmd)
-	if err != nil {
-		return "", err
-	}
-	if opt.ImageName == "" {
-		// Infer image name from the SAVE IMAGE statement.
-		if len(mts.Final.SaveImages) == 0 || mts.Final.SaveImages[0].DockerTag == "" {
-			return "", errors.New(
-				"no docker image tag specified in load and it cannot be inferred from the SAVE IMAGE statement")
+	afterFun := func(ctx context.Context, mts *states.MultiTarget) error {
+		if opt.ImageName == "" {
+			// Infer image name from the SAVE IMAGE statement.
+			if len(mts.Final.SaveImages) == 0 || mts.Final.SaveImages[0].DockerTag == "" {
+				return errors.New(
+					"no docker image tag specified in load and it cannot be inferred from the SAVE IMAGE statement")
+			}
+			if len(mts.Final.SaveImages) > 1 {
+				return errors.New(
+					"no docker image tag specified in load and it cannot be inferred from the SAVE IMAGE statement: " +
+						"multiple tags mentioned in SAVE IMAGE")
+			}
+			opt.ImageName = mts.Final.SaveImages[0].DockerTag
 		}
-		if len(mts.Final.SaveImages) > 1 {
-			return "", errors.New(
-				"no docker image tag specified in load and it cannot be inferred from the SAVE IMAGE statement: " +
-					"multiple tags mentioned in SAVE IMAGE")
+		err := wdrl.solveImage(
+			ctx, mts, depTarget.String(), opt.ImageName,
+			llb.WithCustomNamef(
+				"%sDOCKER LOAD %s %s", wdrl.c.imageVertexPrefix(depTarget.String()), depTarget.String(), opt.ImageName))
+		if err != nil {
+			return err
 		}
-		opt.ImageName = mts.Final.SaveImages[0].DockerTag
+		optPromise <- opt
+		return nil
 	}
-	return wdrl.solveImage(
-		ctx, mts, depTarget.String(), opt.ImageName,
-		llb.WithCustomNamef(
-			"%sDOCKER LOAD %s %s", wdrl.c.imageVertexPrefix(depTarget.String()), depTarget.String(), opt.ImageName))
+	if wdrl.enableParallel {
+		err = wdrl.c.BuildAsync(ctx, depTarget.String(), opt.Platform, opt.AllowPrivileged, opt.BuildArgs, loadCmd, afterFun, wdrl.sem)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		mts, err := wdrl.c.buildTarget(ctx, depTarget.String(), opt.Platform, opt.AllowPrivileged, opt.BuildArgs, false, loadCmd)
+		if err != nil {
+			return nil, err
+		}
+		err = afterFun(ctx, mts)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return optPromise, nil
 }
 
-func (wdrl *withDockerRunLocal) solveImage(ctx context.Context, mts *states.MultiTarget, opName string, dockerTag string, opts ...llb.RunOption) (string, error) {
+func (wdrl *withDockerRunLocal) solveImage(ctx context.Context, mts *states.MultiTarget, opName string, dockerTag string, opts ...llb.RunOption) error {
 	outDir, err := os.MkdirTemp(os.TempDir(), "earthly-docker-load")
 	if err != nil {
-		return "", errors.Wrap(err, "mk temp dir for docker load")
+		return errors.Wrap(err, "mk temp dir for docker load")
 	}
 	wdrl.c.opt.CleanCollection.Add(func() error {
 		return os.RemoveAll(outDir)
@@ -97,7 +149,13 @@ func (wdrl *withDockerRunLocal) solveImage(ctx context.Context, mts *states.Mult
 	outFile := path.Join(outDir, "image.tar")
 	err = wdrl.c.opt.DockerBuilderFun(ctx, mts, dockerTag, outFile)
 	if err != nil {
-		return "", errors.Wrapf(err, "build target %s for docker load", opName)
+		return errors.Wrapf(err, "build target %s for docker load", opName)
 	}
-	return outFile, nil
+	wdrl.mu.Lock()
+	defer wdrl.mu.Unlock()
+	wdrl.tarLoads = append(wdrl.tarLoads, tarLoadLocal{
+		imgName: dockerTag,
+		imgFile: outFile,
+	})
+	return nil
 }

--- a/features/features.go
+++ b/features/features.go
@@ -30,6 +30,7 @@ type Features struct {
 	UseHostCommand             bool `long:"use-host-command" description:"allow use of HOST command in Earthfiles"`
 	ExecAfterParallel          bool `long:"exec-after-parallel" description:"force execution after parallel conversion"`
 	UseCopyLink                bool `long:"use-copy-link" description:"use the equivalent of COPY --link for all copy-like operations"`
+	ParallelLoad               bool `long:"parallel-load" description:"perform parallel loading of images into WITH DOCKER"`
 
 	Major int
 	Minor int
@@ -181,6 +182,7 @@ func GetFeatures(version *spec.Version) (*Features, error) {
 		ftrs.UseCacheCommand = true
 		ftrs.UseHostCommand = true
 		ftrs.UseCopyLink = true
+		ftrs.ParallelLoad = true
 	}
 
 	return &ftrs, nil

--- a/tests/with-docker/Earthfile
+++ b/tests/with-docker/Earthfile
@@ -1,9 +1,10 @@
-VERSION 0.6
+VERSION --parallel-load 0.6
 FROM earthly/dind:alpine
 
 all:
     BUILD +docker-load-test
     BUILD +docker-load-arg-test
+    BUILD +docker-load-multi-test
     BUILD +docker-pull-test
     BUILD +load-parallel-test
     BUILD +one-target-many-names
@@ -18,6 +19,14 @@ a-test-image:
     RUN echo "hello $var" >def.txt
     ENTRYPOINT cat /$name/def.txt && pwd
     SAVE IMAGE test-${name}-img:xyz
+
+another-test-image:
+    FROM alpine:3.15
+    WORKDIR /work
+    ARG INDEX=0
+    RUN echo "hello another test img $INDEX" >file.txt
+    ENTRYPOINT cat /work/file.txt
+    SAVE IMAGE another-test-img:i${INDEX}
 
 docker-load-test:
     # Index is used to create parallel tests.
@@ -57,6 +66,20 @@ docker-load-arg-test:
     END
     WITH DOCKER --load=other-name:latest="(+a-test-image --name=bar --var buz)"
         RUN docker run other-name:latest | grep "hello buz"
+    END
+
+docker-load-multi-test:
+    WITH DOCKER \
+        --load=(+another-test-image --INDEX=1) \
+        --load=(+another-test-image --INDEX=2) \
+        --load=(+another-test-image --INDEX=3) \
+        --load=(+another-test-image --INDEX=4) \
+        --load=(+another-test-image --INDEX=5)
+        RUN docker run --rm another-test-img:i1 && \
+            docker run --rm another-test-img:i2 && \
+            docker run --rm another-test-img:i3 && \
+            docker run --rm another-test-img:i4 && \
+            docker run --rm another-test-img:i5
     END
 
 docker-pull-test:

--- a/util/syncutil/semutil/multisem.go
+++ b/util/syncutil/semutil/multisem.go
@@ -1,0 +1,54 @@
+package semutil
+
+import (
+	"context"
+)
+
+// MultiSem is a semaphore that is made out of multiple underlying semaphores.
+// The semaphores are attempted one at a time.
+type MultiSem struct {
+	sems []Semaphore
+}
+
+// NewMultiSem creates a new MultiSem.
+func NewMultiSem(sems ...Semaphore) Semaphore {
+	if len(sems) == 0 {
+		panic("no semaphores passed")
+	}
+	return &MultiSem{
+		sems: sems,
+	}
+}
+
+// Acquire acquires a semaphore. If all semaphores are starved, it only blocks
+// on the last semaphore.
+func (ms *MultiSem) Acquire(ctx context.Context, n int64) (ReleaseFun, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+	for _, sem := range ms.sems {
+		rel, ok := sem.TryAcquire(n)
+		if ok {
+			return rel, nil
+		}
+	}
+	lastSem := ms.sems[len(ms.sems)-1]
+	rel, err := lastSem.Acquire(ctx, n)
+	if err != nil {
+		return nil, err
+	}
+	return rel, nil
+}
+
+// TryAcquire acquires a semaphore, but does not block.
+func (ms *MultiSem) TryAcquire(n int64) (ReleaseFun, bool) {
+	for _, sem := range ms.sems {
+		rel, ok := sem.TryAcquire(n)
+		if ok {
+			return rel, true
+		}
+	}
+	return nil, false
+}

--- a/util/syncutil/semutil/sem.go
+++ b/util/syncutil/semutil/sem.go
@@ -1,0 +1,16 @@
+package semutil
+
+import "context"
+
+// ReleaseFun is a function that needs to be called to release the semaphore.
+type ReleaseFun func()
+
+// Semaphore is a generic semaphore.
+type Semaphore interface {
+	// Acquire acquires a resource on the semaphore. If no resource is available,
+	// the call blocks until one is made available.
+	Acquire(ctx context.Context, n int64) (ReleaseFun, error)
+	// TryAcquire acquires a resource on the semaphore. If no resource is
+	// available, the call returns immediately with false.
+	TryAcquire(n int64) (ReleaseFun, bool)
+}

--- a/util/syncutil/semutil/weighted.go
+++ b/util/syncutil/semutil/weighted.go
@@ -1,0 +1,39 @@
+package semutil
+
+import (
+	"context"
+
+	"golang.org/x/sync/semaphore"
+)
+
+// Weighted is a weighted semaphore.
+type Weighted struct {
+	sem *semaphore.Weighted
+}
+
+// NewWeighted creates a new weighted semaphore.
+func NewWeighted(n int64) Semaphore {
+	return &Weighted{sem: semaphore.NewWeighted(n)}
+}
+
+// Acquire acquires a semaphore.
+func (w *Weighted) Acquire(ctx context.Context, n int64) (ReleaseFun, error) {
+	err := w.sem.Acquire(ctx, n)
+	if err != nil {
+		return nil, err
+	}
+	return func() {
+		w.sem.Release(n)
+	}, nil
+}
+
+// TryAcquire acquires a semaphore, but does not block.
+func (w *Weighted) TryAcquire(n int64) (ReleaseFun, bool) {
+	ok := w.sem.TryAcquire(n)
+	if !ok {
+		return nil, false
+	}
+	return func() {
+		w.sem.Release(n)
+	}, true
+}


### PR DESCRIPTION
Re https://github.com/earthly/earthly/issues/1268. This addresses point 2 in this comment: https://github.com/earthly/earthly/issues/1268#issuecomment-938261849.

This PR takes the multiple `--load`s and `--pull`s in a `WITH DOCKER` and builds the necessary image tars in parallel. This includes converting the referenced targets in parallel, but also outputting the tars in parallel.

To enable this feature use `VERSION --parallel-load 0.6`.

Separately, this also fixes https://github.com/earthly/earthly/issues/1724. No feature flag is needed to benefit from this.