### PR TITLE
docs: workaround gitbook bug

### DIFF
--- a/docs/basics/final-words.md
+++ b/docs/basics/final-words.md
@@ -8,7 +8,8 @@ Learning Earthly does not stop here. Discover more of what Earthly can do by exp
 
 * [The Earthfile reference](../earthfile/earthfile.md)
 * [The **earthly command** reference](../earthly-command/earthly-command.md)
-* [Guides](../earthfile/guides)
+* [Guides](https://tinyurl.com/2p8cpnxv) <!-- should be ../earthfile/guides but gitbook produces a 404 link for this -->
+
 * [Examples using Earthly](../examples/examples.md)
 * [Best practices](../best-practices/best-practices.md)
 


### PR DESCRIPTION
Rather than get a link to https://docs.earthly.dev/docs/guides/
gitbook is linking to 	https://github.com/earthly/earthly/blob/main/docs/earthfile/guides/README.md
(which doesn't exist); use a tinyurl to point to the correct location
instead (as suggested by gitbook support).

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>