### PR TITLE
Disable output when building a tar for loading via WITH DOCKER

### DIFF
--- a/.earthly_version_flag_overrides
+++ b/.earthly_version_flag_overrides
@@ -1,1 +1,1 @@
-referenced-save-only,use-copy-include-patterns,earthly-version-arg,use-cache-command,use-host-command,check-duplicate-images,use-copy-link,parallel-load,shell-out-anywhere
+referenced-save-only,use-copy-include-patterns,earthly-version-arg,use-cache-command,use-host-command,check-duplicate-images,use-copy-link,parallel-load,shell-out-anywhere,no-tar-build-output

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,13 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 
 ### Added
 
-* The feature flag `--exec-after-build` has been enabled retroactively for `VERSION 0.5`. This speeds up largs builds by 15-20%.
-* The feature flag `--parallel-load` has been enabled for every `VERSION`. This speeds up by parallelizing targets built for loading via `WITH DOCKER --load`.
-* `VERSION 0.0` is now permitted, however it is only meant for Earthly internal debugging purposes. `VERSION 0.0` disables all feature flags.
+- The feature flag `--exec-after-build` has been enabled retroactively for `VERSION 0.5`. This speeds up largs builds by 15-20%.
+- The feature flag `--parallel-load` has been enabled for every `VERSION`. This speeds up by parallelizing targets built for loading via `WITH DOCKER --load`.
+- `VERSION 0.0` is now permitted, however it is only meant for Earthly internal debugging purposes. `VERSION 0.0` disables all feature flags.
 
 ### Fixed
 
-* An experimental fix for duplicate output when building images that are loaded via `WITH DOCKER --load`. This can be enabled via `VERSION --no-tar-build-output 0.6`.
+- An experimental fix for duplicate output when building images that are loaded via `WITH DOCKER --load`. This can be enabled via `VERSION --no-tar-build-output 0.6`.
 
 ## v0.6.11 - 2022-03-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 
 ## Unreleased
 
+### Added
+
+* The feature flag `--exec-after-build` has been enabled retroactively for `VERSION 0.5`. This speeds up largs builds by 15-20%.
+* The feature flag `--parallel-load` has been enabled for every `VERSION`. This speeds up by parallelizing targets built for loading via `WITH DOCKER --load`.
+* `VERSION 0.0` is now permitted, however it is only meant for Earthly internal debugging purposes. `VERSION 0.0` disables all feature flags.
+
+### Fixed
+
+* An experimental fix for duplicate output when building images that are loaded via `WITH DOCKER --load`. This can be enabled via `VERSION --no-tar-build-output 0.6`.
+
 ## v0.6.11 - 2022-03-17
 
 ### Added

--- a/Earthfile
+++ b/Earthfile
@@ -459,7 +459,7 @@ for-darwin-m1:
     # TODO: Use the USERARCH variant after the next Earthly release.
     # ARG USERARCH
     # BUILD --platform=linux/$USERARCH ./ast/parser+parser
-    BUILD --platform=linux/amd64 ./ast/parser+parser
+    BUILD ./ast/parser+parser
     COPY +earthly-darwin-arm64/earthly ./
     SAVE ARTIFACT ./earthly AS LOCAL ./build/darwin/arm64/earthly
 

--- a/Earthfile
+++ b/Earthfile
@@ -459,7 +459,7 @@ for-darwin-m1:
     # TODO: Use the USERARCH variant after the next Earthly release.
     # ARG USERARCH
     # BUILD --platform=linux/$USERARCH ./ast/parser+parser
-    BUILD ./ast/parser+parser
+    BUILD --platform=linux/amd64 ./ast/parser+parser
     COPY +earthly-darwin-arm64/earthly ./
     SAVE ARTIFACT ./earthly AS LOCAL ./build/darwin/arm64/earthly
 

--- a/ast/validator.go
+++ b/ast/validator.go
@@ -13,6 +13,7 @@ import (
 // into it's own package with some helper functions that are
 // consumable from other packages.
 var validEarthfileVersions = []string{
+	"0.0", // Meant only for testing/debugging. Disables all feature flags.
 	"0.5",
 	"0.6",
 }

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -133,8 +133,8 @@ func (b *Builder) BuildTarget(ctx context.Context, target domain.Target, opt Bui
 
 // MakeImageAsTarBuilderFun returns a function which can be used to build an image as a tar.
 func (b *Builder) MakeImageAsTarBuilderFun() states.DockerBuilderFun {
-	return func(ctx context.Context, mts *states.MultiTarget, dockerTag string, outFile string) error {
-		return b.buildOnlyLastImageAsTar(ctx, mts, dockerTag, outFile, BuildOpt{})
+	return func(ctx context.Context, mts *states.MultiTarget, dockerTag string, outFile string, printOutput bool) error {
+		return b.buildOnlyLastImageAsTar(ctx, mts, dockerTag, outFile, BuildOpt{}, printOutput)
 	}
 }
 
@@ -639,14 +639,14 @@ func (b *Builder) artifactStateToRef(ctx context.Context, gwClient gwclient.Clie
 	return llbutil.StateToRef(ctx, gwClient, state, noCache, platform, b.opt.CacheImports.AsMap())
 }
 
-func (b *Builder) buildOnlyLastImageAsTar(ctx context.Context, mts *states.MultiTarget, dockerTag string, outFile string, opt BuildOpt) error {
+func (b *Builder) buildOnlyLastImageAsTar(ctx context.Context, mts *states.MultiTarget, dockerTag string, outFile string, opt BuildOpt, printOutput bool) error {
 	platform, err := llbutil.ResolvePlatform(mts.Final.Platform, opt.Platform)
 	if err != nil {
 		platform = mts.Final.Platform
 	}
 	plat := llbutil.PlatformWithDefault(platform)
 	saveImage := mts.Final.LastSaveImage()
-	err = b.s.solveDockerTar(ctx, saveImage.State, plat, saveImage.Image, dockerTag, outFile)
+	err = b.s.solveDockerTar(ctx, saveImage.State, plat, saveImage.Image, dockerTag, outFile, printOutput)
 	if err != nil {
 		return errors.Wrapf(err, "solve image tar %s", outFile)
 	}

--- a/builder/solver.go
+++ b/builder/solver.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"strconv"
@@ -40,7 +41,7 @@ type solver struct {
 	saveInlineCache bool
 }
 
-func (s *solver) solveDockerTar(ctx context.Context, state pllb.State, platform specs.Platform, img *image.Image, dockerTag string, outFile string) error {
+func (s *solver) solveDockerTar(ctx context.Context, state pllb.State, platform specs.Platform, img *image.Image, dockerTag string, outFile string, printOutput bool) error {
 	dt, err := state.Marshal(ctx, llb.Platform(platform))
 	if err != nil {
 		return errors.Wrap(err, "state marshal")
@@ -65,8 +66,24 @@ func (s *solver) solveDockerTar(ctx context.Context, state pllb.State, platform 
 	var vertexFailureOutput string
 	eg.Go(func() error {
 		var err error
-		vertexFailureOutput, err = s.sm.MonitorProgress(ctx, ch, "", true)
-		return err
+		if printOutput {
+			vertexFailureOutput, err = s.sm.MonitorProgress(ctx, ch, "", true)
+			return err
+		}
+		// Silent case.
+		fmt.Printf("@# ENTERING silent case\n")
+		for {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case _, ok := <-ch:
+				if !ok {
+					fmt.Printf("@# silent case DONE\n")
+					return nil
+				}
+				// Do nothing - just consume the status updates silently.
+			}
+		}
 	})
 	eg.Go(func() error {
 		file, err := os.Create(outFile)

--- a/builder/solver.go
+++ b/builder/solver.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"os"
 	"strconv"
@@ -71,14 +70,12 @@ func (s *solver) solveDockerTar(ctx context.Context, state pllb.State, platform 
 			return err
 		}
 		// Silent case.
-		fmt.Printf("@# ENTERING silent case\n")
 		for {
 			select {
 			case <-ctx.Done():
 				return ctx.Err()
 			case _, ok := <-ch:
 				if !ok {
-					fmt.Printf("@# silent case DONE\n")
 					return nil
 				}
 				// Do nothing - just consume the status updates silently.

--- a/earthfile2llb/withdockerrun.go
+++ b/earthfile2llb/withdockerrun.go
@@ -395,7 +395,7 @@ func (wdr *withDockerRun) solveImage(ctx context.Context, mts *states.MultiTarge
 			return os.RemoveAll(outDir)
 		})
 		outFile := path.Join(outDir, "image.tar")
-		err = wdr.c.opt.DockerBuilderFun(ctx, mts, dockerTag, outFile)
+		err = wdr.c.opt.DockerBuilderFun(ctx, mts, dockerTag, outFile, !wdr.c.ftrs.NoTarBuildOutput)
 		if err != nil {
 			return pllb.State{}, errors.Wrapf(err, "build target %s for docker load", opName)
 		}

--- a/earthfile2llb/withdockerrunlocal.go
+++ b/earthfile2llb/withdockerrunlocal.go
@@ -147,7 +147,7 @@ func (wdrl *withDockerRunLocal) solveImage(ctx context.Context, mts *states.Mult
 		return os.RemoveAll(outDir)
 	})
 	outFile := path.Join(outDir, "image.tar")
-	err = wdrl.c.opt.DockerBuilderFun(ctx, mts, dockerTag, outFile)
+	err = wdrl.c.opt.DockerBuilderFun(ctx, mts, dockerTag, outFile, !wdrl.c.ftrs.NoTarBuildOutput)
 	if err != nil {
 		return errors.Wrapf(err, "build target %s for docker load", opName)
 	}

--- a/features/features.go
+++ b/features/features.go
@@ -31,6 +31,7 @@ type Features struct {
 	ExecAfterParallel          bool `long:"exec-after-parallel" description:"force execution after parallel conversion"`
 	UseCopyLink                bool `long:"use-copy-link" description:"use the equivalent of COPY --link for all copy-like operations"`
 	ParallelLoad               bool `long:"parallel-load" description:"perform parallel loading of images into WITH DOCKER"`
+	NoTarBuildOutput           bool `long:"no-tar-build-output" description:"do not print output when creating a tarball to load into WITH DOCKER"`
 	ShellOutAnywhere           bool `long:"shell-out-anywhere" description:"allow shelling-out in the middle of ARGs, or any other command"`
 
 	Major int
@@ -168,22 +169,25 @@ func GetFeatures(version *spec.Version) (*Features, error) {
 	}
 
 	// Enable version-specific features.
-	switch {
-	case versionAtLeast(ftrs, 0, 6):
+	if versionAtLeast(ftrs, 0, 5) {
+		ftrs.ExecAfterParallel = true
+		ftrs.ParallelLoad = true
+	}
+	if versionAtLeast(ftrs, 0, 6) {
 		ftrs.ReferencedSaveOnly = true
 		ftrs.UseCopyIncludePatterns = true
 		ftrs.ForIn = true
 		ftrs.RequireForceForUnsafeSaves = true
 		ftrs.NoImplicitIgnore = true
-		ftrs.ExecAfterParallel = true
-	case versionAtLeast(ftrs, 0, 7):
+	}
+	if versionAtLeast(ftrs, 0, 7) {
 		ftrs.ExplicitGlobal = true
 		ftrs.CheckDuplicateImages = true
 		ftrs.EarthlyVersionArg = true
 		ftrs.UseCacheCommand = true
 		ftrs.UseHostCommand = true
 		ftrs.UseCopyLink = true
-		ftrs.ParallelLoad = true
+		ftrs.NoTarBuildOutput = true
 	}
 
 	return &ftrs, nil

--- a/states/builderfun.go
+++ b/states/builderfun.go
@@ -5,4 +5,4 @@ import (
 )
 
 // DockerBuilderFun is a function able to build a target into a docker tar file.
-type DockerBuilderFun = func(ctx context.Context, mts *MultiTarget, dockerTag string, outFile string) error
+type DockerBuilderFun = func(ctx context.Context, mts *MultiTarget, dockerTag string, outFile string, printOutput bool) error


### PR DESCRIPTION
Some recent buildkit changes are causing some duplicate output when building images that are to be loaded via `WITH DOCKER`. This PR fixes that.

To benefit from these changes, you need to enable this via the feature flag: `VERSION --no-tar-build-output 0.6`. This is experimental for now.

Summary of changes:

* Enables `--parallel-load` and `--exec-after-parallel` feature flags for everyone. These don't cause compatibility issues so they can be safely enabled retroactively. These two flags will force execution of the every loaded tar build within the main build session. This means that their output will show up as part of the main build.
* Introduces a feature flag `--no-tar-build-output` which disables output for any tar build (this side-build is needed to turn the images into tar files to be loaded later). Because of the above two flags being enabled, the output will have anyway been printed as part of the main build.
* Adds a valid (but hidden) `VERSION 0.0`, which disables all feature flags. This is useful in case `--parallel-load` or `--exec-after-parallel` need to be disabled for debugging / testing purposes.

This addresses a fix for the following case, where output shows up as duplicated:

```Earthfile
VERSION 0.6

FROM busybox:latest

WORKDIR /app

PIP_INSTALL:
    COMMAND
    ARG target
    RUN echo "I am running PIP_INSTALL for target $target $RANDOM"

CHECK_TYPES:
    COMMAND
    ARG target
    RUN echo "I am running CHECK_TYPES for target $target $RANDOM"

test-venv:
    DO +PIP_INSTALL --target="test-venv"
    SAVE ARTIFACT . venv

test-img:
    ARG workbox=false

    COPY +test-venv/venv .
    DO +CHECK_TYPES --target="test-img"
    IF [ "$workbox" = "true" ]
        ENTRYPOINT ["sh"]
        SAVE IMAGE base-test-img:latest
    END

base-test:
    ARG workbox=false

    IF [ "$workbox" = "true" ]
        LOCALLY
        WITH DOCKER --load=(+test-img --workbox="$workbox")
            RUN docker run --rm --net=host base-test-img:latest -c "echo 'I am inside WITH DOCKER'"
        END
    ELSE
        BUILD +test-img --workbox="$workbox"
    END

```

Running the following was causing duplicate output:

```bash
earthly --no-cache +base-test --workbox=true
```