### PR TITLE
Use 3 second ssh timeout rather than default 20min

### DIFF
--- a/buildcontext/gitlookup.go
+++ b/buildcontext/gitlookup.go
@@ -13,6 +13,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/ssh"
@@ -406,6 +407,7 @@ func (gl *GitLookup) detectProtocol(host string) (protocol gitProtocol, err erro
 		},
 		HostKeyAlgorithms: algs,
 		HostKeyCallback:   gl.newHostKeyCallback(keys),
+		Timeout:           time.Second * 3,
 	}
 
 	client, err := ssh.Dial("tcp", fmt.Sprintf("%s:22", host), config)


### PR DESCRIPTION
The default SSH timeout value is 20 minutes, this causes
earthly to hang when outbound ssh connection packets are silently
dropped. Instead, if an ssh connection can not be established within 3
seconds, default to using http(s).

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>