### PR TITLE
prevent docker pull in +earthly-script-no-stdout

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -104,9 +104,12 @@ earthly-script-no-stdout:
     FROM earthly/dind:alpine
     RUN apk add --no-cache --update bash
     COPY earthly .earthly_version_flag_overrides .
-    WITH DOCKER --pull earthly/earthlybinaries
-        RUN ./earthly --version > earthly-version-output
-    END
+
+    # This script performs an explicit "docker pull earthlybinaries:prerelease" which can cause rate-limiting
+    # to work-around this, we will copy an earthly binary in, and disable auto-updating (and therefore don't require a WITH DOCKER)
+    COPY +for-linux/earthly /root/.earthly/earthly-prerelease
+    RUN EARTHLY_DISABLE_AUTO_UPDATE=true ./earthly --version > earthly-version-output
+
     RUN test "$(cat earthly-version-output | wc -l)" = "1"
     RUN grep '^earthly version.*$' earthly-version-output # only --version info should go to stdout
 

--- a/earthly
+++ b/earthly
@@ -134,7 +134,7 @@ case "$1" in
                 update="true"
             fi
 
-            if [ "$update" = "true" ]; then
+            if [ "$update" = "true" ] && [ "$EARTHLY_DISABLE_AUTO_UPDATE" != "true" ]; then
                 get_latest_binary
                 echo "Updated prerelease binary. Version:" >&2
                 "$bindir/earthly-prerelease" --version >&2


### PR DESCRIPTION
This prevents an explicit pull to docker.io/earthly/earthlybinaries:prerelease
in the +earthly-script-no-stdout target which can lead to rate-limiting.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>