### PR TITLE
fix tests with insecure dockerhub mirror

### DIFF
--- a/earthly-entrypoint.sh
+++ b/earthly-entrypoint.sh
@@ -9,7 +9,7 @@ if [ ! -f "$earthly_config" ]; then
 
   # Apply global configuration
   if [ -n "$GLOBAL_CONFIG" ]; then
-    earthly --config $earthly_config config global "$GLOBAL_CONFIG"
+    earthly --config "$earthly_config" config global "$GLOBAL_CONFIG"
   fi
 
   # Apply git configuration

--- a/tests/git-webserver/Earthfile
+++ b/tests/git-webserver/Earthfile
@@ -46,10 +46,10 @@ extendedKeyUsage = clientAuth, serverAuth
     RUN openssl x509 -req -in /root/selfsigned-example-com.csr -CA /etc/ssl/certs/ca-cert-SelfSigned_Root_CA.pem \
         -CAkey /root/selfsigned-ca.key -CAcreateserial -out /root/selfsigned-example-com.pem \
         -days 9999 -extensions v3_req -extfile /root/openssl.config
-	
-	SAVE ARTIFACT /etc/ssl/certs/ca-cert-SelfSigned_Root_CA.pem SelfSigned_Root_CA.pem
-	SAVE ARTIFACT /root/selfsigned-example-com.pem selfsigned-example-com.pem
-	SAVE ARTIFACT /root/selfsigned-example-com.key selfsigned-example-com.key
+
+    SAVE ARTIFACT /etc/ssl/certs/ca-cert-SelfSigned_Root_CA.pem SelfSigned_Root_CA.pem
+    SAVE ARTIFACT /root/selfsigned-example-com.pem selfsigned-example-com.pem
+    SAVE ARTIFACT /root/selfsigned-example-com.key selfsigned-example-com.key
 
 # server creates a https-based git server using nginx; this repo can then be cloned by running
 # "git clone https://testuser:keepitsecret@selfsigned.example.com/repo.git"


### PR DESCRIPTION
This works around https://github.com/earthly/earthly/issues/1764
and fixes some indentation issues which were preventing running our
tests against a self-hosted insecure pullthrough cache.

With this PR, I can now run our tests against a self-hosted cache:

   env -i HOME=$HOST PATH=$PATH ./build/linux/amd64/earthly --env-file=<(echo "") --config=$HOME/.earthly/config.yml -P ./tests+all --DOCKERHUB_AUTH=false --DOCKERHUB_MIRROR=192.168.0.80:5000 --DOCKERHUB_MIRROR_INSECURE=true

Note that `env -i HOME=$HOST PATH=$PATH`, and `--env-file=<(echo "")`
are used to ensure no additional cache environment variables are
accidentally fed into earthly.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>