### PR TITLE
Quick-start example for insecure dockerhub mirror

### DIFF
--- a/docs/ci-integration/pull-through-cache.md
+++ b/docs/ci-integration/pull-through-cache.md
@@ -20,7 +20,7 @@ To run a cache, you'll need the ability to deploy a persistent service, somewher
 There are multiple ways to setup a registry -- Docker, for example, has a [guide for using the registry as a pull through cache](https://docs.docker.com/registry/recipes/mirror),
 as well as documentation for the [available options](https://docs.docker.com/registry/configuration/), and other details under the [registry image](https://hub.docker.com/_/registry).
 
-Documenting all the possible ways to setup a pull through cache is beyond the scope of this document; however, includes a [quick getting-started section](#insecure-docker-hub-cache-example) for those who wish
+Documenting all the possible ways to setup a pull through cache is beyond the scope of this document; however, it does include a [quick getting-started section](#insecure-docker-hub-cache-example) for those who wish
 to run an insecure pull through cache.
 
 ### Configuration & Tips
@@ -119,8 +119,10 @@ You can then verify the registry is running by tailing logs with:
 docker logs --follow docker-registry
 ```
 
-*Hint: Leave a second terminal window open to display the logs while you work on the following sections;
-this will make it more obvious when the cache is being used.*
+{% hint style='info' %}
+You may want to leave a second terminal window open to display the logs while you work on the following sections;
+this will make it more obvious when the cache is being used.
+{% endhint %}
 
 The rest of the guide focus on configuring your workstation to use this cache.
 
@@ -184,5 +186,5 @@ The next time earthly is run, it will detect the configuration change and will r
 You can force these settings to be applied, and verify the mirror appears in the buildkit config by running:
 
 ```
-earthly-v0.5.12 bootstrap && docker exec earthly-buildkitd cat /etc/buildkitd.toml
+earthly bootstrap && docker exec earthly-buildkitd cat /etc/buildkitd.toml
 ```

--- a/docs/ci-integration/pull-through-cache.md
+++ b/docs/ci-integration/pull-through-cache.md
@@ -2,7 +2,9 @@
 
 ## Introduction
 
-Docker Hub, Quay, and other registry providers all have pull limits, and costs associated with running them. Running large builds (or many small builds, frequently) may incur excess costs, rate limiting, or both. This guide will help you set up your own "pull-through" cache to optimize traffic, and bypass the limitations imposed by registry providers.
+Docker Hub, Quay, and other registry providers have pull limits, and costs associated with using them.
+Running large builds (or many small builds, frequently) may incur costs, rate limiting, or both.
+This guide will help you set up your own "pull-through" cache to reduce network traffic, and bypass the limitations imposed by registry providers.
 
 ## What Is A Pull Through Cache?
 
@@ -13,9 +15,13 @@ A pull through cache is a registry mirror that contains no images. When your cli
 
 ## Running A Pull-Through Cache
 
-To run a cache, you'll need the ability to deploy a persistent service, somewhere. This could be a dedicated instance with Docker installed, or a container in your Kubernetes cluster. While we won't be giving details for *how* to set up either of these ways to run a service, we will be sharing configuration and usage details, and how you can use it with Earthly. 
+To run a cache, you'll need the ability to deploy a persistent service, somewhere. This could be a dedicated instance with Docker installed, or a container in your Kubernetes cluster.
 
-Docker has a [guide for getting a pull-through cache up and running](https://docs.docker.com/registry/recipes/mirror/#run-a-registry-as-a-pull-through-cache), and good [documentation of the available options](https://docs.docker.com/registry/configuration/). Check out the [registry image (and details)](https://hub.docker.com/_/registry).
+There are multiple ways to setup a registry -- Docker, for example, has a [guide for using the registry as a pull through cache](https://docs.docker.com/registry/recipes/mirror),
+as well as documentation for the [available options](https://docs.docker.com/registry/configuration/), and other details under the [registry image](https://hub.docker.com/_/registry).
+
+Documenting all the possible ways to setup a pull through cache is beyond the scope of this document; however, includes a [quick getting-started section](#insecure-docker-hub-cache-example) for those who wish
+to run an insecure pull through cache.
 
 ### Configuration & Tips
 
@@ -59,3 +65,124 @@ global:
 ```
 
 Where `<mirror>` is the host/port of your mirror, and `<upstream>` is the address of the registry you are intending to mirror.
+
+## Insecure Docker Hub Cache Example
+
+This section contains a quick-start guide for running an insecure pull through cache using docker's `registry` container.
+
+This guide assumes you are running on a trusted network with one computer acting as a server,
+and the other as your development workstation.
+
+In these examples, we will assume the server has an IP set to `192.168.0.80`.
+
+### Setting up the pull through cache
+
+First connect to the server where you will be running the cache (e.g. `ssh 192.168.0.80`),
+and create a file under `~/.docker-registry-config.yml` containing:
+
+```
+version: 0.1
+log:
+  fields:
+    service: registry
+storage:
+  cache:
+    blobdescriptor: inmemory
+  filesystem:
+    rootdirectory: /var/lib/registry
+http:
+  addr: :5000
+  headers:
+    X-Content-Type-Options: [nosniff]
+health:
+  storagedriver:
+    enabled: true
+    interval: 10s
+    threshold: 3
+proxy:
+  remoteurl: https://registry-1.docker.io
+  username: [username]
+  password: [password]
+```
+
+*Note that you'll need to replace `[username]` and `[password]` with your dockerhub credentials.*
+
+Next, start the registry container with:
+
+```
+docker run --rm --network host -d --name docker-registry -v $HOME/.docker-registry-config.yml:/root/config.yml registry.hub.docker.com/library/registry:2 registry serve /root/config.yml
+```
+
+You can then verify the registry is running by tailing logs with:
+
+```
+docker logs --follow docker-registry
+```
+
+*Hint: Leave a second terminal window open to display the logs while you work on the following sections;
+this will make it more obvious when the cache is being used.*
+
+The rest of the guide focus on configuring your workstation to use this cache.
+
+### Configuring Docker to Use the Cache
+
+To configure docker to use this cache as a mirror, edit the `/etc/docker/daemon.json` file, and add:
+
+```
+{
+  "registry-mirrors" : ["http://192.168.0.80:5000"]
+}
+```
+
+Then restart docker:
+
+```
+sudo service docker restart
+```
+
+Next you should be able to pull an image (e.g. `docker pull alpine:3.15`), which should use the cache.
+
+#### Verifying the Cache is Actually Working (Optional)
+
+If you want to verify the cache is working, you can block access to dockerhub on your workstation by adding
+
+```
+0.0.0.0 index.docker.io auth.docker.io registry-1.docker.io dseasb33srnrn.cloudfront.net production.cloudflare.docker.com
+```
+
+to your `/etc/hosts` file.
+
+If `/etc/docker/daemon.json` was not correctly configured, you should see an error such as:
+
+```
+Error response from daemon: Get "https://registry-1.docker.io/v2/": dial tcp 0.0.0.0:443: connect: connection refused
+```
+
+If the cache is correctly configured, the pull command should work, and you should see logs on your server under the docker-registry container:
+
+```
+
+192.168.0.126 - - [22/Mar/2022:19:10:39 +0000] "HEAD /v2/library/alpine/manifests/3.15 HTTP/1.1" 200 1638 "" "docker/20.10.12 go/go1.16.12 git-commit/459d0df kernel/5.13.0-35-generic os/linux arch/amd64 UpstreamClient(Docker-Client/20.10.12 \\(linux\\))"
+```
+
+### Configuring Earthly to Use the Cache
+
+To configure earthly to use the cache, you must edit `~/.earthly/config.yml` to include:
+
+```yaml
+global:
+  buildkit_additional_config: |
+    [registry."docker.io"]
+      mirrors = ["192.168.0.80:5000"]
+    [registry."192.168.0.80:5000"]
+      http = true
+      insecure = true
+```
+
+The next time earthly is run, it will detect the configuration change and will restart the `earthly-buildkitd` container to reflect these settings.
+
+You can force these settings to be applied, and verify the mirror appears in the buildkit config by running:
+
+```
+earthly-v0.5.12 bootstrap && docker exec earthly-buildkitd cat /etc/buildkitd.toml
+```

--- a/docs/ci-integration/pull-through-cache.md
+++ b/docs/ci-integration/pull-through-cache.md
@@ -80,7 +80,7 @@ In these examples, we will assume the server has an IP set to `192.168.0.80`.
 First connect to the server where you will be running the cache (e.g. `ssh 192.168.0.80`),
 and create a file under `~/.docker-registry-config.yml` containing:
 
-```
+```yaml
 version: 0.1
 log:
   fields:
@@ -109,13 +109,13 @@ proxy:
 
 Next, start the registry container with:
 
-```
+```bash
 docker run --rm --network host -d --name docker-registry -v $HOME/.docker-registry-config.yml:/root/config.yml registry.hub.docker.com/library/registry:2 registry serve /root/config.yml
 ```
 
 You can then verify the registry is running by tailing logs with:
 
-```
+```bash
 docker logs --follow docker-registry
 ```
 
@@ -130,7 +130,7 @@ The rest of the guide focus on configuring your workstation to use this cache.
 
 To configure docker to use this cache as a mirror, edit the `/etc/docker/daemon.json` file, and add:
 
-```
+```json
 {
   "registry-mirrors" : ["http://192.168.0.80:5000"]
 }
@@ -138,7 +138,7 @@ To configure docker to use this cache as a mirror, edit the `/etc/docker/daemon.
 
 Then restart docker:
 
-```
+```bash
 sudo service docker restart
 ```
 
@@ -163,7 +163,6 @@ Error response from daemon: Get "https://registry-1.docker.io/v2/": dial tcp 0.0
 If the cache is correctly configured, the pull command should work, and you should see logs on your server under the docker-registry container:
 
 ```
-
 192.168.0.126 - - [22/Mar/2022:19:10:39 +0000] "HEAD /v2/library/alpine/manifests/3.15 HTTP/1.1" 200 1638 "" "docker/20.10.12 go/go1.16.12 git-commit/459d0df kernel/5.13.0-35-generic os/linux arch/amd64 UpstreamClient(Docker-Client/20.10.12 \\(linux\\))"
 ```
 
@@ -185,6 +184,6 @@ The next time earthly is run, it will detect the configuration change and will r
 
 You can force these settings to be applied, and verify the mirror appears in the buildkit config by running:
 
-```
+```bash
 earthly bootstrap && docker exec earthly-buildkitd cat /etc/buildkitd.toml
 ```


### PR DESCRIPTION
This extends the pull-through-cache docs to include
a quick start guide on how to run an insecure pull through cache on a
trusted network.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>