### PR TITLE
Skip the date check for staging-release

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -51,6 +51,7 @@ jobs:
             set -euo pipefail
             export SHA_DEC="$(echo "ibase=16; $(git rev-parse --short HEAD | tr '[:lower:]' '[:upper:]')" | bc)"
             export RELEASE_TAG="v0.$(date +%s).$SHA_DEC"
+            export SKIP_CHANGELOG_DATE_TEST=true
             export earthly="./build/linux/amd64/earthly"
             echo "attempting staging-release version: $RELEASE_TAG"
             eval "$(ssh-agent -s)"

--- a/release/Earthfile
+++ b/release/Earthfile
@@ -57,7 +57,10 @@ release-notes:
     COPY ..+changelog/CHANGELOG.md .
     ARG --required RELEASE_TAG
     RUN changelogparser --changelog CHANGELOG.md --version "$RELEASE_TAG" > notes.txt
-    RUN --no-cache test "$(changelogparser --changelog CHANGELOG.md --version "$RELEASE_TAG" --date)" = "$(date "+%Y-%m-%d")"
+    ARG SKIP_CHANGELOG_DATE_TEST="false"
+    IF [ "$SKIP_CHANGELOG_DATE_TEST" != "true" ]
+        RUN --no-cache test "$(changelogparser --changelog CHANGELOG.md --version "$RELEASE_TAG" --date)" = "$(date "+%Y-%m-%d")"
+    END
     SAVE ARTIFACT notes.txt
 
 release-github:

--- a/release/release.sh
+++ b/release/release.sh
@@ -51,6 +51,7 @@ export EARTHLY_REPO=${EARTHLY_REPO:-earthly}
 export BREW_REPO=${BREW_REPO:-homebrew-earthly}
 export GITHUB_SECRET_PATH=$GITHUB_SECRET_PATH
 export PRERELEASE=${PRERELEASE:-false}
+export SKIP_CHANGELOG_DATE_TEST=${SKIP_CHANGELOG_DATE_TEST:-false}
 
 
 if [ "$PRERELEASE" != "false" ] && [ "$PRERELEASE" != "true" ]; then
@@ -71,7 +72,7 @@ if [ -z "$earthly" ]; then
 fi
 
 # fail-fast if release-notes do not exist (or if date is incorrect)
-"$earthly" --build-arg DOCKERHUB_USER --build-arg RELEASE_TAG +release-notes
+"$earthly" --build-arg DOCKERHUB_USER --build-arg RELEASE_TAG --build-arg SKIP_CHANGELOG_DATE_TEST +release-notes
 
 if [ -n "$GITHUB_SECRET_PATH" ]; then
     GITHUB_SECRET_PATH_BUILD_ARG="--build-arg GITHUB_SECRET_PATH=$GITHUB_SECRET_PATH"


### PR DESCRIPTION
The staging-release occurs automatically whenever a PR occurs,
if the process starts before midnight and the date changes before
we check the CHANGELOG release date, the release will fail.

Since the release date is automatically generated for staging releases,
we can remove this check.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>