### PR TITLE
ignore date check for staging +release-github

### DIFF
--- a/release/release.sh
+++ b/release/release.sh
@@ -93,7 +93,7 @@ if [ "$existing_release" != "null" ]; then
 fi
 
 "$earthly" --push --build-arg DOCKERHUB_USER --build-arg RELEASE_TAG +release-dockerhub
-"$earthly" --push --build-arg GITHUB_USER --build-arg EARTHLY_REPO --build-arg BREW_REPO --build-arg DOCKERHUB_USER --build-arg RELEASE_TAG --build-arg PRERELEASE="$PRERELEASE" $GITHUB_SECRET_PATH_BUILD_ARG +release-github
+"$earthly" --push --build-arg GITHUB_USER --build-arg EARTHLY_REPO --build-arg BREW_REPO --build-arg DOCKERHUB_USER --build-arg RELEASE_TAG --build-arg SKIP_CHANGELOG_DATE_TEST --build-arg PRERELEASE="$PRERELEASE" $GITHUB_SECRET_PATH_BUILD_ARG +release-github
 
 if [ "$PRERELEASE" != "false" ]; then
     echo "exiting due to prerelease = true"


### PR DESCRIPTION
The previous fix in 51b44439523616ce4437c6ad57e9a4b2de2807ec
needed to also pass through the SKIP_CHANGELOG_DATE_TEST
build-arg for the release-github target too.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>