### PR TITLE
Keep existing daemon.json data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 ### Changed
 
 - A more obvious error is printed if `WITH DOCKER` starts non-natively. This is not supported and it wasn't obvious before.
+- `WITH DOCKER` will keep any settings pre-applied in `/etc/docker/daemon.json` rather than overwriting them.
 
 ### Added
 

--- a/buildkitd/dockerd-wrapper.sh
+++ b/buildkitd/dockerd-wrapper.sh
@@ -70,8 +70,13 @@ execute() {
 start_dockerd() {
     # Use a specific IP range to avoid collision with host dockerd (we need to also connect to host
     # docker containers for the debugger).
-    mkdir -p /etc/docker
-    cat <<'EOF' >/etc/docker/daemon.json
+    if ! [ -f /etc/docker/daemon.json ]; then
+        mkdir -p /etc/docker
+        echo >/etc/docker/daemon.json '{}'
+    fi
+
+    daemon_data="$(cat /etc/docker/daemon.json)"
+    cat <<EOF | jq ". + $daemon_data" > /etc/docker/daemon.json
 {
     "default-address-pools" : [
         {
@@ -82,14 +87,16 @@ start_dockerd() {
             "base" : "172.22.0.0/16",
             "size" : 24
         }
-    ]
+    ],
+    "bip": "172.20.0.1/16",
+    "data-root": "$EARTHLY_DOCKERD_DATA_ROOT"
 }
 EOF
 
     # Start with a rm -rf to make sure a previous interrupted build did not leave its state around.
     rm -rf "$EARTHLY_DOCKERD_DATA_ROOT"
     mkdir -p "$EARTHLY_DOCKERD_DATA_ROOT"
-    dockerd --data-root="$EARTHLY_DOCKERD_DATA_ROOT" --bip=172.20.0.1/16 >/var/log/docker.log 2>&1 &
+    dockerd >/var/log/docker.log 2>&1 &
     dockerd_pid="$!"
     i=1
     timeout=300

--- a/tests/dind-auto-install/Earthfile
+++ b/tests/dind-auto-install/Earthfile
@@ -13,7 +13,7 @@ all:
         --BASE_IMAGE=../..+dind-ubuntu
 
 test:
-    ARG BASE_IMAGE
+    ARG --required BASE_IMAGE
     FROM $BASE_IMAGE
     COPY ./docker-compose.yml ./
     WITH DOCKER --compose docker-compose.yml


### PR DESCRIPTION
If /etc/docker/daemon.json already exists, rather than overwrite
it, we should simply update it with the new network IP ranges.

This, for example, allows a user to define an Earthfile which
configures the WITH DOCKER instance to use a different mirror:

    test:
        FROM earthly/dind:alpine
        RUN mkdir -p /etc/docker && echo '{"registry-mirrors" : ["http://192.168.0.80:5000"]}' > /etc/docker/daemon.json
        WITH DOCKER
            RUN --no-cache \
               cat /etc/docker/daemon.json && \
               docker run --rm alpine:3.15 hostname
        END

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>