### PR TITLE
Fix typo in Earthfile reference

### DIFF
--- a/docs/earthfile/earthfile.md
+++ b/docs/earthfile/earthfile.md
@@ -690,7 +690,7 @@ If you are referencing a target via some other command, such as `COPY` and you w
 
 ```Dockerfile
 my-target:
-    COPY --plattform=linux/amd64 (+some-target/some-file.txt --FOO=bar) ./
+    COPY --platform=linux/amd64 (+some-target/some-file.txt --FOO=bar) ./
 ```
 
 Should be amended with the following additional `BUILD` call:


### PR DESCRIPTION
This PR fixes a typo "--plattform" in [Earthfile reference](https://docs.earthly.dev/docs/earthfile#build) (from the code example in "What is being output and pushed").