### PR TITLE
Display cursor on same line as prompt

### DIFF
--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -2041,16 +2041,18 @@ func (app *earthlyApp) actionRegister(c *cli.Context) error {
 
 	pword := app.password
 	if app.password == "" {
-		fmt.Println("pick a password")
+		fmt.Printf("pick a password: ")
 		enteredPassword, err := term.ReadPassword(int(syscall.Stdin))
 		if err != nil {
 			return err
 		}
-		fmt.Println("confirm password")
+		fmt.Println("")
+		fmt.Printf("confirm password: ")
 		enteredPassword2, err := term.ReadPassword(int(syscall.Stdin))
 		if err != nil {
 			return err
 		}
+		fmt.Println("")
 		if string(enteredPassword) != string(enteredPassword2) {
 			return errors.Errorf("passwords do not match")
 		}


### PR DESCRIPTION
When prompting the user to pick a password, the cursor should be
displayed on the same line as the prompt:

for example:

    pick a password: <cursor>

Previously the prompt looked like:

    pick a password
    <cursor>

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>