### PR TITLE
jq is now required when using `WITH DOCKER`

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -419,7 +419,8 @@ dind:
 
 dind-alpine:
     FROM docker:dind
-    RUN apk add --update --no-cache docker-compose
+    COPY ./buildkitd/docker-auto-install.sh /usr/local/bin/docker-auto-install.sh
+    RUN docker-auto-install.sh
     ARG EARTHLY_TARGET_TAG_DOCKER
     ARG DIND_ALPINE_TAG=alpine-$EARTHLY_TARGET_TAG_DOCKER
     ARG DOCKERHUB_USER=earthly


### PR DESCRIPTION
jq is now required when using `WITH DOCKER` (dependency was introduced
in https://github.com/earthly/earthly/commit/88f94c5ed342a0162c202f5ce666d8350bf3fcc4), it is installed
automatically via `docker-auto-install.sh`.

dind-ubuntu already installs dependencies with this script, we should
use it for the alpine version as well to be consistent. Note that the
underlying docker:dind already provides dockerd, so only docker-compose
and jq will be installed.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>