### PR TITLE
set EARTHLY_GIT_SHORT_HASH on remote targets

### DIFF
--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -59,6 +59,12 @@ ga:
     BUILD +copy-test-verbose-output
     BUILD +cache-test
     BUILD +git-clone-test
+    BUILD ./git-metadata+test \
+        --DOCKERHUB_AUTH=$DOCKERHUB_AUTH \
+        --DOCKERHUB_USER_SECRET=$DOCKERHUB_USER_SECRET \
+        --DOCKERHUB_TOKEN_SECRET=$DOCKERHUB_TOKEN_SECRET \
+        --DOCKERHUB_MIRROR=$DOCKERHUB_MIRROR \
+        --DOCKERHUB_MIRROR_INSECURE=$DOCKERHUB_MIRROR_INSECURE
     BUILD ./git-ssh-server+all \
         --DOCKERHUB_AUTH=$DOCKERHUB_AUTH \
         --DOCKERHUB_USER_SECRET=$DOCKERHUB_USER_SECRET \

--- a/tests/git-metadata/Earthfile
+++ b/tests/git-metadata/Earthfile
@@ -1,0 +1,69 @@
+VERSION 0.6
+
+ARG DOCKERHUB_USER_SECRET=+secrets/DOCKERHUB_USER
+ARG DOCKERHUB_TOKEN_SECRET=+secrets/DOCKERHUB_TOKEN
+ARG DOCKERHUB_MIRROR
+ARG DOCKERHUB_MIRROR_INSECURE=false
+ARG DOCKERHUB_AUTH=true
+
+test:
+    FROM ../git-ssh-server/setup+server \
+        --DOCKERHUB_AUTH=$DOCKERHUB_AUTH \
+        --DOCKERHUB_USER_SECRET=$DOCKERHUB_USER_SECRET \
+        --DOCKERHUB_TOKEN_SECRET=$DOCKERHUB_TOKEN_SECRET \
+        --DOCKERHUB_MIRROR=$DOCKERHUB_MIRROR \
+        --DOCKERHUB_MIRROR_INSECURE=$DOCKERHUB_MIRROR_INSECURE \
+        --SSHD_RSA=true \
+        --SSHD_ED25519=false \
+        --USER_RSA=true \
+        --USER_ED25519=false
+    COPY test.earth Earthfile
+    RUN echo "#!/bin/sh
+set -ex
+
+# first ensure these two /etc/hosts entries are working
+ping -c 1 git.example.com
+ping -c 1 buildkitsandbox
+
+# load in preauthorized key
+eval \$(ssh-agent)
+ssh-add /root/self-hosted-rsa-key
+ssh-add -l
+
+# next validate ssh is working
+ssh git@git.example.com | grep \"Hi git! You've successfully authenticated, but you get no shellz\"
+
+# setup git email and user (needed to commit)
+git config --global user.email \"onlyspammersemailthis@earthly.dev\"
+git config --global user.name \"test name\"
+
+# clone the repo and add a test Earthfile to it
+git clone git@git.example.com:testuser/repo.git
+mv Earthfile repo/
+git -C repo add Earthfile
+git -C repo commit -m test
+git -C repo push
+export expectedsha=\$(git -C repo rev-parse HEAD)
+
+# finally perform earthly tests
+earthly --config \$earthly_config --verbose -D --build-arg expectedsha ./repo+test-git-metadata
+
+rm -rf repo
+earthly --config \$earthly_config --verbose -D --build-arg expectedsha git.example.com/testuser/repo:main+test-git-metadata
+" >/tmp/test-earthly-script && chmod +x /tmp/test-earthly-script
+    DO +RUN_EARTHLY_ARGS --pre_command=start-sshd --exec_cmd=/tmp/test-earthly-script
+
+RUN_EARTHLY_ARGS:
+    COMMAND
+    ARG earthfile
+    ARG pre_command
+    ARG exec_cmd
+    DO ..+RUN_EARTHLY \
+        --earthfile=$earthfile \
+        --pre_command=$pre_command \
+        --exec_cmd=$exec_cmd \
+        --DOCKERHUB_AUTH=$DOCKERHUB_AUTH \
+        --DOCKERHUB_USER_SECRET=$DOCKERHUB_USER_SECRET \
+        --DOCKERHUB_TOKEN_SECRET=$DOCKERHUB_TOKEN_SECRET \
+        --DOCKERHUB_MIRROR=$DOCKERHUB_MIRROR \
+        --DOCKERHUB_MIRROR_INSECURE=$DOCKERHUB_MIRROR_INSECURE

--- a/tests/git-metadata/test.earth
+++ b/tests/git-metadata/test.earth
@@ -1,0 +1,10 @@
+VERSION 0.6
+
+test-git-metadata:
+    FROM alpine
+    ARG --required expectedsha
+    ARG EARTHLY_GIT_SHORT_HASH
+    ARG EARTHLY_GIT_HASH
+    RUN test "$EARTHLY_GIT_HASH" = "$expectedsha"
+    RUN test -n "$EARTHLY_GIT_SHORT_HASH"
+    RUN echo "$EARTHLY_GIT_HASH" | grep "$EARTHLY_GIT_SHORT_HASH"

--- a/tests/git-ssh-server/setup/Earthfile
+++ b/tests/git-ssh-server/setup/Earthfile
@@ -44,10 +44,10 @@ server:
         passwd git -u
     COPY no-interactive-login /home/git/git-shell-commands/no-interactive-login
     RUN mkdir /home/git/testuser && \
-        git init --bar /home/git/testuser/repo.git && \
+        git init --bare /home/git/testuser/repo.git && \
+        git -C /home/git/testuser/repo.git symbolic-ref HEAD refs/heads/main && \
         chown -R git:git /home/git/testuser
     COPY sshd_config /etc/ssh/sshd_config
-
 
     ARG SSHD_RSA="true"
     ARG SSHD_ED25519="true"

--- a/util/gitutil/detectgit.go
+++ b/util/gitutil/detectgit.go
@@ -117,12 +117,15 @@ func Metadata(ctx context.Context, dir string) (*GitMetadata, error) {
 // Clone returns a copy of the GitMetadata object.
 func (gm *GitMetadata) Clone() *GitMetadata {
 	return &GitMetadata{
-		BaseDir: gm.BaseDir,
-		RelDir:  gm.RelDir,
-		GitURL:  gm.GitURL,
-		Hash:    gm.Hash,
-		Branch:  gm.Branch,
-		Tags:    gm.Tags,
+		BaseDir:   gm.BaseDir,
+		RelDir:    gm.RelDir,
+		RemoteURL: gm.RemoteURL,
+		GitURL:    gm.GitURL,
+		Hash:      gm.Hash,
+		ShortHash: gm.ShortHash,
+		Branch:    gm.Branch,
+		Tags:      gm.Tags,
+		Timestamp: gm.Timestamp,
 	}
 }
 


### PR DESCRIPTION
This fixes a bug where EARTHLY_GIT_SHORT_HASH was not set when building
a remote target -- this is due to the codepath being different for
locally referenced targets and remote targets.

This fix introduces a test to validate EARTHLY_GIT_SHORT_HASH and
EARTHLY_GIT_HASH are correctly set in both cases.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>