### PR TITLE
release-dind doesn't use the RELEASE_TAG

### DIFF
--- a/release/README.md
+++ b/release/README.md
@@ -117,7 +117,7 @@ Docker-in-Docker (dind) images change less frequently than earthly, but take a l
 These images can be rebuilt by running:
 
   ```bash
-  ./earthly --push ./release+release-dind --RELEASE_TAG="$RELEASE_TAG"
+  ./earthly --push ./release+release-dind
   ```
 
 ### VS Code syntax highlighting


### PR DESCRIPTION
dind images are built independently from earthly versions.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>