### PR TITLE
expand LOCALLY copy tests to use WORKDIR

### DIFF
--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -12,7 +12,7 @@ buildkitd:
             ARG BUILDKIT_BASE_IMAGE=$BUILDKIT_PROJECT+build
         END
     ELSE
-        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:7c55df758f46cd7d16e8795c8bb3049b8e68a0b2+build
+        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:f126d5cedf8a91de9948f374b982cce3fb5649f6+build
     END
     FROM $BUILDKIT_BASE_IMAGE
     RUN echo "@edge-community http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,6 @@ replace (
 
 	github.com/jessevdk/go-flags => github.com/alexcb/go-flags v0.0.0-20210722203016-f11d7ecb5ee5
 
-	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.1-0.20220302184113-7c55df758f46
+	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.1-0.20220330184959-f126d5cedf8a
 	github.com/tonistiigi/fsutil => github.com/earthly/fsutil v0.0.0-20220118225905-42fa88fbe869
 )

--- a/go.sum
+++ b/go.sum
@@ -341,8 +341,8 @@ github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
-github.com/earthly/buildkit v0.0.1-0.20220302184113-7c55df758f46 h1:Vj3HlXfZ7En27v4zi+qrgd+1ArFXr8xhhTELSwnUrs8=
-github.com/earthly/buildkit v0.0.1-0.20220302184113-7c55df758f46/go.mod h1:8578flFPixeoiXT6b1RZmxk14dfjISYq2QcKtWqIxC0=
+github.com/earthly/buildkit v0.0.1-0.20220330184959-f126d5cedf8a h1:aBydKJTFxLz4UXy0HUUFjwuyIohut0sKnj7ffFpX4Gs=
+github.com/earthly/buildkit v0.0.1-0.20220330184959-f126d5cedf8a/go.mod h1:8578flFPixeoiXT6b1RZmxk14dfjISYq2QcKtWqIxC0=
 github.com/earthly/cloud-api v1.0.1-0.20220228235811-35dd6315dcf5 h1:NAkGFrFrTZCINnKL6DWauRBxZqdhLFSavHRTqedMGWw=
 github.com/earthly/cloud-api v1.0.1-0.20220228235811-35dd6315dcf5/go.mod h1:Xg9V1xG0/j7GlisqstxcartfOz5OJoXEAJdGPjrBnWw=
 github.com/earthly/fsutil v0.0.0-20220118225905-42fa88fbe869 h1:JOHn11YLRdybmRtdYrJ1LD3PLNqANfvIQoxhjrmcGOQ=

--- a/tests/local/Earthfile
+++ b/tests/local/Earthfile
@@ -74,6 +74,17 @@ test-save-unnamed-local-artifact-dir2:
     COPY --dir +save-unnamed-local-artifact/earthly-test-c5009c71-d573-4562-be15-2c28dae333fc /var/log/.
     RUN cat /var/log/earthly-test-c5009c71-d573-4562-be15-2c28dae333fc/c.txt | grep '^ccc$'
 
+save-local-artifact-with-workdir:
+    LOCALLY
+    RUN rm -rf /tmp/earthly-b1682dd4-b3e3-41c8-8191-b8eeb0b56499
+    WORKDIR /tmp/earthly-b1682dd4-b3e3-41c8-8191-b8eeb0b56499
+    RUN echo ddd > 29998a72-a765-4d48-a395-c5252183934b
+    SAVE ARTIFACT 29998a72-a765-4d48-a395-c5252183934b data
+
+test-save-local-artifact-with-workdir:
+    COPY +save-local-artifact-with-workdir/data .
+    RUN cat data | grep '^ddd$'
+
 
 #################################################################################################################
 # tests for testing containerized artifacts can be referenced by local targets
@@ -88,6 +99,13 @@ test-copy-from-busybox-to-local:
     RUN rm -rf /tmp/4eb5dcb7-2245-4f35-ab41-252f78e7a451
     COPY +busybox-artifact/the-data /tmp/4eb5dcb7-2245-4f35-ab41-252f78e7a451
     RUN cat /tmp/4eb5dcb7-2245-4f35-ab41-252f78e7a451 | grep "BusyBox v1.32.1"
+
+test-copy-from-busybox-to-local-with-workdir:
+    LOCALLY
+    RUN rm -rf /tmp/earthly-test-5816ebd4-6b18-421e-a1b4-5991af91e11e
+    WORKDIR /tmp/earthly-test-5816ebd4-6b18-421e-a1b4-5991af91e11e
+    COPY +busybox-artifact/the-data 0b59ac77-91d7-4b84-9d1c-12f64fc6f48e
+    RUN cat /tmp/earthly-test-5816ebd4-6b18-421e-a1b4-5991af91e11e/0b59ac77-91d7-4b84-9d1c-12f64fc6f48e | grep "BusyBox v1.32.1"
 
 alpine-artifacts:
     FROM alpine:3.15.0 # if this is changed, the grep in test-multi-copy-from-alpine-to-local must also be updated
@@ -167,19 +185,20 @@ test-with-two-dockers:
 # tests for WITH DOCKER and compose
 
 all:
-    BUILD +test-locally-workdir
-    BUILD +test-copy-from-busybox-to-local
-    BUILD --build-arg pattern=memory +test-local-with-arg
-    BUILD +test-local
-    BUILD +test-copy-file-from-local
     BUILD +test-copy-dir-from-local
+    BUILD +test-copy-file-from-local
+    BUILD +test-copy-from-busybox-to-local
+    BUILD +test-copy-from-busybox-to-local-with-workdir
+    BUILD +test-local
+    BUILD +test-local-with-arg --pattern=memory
+    BUILD +test-locally-can-copy-dir
+    BUILD +test-locally-can-copy-dir-contents
+    BUILD +test-locally-workdir
+    BUILD +test-locally-workdir
+    BUILD +test-multi-copy-from-alpine-to-local
     BUILD +test-save-unnamed-local-artifact
     BUILD +test-save-unnamed-local-artifact-dir
     BUILD +test-save-unnamed-local-artifact-dir2
-    BUILD +test-multi-copy-from-alpine-to-local
-    BUILD +test-locally-can-copy-dir-contents
-    BUILD +test-locally-can-copy-dir
-    BUILD +test-locally-workdir
     BUILD +test-with-docker
     BUILD +test-with-two-dockers
     BUILD ./with-docker-compose-local+all


### PR DESCRIPTION
Updates buildkit which contains a fix where LOCALLY COPY was not using
the set WORKDIR

This additional expands our test coverage.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>