### PR TITLE
WIP: dotEnv might contain secrets, dont print them

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -64,6 +64,7 @@ type Opt struct {
 	SaveInlineCache        bool
 	ImageResolveMode       llb.ResolveMode
 	CleanCollection        *cleanup.Collection
+	DotEnvVars             *variables.Scope
 	OverridingVars         *variables.Scope
 	BuildContextProvider   *provider.BuildContextProvider
 	GitLookup              *buildcontext.GitLookup
@@ -158,7 +159,7 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 		}
 		var err error
 		if !b.builtMain {
-			opt := earthfile2llb.ConvertOpt{
+			convertOpt := earthfile2llb.ConvertOpt{
 				GwClient:             gwClient,
 				Resolver:             b.resolver,
 				ImageResolveMode:     b.opt.ImageResolveMode,
@@ -166,6 +167,7 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 				CleanCollection:      b.opt.CleanCollection,
 				PlatformResolver:     opt.PlatformResolver.SubResolver(opt.PlatformResolver.Current()),
 				OverridingVars:       b.opt.OverridingVars,
+				DotEnvVars:           b.opt.DotEnvVars,
 				BuildContextProvider: b.opt.BuildContextProvider,
 				CacheImports:         b.opt.CacheImports,
 				UseInlineCache:       b.opt.UseInlineCache,
@@ -183,7 +185,7 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 				NoCache:              b.opt.NoCache,
 				ContainerFrontend:    b.opt.ContainerFrontend,
 			}
-			mts, err = earthfile2llb.Earthfile2LLB(childCtx, target, opt, true)
+			mts, err = earthfile2llb.Earthfile2LLB(childCtx, target, convertOpt, true)
 			if err != nil {
 				return nil, err
 			}

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -101,7 +101,7 @@ func NewConverter(ctx context.Context, target domain.Target, bc *buildcontext.Da
 		Final:   sts,
 		Visited: opt.Visited,
 	}
-	sts.AddOverridingVarsAsBuildArgInputs(opt.OverridingVars)
+	sts.AddOverridingVarsAsBuildArgInputs(opt.DotEnvVars, opt.OverridingVars)
 	newCollOpt := variables.NewCollectionOpt{
 		Console:          opt.Console,
 		Target:           target,
@@ -109,6 +109,7 @@ func NewConverter(ctx context.Context, target domain.Target, bc *buildcontext.Da
 		GitMeta:          bc.GitMetadata,
 		BuiltinArgs:      opt.BuiltinArgs,
 		OverridingVars:   opt.OverridingVars,
+		DotEnvVars:       opt.DotEnvVars,
 		GlobalImports:    opt.GlobalImports,
 		Features:         opt.Features,
 	}
@@ -1432,6 +1433,10 @@ func (c *Converter) buildTarget(ctx context.Context, fullTargetName string, plat
 			// Check if the build arg has been overridden. If it has, it can no longer be an input
 			// directly, so skip it.
 			_, found := opt.OverridingVars.GetAny(bai.Name)
+			if found {
+				continue
+			}
+			_, found = opt.DotEnvVars.GetAny(bai.Name)
 			if found {
 				continue
 			}

--- a/earthfile2llb/earthfile2llb.go
+++ b/earthfile2llb/earthfile2llb.go
@@ -48,6 +48,8 @@ type ConvertOpt struct {
 	PlatformResolver *platutil.Resolver
 	// OverridingVars is a collection of build args used for overriding args in the build.
 	OverridingVars *variables.Scope
+	// DotEnvVars is a collection of .env args used for overriding args in the build, this collection may also include secrets
+	DotEnvVars *variables.Scope
 	// A cache for image solves. (maybe dockerTag +) depTargetInputHash -> context containing image.tar.
 	SolveCache *states.SolveCache
 	// BuildContextProvider is the provider used for local build context files.

--- a/states/states.go
+++ b/states/states.go
@@ -135,9 +135,14 @@ func (sts *SingleTarget) AddBuildArgInput(bai dedup.BuildArgInput) {
 }
 
 // AddOverridingVarsAsBuildArgInputs adds some vars to the sts's target input.
-func (sts *SingleTarget) AddOverridingVarsAsBuildArgInputs(overridingVars *variables.Scope) {
+func (sts *SingleTarget) AddOverridingVarsAsBuildArgInputs(dotEnvVars, overridingVars *variables.Scope) {
 	sts.tiMu.Lock()
 	defer sts.tiMu.Unlock()
+	for _, key := range dotEnvVars.SortedAny() {
+		ovVar, _ := dotEnvVars.GetAny(key)
+		sts.targetInput = sts.targetInput.WithBuildArgInput(
+			dedup.BuildArgInput{ConstantValue: ovVar, Name: key})
+	}
 	for _, key := range overridingVars.SortedAny() {
 		ovVar, _ := overridingVars.GetAny(key)
 		sts.targetInput = sts.targetInput.WithBuildArgInput(

--- a/states/visited.go
+++ b/states/visited.go
@@ -141,6 +141,7 @@ func CompareTargetInputs(target domain.Target, platr *platutil.Resolver, allowPr
 		return false, nil
 	}
 	for _, bai := range other.BuildArgs {
+		// TODO check for dotEnv here too? or better yet: make a GetAny helper which checks multiple scopes at a time
 		variable, found := overridingVars.GetAny(bai.Name)
 		if found {
 			baiVariable := dedup.BuildArgInput{


### PR DESCRIPTION
Initial work on keeping .env variables as a seperate scope
as they might contain secrets, and should never be printed.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>