### PR TITLE
`SAVE IMAGE --no-manifest-list`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 
 ## Unreleased
 
+### Added
+
+- Experimental support for `SAVE IMAGE --no-manifest-list`. This option disables creating a multi-platform manifest list for the image, even if the image is created with a non-default platform. This allows the user to create non-native images (e.g. amd64 image on an M1 laptop) that are still compatible with AWS lambda. To enable this feature, please use `VERSION --use-no-manifest-list 0.6`. [#1802](https://github.com/earthly/earthly/pull/1802)
+
 ## v0.6.13 - 2022-03-30
 
 ### Added

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -886,10 +886,13 @@ func (c *Converter) SaveArtifactFromLocal(ctx context.Context, saveFrom, saveTo 
 }
 
 // SaveImage applies the earthly SAVE IMAGE command.
-func (c *Converter) SaveImage(ctx context.Context, imageNames []string, pushImages bool, insecurePush bool, cacheHint bool, cacheFrom []string) error {
+func (c *Converter) SaveImage(ctx context.Context, imageNames []string, pushImages bool, insecurePush bool, cacheHint bool, cacheFrom []string, noManifestList bool) error {
 	err := c.checkAllowed(saveImageCmd)
 	if err != nil {
 		return err
+	}
+	if noManifestList && !c.ftrs.UseNoManifestList {
+		return fmt.Errorf("SAVE IMAGE --no-manifest-list is not supported in this version")
 	}
 	for _, cf := range cacheFrom {
 		c.opt.CacheImports.Add(cf)
@@ -916,6 +919,7 @@ func (c *Converter) SaveImage(ctx context.Context, imageNames []string, pushImag
 					HasPushDependencies: true,
 					DoSave:              c.opt.DoSaves || c.opt.ForceSaveImage,
 					CheckDuplicate:      c.ftrs.CheckDuplicateImages,
+					NoManifestList:      noManifestList,
 				})
 		} else {
 			pcState := c.persistCache(c.mts.Final.MainState)
@@ -930,6 +934,7 @@ func (c *Converter) SaveImage(ctx context.Context, imageNames []string, pushImag
 					HasPushDependencies: false,
 					DoSave:              c.opt.DoSaves || c.opt.ForceSaveImage,
 					CheckDuplicate:      c.ftrs.CheckDuplicateImages,
+					NoManifestList:      noManifestList,
 				})
 		}
 

--- a/earthfile2llb/flags.go
+++ b/earthfile2llb/flags.go
@@ -69,10 +69,11 @@ type saveArtifactOpts struct {
 }
 
 type saveImageOpts struct {
-	Push      bool     `long:"push" description:"Push the image to the remote registry provided that the build succeeds and also that earthly is invoked in push mode"`
-	CacheHint bool     `long:"cache-hint" description:"Instruct Earthly that the current target shuold be saved entirely as part of the remote cache"`
-	Insecure  bool     `long:"insecure" description:"Use unencrypted connection for the push"`
-	CacheFrom []string `long:"cache-from" description:"Declare additional cache import as a Docker tag"`
+	Push           bool     `long:"push" description:"Push the image to the remote registry provided that the build succeeds and also that earthly is invoked in push mode"`
+	CacheHint      bool     `long:"cache-hint" description:"Instruct Earthly that the current target shuold be saved entirely as part of the remote cache"`
+	Insecure       bool     `long:"insecure" description:"Use unencrypted connection for the push"`
+	NoManifestList bool     `long:"no-manifest-list" description:"Do not include a manifest list (specifying the platform) in the creation of the image"`
+	CacheFrom      []string `long:"cache-from" description:"Declare additional cache import as a Docker tag"`
 }
 
 type buildOpts struct {

--- a/earthfile2llb/interpreter.go
+++ b/earthfile2llb/interpreter.go
@@ -907,7 +907,7 @@ func (i *Interpreter) handleSaveImage(ctx context.Context, cmd spec.Command) err
 		fmt.Fprintf(os.Stderr, "Deprecation: using SAVE IMAGE with no arguments is no longer necessary and can be safely removed\n")
 		return nil
 	}
-	err = i.converter.SaveImage(ctx, imageNames, opts.Push, opts.Insecure, opts.CacheHint, opts.CacheFrom)
+	err = i.converter.SaveImage(ctx, imageNames, opts.Push, opts.Insecure, opts.CacheHint, opts.CacheFrom, opts.NoManifestList)
 	if err != nil {
 		return i.wrapError(err, cmd.SourceLocation, "save image")
 	}

--- a/features/features.go
+++ b/features/features.go
@@ -34,6 +34,7 @@ type Features struct {
 	NoTarBuildOutput           bool `long:"no-tar-build-output" description:"do not print output when creating a tarball to load into WITH DOCKER"`
 	ShellOutAnywhere           bool `long:"shell-out-anywhere" description:"allow shelling-out in the middle of ARGs, or any other command"`
 	NewPlatform                bool `long:"new-platform" description:"enable new platform behavior"`
+	UseNoManifestList          bool `long:"use-no-manifest-list" description:"enable the SAVE IMAGE --no-manifest-list option"`
 
 	Major int
 	Minor int
@@ -194,6 +195,7 @@ func GetFeatures(version *spec.Version) (*Features, bool, error) {
 		ftrs.UseCopyLink = true
 		ftrs.NewPlatform = true
 		ftrs.NoTarBuildOutput = true
+		ftrs.UseNoManifestList = true
 	}
 
 	return &ftrs, hasVersion, nil

--- a/states/states.go
+++ b/states/states.go
@@ -238,6 +238,10 @@ type SaveImage struct {
 	// CheckDuplicate indicates whether to check if the image name shows up
 	// multiple times during output.
 	CheckDuplicate bool
+	// NoManifestList indicates that the image should not include a manifest
+	// list (usually used for multi-platform setups). This means that the image
+	// can only be a single-platform image.
+	NoManifestList bool
 }
 
 // RunPush is a series of RUN --push commands to be run after the build has been deemed as


### PR DESCRIPTION
To enable this experimental feature you must use `VERSION --use-no-manifest-list 0.6`.

This PR implements support for `SAVE IMAGE --no-manifest-list`. This option disables creating a multi-platform manifest list for the image, even if the image is created with a non-default platform. This allows the user to create non-native images (e.g. amd64 image on an M1 laptop) that are still compatible with AWS lambda (AWS lambda does not support multi-platform images).