### PR TITLE
split build-args and secrets into seperate files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 ### Added
 
 - Experimental support for `SAVE IMAGE --no-manifest-list`. This option disables creating a multi-platform manifest list for the image, even if the image is created with a non-default platform. This allows the user to create non-native images (e.g. amd64 image on an M1 laptop) that are still compatible with AWS lambda. To enable this feature, please use `VERSION --use-no-manifest-list 0.6`. [#1802](https://github.com/earthly/earthly/pull/1802)
+- Introduced two new experimental files: `.earthlyargs` and `.earthlysecrets`, to allow users to separate build-args from secrets; without this separation it is not clear if a value is a build-arg or secret which led to earthly printing out potentially secrets to stdout on errors. [#1808](https://github.com/earthly/earthly/issues/1808)
 
 ### Fixed
 

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -89,8 +89,9 @@ const (
 	defaultEnvFile = ".env"
 	envFileFlag    = "env-file"
 
-	defaultSecretsFile = ".earthlysecrets"
-	defaultArgsFile    = ".earthlyargs"
+	hideEarthlySecretsAndArgs = true
+	defaultSecretsFile        = ".earthlysecrets"
+	defaultArgsFile           = ".earthlyargs"
 )
 
 type earthlyApp struct {
@@ -633,18 +634,20 @@ func newEarthlyApp(ctx context.Context, console conslogging.ConsoleLogger) *eart
 			Destination: &app.envFile,
 		},
 		&cli.StringFlag{
-			Name:        "secrets-file",
+			Name:        "earthlysecrets",
 			EnvVars:     []string{"EARTHLY_SECRETS_FILE"},
 			Usage:       "Use secrets from this file",
 			Value:       defaultSecretsFile,
 			Destination: &app.secretsFile,
+			Hidden:      hideEarthlySecretsAndArgs,
 		},
 		&cli.StringFlag{
-			Name:        "args-file",
+			Name:        "earthlyargs",
 			EnvVars:     []string{"EARTHLY_ARGS_FILE"},
 			Usage:       "Use build args from this file",
 			Value:       defaultArgsFile,
 			Destination: &app.argsFile,
+			Hidden:      hideEarthlySecretsAndArgs,
 		},
 	}
 
@@ -2877,7 +2880,7 @@ func (app *earthlyApp) actionBuildImp(c *cli.Context, flagArgs, nonFlagArgs []st
 			secretsStringMap[key] = val
 		}
 	}
-	if len(nonEarthlyEnvs) > 0 {
+	if !hideEarthlySecretsAndArgs && len(nonEarthlyEnvs) > 0 {
 		sort.Strings(nonEarthlyEnvs)
 		keys := strings.Join(nonEarthlyEnvs, ", ")
 		app.console.Warnf("Warning: build-args or secrets (%s) should be defined in .earthlyargs or .earthlysecrets; this will become mandatory in a future version of earthly.", keys)

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -498,6 +498,20 @@ dotenv-test:
     # --env-file takes preceddence
     DO +RUN_EARTHLY --earthfile=dotenv.earth --extra_args="--no-output --env-file .some-other-env" --pre_command="export EARTHLY_ENV_FILE=.this-should-be-ignored" --target=+test
 
+earthlyargs-test:
+    RUN echo "foo=bar" >.earthlyargs
+    RUN echo "foo=secretbar" >.earthlysecrets
+    DO +RUN_EARTHLY --earthfile=earthlyargs.earth --extra_args="--no-output"
+
+    RUN echo "foo=duplicate-key-should-fail" >.env
+    DO +RUN_EARTHLY --earthfile=earthlyargs.earth --extra_args="--no-output" --should_fail="true" --output_contains="build arg foo found in both .env and .earthlyargs"
+
+earthlyargs-override-test:
+    RUN echo "foo=bar" > other.args
+    RUN echo "foo=secretbar" > other.secrets
+    RUN echo "EARTHLY_ARGS_FILE=other.args
+EARTHLY_SECRETS_FILE=other.secrets" > .env
+    DO +RUN_EARTHLY --earthfile=earthlyargs.earth --extra_args="--no-output"
 
 env-test:
     DO +RUN_EARTHLY --earthfile=env.earth --extra_args="--no-output" --target=+test

--- a/tests/earthlyargs.earth
+++ b/tests/earthlyargs.earth
@@ -1,0 +1,19 @@
+VERSION 0.6
+FROM alpine:3.15
+
+test-arg:
+    ARG foo=incorrect
+    RUN test "$foo" == "bar"
+
+test-secret:
+    RUN --secret foo test "$foo" == "secretbar"
+
+test-both:
+    ARG foo=incorrect
+    RUN --secret foo test "$foo" = "bar" # arg takes precedence
+    RUN --secret secretfoo=+secrets/foo test "$secretfoo" == "secretbar" && test "$foo" = "bar"
+
+all:
+    BUILD +test-arg
+    BUILD +test-secret
+    BUILD +test-both


### PR DESCRIPTION
.env should only contain earthly cli flag env values; build-args and
secrets should be stored in .earthlyargs and .earthlysecrets
respectively.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>