### PR TITLE
Pre-released binary shows `GitSha` twice

### DIFF
--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -316,11 +316,10 @@ func main() {
 
 func getVersionPlatform() string {
 	var isRelease = regexp.MustCompile(`^v[0-9]+\.[0-9]+\.[0-9]+$`)
-	v := Version
-	if !isRelease.MatchString(Version) {
-		v = fmt.Sprintf("%s-%s", Version, GitSha)
+	if isRelease.MatchString(Version) {
+		return fmt.Sprintf("%s %s %s", Version, GitSha, getPlatform())
 	}
-	return fmt.Sprintf("%s %s %s", v, GitSha, getPlatform())
+	return fmt.Sprintf("%s-%s %s", Version, GitSha, getPlatform())
 }
 
 func getPlatform() string {


### PR DESCRIPTION
According to #1636, the version string of a pre-released binary is intended to show as below:
```
earthly version prerelease-40ac00a17b4174f3b332ee8be3df441d493a9013 linux/amd64; Ubuntu 20.04
```
but actually shows:
```
earthly-linux-amd64 version prerelease-fa59ac4ea52bc2e9ae9e1fa9eb4838393816d283 fa59ac4ea52bc2e9ae9e1fa9eb4838393816d283 linux/amd64; Arch Linux
```

This pull request changes `getVersionPlatform()` to make showing `GitSha` once in both cases.