### PR TITLE
Better file missing error message

### DIFF
--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -1566,6 +1566,10 @@ func (app *earthlyApp) run(ctx context.Context, args []string) int {
 				"Check your git auth settings.\n" +
 					"Did you ssh-add today? Need to configure ~/.earthly/config.yml?\n" +
 					"For more information see https://docs.earthly.dev/guides/auth\n")
+		} else if strings.Contains(err.Error(), "failed to compute cache key") && strings.Contains(err.Error(), ": not found") {
+			var re = regexp.MustCompile(`".*?"`)
+			var path = re.FindString(err.Error())
+			app.console.Warnf("Error: File not found %v\n", path)
 		} else if strings.Contains(failedOutput, "Invalid ELF image for this architecture") {
 			app.console.Warnf("Error: %v\n", err)
 			app.console.Printf(

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -1567,9 +1567,13 @@ func (app *earthlyApp) run(ctx context.Context, args []string) int {
 					"Did you ssh-add today? Need to configure ~/.earthly/config.yml?\n" +
 					"For more information see https://docs.earthly.dev/guides/auth\n")
 		} else if strings.Contains(err.Error(), "failed to compute cache key") && strings.Contains(err.Error(), ": not found") {
-			var re = regexp.MustCompile(`".*?"`)
-			var path = re.FindString(err.Error())
-			app.console.Warnf("Error: File not found %v\n", path)
+			re := regexp.MustCompile(`("[^"]*"): not found`)
+			var matches = re.FindStringSubmatch(err.Error())
+			if len(matches) == 2 {
+				app.console.Warnf("Error: File not found %v\n", matches[1])
+			} else {
+				app.console.Warnf("Error: File not found: %v\n", err.Error())
+			}
 		} else if strings.Contains(failedOutput, "Invalid ELF image for this architecture") {
 			app.console.Warnf("Error: %v\n", err)
 			app.console.Printf(


### PR DESCRIPTION
I might need some pointers on this. I am trying to improve an error message.

Old Error message for the file does not exist:
```
Error: build target: build main: failed to solve: failed to compute cache key: failed to calculate checksum of ref 4z7jcxhngtwp6n799l897lhff::54sya1iypr5uovhhi03tce12r: "/bla": not found
```

New error:

```
Error: File not found "/bla"
```

The actual error for `file not found` is in checksum.go and private so the only way I could figure to get the context out was via text matching. Is there a better way?  Ideally, I'd like to actually get the line number of the Earthfile out as well, so the error would be:
```
Earthfile:58  "/bla" not found`
```

