### PR TITLE
refactor secretprovider to use chain of stores

### DIFF
--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -2930,7 +2930,10 @@ func (app *earthlyApp) actionBuildImp(c *cli.Context, flagArgs, nonFlagArgs []st
 	buildContextProvider := provider.NewBuildContextProvider(app.console)
 	buildContextProvider.AddDirs(defaultLocalDirs)
 	attachables := []session.Attachable{
-		secretprovider.New(cc, secretsMap),
+		secretprovider.New(
+			secretprovider.NewMapStore(secretsMap),
+			secretprovider.NewCloudStore(cc),
+		),
 		buildContextProvider,
 		localhostProvider,
 	}

--- a/util/llbutil/secretprovider/cloud.go
+++ b/util/llbutil/secretprovider/cloud.go
@@ -1,0 +1,34 @@
+package secretprovider
+
+import (
+	"context"
+	"strings"
+
+	"github.com/earthly/earthly/cloud"
+	"github.com/moby/buildkit/session/secrets"
+)
+
+type cloudStore struct {
+	client cloud.Client
+}
+
+// NewCloudStore returns a new cloud secret store
+func NewCloudStore(client cloud.Client) secrets.SecretStore {
+	return &cloudStore{
+		client: client,
+	}
+}
+
+// GetSecret returns a secret.
+// secrets are referenced via +secret/name or +secret/org/name (or +secret/org/subdir1/.../name)
+// however by the time GetSecret is called, the "+secret" prefix is removed.
+func (cs *cloudStore) GetSecret(ctx context.Context, id string) ([]byte, error) {
+	if !strings.HasPrefix(id, "/") {
+		return nil, secrets.ErrNotFound
+	}
+	dt, err := cs.client.Get(id)
+	if err != nil {
+		return nil, err
+	}
+	return dt, nil
+}

--- a/util/llbutil/secretprovider/map_store.go
+++ b/util/llbutil/secretprovider/map_store.go
@@ -4,16 +4,20 @@ import (
 	"context"
 
 	"github.com/moby/buildkit/session/secrets"
-	"github.com/pkg/errors"
 )
 
 type mapStore map[string][]byte
+
+// NewMapStore returns a new map-based secret store
+func NewMapStore(m map[string][]byte) secrets.SecretStore {
+	return mapStore(m)
+}
 
 // GetSecret gets a secret from the map store
 func (m mapStore) GetSecret(ctx context.Context, id string) ([]byte, error) {
 	v, ok := m[id]
 	if !ok {
-		return nil, errors.WithStack(errors.Wrapf(secrets.ErrNotFound, "unable to lookup secret %s", id))
+		return nil, secrets.ErrNotFound
 	}
 	return v, nil
 }

--- a/util/llbutil/secretprovider/secrets.go
+++ b/util/llbutil/secretprovider/secrets.go
@@ -2,22 +2,16 @@ package secretprovider
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
-	"github.com/earthly/earthly/cloud"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/secrets"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 )
 
-// ErrNoCloudClient occurs when the secrets client is referenced but was never provided
-var ErrNoCloudClient = errors.Errorf("no cloud client provided")
-
 type secretProvider struct {
-	store  secrets.SecretStore
-	client cloud.Client
+	stores []secrets.SecretStore
 }
 
 // Register registers the secret provider
@@ -25,53 +19,42 @@ func (sp *secretProvider) Register(server *grpc.Server) {
 	secrets.RegisterSecretsServer(server, sp)
 }
 
-func (sp *secretProvider) getSecretFromServer(path string) ([]byte, error) {
-	if sp.client == nil {
-		return nil, ErrNoCloudClient
-	}
-	data, err := sp.client.Get(path)
-	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("failed to lookup secret %q from secrets server", path))
-	}
-	return data, nil
-}
-
 // GetSecret returns a secret.
 // secrets are referenced via +secret/name or +secret/org/name (or +secret/org/subdir1/.../name)
 // however by the time GetSecret is called, the "+secret/" prefix is removed.
 // if the name contains a /, then we can infer that it references the shared secret service.
 func (sp *secretProvider) GetSecret(ctx context.Context, req *secrets.GetSecretRequest) (*secrets.GetSecretResponse, error) {
-	isSharedSecret := false
+
+	// shared secrets will be of the form org/path
+	// and must be transformed into /org/path
 	secretName := req.ID
-	if strings.Contains(req.ID, "/") {
-		isSharedSecret = true
+	if strings.Contains(secretName, "/") {
 		if req.ID[0] == '/' {
 			panic("secret name starts with '/'; this should never happen")
 		}
-		secretName = "/" + req.ID
+		secretName = "/" + secretName
 	}
 
-	dt, err := sp.store.GetSecret(ctx, secretName)
-	if err != nil {
-		if errors.Is(err, secrets.ErrNotFound) && isSharedSecret {
-			dt, err = sp.getSecretFromServer(secretName)
-			if err != nil {
-				return nil, err
+	for _, store := range sp.stores {
+		dt, err := store.GetSecret(ctx, secretName)
+		if err != nil {
+			if errors.Is(err, secrets.ErrNotFound) {
+				continue
 			}
-		} else {
 			return nil, err
 		}
+		return &secrets.GetSecretResponse{
+			Data: dt,
+		}, nil
 	}
 
-	return &secrets.GetSecretResponse{
-		Data: dt,
-	}, nil
+	return nil, errors.WithStack(errors.Wrapf(secrets.ErrNotFound, "unable to lookup secret %s", secretName))
 }
 
-// New returns a new secrets provider
-func New(client cloud.Client, overrides map[string][]byte) session.Attachable {
+// New returns a new secrets provider which looks up secrets
+// in each supplied secret store (ordered by argument ordering) and returns the first found secret
+func New(stores ...secrets.SecretStore) session.Attachable {
 	return &secretProvider{
-		store:  mapStore(overrides),
-		client: client,
+		stores: stores,
 	}
 }


### PR DESCRIPTION
This refactors the secretprovider to accept an arbitraty chain of stores
which could potentially return the secret. This will make it easier to
insert new secret stores in the future.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>