### PR TITLE
Document earthly can use the ~/.netrc file

### DIFF
--- a/docs/guides/auth.md
+++ b/docs/guides/auth.md
@@ -69,6 +69,10 @@ git:
         password: <password>
 ```
 
+If no `user` or `password` are found, earthly will check for entries under [`~/.netrc`](https://everything.curl.dev/usingcurl/netrc).
+
+##### Global override via environment variables (deprecated)
+
 Alternatively, environment variables can be set which will be override all host entries from the config file:
 
 * `GIT_USERNAME`


### PR DESCRIPTION
Signed-off-by: Alex Couture-Beil <alex@earthly.dev>