### PR TITLE
COPY into CACHE doesn't work

### DIFF
--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -490,6 +490,13 @@ func (c *Converter) CopyClassical(ctx context.Context, srcs []string, dest strin
 		srcState = c.buildContextFactory.Construct()
 	}
 
+	// TODO add support for caches
+	for path := range c.persistentCacheDirs {
+		if dest == path || strings.HasPrefix(dest, path+"/") {
+			return fmt.Errorf("unable to copy to dest=%s which is located under CACHE=%s", dest, path)
+		}
+	}
+
 	c.nonSaveCommand()
 	c.mts.Final.MainState = llbutil.CopyOp(
 		srcState,


### PR DESCRIPTION
Currently the following code is accepted by earthly:

    target:
        CACHE /my-cache
        COPY local-file /my-cache/

However it doesn't correctly copy the file into the cache.
We will fix it in a follow up PR when time permits; however,
for the time-being it's better to explicitly fail if such a COPY
is attempted.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>