### PR TITLE
unmask cgroups for podman

### DIFF
--- a/util/containerutil/podman.go
+++ b/util/containerutil/podman.go
@@ -25,7 +25,7 @@ func NewPodmanShellFrontend(ctx context.Context, cfg *FrontendConfig) (Container
 	fe := &podmanShellFrontend{
 		shellFrontend: &shellFrontend{
 			binaryName:              "podman",
-			runCompatibilityArgs:    make([]string, 0),
+			runCompatibilityArgs:    []string{"--security-opt", "unmask=/sys/fs/cgroup"},
 			globalCompatibilityArgs: make([]string, 0),
 		},
 	}


### PR DESCRIPTION
podman masks off `/sys/fs/cgroup` as read-only by default, which prevents earthly from managing cgroup v2 limits.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>