### PR TITLE
Update example workflow in GitHub Actions integration guide

### DIFF
--- a/docs/ci-integration/guides/gh-actions-integration.md
+++ b/docs/ci-integration/guides/gh-actions-integration.md
@@ -20,7 +20,7 @@ jobs:
     env:
       FORCE_COLOR: 1
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Put back the git branch into git (Earthly uses it for tagging)
       run: |
         branch=""

--- a/docs/ci-integration/guides/gh-actions-integration.md
+++ b/docs/ci-integration/guides/gh-actions-integration.md
@@ -34,8 +34,10 @@ jobs:
         git checkout -b "$branch" || true
     - name: Docker Login
       run: docker login --username "$DOCKERHUB_USERNAME" --password "$DOCKERHUB_TOKEN"
-    - name: Download latest earthly
-      run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/download/v0.6.14/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly'"
+    - name: Setup Earthly
+      uses: earthly/actions-setup@v1
+      with:
+        version: "v0.6.10"
     - name: Earthly version
       run: earthly --version
     - name: Run build

--- a/docs/ci-integration/guides/gh-actions-integration.md
+++ b/docs/ci-integration/guides/gh-actions-integration.md
@@ -18,8 +18,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
       FORCE_COLOR: 1
     steps:
     - uses: actions/checkout@v2
@@ -33,7 +31,7 @@ jobs:
         fi
         git checkout -b "$branch" || true
     - name: Docker Login
-      run: docker login --username "$DOCKERHUB_USERNAME" --password "$DOCKERHUB_TOKEN"
+      run: echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
     - name: Setup Earthly
       uses: earthly/actions-setup@v1
       with:

--- a/docs/ci-integration/guides/gh-actions-integration.md
+++ b/docs/ci-integration/guides/gh-actions-integration.md
@@ -38,8 +38,6 @@ jobs:
       uses: earthly/actions-setup@v1
       with:
         version: "v0.6.10"
-    - name: Earthly version
-      run: earthly --version
     - name: Run build
       run: earthly --ci --push +build
 ```


### PR DESCRIPTION
This PR updates the [GitHub Actions guide](https://docs.earthly.dev/ci-integration/vendor-specific-guides/gh-actions-integration) with the following changes:

- Use [earthly/actions-setup](https://github.com/earthly/actions-setup) instead of installing Earthly manually (thanks for this, by the way — this is a big quality of life improvement)
- Remove `earthly --version` step
- Use latest version (v3) of [actions/checkout](https://github.com/actions/checkout)
- Some more opinionated changes that I can back out of if you prefer:
  - Don't set Docker Hub credentials as environment variables
  - Pass Docker Hub token through standard input