### PR TITLE
simplify --version value

### DIFF
--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -306,12 +306,7 @@ func main() {
 }
 
 func getVersionPlatform() string {
-	var isRelease = regexp.MustCompile(`^v[0-9]+\.[0-9]+\.[0-9]+$`)
-	v := Version
-	if !isRelease.MatchString(Version) {
-		v = fmt.Sprintf("%s-%s", Version, GitSha)
-	}
-	return fmt.Sprintf("%s %s %s", v, GitSha, getPlatform())
+	return fmt.Sprintf("%s %s %s", Version, GitSha, getPlatform())
 }
 
 func getPlatform() string {


### PR DESCRIPTION
non-released versions are displaying the gitsha twice.

before:

    earthly version dev-acb_simplify-version-string-5a6b598faaaa647b15fbee961dbe9d4741dcd082 5a6b598faaaa647b15fbee961dbe9d4741dcd082 linux/amd64; Ubuntu 20.04

after:

    earthly version dev-acb_simplify-version-string 5a6b598faaaa647b15fbee961dbe9d4741dcd082 linux/amd64; Ubuntu 20.04

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>