### PR TITLE
Add note about with docker registry to feature docs

### DIFF
--- a/docs/earthfile/features.md
+++ b/docs/earthfile/features.md
@@ -42,6 +42,7 @@ to require version `0.X` (or later), and could be rewritten as `VERSION 0.X`.
 | `--no-implicit-ignore` | 0.6 | Eliminates implicit `.earthlyignore` entries, such as `Earthfile` and `.tmp-earthly-out` |
 | `--earthly-version-arg` | Beta | Enables builtin ARGs: `EARTHLY_VERSION` and `EARTHLY_BUILD_SHA` |
 | `--shell-out-anywhere` | Experimental | Allows shelling-out in any earthly command (including in the middle of `ARG`) |
+| `--use-registry-for-with-docker` | Experimental | Makes use of the embedded BuildKit Docker registry (instead of tar files) for `WITH DOCKER` loads and pulls |
 
 Note that the features flags are disabled by default in Earthly versions lower than the version listed in the "status" column above.
 


### PR DESCRIPTION
Adds a note to the feature list for the new `--use-registry-for-with-docker` feature. Full description here: https://github.com/earthly/earthly/pull/1858