### PR TITLE
Print key of missing arg in error message

### DIFF
--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -1133,10 +1133,10 @@ func (c *Converter) Arg(ctx context.Context, argKey string, defaultArgValue stri
 		return err
 	}
 	if opts.Required && len(effective) == 0 {
-		return errors.New("arg not supplied for required ARG")
+		return fmt.Errorf("value not supplied for required ARG: %s", argKey)
 	}
 	if len(defaultArgValue) > 0 && reserved.IsBuiltIn(argKey) {
-		return errors.New("arg default value supplied for built-in ARG")
+		return fmt.Errorf("arg default value supplied for built-in ARG: %s", argKey)
 	}
 	if c.varCollection.IsStackAtBase() { // Only when outside of UDC.
 		c.mts.Final.AddBuildArgInput(dedup.BuildArgInput{


### PR DESCRIPTION
Minor change for error messages when missing required args. May improve debug-ability for large Earthfiles with multiple required args.

Changes made:

1. print the key of the missing `ARG --required` in error message


Local testing:

```
build/darwin/arm64/earthly +run

 1. Init 🚀
————————————————————————————————————————————————————————————————————————————————

           buildkitd | Found buildkit daemon as docker container (earthly-buildkitd)


 3. Build 🔧
————————————————————————————————————————————————————————————————————————————————

Share your logs with an Earthly account (experimental)! Register for one at https://ci.earthly.dev.
Error: build target: build main: failed to solve: Earthfile line 5:2 apply ARG: value not supplied for required ARG: please_set_me
in              +run
```