### PR TITLE
tutorial: double quotes must be used

### DIFF
--- a/docs/basics/part-6-using-docker-with-earthly.md
+++ b/docs/basics/part-6-using-docker-with-earthly.md
@@ -31,7 +31,7 @@ We can load in an image created by another target with the `--load` flag.
 ```Dockerfile
 my-hello-world:
     FROM ubuntu
-    CMD echo 'hello world'
+    CMD echo "hello world"
     SAVE IMAGE my-hello:latest
 
 hello:


### PR DESCRIPTION
Currently this example is breaking with:

    Error: build target: build main: failed to solve: async earthfile2llb for +my-hello-world: Earthfile line 4:4 failed to expand CMD 'hello: failed to process "'hello": unexpected end of statement while looking for matching single-quote
    in		+my-hello-world

Perhaps this is related to https://github.com/earthly/earthly/issues/86
?

We should change this example, and work on a fix in a follow-up PR.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>