### PR TITLE
Pin dind version as 20.10.15 is failing

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -418,7 +418,7 @@ dind:
     BUILD +dind-ubuntu
 
 dind-alpine:
-    FROM docker:dind
+    FROM docker:20.10.14-dind
     COPY ./buildkitd/docker-auto-install.sh /usr/local/bin/docker-auto-install.sh
     RUN docker-auto-install.sh
     ARG EARTHLY_TARGET_TAG_DOCKER

--- a/tests/dind-auto-install/Earthfile
+++ b/tests/dind-auto-install/Earthfile
@@ -2,7 +2,7 @@ VERSION 0.6
 
 all:
     BUILD +test \
-        # Pin the versiob here as 20.10.15 seems to have introduced a bug.
+        # Pin the version here as 20.10.15 seems to have introduced a bug.
         --BASE_IMAGE=docker:20.10.14-dind \
         --BASE_IMAGE=alpine:latest \
         --BASE_IMAGE=debian:stable \

--- a/tests/dind-auto-install/Earthfile
+++ b/tests/dind-auto-install/Earthfile
@@ -2,7 +2,8 @@ VERSION 0.6
 
 all:
     BUILD +test \
-        --BASE_IMAGE=docker:dind \
+        # Pin the versiob here as 20.10.15 seems to have introduced a bug.
+        --BASE_IMAGE=docker:20.10.14-dind \
         --BASE_IMAGE=alpine:latest \
         --BASE_IMAGE=debian:stable \
         --BASE_IMAGE=debian:stable-slim \


### PR DESCRIPTION
The 20.10.15 Docker image seems to have introduced a bug/issue. Let's pin our version for now until it's fixed.

```
Repeating the output of the command that caused the failure
./t/dind-auto-install+test *failed* | BASE_IMAGE=../..+dind-alpine
./t/dind-auto-install+test *failed* | --> WITH DOCKER RUN --privileged true
./t/dind-auto-install+test *failed* | Loading images...
./t/dind-auto-install+test *failed* | Loaded image: hello-world:latest
./t/dind-auto-install+test *failed* | ...done
./t/dind-auto-install+test *failed* | Network _default  Creating
./t/dind-auto-install+test *failed* | Network _default  Created
./t/dind-auto-install+test *failed* | Container -hello-1  Creating
./t/dind-auto-install+test *failed* | Error response from daemon: Invalid container name (-hello-1), only [a-zA-Z0-9][a-zA-Z0-9_.-] are allowed
./t/dind-auto-install+test *failed* | ERROR: Command exited with non-zero code: WITH DOCKER RUN --privileged true
```