### PR TITLE
Add WORKDIR to dind test for Compose image name issue

### DIFF
--- a/tests/dind-auto-install/Earthfile
+++ b/tests/dind-auto-install/Earthfile
@@ -2,8 +2,8 @@ VERSION 0.6
 
 all:
     BUILD +test \
-        # Pin the version here as 20.10.15 seems to have introduced a bug.
         --BASE_IMAGE=docker:20.10.14-dind \
+        --BASE_IMAGE=docker:20.10.15-dind \
         --BASE_IMAGE=alpine:latest \
         --BASE_IMAGE=debian:stable \
         --BASE_IMAGE=debian:stable-slim \
@@ -16,6 +16,7 @@ all:
 test:
     ARG --required BASE_IMAGE
     FROM $BASE_IMAGE
+    WORKDIR /root
     COPY ./docker-compose.yml ./
     WITH DOCKER --compose docker-compose.yml
         RUN true

--- a/tests/dind-auto-install/Earthfile
+++ b/tests/dind-auto-install/Earthfile
@@ -4,6 +4,7 @@ all:
     BUILD +test \
         --BASE_IMAGE=docker:20.10.14-dind \
         --BASE_IMAGE=docker:20.10.15-dind \
+        --BASE_IMAGE=docker:dind \
         --BASE_IMAGE=alpine:latest \
         --BASE_IMAGE=debian:stable \
         --BASE_IMAGE=debian:stable-slim \


### PR DESCRIPTION
Docker Compose v2 is referencing the directory name when choosing a container name. If we run at `/` the name is empty and causes an error. This change uses `WORKDIR` to resolve that problem.

Related: https://github.com/earthly/earthly/pull/1884
