### PR TITLE
Experimental `nerdctl` support

### DIFF
--- a/util/containerutil/frontend.go
+++ b/util/containerutil/frontend.go
@@ -64,8 +64,9 @@ func autodetectFrontend(ctx context.Context, cfg *FrontendConfig) (ContainerFron
 	var errs error
 
 	for _, feType := range []string{
-		FrontendDockerShell,
-		FrontendPodmanShell,
+		//FrontendDockerShell,
+		//FrontendPodmanShell,
+		FrontendNerdctlShell,
 	} {
 		fe, err := frontendIfAvaliable(ctx, feType, cfg)
 		if err != nil {
@@ -84,6 +85,8 @@ func frontendIfAvaliable(ctx context.Context, feType string, cfg *FrontendConfig
 		newFe = NewDockerShellFrontend
 	case FrontendPodmanShell:
 		newFe = NewPodmanShellFrontend
+	case FrontendNerdctlShell:
+		newFe = NewNerdctlShellFrontend
 	default:
 		return nil, fmt.Errorf("%s is not a supported container frontend", feType)
 	}

--- a/util/containerutil/nerdctl.go
+++ b/util/containerutil/nerdctl.go
@@ -1,0 +1,278 @@
+package containerutil
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+
+	"github.com/alessio/shellescape"
+	"github.com/hashicorp/go-multierror"
+	"github.com/pkg/errors"
+)
+
+type nerdctlShellFrontend struct {
+	*shellFrontend
+}
+
+// NewNerdctlShellFrontend constructs a new Frontend using the nerdctl binary installed on the host.
+// It also ensures that the binary is functional for our needs and collects compatibility information.
+func NewNerdctlShellFrontend(ctx context.Context, cfg *FrontendConfig) (ContainerFrontend, error) {
+	fe := &nerdctlShellFrontend{
+		shellFrontend: &shellFrontend{
+			binaryName:              "nerdctl",
+			runCompatibilityArgs:    make([]string, 0),
+			globalCompatibilityArgs: make([]string, 0),
+		},
+	}
+
+	output, err := fe.commandContextOutput(ctx, "info", "--format={{.SecurityOptions}}")
+	if err != nil {
+		return nil, err
+	}
+	fe.rootless = strings.Contains(output.string(), "rootless")
+
+	fe.urls, err = fe.setupAndValidateAddresses(FrontendNerdctlShell, cfg)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to calculate buildkit URLs")
+	}
+
+	return fe, nil
+}
+
+func (nsf *nerdctlShellFrontend) Scheme() string {
+	return "nerdctl-container"
+}
+
+func (nsf *nerdctlShellFrontend) Config() *CurrentFrontend {
+	return &CurrentFrontend{
+		Setting:      FrontendNerdctlShell,
+		Binary:       nsf.binaryName,
+		Type:         FrontendTypeShell,
+		FrontendURLs: nsf.urls,
+	}
+}
+
+func (nsf *nerdctlShellFrontend) Information(ctx context.Context) (*FrontendInfo, error) {
+	output, err := nsf.commandContextOutput(ctx, "version", "--format={{json .}}")
+	if err != nil {
+		return nil, err
+	}
+
+	type info struct {
+		Client struct {
+			Version   string
+			GitCommit string
+			OS        string
+			Arch      string
+		}
+		Server struct {
+			Components []struct {
+				Name    string
+				Version string
+				Details struct {
+					GitCommit string
+				}
+			}
+		}
+	}
+
+	allInfo := info{}
+	json.Unmarshal([]byte(output.string()), &allInfo)
+
+	var serverVersion, serverAPIVersion string
+	for _, component := range allInfo.Server.Components {
+		if component.Name == " containerd" {
+			serverVersion = component.Version
+			serverAPIVersion = component.Details.GitCommit
+		}
+	}
+
+	// Note that nerdctl does not support remote containerd: https://github.com/containerd/nerdctl/issues/473
+	return &FrontendInfo{
+		ClientVersion:    allInfo.Client.Version,
+		ClientAPIVersion: allInfo.Client.GitCommit,
+		ClientPlatform:   fmt.Sprintf("%s/%s", allInfo.Client.OS, allInfo.Client.Arch),
+		ServerVersion:    serverVersion,
+		ServerAPIVersion: serverAPIVersion,
+		ServerPlatform:   fmt.Sprintf("%s/%s", allInfo.Client.OS, allInfo.Client.Arch),
+	}, nil
+}
+
+func (nsf *nerdctlShellFrontend) ContainerInfo(ctx context.Context, namesOrIDs ...string) (map[string]*ContainerInfo, error) {
+	results, err := nsf.shellFrontend.ContainerInfo(ctx, namesOrIDs...)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, v := range results {
+		// nerdctl puts an image tag where podman & docker put an image sha. We will unflip this here, and shell out to
+		// the image command to get what we can. Note that the Id is (probably) not the same as Docker/Podman - it uses
+		// a repo ID. Regular sha ids are not taggable here, but the special nerdctl one is... so we report that one.
+		if v.Status == StatusMissing {
+			continue
+		}
+
+		v.Image = v.ImageID
+		v.ImageID = ""
+
+		id, imageErr := nsf.commandContextOutput(ctx, "image", "inspect", `--format="{{json .RepoDigests}}"`, v.Image)
+		if imageErr != nil {
+			err = multierror.Append(err, imageErr)
+			continue
+		}
+
+		// We assume the first repo digest is the correct one with no basis in reality, but it seems to work
+		repoDigests := make([]string, 0)
+		jsonErr := json.Unmarshal([]byte(id.stdout.String()), &repoDigests)
+		if jsonErr != nil {
+			err = multierror.Append(err, jsonErr)
+			continue
+		}
+
+		digest, digestErr := nsf.getRepoDigest(repoDigests)
+		if digestErr != nil {
+			err = multierror.Append(err, errors.Wrapf(digestErr, "%s has no digests", v.Image))
+			continue
+		}
+
+		v.ImageID = digest
+	}
+
+	return results, nil
+}
+
+func (nsf *nerdctlShellFrontend) ImageInfo(ctx context.Context, refs ...string) (map[string]*ImageInfo, error) {
+	args := append([]string{"image", "inspect"}, refs...)
+
+	// Ignore the error. This is because one or more of the provided refs could be missing.
+	// This allows for Info to report that the image itself is missing.
+	output, _ := nsf.commandContextOutput(ctx, args...)
+
+	infos := map[string]*ImageInfo{}
+	for _, ref := range refs {
+		// preinitialize all as missing. It will get overwritten when we encounter a real one from the actual output.
+		infos[ref] = &ImageInfo{}
+	}
+
+	// Anonymous struct to just pick out what we need
+	images := []struct {
+		RepoDigests []string `json:"RepoDigests"`
+		Tags        []string `json:"RepoTags"`
+	}{}
+	json.Unmarshal([]byte(output.stdout.String()), &images)
+
+	var err error
+	for i, image := range images {
+		digest, digestErr := nsf.getRepoDigest(image.RepoDigests)
+		if digestErr != nil {
+			err = multierror.Append(err, errors.Wrapf(digestErr, "%s has no digests", refs[i]))
+			continue
+		}
+
+		infos[refs[i]] = &ImageInfo{
+			ID:   digest,
+			Tags: image.Tags,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return infos, nil
+}
+
+func (nsf *nerdctlShellFrontend) ImagePull(ctx context.Context, refs ...string) error {
+	var err error
+	for _, ref := range refs {
+		_, cmdErr := nsf.commandContextOutput(ctx, "pull", ref)
+		if cmdErr != nil {
+			err = multierror.Append(err, cmdErr)
+		}
+	}
+
+	return err
+}
+
+func (nsf *nerdctlShellFrontend) ImageLoad(ctx context.Context, images ...io.Reader) error {
+	var err error
+	args := append(nsf.globalCompatibilityArgs, "load")
+	for _, image := range images {
+		// Do not use the wrapper to allow the image to come in on stdin
+		cmd := exec.CommandContext(ctx, nsf.binaryName, args...)
+		cmd.Stdin = image
+		output, cmdErr := cmd.CombinedOutput()
+		if cmdErr != nil {
+			err = multierror.Append(err, errors.Wrapf(cmdErr, "image load failed: %s", string(output)))
+		}
+	}
+
+	return err
+}
+
+func (nsf *nerdctlShellFrontend) ImageLoadFromFileCommand(filename string) string {
+	binary, args := nsf.commandContextStrings("load")
+
+	all := []string{binary}
+	all = append(all, args...)
+
+	return fmt.Sprintf("cat %s | %s", shellescape.Quote(filename), strings.Join(all, " "))
+}
+
+func (nsf *nerdctlShellFrontend) VolumeInfo(ctx context.Context, volumeNames ...string) (map[string]*VolumeInfo, error) {
+	// Ignore the error. This is because one or more of the provided names could be missing.
+	// This allows for Info to report that the volume itself is missing.
+	output, _ := nsf.commandContextOutput(ctx, "volume", "ls", "--format={{json  .}}")
+
+	results := map[string]*VolumeInfo{}
+	for _, name := range volumeNames {
+		// Preinitialize all as missing. It will get overwritten when we encounter a real one from the actual output.
+		results[name] = &VolumeInfo{Name: name}
+	}
+
+	// simple struct to just pick out what we need
+	type volume struct {
+		Name string `json:"Name"`
+		// Size is not yet supported here. It does not appear to be anywhere in the public APIs?
+		Mountpoint string `json:"Mountpoint"`
+	}
+	volumeInfos := make([]volume, 0)
+
+	var err error
+	for _, line := range strings.Split(strings.TrimSpace(output.stdout.String()), "\n") {
+		v := volume{}
+		jsonErr := json.Unmarshal([]byte(line), &v)
+		if jsonErr != nil {
+			err = multierror.Append(err, errors.Wrapf(jsonErr, "failed to decode docker volume info: '%v'", line))
+			continue
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	for _, name := range volumeNames {
+		for _, volumeInfo := range volumeInfos {
+			if name == volumeInfo.Name {
+				results[name] = &VolumeInfo{
+					Name:       volumeInfo.Name,
+					Mountpoint: volumeInfo.Mountpoint,
+				}
+				break
+			}
+		}
+	}
+
+	return results, nil
+}
+
+func (nsf *nerdctlShellFrontend) getRepoDigest(digests []string) (string, error) {
+	if len(digests) == 0 {
+		return "", errors.New("no repo digests")
+	}
+	return strings.TrimLeftFunc(digests[0], func(r rune) bool {
+		return r != '@'
+	})[1:], nil // Trim off the remaining '@'
+}

--- a/util/containerutil/shell_shared.go
+++ b/util/containerutil/shell_shared.go
@@ -35,23 +35,8 @@ func (sf *shellFrontend) IsAvaliable(ctx context.Context) bool {
 }
 
 func (sf *shellFrontend) ContainerInfo(ctx context.Context, namesOrIDs ...string) (map[string]*ContainerInfo, error) {
-	args := append([]string{"container", "inspect"}, namesOrIDs...)
-
-	// Ignore the error. This is because one or more of the provided names or IDs could be missing.
-	// This allows for Info to report that the container itself is missing.
-	output, _ := sf.commandContextOutput(ctx, args...)
-
-	infos := map[string]*ContainerInfo{}
-	for _, nameOrID := range namesOrIDs {
-		// Preinitialize all as missing. It will get overwritten when we encounter a real one from the actual output.
-		infos[nameOrID] = &ContainerInfo{
-			Name:   nameOrID,
-			Status: StatusMissing,
-		}
-	}
-
-	// Anonymous struct to just pick out what we need
-	containers := []struct {
+	// struct to just pick out what we need for docker-compatible container info
+	type frontendContainerInfo struct {
 		ID    string `json:"Id"`
 		Name  string `json:"Name"`
 		State struct {
@@ -67,23 +52,48 @@ func (sf *shellFrontend) ContainerInfo(ctx context.Context, namesOrIDs ...string
 			Labels map[string]string `json:"Labels"`
 		} `json:"Config"`
 		Image string `json:"Image"`
-	}{}
-	json.Unmarshal([]byte(output.stdout.String()), &containers)
+	}
 
-	for i, container := range containers {
-		ipAddresses := map[string]string{}
-		for k, v := range container.NetworkSettings.Networks {
-			ipAddresses[k] = v.IPAddress
+	infos := map[string]*ContainerInfo{}
+
+	for _, nameOrID := range namesOrIDs {
+		// Preinitialize all as missing. It will get overwritten when we encounter a real one from the actual output.
+		infos[nameOrID] = &ContainerInfo{
+			Name:   nameOrID,
+			Status: StatusMissing,
 		}
 
-		infos[namesOrIDs[i]] = &ContainerInfo{
-			ID:      container.ID,
-			Name:    container.Name,
-			Status:  container.State.Status,
-			IPs:     ipAddresses,
-			Image:   container.Config.Image,
-			ImageID: container.Image,
-			Labels:  container.Config.Labels,
+		args := []string{"container", "inspect", nameOrID}
+
+		// Ignore the error. This is because one or more of the provided names or IDs could be missing.
+		// This allows for Info to report that the container itself is missing.
+		output, err := sf.commandContextOutput(ctx, args...)
+		if err != nil {
+			// Some shell frontends (nerdctl, in particular) exit early if there is a single missing container in a
+			// list when extracting data. Assume an error is missing and continue.
+			continue
+		}
+
+		containers := make([]frontendContainerInfo, 1)
+		json.Unmarshal([]byte(output.stdout.String()), &containers)
+
+		// Its an array that comes back. I don't know if/how you could manage to get more than one back? But if we
+		// somehow do, last one wins I guess. Technically correct is the best correct.
+		for _, container := range containers {
+			ipAddresses := map[string]string{}
+			for k, v := range container.NetworkSettings.Networks {
+				ipAddresses[k] = v.IPAddress
+			}
+
+			infos[nameOrID] = &ContainerInfo{
+				ID:      container.ID,
+				Name:    container.Name,
+				Status:  container.State.Status,
+				IPs:     ipAddresses,
+				Image:   container.Config.Image,
+				ImageID: container.Image,
+				Labels:  container.Config.Labels,
+			}
 		}
 	}
 
@@ -377,6 +387,9 @@ func DefaultAddressForSetting(setting string) (string, error) {
 	case FrontendPodmanShell:
 		return TCPAddress, nil // Right now, podman only works over TCP. There are weird errors when trying to use the provided helper from buildkit.
 
+	case FrontendNerdctlShell:
+		return TCPAddress, nil
+
 	case FrontendStub:
 		return DockerAddress, nil // Maintiain old behavior
 	}
@@ -390,8 +403,8 @@ func parseAndValidateURL(addr string) (*url.URL, error) {
 		return nil, fmt.Errorf("%s: %w", addr, errURLParseFailure)
 	}
 
-	if parsed.Scheme != "tcp" && parsed.Scheme != "docker-container" && parsed.Scheme != "podman-container" {
-		return nil, fmt.Errorf("%s is not a valid scheme. Only tcp or docker-container is allowed at this time: %w", parsed.Scheme, errURLValidationFailure)
+	if parsed.Scheme != "tcp" && parsed.Scheme != "docker-container" && parsed.Scheme != "podman-container" && parsed.Scheme != "nerdctl-container" {
+		return nil, fmt.Errorf("%s is not a valid scheme. Only tcp or (docker | podman | nerdctl)-container is allowed at this time: %w", parsed.Scheme, errURLValidationFailure)
 	}
 
 	if parsed.Port() == "" && parsed.Scheme == "tcp" {
@@ -415,5 +428,6 @@ func IsLocal(addr string) bool {
 		hostname == net.IPv6loopback.String() ||
 		hostname == "localhost" || // Convention. Users hostname omitted; this is only really here for convenience.
 		parsed.Scheme == "docker-container" || // Accomodate feature flagging during transition. This will have omitted TLS?
-		parsed.Scheme == "podman-container"
+		parsed.Scheme == "podman-container" ||
+		parsed.Scheme == "nerdctl-container"
 }

--- a/util/containerutil/types.go
+++ b/util/containerutil/types.go
@@ -164,6 +164,9 @@ const (
 	// FrontendPodmanShell forces usage of the podman binary for container operations.
 	FrontendPodmanShell = "podman-shell"
 
+	// FrontendNerdctlShell forces usage of the nerdctl binary for container operations.
+	FrontendNerdctlShell = "nerdctl-shell"
+
 	// FrontendStub is for when there is no valid provider but attempting to run anyways is desired; like integration tests, or the earthly/earthly image when NO_DOCKER is set.
 	FrontendStub = "stub"
 )


### PR DESCRIPTION
I have been able to run `github.com/earthly/hello-world+hello`, so far. To get rootful `nerdctl`, you need to run `earthly` with `sudo`, too.

See #1726.

Rootless is still a WIP. It looks like it needs compatibility args to expose the cgroups fs within the container (like Podman), but it does not appear to support the same `securityOpts`.