### PR TITLE
Avoid panic in osutil

### DIFF
--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -311,7 +311,17 @@ func getVersionPlatform() string {
 }
 
 func getPlatform() string {
-	return fmt.Sprintf("%s/%s; %s", runtime.GOOS, runtime.GOARCH, osutil.GetDisplay())
+	showOSInfo := func() (info string) {
+		defer func() {
+			if err := recover(); err != nil {
+				// skipped
+				info = "unknown"
+				return
+			}
+		}()
+		return osutil.GetDisplay()
+	}
+	return fmt.Sprintf("%s/%s; %s", runtime.GOOS, runtime.GOARCH, showOSInfo())
 }
 
 func getBinaryName() string {

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -311,6 +311,7 @@ func getVersionPlatform() string {
 }
 
 func getPlatform() string {
+	// Work-around for windows panics; this can be removed once https://github.com/wille/osutil/pull/10 is merged
 	showOSInfo := func() (info string) {
 		defer func() {
 			if err := recover(); err != nil {


### PR DESCRIPTION
It's a bug of `osutil`.
So maybe we could just avoid it, and wait for this pr to be merged.
https://github.com/wille/osutil/pull/10