### PR TITLE
Fix git clone with matcher

### DIFF
--- a/tests/git-ssh-server/Earthfile
+++ b/tests/git-ssh-server/Earthfile
@@ -348,6 +348,8 @@ cat output.txt | grep $(echo MTIzM2MwODQtNGNmNS00Nzk3LWE0YzUtZWI2NTM1NGVlN2Vl | 
     DO +RUN_EARTHLY_ARGS --pre_command=start-sshd --earthfile=from-funnyserver.earth --exec_cmd=/tmp/test-earthly-script
 
 test-git-clone-command-with-custom-matcher:
+    ARG SSHD_PORT
+    ARG EFFECTIVE_PORT=${SSHD_PORT:-22}
     FROM ./setup+server \
         --DOCKERHUB_AUTH=$DOCKERHUB_AUTH \
         --DOCKERHUB_USER_SECRET=$DOCKERHUB_USER_SECRET \
@@ -357,7 +359,8 @@ test-git-clone-command-with-custom-matcher:
         --SSHD_RSA=true \
         --SSHD_ED25519=true \
         --USER_RSA=true \
-        --USER_ED25519=false
+        --USER_ED25519=false \
+        --SSHD_PORT=$EFFECTIVE_PORT
     RUN --no-cache echo "#!/bin/sh
 set -ex
 
@@ -370,12 +373,18 @@ eval \$(ssh-agent)
 ssh-add /root/self-hosted-rsa-key
 ssh-add -l
 
-# Setup auth to be ssh; with custom pattern/sub that converts `funnyserver/repo` to `ssh://git@git.example.com:22/home/git/testuser/repo.git`
-#earthly --config \$earthly_config config 'git.\"git.example.com\"' '{\"auth\": \"ssh\", \"user\": \"git\", \"pattern\": \"funnyserver/([^/]+)\", \"substitute\": \"ssh://git@git.example.com:22/home/git/testuser/\$1.git\"}'
-#cat \$earthly_config
+# Setup auth to be ssh; with custom pattern/sub that converts 'funnyserver/repo' to 'ssh://git@git.example.com:<port>/home/git/testuser/repo.git'
+earthly --config \$earthly_config config 'git.\"git.example.com\"' '{\"auth\": \"ssh\", \"user\": \"git\", \"pattern\": \"funnyserver/([^/]+)\", \"substitute\": \"ssh://git@git.example.com@PORT@/home/git/testuser/\$1.git\"}'
+git_port=${SSHD_PORT:+":$SSHD_PORT"}
+sed -i "s/@PORT@/\$git_port/" \$earthly_config
+cat \$earthly_config
 
 # call target which performs a git-clone
-(set +e; earthly --config \$earthly_config --verbose -D +test 2>&1; echo \"\$?\" > status) | tee output.txt
+if [ "$EFFECTIVE_PORT" -eq 22 ]; then
+    (set +e; earthly --config \$earthly_config --verbose -D +test 2>&1; echo \"\$?\" > status) | tee output.txt
+else
+    (set +e; earthly --config \$earthly_config --verbose -D +test-custom-port --port=$EFFECTIVE_PORT 2>&1; echo \"\$?\" > status) | tee output.txt
+fi
 test \"\$(cat status)\" = \"0\"
 grep fb5de6fc4b750a88841cd91b55bdec6d output.txt
 " >/tmp/test-earthly-script && chmod +x /tmp/test-earthly-script
@@ -392,7 +401,9 @@ all:
     BUILD +test-configured-ssh-no-keyscan
     BUILD +test-server-with-unhashed-keyscan
     BUILD +test-with-custom-matcher
-    BUILD +test-git-clone-command-with-custom-matcher
+    BUILD +test-git-clone-command-with-custom-matcher --SSHD_PORT= \
+                                                      --SSHD_PORT=22 \
+                                                      --SSHD_PORT=7999
 
 RUN_EARTHLY_ARGS:
     COMMAND

--- a/tests/git-ssh-server/git-clone-funnyserver.earth
+++ b/tests/git-ssh-server/git-clone-funnyserver.earth
@@ -16,3 +16,20 @@ test:
 
     # Display hash of Earthfile so the caller can verify we cloned the right file
     RUN --no-cache md5sum /repo/Earthfile
+
+test-custom-port:
+    FROM alpine:3.15
+    ARG --required port
+    GIT CLONE ssh://git.example.com:${port}/home/git/testuser/repo.git /repo
+    GIT CLONE ssh://git@git.example.com:${port}/home/git/testuser/repo.git /repo2
+
+    # Pseudo-documentation that this does *not* work, even if one would expect it to.  This implicit style
+    # leads to ambiguities around whether what appears after the host is a port or a 'user'.  Someone will have
+    # to decide whether this should be allowed, and if so, how to resolve the ambiguity.
+    #GIT CLONE git@git.example.com:${port}/testuser/repo.git /repo3
+
+    # Make sure all cloned repos are the same
+    RUN diff /repo/Earthfile /repo2/Earthfile
+
+    # Display hash of Earthfile so the caller can verify we cloned the right file
+    RUN --no-cache md5sum /repo/Earthfile

--- a/tests/git-ssh-server/setup/Earthfile
+++ b/tests/git-ssh-server/setup/Earthfile
@@ -49,10 +49,12 @@ server:
         chown -R git:git /home/git/testuser
     COPY sshd_config /etc/ssh/sshd_config
 
+    ARG SSHD_PORT=22
     ARG SSHD_RSA="true"
     ARG SSHD_ED25519="true"
     RUN if [ "$SSHD_RSA" = "true" ]; then echo "HostKey /etc/sshd_keys/sshd_rsa_key" >> /etc/ssh/sshd_config; fi && \
-        if [ "$SSHD_ED25519" = "true" ]; then echo "HostKey /etc/sshd_keys/sshd_ed25519_key" >> /etc/ssh/sshd_config; fi
+        if [ "$SSHD_ED25519" = "true" ]; then echo "HostKey /etc/sshd_keys/sshd_ed25519_key" >> /etc/ssh/sshd_config; fi && \
+        echo "Port $SSHD_PORT" >> /etc/ssh/sshd_config
 
     RUN echo "Welcome to our self-hosted git ssh server" > /etc/motd
 
@@ -72,8 +74,8 @@ fi
 
     RUN --privileged start-sshd && \
         mkdir -p ~/.ssh && \
-        timeout 5 sh -c 'until nc -z $0 $1; do sleep 1; done' git.example.com 22 && \
-        ssh-keyscan -H git.example.com > ~/.ssh/known_hosts && \
+        timeout 5 sh -c 'until nc -z $0 $1; do sleep 1; done' git.example.com "$SSHD_PORT" && \
+        ssh-keyscan -H -p "$SSHD_PORT" git.example.com > ~/.ssh/known_hosts && \
         echo done setup.
 
     RUN --privileged start-sshd && \ # starts in background
@@ -81,8 +83,8 @@ fi
         if [ "$USER_RSA" = "true" ]; then ssh-add /root/self-hosted-rsa-key; fi && \
         if [ "$USER_ED25519" = "true" ]; then ssh-add /root/self-hosted-ed25519-key; fi && \
         ssh-add -l && \
-        timeout 5 sh -c 'until nc -z $0 $1; do sleep 1; done' git.example.com 22 && \
-        ssh-keyscan -H git.example.com && \
+        timeout 5 sh -c 'until nc -z $0 $1; do sleep 1; done' git.example.com "$SSHD_PORT" && \
+        ssh-keyscan -H -p "$SSHD_PORT" git.example.com && \
         mkdir -p /test/repo && \
         cd /test/repo && \
         git init --initial-branch=main . && \
@@ -92,6 +94,7 @@ fi
         git config --global user.name "test name" && \
         git commit -m "An Earthfile to test against" && \
         git remote add origin git@git.example.com:testuser/repo.git && \
-        git push --set-upstream origin main && \
+        # Maybe the above 'implicit' syntax is required for some existing tests, so use this trick to use the correct port
+        GIT_SSH_COMMAND='ssh -p $SSHD_PORT' git push --set-upstream origin main && \
         cd .. && \
         rm -rf repo # remove this repo dir now that it has been pushed to the server


### PR DESCRIPTION
This is a continuation of done previously done in #1829, which in turn received attention via #1904.  

This probably isn't the *best* solution; the best solution would probably entail making some of the config more explicit.  And it's not the most user-friendly solution; it would be convenient to have things like custom port information, already present in the config, be utilized automatically for `GIT CLONE`.  But this solution is unobtrusive and doesn't change any existing semantics (excluding the new capability itself).

If this is fairly close to what you wanted anyway (or even pieces of it), I can make the time to do what's needed to polish it.  If nothing else, it can provide a springboard for a better solution.  I wasn't confident this would be used as-is (hence submitting as a draft), but I thought/hoped elements of it would be useful.

The true starting point is https://github.com/earthly/earthly/blob/0329b4263089f8c3bb5cb873c47c04647a6fa98b/tests/git-ssh-server/Earthfile#L374
I'm sure it's purely accident/oversight that it's commented out, but enabling that line is what led to this change.

This change does work "for real" (against a real git server), but does incur a two minute delay.  That is almost certainly due to the keyscan (i.e., #1769) work that is ongoing, though I haven't taken the time to prove it.