### PR TITLE
display warning for ARG help

### DIFF
--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -1188,6 +1188,9 @@ func (c *Converter) Arg(ctx context.Context, argKey string, defaultArgValue stri
 	if len(defaultArgValue) > 0 && reserved.IsBuiltIn(argKey) {
 		return fmt.Errorf("arg default value supplied for built-in ARG: %s", argKey)
 	}
+	if argKey == "help" {
+		c.opt.Console.Warnf("\"ARG help\" will become reserved in a future version of earthly and should be renamed")
+	}
 	if c.varCollection.IsStackAtBase() { // Only when outside of UDC.
 		c.mts.Final.AddBuildArgInput(dedup.BuildArgInput{
 			Name:          argKey,


### PR DESCRIPTION
"ARG help" will become a reserved argument name in the future, print a
warning notifying users it will eventually become an error.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>