### PR TITLE
secretprovider: pass user's env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 
 ## Unreleased
 
+### Changed
+
+- Custom `secret_provider` is now called with user's env variables.
+
 ## v0.6.15 - 2022-06-02
 
 ### Changed

--- a/util/llbutil/secretprovider/cmd.go
+++ b/util/llbutil/secretprovider/cmd.go
@@ -2,7 +2,6 @@ package secretprovider
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"os/exec"
 	"syscall"
@@ -34,10 +33,8 @@ func (c *cmdStore) GetSecret(ctx context.Context, id string) ([]byte, error) {
 		return nil, secrets.ErrNotFound
 	}
 	cmd := exec.CommandContext(ctx, c.cmd, id)
+	cmd.Env = os.Environ()
 	cmd.Stderr = os.Stderr
-	if path, ok := os.LookupEnv("PATH"); ok {
-		cmd.Env = append(cmd.Env, fmt.Sprintf("PATH=%s", path))
-	}
 	dt, err := cmd.Output()
 	if err != nil {
 		if exiterr, ok := err.(*exec.ExitError); ok {


### PR DESCRIPTION
This allows the custom secret provider access to the user's environment
variables (which might contain required authorization data needed to
access the user's secret-data-store)

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>