### PR TITLE
secretprovider: allow args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 ### Changed
 
 - Custom `secret_provider` is now called with user's env variables.
+- Additional args can be passed to `secret_provider`, e.g. `secret_provider: my-password-manager --db=$HOME/path/to/secrets.db`
 
 ## v0.6.15 - 2022-06-02
 

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -2943,12 +2943,19 @@ func (app *earthlyApp) actionBuildImp(c *cli.Context, flagArgs, nonFlagArgs []st
 	defaultLocalDirs["earthly-cache"] = cacheLocalDir
 	buildContextProvider := provider.NewBuildContextProvider(app.console)
 	buildContextProvider.AddDirs(defaultLocalDirs)
+
+	customSecretProviderCmd, err := secretprovider.NewSecretProviderCmd(app.cfg.Global.SecretProvider)
+	if err != nil {
+		return errors.Wrap(err, "NewSecretProviderCmd")
+	}
+	secretProvider := secretprovider.New(
+		customSecretProviderCmd,
+		secretprovider.NewMapStore(secretsMap),
+		secretprovider.NewCloudStore(cc),
+	)
+
 	attachables := []session.Attachable{
-		secretprovider.New(
-			secretprovider.NewSecretProviderCmd(app.cfg.Global.SecretProvider),
-			secretprovider.NewMapStore(secretsMap),
-			secretprovider.NewCloudStore(cc),
-		),
+		secretProvider,
 		buildContextProvider,
 		localhostProvider,
 	}

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/earthly/cloud-api v1.0.1-0.20220228235811-35dd6315dcf5
 	github.com/fatih/color v1.9.0
 	github.com/golang/protobuf v1.5.2
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/jdxcode/netrc v0.0.0-20210204082910-926c7f70242a

--- a/tests/secret-provider-config/Earthfile
+++ b/tests/secret-provider-config/Earthfile
@@ -14,7 +14,9 @@ FROM ..+base \
     --DOCKERHUB_MIRROR_INSECURE=$DOCKERHUB_MIRROR_INSECURE
 
 COPY test-secret-provider /weird/path/.
-RUN echo "#!/bin/sh
+
+base-secret-provider:
+    RUN echo "#!/bin/sh
 set -ex
 export PATH=/weird/path:\$PATH
 earthly --config \$earthly_config config global.secret_provider test-secret-provider
@@ -22,15 +24,45 @@ earthly --config \$earthly_config --verbose -D +test
 " >/tmp/test-earthly-script && chmod +x /tmp/test-earthly-script
 
 test:
+    FROM +base-secret-provider
     DO +RUN_EARTHLY_ARGS --earthfile=test.earth --exec_cmd=/tmp/test-earthly-script
     RUN test "$(cat output/value)" = "my secret is williwaw; don't tell anyone."
 
 test-binary:
+    FROM +base-secret-provider
     DO +RUN_EARTHLY_ARGS --earthfile=test-binary.earth --exec_cmd=/tmp/test-earthly-script
+
+base-secret-provider-with-flag:
+    RUN echo "#!/bin/sh
+set -ex
+export PATH=/weird/path:\$PATH
+earthly --config \$earthly_config config global.secret_provider \"test-secret-provider --uppercase\"
+earthly --config \$earthly_config --verbose -D +test
+" >/tmp/test-earthly-script && chmod +x /tmp/test-earthly-script
+
+test-with-flag:
+    FROM +base-secret-provider-with-flag
+    DO +RUN_EARTHLY_ARGS --earthfile=test.earth --exec_cmd=/tmp/test-earthly-script
+    RUN test "$(cat output/value)" = "my secret is WILLIWAW; don't tell anyone."
+
+base-secret-provider-with-env:
+    RUN echo "#!/bin/sh
+set -ex
+export PATH=/weird/path:\$PATH
+earthly --config \$earthly_config config global.secret_provider \"rot13=true test-secret-provider\"
+earthly --config \$earthly_config --verbose -D +test
+" >/tmp/test-earthly-script && chmod +x /tmp/test-earthly-script
+
+test-with-env:
+    FROM +base-secret-provider-with-env
+    DO +RUN_EARTHLY_ARGS --earthfile=test.earth --exec_cmd=/tmp/test-earthly-script
+    RUN test "$(cat output/value)" = "my secret is jvyyvjnj; don't tell anyone."
 
 test-all:
     BUILD +test
     BUILD +test-binary
+    BUILD +test-with-flag
+    BUILD +test-with-env
 
 RUN_EARTHLY_ARGS:
     COMMAND

--- a/tests/secret-provider-config/test-secret-provider
+++ b/tests/secret-provider-config/test-secret-provider
@@ -1,10 +1,30 @@
 #!/bin/sh
 set -e
 
+uppercase=false
+for arg in "$@"; do
+    if echo $arg | grep "^-" >/dev/null; then
+        echo >&2 "GOT A FLAG: $arg"
+        if [ "$arg" = "--uppercase" ]; then
+            uppercase=true
+        fi
+        shift # drop the flag
+    else
+        break
+    fi
+done
+
 echo >&2 "GOT CALL FOR $1"
 
 if [ "$1" = "testsecret" ]; then
-    echo -n "williwaw"
+    secret="williwaw"
+    if [ "$uppercase" = "true" ]; then
+        secret="$(echo "$secret" | awk '{print toupper($0)}')"
+    fi
+    if [ "$rot13" = "true" ]; then
+        secret="$(echo "$secret" | perl -pe 'tr/N-ZA-Mn-za-m/A-Za-z/')"
+    fi
+    echo -n "$secret"
     exit 0
 fi
 

--- a/tests/secret-provider-config/test.earth
+++ b/tests/secret-provider-config/test.earth
@@ -1,5 +1,5 @@
 FROM alpine
 
 test:
-    RUN --secret testsecret echo "my secret is $testsecret; don't tell anyone." > value
+    RUN --no-cache --secret testsecret echo "my secret is $testsecret; don't tell anyone." > value
     SAVE ARTIFACT value AS LOCAL output/value


### PR DESCRIPTION
This allows a user to pass args to a secret provider, e.g.

    secret_provider: my-secret-lookup-script --key=$HOME/.ssh/id_rsa

Additionally, users can set env variables with:

    secret_provider: KEY="my value" my-secret-lookup-script

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>