### PR TITLE
wait-block: initial tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,6 +260,17 @@ jobs:
       - name: Execute registry-certs test (Fork Only)
         run: ./tests/registry-certs/test.sh --build-arg DOCKERHUB_AUTH=false
         if: github.event_name != 'push' && github.event.pull_request.head.repo.full_name != github.repository
+      - name: Execute wait-block test (Earthly Only)
+        run: |-
+          ./tests/wait-block/test.sh \
+              --build-arg DOCKERHUB_AUTH=true \
+              --build-arg DOCKERHUB_USER_SECRET=+secrets/earthly-technologies/dockerhub-mirror/user \
+              --build-arg DOCKERHUB_TOKEN_SECRET=+secrets/earthly-technologies/dockerhub-mirror/pass \
+              --build-arg DOCKERHUB_MIRROR=registry-1.docker.io.mirror.corp.earthly.dev
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+      - name: Execute wait-block test (Fork Only)
+        run: ./tests/wait-block/test.sh --build-arg DOCKERHUB_AUTH=false
+        if: github.event_name != 'push' && github.event.pull_request.head.repo.full_name != github.repository
       - name: Execute local buildkit with mTLS test
         run: ./tests/remote-buildkit/remote-buildkit-test.sh
       - name: Run linux-amd64 specific tests (Earthly Only)

--- a/tests/wait-block/Earthfile
+++ b/tests/wait-block/Earthfile
@@ -1,0 +1,28 @@
+VERSION --wait-block 0.6
+
+myimg:
+    FROM alpine:3.15
+    RUN echo NWMyMTQ2YjctZGFlNS00YzQ5LWE1MTktNDM2Zjc4YzNkNzAwCg== > /special-data
+    RUN sleep 5 # increase the likelyhood of +check-tag-exists to run in the event the WAIT/END code fails to block
+    ARG --required REGISTRY
+    ARG --required tag
+    SAVE IMAGE --push $REGISTRY/myuser/myimg:$tag
+
+deps:
+    FROM alpine:3.15
+    RUN apk add curl jq
+
+check-tag-exists:
+    FROM +deps
+    ARG --required REGISTRY
+    ARG --required tag
+    RUN curl -k "https://$REGISTRY/v2/myuser/myimg/manifests/$tag" > output && \
+        test "$(cat output | jq -r .tag)" = "$tag" && echo "verified $tag was pushed 🎉"
+
+test:
+    ARG --required REGISTRY
+    ARG --required tag
+    WAIT
+        BUILD +myimg --REGISTRY=$REGISTRY --tag=$tag
+    END
+    BUILD +check-tag-exists --REGISTRY=$REGISTRY --tag=$tag

--- a/tests/wait-block/test.sh
+++ b/tests/wait-block/test.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# This test is designed to be run directly by github actions or on your host (i.e. not earthly-in-earthly);
+# as a result, you may run into issues if you have a firewall which prevents access to the registry -- make sure access to it's port is open
+set -uxe
+set -o pipefail
+
+cd "$(dirname "$0")"
+
+earthly=${earthly-"../../build/linux/amd64/earthly"}
+echo "using earthly=$(realpath "$earthly")"
+
+registry_name="wait-block-registry"
+
+# Cleanup previous run.
+docker stop "$registry_name" || true
+docker rm "$registry_name" || true
+rm -rf ./certs || true
+
+# Get host IP (it must be accessible from both docker and runc)
+HOST_IP=$(ip route get 8.8.8.8 | awk -F"src " 'NR==1{split($2,a," ");print a[1]}')
+
+# pick the first free port starting at 5000 (up to 5050)
+PORT_FOUND="false"
+for i in {0..50}
+do
+    PORT="$(( 5000 + i ))"
+    ACTIVE_PORT="$(netstat -lnt | awk '{print $4}' | (grep ":$PORT\$" || true) | wc -l)"
+    if [ "$ACTIVE_PORT" = "0" ]; then
+        PORT_FOUND="true"
+        break
+    fi
+done
+test "$PORT_FOUND" = "true"
+
+REGISTRY="$HOST_IP:$PORT"
+echo "running registry on $REGISTRY"
+
+# Generate certs.
+"$earthly" \
+    --build-arg REGISTRY_IP="$HOST_IP" \
+    --artifact ../registry-certs+certs/certs "$(pwd)/certs"
+
+CRT_PATH="$(pwd)/certs/domain.crt"
+
+# A random tmp file which shouldn't conflict with anything else
+config_path="/tmp/earthly-34a5d7b5-903e-40d8-ade3-260ff9794f93.yml"
+
+cat > "$config_path" <<EOF
+global:
+  buildkit_additional_args: ["-v", "$CRT_PATH:/etc/config/wait-block-test.ca"]
+  buildkit_additional_config: |
+    [registry."$REGISTRY"]
+      ca=["/etc/config/wait-block-test.ca"]
+EOF
+
+# Run registry. This will use the same IP address as allocated above.
+docker run -d \
+    -p "$PORT:$PORT" \
+    -v "$(pwd)"/certs:/certs \
+    -e REGISTRY_HTTP_ADDR="0.0.0.0:$PORT" \
+    -e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/domain.crt \
+    -e REGISTRY_HTTP_TLS_KEY=/certs/domain.key \
+    --name "$registry_name" registry:2
+
+# First make sure all deps get cached, to increase the likelihood of a race-condition
+"$earthly" --config="$config_path" +deps
+
+# Test.
+tag="$(uuidgen)"
+test -n "$tag"
+echo "using tag=$tag"
+pwd
+set +e
+"$earthly" --config="$config_path" --push $@ +test --tag="$tag" --REGISTRY="$REGISTRY"
+exit_code="$?"
+set -e
+
+# Cleanup.
+docker stop "$registry_name" || true
+
+exit "$exit_code"


### PR DESCRIPTION
This introduces tests for the `VERSION --wait-block` feature.
It runs a registry on the localhost's docker, pushes an image to it,
then performs a curl against the regsitry to verify the image was pushed
in the correct order.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>