### PR TITLE
Add docs on how to use earthly/earthly image and remove `SRC_DIR`

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -342,6 +342,7 @@ earthly-docker:
     ENV EARTHLY_IMAGE=true
     COPY earthly-entrypoint.sh /usr/bin/earthly-entrypoint.sh
     ENTRYPOINT ["/usr/bin/earthly-entrypoint.sh"]
+    WORKDIR /workspace
     ARG EARTHLY_TARGET_TAG_DOCKER
     ARG TAG="dev-$EARTHLY_TARGET_TAG_DOCKER"
     COPY (+earthly/earthly --VERSION=$TAG) /usr/bin/earthly
@@ -350,8 +351,8 @@ earthly-docker:
 earthly-integration-test-base:
     FROM +earthly-docker
     ENV NO_DOCKER=1
-    ENV SRC_DIR=/test
     ENV NETWORK_MODE=host
+    WORKDIR /test
 
     # The inner buildkit requires Docker hub creds to prevent rate-limiting issues.
     ARG DOCKERHUB_MIRROR

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -51,7 +51,8 @@
 ## 🔧 CI Integration
 
 * [Overview](ci-integration/overview.md)
-* [Build An Earthly CI Image](ci-integration/build-an-earthly-ci-image.md)
+* [Use the Earthly CI Image](ci-integration/use-earthly-ci-image.md)
+* [Build your own Earthly CI Image](ci-integration/build-an-earthly-ci-image.md)
 * [Pull-Through Cache](ci-integration/pull-through-cache.md)
 * [Remote BuildKit](ci-integration/remote-buildkit.md)
 * Vendor-Specific Guides

--- a/docs/ci-integration/guides/kubernetes.md
+++ b/docs/ci-integration/guides/kubernetes.md
@@ -54,7 +54,7 @@ volumes:
 
 The location within the container for this temporary folder is configurable with the `EARTHLY_TMP_DIR` environment variable.
 
-The `earthly/earthly` image will expect to find the source code (with `Earthfile`) rooted in `/workspace`. To configure this, ensure that the `SRC_DIR` environment variable is set correctly. In the case of the example, we are building a remote target, so mounting a dummy volume is needed.
+The `earthly/earthly` image will expect to find the source code (with `Earthfile`) rooted in the default working directory, which is set to `/workspace`.
 
 ## Setup (Remote `earthly/buildkitd`)
 

--- a/docs/ci-integration/use-earthly-ci-image.md
+++ b/docs/ci-integration/use-earthly-ci-image.md
@@ -1,0 +1,71 @@
+# Building An Earthly CI Image
+
+## Introduction
+
+This guide is intended to help you use the Earthly image for your containerized CI workflows.
+
+## Prerequisites
+
+The `earthly/earthly` image requires that it is run as `--privileged`, if it is meant to be used with the embedded BuiltKit daemon. This is mainly due to the use of overlayfs and the internal networking setup.
+
+## Getting Started
+
+Please see the reference documentation of the [`earthly/earthly` image on DockerHub](https://hub.docker.com/r/earthly/earthly).
+
+It is recommended that the `earthly/earthly` image is used with a pinned version when used in the context of a CI, in order to avoid accidental future breakage as `earthly` evolves.
+
+#### Using `/usr/bin/earthly-entrypoint.sh` as the entrypoint
+
+The `earthly/earthly` image comes with an entrypoint that first starts up BuildKit and then issues an `earthly` command that makes use of it. You may use the image just as you would use `earthly` itself otherwise. Any arguments are passed into the `earthly` command directly.
+
+{% hint style='danger' %}
+##### Important
+Note that using the `earthly` binary as the entrypoint will not start up BuildKit within the same container and will instead attempt to use the Docker Daemon (assuming one is available via `/var/run/docker.sock`) to start up BuildKit.
+{% endhint %}
+
+#### Remote Daemon
+
+An alternative option is to use the `earthly/earthly` image in conjunction with a remote BuildKit Daemon. You may use the environment variable `BUILDKIT_HOST` to specify the hostname of the remote BuildKit Daemon. When this environment variable is set, the `earthly/earthly` image will not attempt to start BuildKit and will instead use the remote BuildKit Daemon.
+
+For more details on using a remote BuildKit daemon, [see our guide](./remote-buildkit.md).
+
+#### Mounting the source code
+
+The image expects the source code of the application you are building in the current working directory (by default `/workspace`). You will need to copy or mount the necessary files to that directory prior to invoking the entrypoint.
+
+```bash
+docker run --privileged --rm -v "$PWD":/workspace earthly/earthly:v0.6.14 +my-target
+```
+
+Or, if you would like to use an alternative directory:
+
+```bash
+docker run --privileged --rm -v "$PWD":/my-dir -w /my-dir earthly/earthly:v0.6.14 +my-target
+```
+
+#### `NO_DOCKER` Environment Variable
+
+In many CI use-cases outputting images locally is not necessary. In fact, Earthly's `--ci` flag disables output by default. In such circumstances, you can use the `NO_DOCKER` environment variable to disable checking for the presence of Docker. This will disable some warnings that would otherwise be printed to the console as Earthly starts up.
+
+## An important note about running the image
+
+When running the built image in your CI of choice, if you're not using a remote daemon, Earthly will start Buildkit within the same container. In this case, it is important to ensure that the directory used by Buildkit to cache the builds is mounted as a Docker volume. Failing to do so may result in excessive disk usage, slow builds, or Earthly not functioning properly.
+
+{% hint style='danger' %}
+##### Important
+We *strongly* recommend using a Docker volume for mounting `EARTHLY_TMP_DIR`. If you do not, Buildkit can consume excessive disk space, operate very slowly, or it might not function correctly.
+{% endhint %}
+
+In some environments, not mounting `EARTHLY_TMP_DIR` as a Docker volume results in the following error:
+
+```
+--> WITH DOCKER RUN --privileged ...
+...
+rm: can't remove '/var/earthly/dind/...': Resource busy
+```
+
+In EKS, users reported that mounting an EBS volume, instead of a Kubernetes `emptyDir` worked.
+
+This part of our documentation needs improvement. If you have a Kubernetes-based setup, please [let us know](https://earthly.dev/slack) how you have mounted `EARTHLY_TMP_DIR` and whether `WITH DOCKER` worked well for you.
+
+For more information, see the [documentation for `earthly/earthly` on DockerHub](https://hub.docker.com/r/earthly/earthly).

--- a/docs/docker-images/all-in-one.md
+++ b/docs/docker-images/all-in-one.md
@@ -64,7 +64,7 @@ rm: can't remove '/var/earthly/dind/...': Resource busy
 
 #### Source Mounting
 
-Because `earthly` is running inside a container, it does not have access to your source code unless you grant it. Unless otherwise specified via `SRC_DIR`, or our target path, this image expects to find a valid `Earthfile` at `/workspace`.
+Because `earthly` is running inside a container, it does not have access to your source code unless you grant it. This image expects to find a valid `Earthfile` in the working directory, which is set by default to `/workspace`.
 
 #### DOCKER_HOST
 
@@ -85,7 +85,6 @@ This is the easiest way to ensure you get the nice, colorized output from `earth
 | NO_DOCKER                           |                                | Disables the check for a working Docker Daemon. Setting this _at all_ disables the check.                                                                                                                     |
 | DOCKER_HOST                         | `/var/run/docker.sock`         | From Docker's CLI.                                                                                                                                                                                            |
 | BUILDKIT_HOST                       | `tcp://<hostname>:8372`        | The address of your BuildKit host. Use this when you have a remote `buildkitd` you would like to connect to.                                                                                                  |
-| SRC_DIR                             | `/workspace`                   | The working directory for `earthly`. Usually host-mounted.                                                                                                                                                    |
 | EARTHLY_ADDITIONAL_BUILDKIT_CONFIG  |                                | Additional `buildkitd` config to append to the generated configuration file.                                                                                                                                  |
 | BUILDKIT_TCP_TRANSPORT_ENABLED      |                                | Required to be set to `true` when using an external `buildkitd` via `BUILDKIT_HOST`. `true` when using the baked-in `buildkitd`.                                                                              |
 | BUILDKIT_TLS_ENABLED                |                                | Required when using an external `buildkitd` via `BUILDKITD_HOST`, and the external `buildkitd` requires mTLS. You will also need to mount certificates into the right place (`/etc/.earthly/certs`).          |

--- a/earthly-entrypoint.sh
+++ b/earthly-entrypoint.sh
@@ -57,14 +57,6 @@ fi
 
 echo "Using $EARTHLY_BUILDKIT_HOST as buildkit daemon"
 
-# Use the desired target dir for running a target, saves typing if you use the convention
-BASE_DIR="/workspace"
-if [ -n "$SRC_DIR" ]; then
-  BASE_DIR="$SRC_DIR"
-fi
-
-cd "$BASE_DIR"
-
 if [ -n "$EARTHLY_EXEC_CMD" ]; then
     export earthly_config
     exec "$EARTHLY_EXEC_CMD"

--- a/earthly-entrypoint.sh
+++ b/earthly-entrypoint.sh
@@ -57,6 +57,12 @@ fi
 
 echo "Using $EARTHLY_BUILDKIT_HOST as buildkit daemon"
 
+if [ -n "$SRC_DIR" ]; then
+  echo 'Please note that SRC_DIR is deprecated. This script will no longer automatically switch to it in the future.'
+  echo 'Please change the container'"'"'s working directory instead (e.g. via docker run -w)'
+  cd "$SRC_DIR"
+fi
+
 if [ -n "$EARTHLY_EXEC_CMD" ]; then
     export earthly_config
     exec "$EARTHLY_EXEC_CMD"

--- a/tests/autocompletion/Earthfile
+++ b/tests/autocompletion/Earthfile
@@ -14,8 +14,7 @@ FROM ../..+earthly-integration-test-base \
 ENV EARTHLY_SHOW_HIDDEN=0
 
 test-root-commands:
-    RUN echo "./
-account 
+    RUN echo "account 
 bootstrap 
 config 
 ls 
@@ -27,8 +26,7 @@ secrets " > expected
 
 test-hidden-root-commands:
     ENV EARTHLY_SHOW_HIDDEN=1
-    RUN echo "./
-account 
+    RUN echo "account 
 bootstrap 
 config 
 debug 

--- a/tests/locally-in-command/Earthfile
+++ b/tests/locally-in-command/Earthfile
@@ -48,7 +48,6 @@ test-command-in-sub-dir:
 
 test-udc-that-calls-other-udc:
     WORKDIR /my/test
-    ENV SRC_DIR=/my/test # required for RUN_EARTHLY's earthly-entrypoint.sh to execute out of a dir other than /test
     RUN mkdir -p some/subdir/submarine
     COPY command.earth some/subdir/Earthfile
     COPY command-that-calls-command.earth some/subdir/submarine/Earthfile


### PR DESCRIPTION
This PR removes the setting `SRC_DIR` in favor of simply using the current working directory (which also defaults to `/workspace`, just as `SRC_DIR` did before). The user can now override this by using `-w` instead of `-e SRC_DIR` in a typical `docker run` command.

In addition, this also adds a separate page about using the `earthly/earthly` image in general.