### PR TITLE
fix staging release pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -769,59 +769,6 @@ jobs:
         run: docker logs earthly-buildkitd
         if: ${{ failure() }}
 
-  buildkitd-armv7:
-    name: +all-buildkitd
-    runs-on: ubuntu-latest
-    env:
-      FORCE_COLOR: 1
-      EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"
-      EARTHLY_INSTALL_ID: "earthly-githubactions"
-    steps:
-      - uses: earthly/actions-setup@v1.0.1
-      - uses: actions/checkout@v3
-      -
-        name: Set up QEMU
-        id: qemu
-        uses: docker/setup-qemu-action@v1
-        with:
-          image: tonistiigi/binfmt:latest
-          platforms: all
-      - name: "Put back the git branch into git (Earthly uses it for tagging)"
-        run: |
-          branch=""
-          if [ -n "$GITHUB_HEAD_REF" ]; then
-            branch="$GITHUB_HEAD_REF"
-          else
-            branch="${GITHUB_REF##*/}"
-          fi
-          git checkout -b "$branch" || true
-      - name: Docker mirror login (Earthly Only)
-        run: docker login registry-1.docker.io.mirror.corp.earthly.dev --username "${{ secrets.DOCKERHUB_MIRROR_USERNAME }}" --password "${{ secrets.DOCKERHUB_MIRROR_PASSWORD }}"
-        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-      - name: Configure Earthly to use mirror (Earthly Only)
-        run: |-
-          earthly config global.buildkit_additional_config "'[registry.\"docker.io\"]
-
-          mirrors = [\"registry-1.docker.io.mirror.corp.earthly.dev\"]'"
-        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-      - name: Build latest earthly using released earthly
-        run: earthly --use-inline-cache +for-linux
-      - name: Set EARTHLY_VERSION_FLAG_OVERRIDES env
-        run: |-
-            set -euo pipefail
-            EARTHLY_VERSION_FLAG_OVERRIDES="$(tr -d '\n' < .earthly_version_flag_overrides)"
-            echo "EARTHLY_VERSION_FLAG_OVERRIDES=$EARTHLY_VERSION_FLAG_OVERRIDES" >> "$GITHUB_ENV"
-      - name: Enable local registry-based exporter
-        run: ./build/linux/amd64/earthly config global.local_registry_host 'tcp://127.0.0.1:8371'
-      - name: Configure Earthly Conversion Parallelism
-        run: ./build/linux/amd64/earthly config global.conversion_parallelism 5
-      - name: Build linux/armv7 +buildkitd
-        run: |-
-          ./build/linux/amd64/earthly --ci  --platform=linux/arm/v7 ./buildkitd+buildkitd --BUILDKIT_PROJECT="$BUILDKIT_PROJECT"
-      - name: Buildkit logs (runs on failure)
-        run: docker logs earthly-buildkitd
-        if: ${{ failure() }}
-
   buildkitd-arm64:
     name: +all-buildkitd
     runs-on: ubuntu-latest
@@ -1048,7 +995,6 @@ jobs:
       - export-test
       - test-local
       - buildkitd-amd64
-      - buildkitd-armv7
       - buildkitd-arm64
       - all-dind
       - prerelease

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -1,4 +1,4 @@
-name: GitHub Actions CI
+name: staging release
 
 on:
   push:

--- a/Earthfile
+++ b/Earthfile
@@ -282,14 +282,6 @@ earthly-linux-amd64:
         ) ./
     SAVE ARTIFACT ./*
 
-earthly-linux-arm7:
-    COPY (+earthly/* \
-        --GOARCH=arm \
-        --VARIANT=v7 \
-        --GO_EXTRA_LDFLAGS= \
-        ) ./
-    SAVE ARTIFACT ./*
-
 earthly-linux-arm64:
     COPY (+earthly/* \
         --GOARCH=arm64 \
@@ -328,7 +320,6 @@ earthly-windows-amd64:
 
 earthly-all:
     COPY +earthly-linux-amd64/earthly ./earthly-linux-amd64
-    COPY +earthly-linux-arm7/earthly ./earthly-linux-arm7
     COPY +earthly-linux-arm64/earthly ./earthly-linux-arm64
     COPY +earthly-darwin-amd64/earthly ./earthly-darwin-amd64
     COPY +earthly-darwin-arm64/earthly ./earthly-darwin-arm64
@@ -401,7 +392,6 @@ prerelease:
     ARG BUILDKIT_PROJECT
     BUILD \
         --platform=linux/amd64 \
-        --platform=linux/arm/v7 \
         --platform=linux/arm64 \
         ./buildkitd+buildkitd --TAG=prerelease  --BUILDKIT_PROJECT="$BUILDKIT_PROJECT"
     COPY (+earthly-all/* --VERSION=prerelease) ./
@@ -472,7 +462,6 @@ all-buildkitd:
     ARG BUILDKIT_PROJECT
     BUILD \
         --platform=linux/amd64 \
-        --platform=linux/arm/v7 \
         --platform=linux/arm64 \
         ./buildkitd+buildkitd --BUILDKIT_PROJECT="$BUILDKIT_PROJECT"
 

--- a/ast/parser/Earthfile
+++ b/ast/parser/Earthfile
@@ -5,7 +5,7 @@ ARG TARGETARCH
 IF [ "$TARGETARCH" = "arm64" ]
     FROM arm64v8/openjdk:19-slim
 ELSE
-    FROM --platform=linux/amd64 openjdk:19-slim
+    FROM --platform="linux/$TARGETARCH" openjdk:19-slim
 END
 
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/release/Earthfile
+++ b/release/Earthfile
@@ -33,21 +33,21 @@ release-dind:
 release-dockerhub:
     ARG --required RELEASE_TAG
     ARG DOCKERHUB_USER="earthly"
+    ARG PUSH_LATEST_TAG="false"
+    BUILD +perform-release-dockerhub --RELEASE_TAG="$RELEASE_TAG" --DOCKERHUB_USER="$DOCKERHUB_USER"
+    IF [ "$PUSH_LATEST_TAG" = "true" ]
+      BUILD +perform-release-dockerhub --RELEASE_TAG="latest" --DOCKERHUB_USER="$DOCKERHUB_USER"
+    END
+
+perform-release-dockerhub:
+    ARG --required RELEASE_TAG
+    ARG DOCKERHUB_USER="earthly"
     BUILD ../+earthly-docker --TAG="$RELEASE_TAG"
     BUILD \
         --platform=linux/amd64 \
-        --platform=linux/arm/v7 \
         --platform=linux/arm64 \
         ../buildkitd+buildkitd \
         --TAG="$RELEASE_TAG" \
-        --DOCKERHUB_USER="$DOCKERHUB_USER"
-    BUILD ../+earthly-docker --TAG=latest
-    BUILD \
-        --platform=linux/amd64 \
-        --platform=linux/arm/v7 \
-        --platform=linux/arm64 \
-        ../buildkitd+buildkitd \
-        --TAG=latest \
         --DOCKERHUB_USER="$DOCKERHUB_USER"
 
 release-notes:
@@ -85,15 +85,12 @@ release-github:
     RUN test -f ./release/earthly-linux-amd64 && \
         test -f ./release/earthly-darwin-amd64 && \
         test -f ./release/earthly-darwin-arm64 && \
-        test -f ./release/earthly-linux-arm7 && \
         test -f ./release/earthly-linux-arm64 && \
         test -f ./release/earthly-windows-amd64.exe
     RUN file ./release/earthly-linux-amd64 | grep "x86-64"
     RUN file ./release/earthly-linux-amd64 | grep "ELF 64-bit"
     RUN file ./release/earthly-darwin-amd64 | grep "Mach-O 64-bit x86_64"
     RUN file ./release/earthly-darwin-arm64 | grep "Mach-O 64-bit arm64"
-    RUN file ./release/earthly-linux-arm7 | grep "ARM, EABI5 version 1"
-    RUN file ./release/earthly-linux-arm7 | grep "ELF 32-bit"
     RUN file ./release/earthly-linux-arm64 | grep "aarch64"
     RUN file ./release/earthly-linux-arm64 | grep "ELF 64-bit"
     RUN file ./release/earthly-windows-amd64.exe | grep "PE32"


### PR DESCRIPTION
f95c65e4e573f445ee95171fc1ab0465b36d8289 propagated the platform into
the parser, which then caused the parser to attempt to fetch an arm7
version of openJDK which is not supported. ARM7 support was experimental
and was targeting older raspberry pi platforms -- it never worked.

Additionally prevents the prerelease from erroneously pushing a
pre-released version to the latest tag; however the latest tag
is reserved for the latest released version, not pre-released versions.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>