### PR TITLE
update s3-related release scripts with MFA

### DIFF
--- a/release/apt-repo/Earthfile
+++ b/release/apt-repo/Earthfile
@@ -1,3 +1,4 @@
+VERSION 0.6
 FROM alpine:3.15
 
 deps:
@@ -39,16 +40,9 @@ deb-arm64:
         +deb/* ./
     SAVE ARTIFACT *.deb
 
-deb-arm7:
-    COPY \
-        --build-arg  EARTHLY_PLATFORM=arm7 \
-        +deb/* ./
-    SAVE ARTIFACT *.deb
-
 deb-all:
     COPY +deb-amd64/*.deb .
     COPY +deb-arm64/*.deb .
-    COPY +deb-arm7/*.deb .
     SAVE ARTIFACT ./*.deb
 
 # If for any reason you need to generate a new PGP key, it can be done with
@@ -73,28 +67,14 @@ Expire-Date: 0
     SAVE ARTIFACT earthly-pgp-public.pgp AS LOCAL earthly-pgp-public.pgp
     SAVE ARTIFACT earthly-pgp-private.pgp AS LOCAL earthly-pgp-private.pgp
 
-
-aws-base:
-    FROM alpine:latest
-    RUN apk add --update --no-cache curl unzip
-    RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.0.30.zip" -o "awscliv2.zip"
-    RUN unzip awscliv2.zip
-    RUN ./aws/install
-    ENV PATH=$PATH:/usr/local/aws-cli/v2/bin/
-
-aws:
-    FROM amazon/aws-cli
-    RUN mkdir -p ~/.aws && echo "[profile developer]
-    role_arn = arn:aws:iam::404851345508:role/developer
-    source_profile = default" > ~/.aws/config
-    ENV AWS_PROFILE=developer
-
 download:
-    FROM +aws
+    FROM ../common-repo+aws
     ARG --required S3_BUCKET
-    RUN env | grep dev
     RUN --no-cache \
+        --secret MFA_ARN=+secrets/user/earthly-technologies/aws/mfa-arn \
+        --secret MFA_KEY=+secrets/user/earthly-technologies/aws/mfa-key \
         --mount type=secret,id=+secrets/user/earthly-technologies/aws/credentials,target=/root/.aws/credentials \
+        eval $(assume-developer-role) && \
         aws s3 cp --recursive "s3://$S3_BUCKET/deb/" repo
     SAVE ARTIFACT repo AS LOCAL output/repo
 
@@ -120,15 +100,12 @@ index-and-sign:
     RUN rm -rf dists
     RUN mkdir -p dists/stable/main/binary-amd64
     RUN mkdir -p dists/stable/main/binary-arm64
-    RUN mkdir -p dists/stable/main/binary-arm7
 
     RUN dpkg-scanpackages --arch amd64 --multiversion pool/ > dists/stable/main/binary-amd64/Packages
     RUN dpkg-scanpackages --arch arm64 --multiversion pool/ > dists/stable/main/binary-arm64/Packages
-    RUN dpkg-scanpackages --arch arm7 --multiversion pool/ > dists/stable/main/binary-arm7/Packages
 
     RUN gzip -c9 dists/stable/main/binary-amd64/Packages > dists/stable/main/binary-amd64/Packages.gz
     RUN gzip -c9 dists/stable/main/binary-arm64/Packages > dists/stable/main/binary-arm64/Packages.gz
-    RUN gzip -c9 dists/stable/main/binary-arm7/Packages > dists/stable/main/binary-arm7/Packages.gz
 
     WORKDIR /repo/dists/stable
     COPY generate-release.sh /
@@ -139,7 +116,6 @@ index-and-sign:
     RUN set -e; \
         grep amd64 Release; \
         grep arm64 Release; \
-        grep arm7 Release; \
         ls /repo/pool/main/earthly_*.deb; \
         ls /repo/dists/stable/Release;
 
@@ -153,7 +129,7 @@ index-and-sign:
     SAVE ARTIFACT /repo AS LOCAL output/signed-repo
 
 upload:
-    FROM +aws
+    FROM ../common-repo+aws
 
     ARG USE_OUTPUT_COPY=true
     IF [ "$USE_OUTPUT_COPY" = "true" ]
@@ -172,22 +148,21 @@ upload:
     ARG --required S3_BUCKET
     RUN --push \
         --mount type=secret,id=+secrets/earthly-technologies/release/keys/earthly-public.pgp,target=/release-key/earthly-public.pgp \
+        --secret MFA_ARN=+secrets/user/earthly-technologies/aws/mfa-arn \
+        --secret MFA_KEY=+secrets/user/earthly-technologies/aws/mfa-key \
         --mount type=secret,id=+secrets/user/earthly-technologies/aws/credentials,target=/root/.aws/credentials \
         grep PUBLIC /release-key/earthly-public.pgp >/dev/null && \
-        aws s3 cp --acl public-read /release-key/earthly-public.pgp "s3://$S3_BUCKET/earthly.pgp"
-    # upload signed repo
-    # Note: aws s3 sync doesn't always pickup changes to Release and Packages files, so force a cp to ensure they are uploaded
-    RUN --push \
-        --mount type=secret,id=+secrets/user/earthly-technologies/aws/credentials,target=/root/.aws/credentials \
+        eval $(assume-developer-role 1) && \
+        aws s3 cp --acl public-read /release-key/earthly-public.pgp "s3://$S3_BUCKET/earthly.pgp" && \
+        # upload signed repo
+        # Note: aws s3 sync doesn't always pickup changes to Release and Packages files, so force a cp to ensure they are uploaded
         aws s3 cp --acl public-read /repo/dists/stable/Release s3://$S3_BUCKET/deb/dists/stable/Release && \
         aws s3 cp --acl public-read /repo/dists/stable/Release.gpg s3://$S3_BUCKET/deb/dists/stable/Release.gpg && \
         aws s3 cp --acl public-read /repo/dists/stable/InRelease s3://$S3_BUCKET/deb/dists/stable/InRelease && \
         aws s3 cp --acl public-read /repo/dists/stable/main/binary-amd64/Packages s3://$S3_BUCKET/deb/dists/stable/main/binary-amd64/Packages && \
         aws s3 cp --acl public-read /repo/dists/stable/main/binary-arm64/Packages s3://$S3_BUCKET/deb/dists/stable/main/binary-arm64/Packages && \
-        aws s3 cp --acl public-read /repo/dists/stable/main/binary-arm7/Packages s3://$S3_BUCKET/deb/dists/stable/main/binary-arm7/Packages && \
         aws s3 cp --acl public-read /repo/dists/stable/main/binary-amd64/Packages.gz s3://$S3_BUCKET/deb/dists/stable/main/binary-amd64/Packages.gz && \
         aws s3 cp --acl public-read /repo/dists/stable/main/binary-arm64/Packages.gz s3://$S3_BUCKET/deb/dists/stable/main/binary-arm64/Packages.gz && \
-        aws s3 cp --acl public-read /repo/dists/stable/main/binary-arm7/Packages.gz s3://$S3_BUCKET/deb/dists/stable/main/binary-arm7/Packages.gz && \
         aws s3 sync --acl public-read /repo s3://$S3_BUCKET/deb/
 
 build-and-release:

--- a/release/common-repo/Earthfile
+++ b/release/common-repo/Earthfile
@@ -1,0 +1,7 @@
+VERSION 0.6
+
+aws:
+    FROM amazon/aws-cli
+    RUN amazon-linux-extras install epel -y
+    RUN yum -y install oathtool jq
+    COPY assume-developer-role.sh /bin/assume-developer-role

--- a/release/common-repo/assume-developer-role.sh
+++ b/release/common-repo/assume-developer-role.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+set -e
+
+# This script should be run via eval $(assume-developer-role.sh)
+
+test -n "$MFA_ARN" || (echo "echo MFA_ARN not set && exit 1" && exit 1)
+test -n "$MFA_KEY" || (echo "echo MFA_KEY not set && exit 1" && exit 1)
+
+offset="$1"
+if [ -n "$offset" ]; then
+    tokencode="$(oathtool -b --totp "$MFA_KEY" -w "$offset" | tail -n 1)"
+else
+    tokencode="$(oathtool -b --totp "$MFA_KEY")"
+fi
+
+role_path="$(mktemp)"
+
+aws sts assume-role \
+  --role-arn arn:aws:iam::404851345508:role/developer \
+  --role-session-name $(date +%s) \
+  --duration-seconds 3600 \
+  --serial-number $MFA_ARN \
+  --token-code "$tokencode" > "$role_path"
+
+AWS_ACCESS_KEY_ID=$(jq -r '.Credentials.AccessKeyId' "$role_path")
+AWS_SECRET_ACCESS_KEY=$(jq -r '.Credentials.SecretAccessKey' "$role_path")
+AWS_SESSION_TOKEN=$(jq -r '.Credentials.SessionToken' "$role_path")
+
+rm "$role_path"
+
+echo "export AWS_ACCESS_KEY_ID=\"$AWS_ACCESS_KEY_ID\";"
+echo "export AWS_SECRET_ACCESS_KEY=\"$AWS_SECRET_ACCESS_KEY\";"
+echo "export AWS_SESSION_TOKEN=\"$AWS_SESSION_TOKEN\";"

--- a/release/yum-repo/Earthfile
+++ b/release/yum-repo/Earthfile
@@ -1,3 +1,4 @@
+VERSION 0.6
 FROM alpine:3.15
 
 deps:
@@ -20,8 +21,6 @@ rpm:
         ENV ARCH_TARGET=x86_64
     ELSE IF [ "$EARTHLY_PLATFORM" = "arm64" ]
         ENV ARCH_TARGET="aarch64"
-    ELSE IF [ "$EARTHLY_PLATFORM" = "arm7" ]
-        ENV ARCH_TARGET="armv7l"
     ELSE
         RUN echo "$EARTHLY_PLATFORM is not supported" && exit 1
     END
@@ -44,25 +43,10 @@ rpm-arm64:
         +rpm/* ./
     SAVE ARTIFACT *.rpm
 
-rpm-arm7:
-    COPY \
-        --build-arg  EARTHLY_PLATFORM=arm7 \
-        +rpm/* ./
-    SAVE ARTIFACT *.rpm
-
 rpm-all:
     COPY +rpm-amd64/*.rpm .
     COPY +rpm-arm64/*.rpm .
-    COPY +rpm-arm7/*.rpm .
     SAVE ARTIFACT ./*.rpm
-
-aws-base:
-    FROM alpine:latest
-    RUN apk add --update --no-cache curl unzip
-    RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.0.30.zip" -o "awscliv2.zip"
-    RUN unzip awscliv2.zip
-    RUN ./aws/install
-    ENV PATH=$PATH:/usr/local/aws-cli/v2/bin/
 
 aws:
     FROM amazon/aws-cli
@@ -72,10 +56,13 @@ aws:
     ENV AWS_PROFILE=developer
 
 download:
-    FROM +aws
+    FROM ../common-repo+aws
     ARG --required S3_BUCKET
     RUN --no-cache \
+        --secret MFA_ARN=+secrets/user/earthly-technologies/aws/mfa-arn \
+        --secret MFA_KEY=+secrets/user/earthly-technologies/aws/mfa-key \
         --mount type=secret,id=+secrets/user/earthly-technologies/aws/credentials,target=/root/.aws/credentials \
+        eval $(assume-developer-role) && \
         aws s3 cp --recursive s3://$S3_BUCKET/rpm/stable repo
     SAVE ARTIFACT repo AS LOCAL output/repo
 
@@ -116,7 +103,7 @@ index-and-sign:
     SAVE ARTIFACT /repo AS LOCAL output/signed-repo
 
 upload:
-    FROM +aws
+    FROM ../common-repo+aws
 
     ARG USE_OUTPUT_COPY=true
     IF [ "$USE_OUTPUT_COPY" = "true" ]
@@ -135,12 +122,13 @@ upload:
     ARG --required S3_BUCKET
     RUN --push \
         --mount type=secret,id=+secrets/earthly-technologies/release/keys/earthly-public.pgp,target=/release-key/earthly-public.pgp \
+        --secret MFA_ARN=+secrets/user/earthly-technologies/aws/mfa-arn \
+        --secret MFA_KEY=+secrets/user/earthly-technologies/aws/mfa-key \
         --mount type=secret,id=+secrets/user/earthly-technologies/aws/credentials,target=/root/.aws/credentials \
+        eval $(assume-developer-role 1) && \
         grep PUBLIC /release-key/earthly-public.pgp >/dev/null && \
-        aws s3 cp --acl public-read /release-key/earthly-public.pgp s3://$S3_BUCKET/earthly.pgp
-    # upload signed repo
-    RUN --push \
-        --mount type=secret,id=+secrets/user/earthly-technologies/aws/credentials,target=/root/.aws/credentials \
+        aws s3 cp --acl public-read /release-key/earthly-public.pgp s3://$S3_BUCKET/earthly.pgp && \
+        # upload signed repo
         aws s3 cp --acl public-read /repo/repodata/repomd.xml s3://$S3_BUCKET/rpm/stable/repodata/repomd.xml && \
         aws s3 cp --acl public-read /repo/repodata/repomd.xml.asc s3://$S3_BUCKET/rpm/stable/repodata/repomd.xml.asc && \
         aws s3 sync --acl public-read /repo s3://$S3_BUCKET/rpm/stable


### PR DESCRIPTION
This introduces a new assume-developer-role.sh script which can be used
to assume the developer role. It must be called in each RUN command via
an `eval $(assume-developer-role.sh)` call.

The assume-developer-role.sh can only be called once every few seconds,
otherwise it will re-use the same TOTP token code, which AWS denies, as
a result one can call `eval $(assume-developer-role.sh N)`, where N is
the next Nth token produced in the sequence.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>