### PR TITLE
Fix registry with-docker loading when no images to load

### DIFF
--- a/tests/with-docker-registry/Earthfile
+++ b/tests/with-docker-registry/Earthfile
@@ -2,11 +2,17 @@ VERSION --parallel-load --shell-out-anywhere --use-registry-for-with-docker 0.6
 FROM earthly/dind:alpine
 
 all:
+    BUILD +empty-test
     BUILD +docker-load-test
     BUILD +docker-pull-test
     BUILD +docker-load-shellout-test
     BUILD +load-parallel-test
     BUILD +docker-load-multi-test
+
+empty-test:
+    WITH DOCKER
+        RUN echo "dummy"
+    END
 
 a-test-image:
     FROM alpine:3.15

--- a/tests/with-docker/Earthfile
+++ b/tests/with-docker/Earthfile
@@ -2,6 +2,7 @@ VERSION --parallel-load --shell-out-anywhere 0.6
 FROM earthly/dind:alpine
 
 all:
+    BUILD +empty-test
     BUILD +docker-load-test
     BUILD +docker-load-shellout-test
     BUILD +docker-load-arg-test
@@ -10,6 +11,11 @@ all:
     BUILD +load-parallel-test
     BUILD +one-target-many-names
     BUILD +if-after
+
+empty-test:
+    WITH DOCKER
+        RUN echo "dummy"
+    END
 
 a-test-image:
     FROM alpine:3.15


### PR DESCRIPTION
Fixes https://github.com/earthly/earthly/issues/1939

I've also included some changes related to channel size and `select <-ctx.Done()` as I noticed that the hang in #1939 wasn't resolved by a single ctrl-c.