### PR TITLE
Add TLS configuration for satellites

### DIFF
--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -12,7 +12,7 @@ buildkitd:
             ARG BUILDKIT_BASE_IMAGE=$BUILDKIT_PROJECT+build
         END
     ELSE
-        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:e0de996ebb10c27b8dbd6af58156852b143a85c1+build
+        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:de75b35133f98ab156ebaf0f4eee4cfcf6257b8c+build
     END
     FROM $BUILDKIT_BASE_IMAGE
     RUN echo "@edge-community http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories

--- a/buildkitd/buildkitd.go
+++ b/buildkitd/buildkitd.go
@@ -761,7 +761,7 @@ func addRequiredOpts(settings Settings, opts ...client.ClientOpt) ([]client.Clie
 			"satellite_name", settings.SatelliteName,
 			"satellite_org", settings.SatelliteOrgID,
 			"satellite_token", settings.SatelliteToken),
-			client.WithCredentials("", "", "", ""),
+			client.WithCredentials("", "", "", ""), // force buildkit to use a TLS connection
 		), nil
 	}
 

--- a/buildkitd/buildkitd.go
+++ b/buildkitd/buildkitd.go
@@ -561,6 +561,7 @@ func checkConnection(ctx context.Context, address string, opts ...client.ClientO
 		if err != nil {
 			connErrMu.Lock()
 			connErr = err
+			fmt.Println(err.Error())
 			connErrMu.Unlock()
 			return
 		}
@@ -761,6 +762,7 @@ func addRequiredOpts(settings Settings, opts ...client.ClientOpt) ([]client.Clie
 			"satellite_name", settings.SatelliteName,
 			"satellite_org", settings.SatelliteOrgID,
 			"satellite_token", settings.SatelliteToken),
+			client.WithCredentials("", "", "", ""),
 		), nil
 	}
 

--- a/buildkitd/buildkitd.go
+++ b/buildkitd/buildkitd.go
@@ -561,7 +561,6 @@ func checkConnection(ctx context.Context, address string, opts ...client.ClientO
 		if err != nil {
 			connErrMu.Lock()
 			connErr = err
-			fmt.Println(err.Error())
 			connErrMu.Unlock()
 			return
 		}

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,6 @@ replace (
 
 	github.com/jessevdk/go-flags => github.com/alexcb/go-flags v0.0.0-20210722203016-f11d7ecb5ee5
 
-	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.1-0.20220601212315-e0de996ebb10
+	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.1-0.20220620195325-de75b35133f9
 	github.com/tonistiigi/fsutil => github.com/earthly/fsutil v0.0.0-20220118225905-42fa88fbe869
 )

--- a/go.sum
+++ b/go.sum
@@ -342,8 +342,8 @@ github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
-github.com/earthly/buildkit v0.0.1-0.20220601212315-e0de996ebb10 h1:ilmuItSPLOylCdvkeIjqxOT9R9teMTkVUnRG2HaXc7k=
-github.com/earthly/buildkit v0.0.1-0.20220601212315-e0de996ebb10/go.mod h1:8578flFPixeoiXT6b1RZmxk14dfjISYq2QcKtWqIxC0=
+github.com/earthly/buildkit v0.0.1-0.20220620195325-de75b35133f9 h1:QIbWL58uTHhTLLMdHo5jE/Ea4z5PpupQLgNOHuOJWSk=
+github.com/earthly/buildkit v0.0.1-0.20220620195325-de75b35133f9/go.mod h1:8578flFPixeoiXT6b1RZmxk14dfjISYq2QcKtWqIxC0=
 github.com/earthly/cloud-api v1.0.1-0.20220603155547-accef7dc6f19 h1:QO4MmqWD3JU5vsF+cAx7xcAxS4HWPEWZ7hsdSMKz7nQ=
 github.com/earthly/cloud-api v1.0.1-0.20220603155547-accef7dc6f19/go.mod h1:t9cO3NUQ2aqEI/pwO1XjeTwv2cAOdVV/aiZ37AHrmZg=
 github.com/earthly/fsutil v0.0.0-20220118225905-42fa88fbe869 h1:JOHn11YLRdybmRtdYrJ1LD3PLNqANfvIQoxhjrmcGOQ=


### PR DESCRIPTION
Depends on: https://github.com/earthly/buildkit/pull/79

The current buildkit TLS client configuration seems to assume that the remote buildkit is configured to handle the TLS connection; especially for an mTLS type configuration.

This, in conjunction with the mentioned buildkit PR, allows just regular old TLS.

This could also be broken out into its own `client.ClientOpt`, but it seemed like it was more code on the `buildkit` side, especially when integrating it with the existing TLS config options. Less code over there means fewer future merge conflicts.