### PR TITLE
Longer timeout for requests to delete or launch a Satellite

### DIFF
--- a/cloud/client.go
+++ b/cloud/client.go
@@ -35,7 +35,10 @@ var ErrUnauthorized = errors.New("unauthorized")
 // ErrNoAuthorizedPublicKeys occurs when no authorized public keys are found
 var ErrNoAuthorizedPublicKeys = errors.New("no authorized public keys found")
 
-const tokenExpiryLayout = "2006-01-02 15:04:05.999999999 -0700 MST"
+const (
+	tokenExpiryLayout    = "2006-01-02 15:04:05.999999999 -0700 MST"
+	satelliteMgmtTimeout = "5M" // 5 minute timeout when launching or deleting a Satellite
+)
 
 // OrgDetail contains an organization and details
 type OrgDetail struct {
@@ -994,7 +997,7 @@ func (c *client) LaunchSatellite(name, orgID string) (*SatelliteInstance, error)
 		Platform: "linux/amd64", // TODO support arm64 as well
 	}
 	status, body, err := c.doCall("POST", "/api/v0/satellites",
-		withAuth(), withHeader("Grpc-Timeout", "5M"), withJSONBody(&req))
+		withAuth(), withHeader("Grpc-Timeout", satelliteMgmtTimeout), withJSONBody(&req))
 	if err != nil {
 		return nil, err
 	}
@@ -1080,7 +1083,8 @@ func (c *client) GetSatellite(name, orgID string) (*SatelliteInstance, error) {
 
 func (c *client) DeleteSatellite(name, orgID string) error {
 	url := fmt.Sprintf("/api/v0/satellites/%s?orgId=%s", name, url.QueryEscape(orgID))
-	status, body, err := c.doCall("DELETE", url, withAuth(), withHeader("Grpc-Timeout", "5M"))
+	status, body, err := c.doCall("DELETE", url,
+		withAuth(), withHeader("Grpc-Timeout", satelliteMgmtTimeout))
 	if err != nil {
 		return err
 	}

--- a/cloud/client.go
+++ b/cloud/client.go
@@ -993,7 +993,8 @@ func (c *client) LaunchSatellite(name, orgID string) (*SatelliteInstance, error)
 		Name:     name,
 		Platform: "linux/amd64", // TODO support arm64 as well
 	}
-	status, body, err := c.doCall("POST", "/api/v0/satellites", withAuth(), withJSONBody(&req))
+	status, body, err := c.doCall("POST", "/api/v0/satellites",
+		withAuth(), withHeader("Grpc-Timeout", "5M"), withJSONBody(&req))
 	if err != nil {
 		return nil, err
 	}
@@ -1079,7 +1080,7 @@ func (c *client) GetSatellite(name, orgID string) (*SatelliteInstance, error) {
 
 func (c *client) DeleteSatellite(name, orgID string) error {
 	url := fmt.Sprintf("/api/v0/satellites/%s?orgId=%s", name, url.QueryEscape(orgID))
-	status, body, err := c.doCall("DELETE", url, withAuth())
+	status, body, err := c.doCall("DELETE", url, withAuth(), withHeader("Grpc-Timeout", "5M"))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
I was frequently getting `unexpected EOF` error messages trying to delete satellites. The satellite delete would still work behind the scenes, but the request would get disconnected early after about 1 minute. 

I'm mostly sure the change in this PR fixes it, but to be honest, I'm still not sure which component is the one causing the disconnect. The request is hung up on a few places when it times out: `earthly-core -> pipelines-gateway -> pipelines-grpc -> builder-grpc` and I haven't been able to find any error messages on any of the components (other than the one I pasted above from earthly-core). 

However, the header I'm setting here is a [standard protocol](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md) for controlling gRPC request timeouts and is supported by [gRPC-Gateway](https://github.com/grpc-ecosystem/grpc-gateway/blob/6d2b64e3a9edc3d206345280e594703a7d4c5543/runtime/context.go#L39-L41). 

I deleted a few satellites with this fix and haven't been able to get the error again.

I was also getting timed-out around the 1 minute mark before having this header, but now it seems to wait much longer without printing the error, some screenshots below of the requests with a timer:

Before:
<img width="1212" alt="Screen Shot 2022-06-21 at 11 00 40 AM" src="https://user-images.githubusercontent.com/3247216/174832722-a169222a-29bf-4c97-adb7-15b8b18e56a3.png">

After:
<img width="1212" alt="Screen Shot 2022-06-21 at 11 03 48 AM" src="https://user-images.githubusercontent.com/3247216/174833072-34c65ce2-df67-4c04-9f04-e66dd0b3fec7.png">

Long story short: I'm actually not 100% sure this is the entire fix, but the evidence seems to show it works.
