### PR TITLE
move earthly-entrypoint.sh to seperate cgroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 
 ## Unreleased
 
+### Fixed
+
+- `sh: write error: Resource busy` error caused by running the earthly/earthly docker image on a cgroups2-enabled host. [#1934](https://github.com/earthly/earthly/issues/1934)
+
 ## v0.6.17 - 2022-06-20
 
 ### Added

--- a/buildkitd/entrypoint.sh
+++ b/buildkitd/entrypoint.sh
@@ -42,11 +42,15 @@ if [ -z "$EARTHLY_CACHE_VERSION" ]; then
 fi
 
 if [ -f "/sys/fs/cgroup/cgroup.controllers" ]; then
-    echo "detected cgroups v2"
+    echo "detected cgroups v2; buildkit/entrypoint.sh running under pid=$$"
 
     mkdir -p /sys/fs/cgroup/earthly
     mkdir -p /sys/fs/cgroup/buildkit
-    echo $$ > /sys/fs/cgroup/earthly/cgroup.procs
+    echo "$$" > /sys/fs/cgroup/earthly/cgroup.procs
+
+    if [ "$(wc -l < /sys/fs/cgroup/cgroup.procs)" != "0" ]; then
+        echo "warning: processes exist in the root cgroup; this may cause errors during cgroup initialization"
+    fi
 
     echo "+pids" > /sys/fs/cgroup/cgroup.subtree_control
     echo "+cpu" > /sys/fs/cgroup/cgroup.subtree_control

--- a/earthly-entrypoint.sh
+++ b/earthly-entrypoint.sh
@@ -1,6 +1,16 @@
 #!/bin/sh
 set -e
 
+if [ -f "/sys/fs/cgroup/cgroup.controllers" ]; then
+    echo "detected cgroups v2; earthly-entrypoint.sh pid=$$"
+
+    # move the process under a new cgroup to prevent buildkitd/entrypoint.sh
+    # from getting a "h: write error: Resource busy" error while enabling controllers
+    # via echo +pids > /sys/fs/cgroup/cgroup.subtree_control
+    mkdir -p /sys/fs/cgroup/earthly-entrypoint
+    echo "$$" > /sys/fs/cgroup/earthly-entrypoint/cgroup.procs
+fi
+
 earthly_config="/etc/.earthly/config.yml"
 if [ ! -f "$earthly_config" ]; then
   # Missing config, generate it and use the env vars


### PR DESCRIPTION
if the earthly is run via the earthly/earthly docker image, it
will first run earthly-entrypoint.sh as the root process (with PID=1),
which will then start up the buildkitd/entrypoint.sh script as a sub
process. That subprocess will then setup earthly and buildkit cgroups
but will fail with `sh: write error: Resource busy` while attempting to
enable pids via `echo +pids > /sys/fs/cgroup/cgroup.subtree_control`.

That fails because `/sys/fs/cgroup/cgroup.procs` contains both the
current process **and** it's parent process. The solution is to ensure
the parent process is in a different cgroup.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>