### PR TITLE
tail buildkit log when BUILDKIT_DEBUG=true

### DIFF
--- a/earthly-entrypoint.sh
+++ b/earthly-entrypoint.sh
@@ -49,6 +49,10 @@ if [ -z "$BUILDKIT_HOST" ]; then
       >/var/log/buildkitd.log 2>&1 \
       &
 
+  if [ "$BUILDKIT_DEBUG" = "true" ]; then
+      tail -f /var/log/buildkitd.log &
+  fi
+
   EARTHLY_BUILDKIT_HOST="tcp://$(hostname):8372" # hostname is not recognized as local for this reason
   export EARTHLY_BUILDKIT_HOST
 else


### PR DESCRIPTION
It is difficult to view the buildkit log (/var/log/buildkitd.log), if
the earthly/earthly docker image crashes (technically a user could
create a snapshot of the exited container, and re-tag it under a new
docker image, then run that new image and cat the contents of the log).

Instead, this change will tail the contents of the log to stdout when BUILDKIT_DEBUG=true

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>