### PR TITLE
Add `--satellite` flag to be used with builds. 

### DIFF
--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -1298,6 +1298,9 @@ func (app *earthlyApp) configureSatellite(c *cli.Context, cc cloud.Client) error
 	if c.IsSet("buildkit-host") && c.IsSet("satellite") {
 		return errors.New("cannot specify both buildkit-host and satellite")
 	}
+	if c.IsSet("satellite") && app.noSatellite {
+		return errors.New("cannot specify both no-satellite and satellite")
+	}
 	if !app.isUsingSatellite(c) || cc == nil {
 		// If the app is not using a cloud client, or the command doesn't interact with the cloud (prune, bootstrap)
 		// then pretend its all good and use your regular configuration.

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -612,7 +612,7 @@ func newEarthlyApp(ctx context.Context, console conslogging.ConsoleLogger) *eart
 		&cli.StringFlag{
 			Name:        "server",
 			Value:       "https://api.earthly.dev",
-			EnvVars:     []string{"EARTHLY_SERVER"},
+			EnvVars:     []string{"EARTHLY_SERVER_ADDRESS"},
 			Usage:       "API server override for dev purposes",
 			Destination: &app.apiServer,
 			Hidden:      true, // Internal.

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -1357,7 +1357,7 @@ func (app *earthlyApp) isUsingSatellite(c *cli.Context) bool {
 		// buildkit-host takes precedence
 		return false
 	}
-	return len(app.cfg.Satellite.Name) > 0 || app.satelliteName != ""
+	return app.cfg.Satellite.Name != "" || app.satelliteName != ""
 }
 
 func (app *earthlyApp) GetBuildkitClient(c *cli.Context, cc cloud.Client) (*client.Client, error) {

--- a/tests/autocompletion/Earthfile
+++ b/tests/autocompletion/Earthfile
@@ -20,6 +20,7 @@ config
 ls 
 org 
 prune 
+satellite 
 secret " > expected
     RUN COMP_LINE="earthly " COMP_POINT=8 earthly > actual
     RUN diff expected actual


### PR DESCRIPTION
This PR enables the following usages:

* `earthly --sat=something +build` (run this specific build on a satellite)
* `earthly --no-sat +build` (run this specific build locally)

This PR also, unhides the `earthly satellite` subcommand.