### PR TITLE
Improved Error Handling in Satellites Commands

### DIFF
--- a/cloud/satellite.go
+++ b/cloud/satellite.go
@@ -83,7 +83,7 @@ func (c *client) DeleteSatellite(ctx context.Context, name, orgID string) error 
 	return nil
 }
 
-func (c *client) LaunchSatellite(ctx context.Context, name, orgID string) (*SatelliteInstance, error) {
+func (c *client) LaunchSatellite(ctx context.Context, name, orgID string) error {
 	req := pipelinesapi.LaunchSatelliteRequest{
 		OrgId:    orgID,
 		Name:     name,
@@ -92,21 +92,10 @@ func (c *client) LaunchSatellite(ctx context.Context, name, orgID string) (*Sate
 	status, body, err := c.doCall(ctx, "POST", "/api/v0/satellites",
 		withAuth(), withHeader("Grpc-Timeout", satelliteMgmtTimeout), withJSONBody(&req))
 	if err != nil {
-		return nil, err
+		return err
 	}
 	if status != http.StatusOK {
-		return nil, errors.Errorf("failed launching satellite: %s", body)
+		return errors.Errorf("failed launching satellite: %s", body)
 	}
-	var resp pipelinesapi.LaunchSatelliteResponse
-	err = c.jm.Unmarshal(bytes.NewReader([]byte(body)), &resp)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to unmarshal LaunchSatellite response")
-	}
-	return &SatelliteInstance{
-		Name:     name,
-		Org:      orgID,
-		Status:   resp.Status.String(),
-		Version:  resp.Version,
-		Platform: "linux/amd64",
-	}, nil
+	return nil
 }

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -3676,8 +3676,12 @@ func (app *earthlyApp) actionSatelliteLaunch(cliCtx *cli.Context) error {
 	}
 
 	app.console.Printf("Launching Satellite. This could take a moment...\n")
-	_, err = cloudClient.LaunchSatellite(cliCtx.Context, app.satelliteName, orgID)
+	err = cloudClient.LaunchSatellite(cliCtx.Context, app.satelliteName, orgID)
 	if err != nil {
+		if errors.Cause(err) == context.Canceled {
+			app.console.Printf("Operation canceled. Satellite should continue to launch in background.")
+			return nil
+		}
 		return errors.Wrapf(err, "failed to create satellite %s", app.satelliteName)
 	}
 	app.console.Printf("...Done\n")
@@ -3739,6 +3743,10 @@ func (app *earthlyApp) actionSatelliteDestroy(cliCtx *cli.Context) error {
 	app.console.Printf("Destroying Satellite. This could take a moment...\n")
 	err = cloudClient.DeleteSatellite(cliCtx.Context, app.satelliteName, orgID)
 	if err != nil {
+		if errors.Cause(err) == context.Canceled {
+			app.console.Printf("Operation canceled. Satellite should continue to delete in background.")
+			return nil
+		}
 		return errors.Wrapf(err, "failed to delete satellite %s", app.satelliteName)
 	}
 	app.console.Printf("...Done\n")


### PR DESCRIPTION
* There was a bug where if a request would retry due to an error, it would result in an "unauthorized" error - this was due to the request headers mutating between retries
* Better handle on user hitting ctrl-c when waiting for a satellite to launch or destroy
* Also improved some errors on the backend