### PR TITLE
Don't run Satellites on PR commits

### DIFF
--- a/.github/workflows/satellites.yml
+++ b/.github/workflows/satellites.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches: [ main ]
     paths-ignore: [ docs/** ]
-  pull_request:
-    branches: [ main ]
-    paths-ignore: [ docs/** ]
 
 jobs:
   tests:


### PR DESCRIPTION
Our poor Satellite can't keep up with all the commits we make on PRs. Let's dial it back a bit until we improve the stability on our instance. 