### PR TITLE
Adding support for saving interactive artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 
 ## Unreleased
 
+### Added
+
+- Adding support for saving artifact from `--interactive-keep`. [#1980](https://github.com/earthly/earthly/issues/1980)
+
 ## v0.6.19 - 2022-06-29
 
 ### Fixed

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -2030,7 +2030,7 @@ func (c *Converter) joinRefs(relRef domain.Reference) (domain.Reference, error) 
 }
 
 func (c *Converter) checkAllowed(command cmdType) error {
-	if c.mts.Final.RanInteractive && command != saveImageCmd {
+	if c.mts.Final.RanInteractive && !(command == saveImageCmd || command == saveArtifactCmd) {
 		return errors.New("If present, a single --interactive command must be the last command in a target")
 	}
 


### PR DESCRIPTION
See #1980. Do I need to feature flag this?

I wasn't sure how to add a test case for this, as it's interactive but I tested it with the following code.

```
interactive-save-art:
    FROM alpine:3.15
    RUN echo "to file" > test.txt
    RUN --interactive-keep /bin/sh
    SAVE ARTIFACT /test.txt AS LOCAL test.txt
```

Any changes made to test.txt in the interactive session show up in the local file. 