### PR TITLE
Add debug calls for buildkit info items. Make prune work with satellites

### DIFF
--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -12,9 +12,12 @@ buildkitd:
             ARG BUILDKIT_BASE_IMAGE=$BUILDKIT_PROJECT+build
         END
     ELSE
-        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:f9b1fc160d49dd40f859123b91674784fd19e845+build
+        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:e5e5399956f09960775cd2892e60917db8afaace+build
     END
-    FROM $BUILDKIT_BASE_IMAGE
+    ARG EARTHLY_TARGET_TAG_DOCKER
+    ARG TAG="dev-$EARTHLY_TARGET_TAG_DOCKER"
+
+    FROM $BUILDKIT_BASE_IMAGE --RELEASE_VERSION=$TAG
     RUN echo "@edge-community http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
     RUN apk add --update --no-cache \
         cni-plugins@edge-community \
@@ -58,8 +61,6 @@ buildkitd:
     ENV EARTHLY_CACHE_VERSION="2" # whenever this value changes, a forced cache reset is performed
     VOLUME /tmp/earthly
     ENTRYPOINT ["/usr/bin/entrypoint.sh", "buildkitd", "--config=/etc/buildkitd.toml"]
-    ARG EARTHLY_TARGET_TAG_DOCKER
-    ARG TAG="dev-$EARTHLY_TARGET_TAG_DOCKER"
     ARG REGISTRY_USER="earthly"
     ARG IMAGE_REGISTRY="docker.io"
 

--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -12,7 +12,7 @@ buildkitd:
             ARG BUILDKIT_BASE_IMAGE=$BUILDKIT_PROJECT+build
         END
     ELSE
-        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:e5e5399956f09960775cd2892e60917db8afaace+build
+        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:04bab2d652bea77688beb7d454abdc6b8a75907d+build
     END
     ARG EARTHLY_TARGET_TAG_DOCKER
     ARG TAG="dev-$EARTHLY_TARGET_TAG_DOCKER"

--- a/cmd/earthly/debug_cmds.go
+++ b/cmd/earthly/debug_cmds.go
@@ -3,8 +3,15 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"time"
 
+	"github.com/containerd/containerd/platforms"
 	"github.com/earthly/earthly/ast"
+	"github.com/earthly/earthly/cloud"
+	"github.com/moby/buildkit/client"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"
 )
@@ -23,6 +30,24 @@ func (app *earthlyApp) debugCmds() []*cli.Command {
 					Destination: &app.enableSourceMap,
 				},
 			},
+		},
+		{
+			Name:      "buildkit-info",
+			Usage:     "Print the buildkit info",
+			UsageText: "earthly [options] debug buildkit-info",
+			Action:    app.actionDebugBuildkitInfo,
+		},
+		{
+			Name:      "buildkit-disk-usage",
+			Usage:     "Print the buildkit disk usage",
+			UsageText: "earthly [options] debug buildkit-disk-usage",
+			Action:    app.actionDebugBuildkitDiskUsage,
+		},
+		{
+			Name:      "buildkit-workers",
+			Usage:     "Print the buildkit workers",
+			UsageText: "earthly [options] debug buildkit-workers",
+			Action:    app.actionDebugBuildkitWorkers,
 		},
 	}
 }
@@ -46,5 +71,118 @@ func (app *earthlyApp) actionDebugAst(cliCtx *cli.Context) error {
 		return errors.Wrap(err, "marshal ast")
 	}
 	fmt.Print(string(efDt))
+	return nil
+}
+
+func (app *earthlyApp) actionDebugBuildkitInfo(cliCtx *cli.Context) error {
+	app.commandName = "debugBuildkitInfo"
+
+	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	if err != nil {
+		return errors.Wrap(err, "failed to create cloud client")
+	}
+	bkClient, err := app.getBuildkitClient(cliCtx, cloudClient)
+	if err != nil {
+		return errors.Wrap(err, "build new buildkitd client")
+	}
+	defer bkClient.Close()
+
+	info, err := bkClient.Info(cliCtx.Context)
+	if err != nil {
+		return errors.Wrap(err, "get buildkit info")
+	}
+
+	fmt.Printf("Buildkit version: %s\n", info.BuildkitVersion.Version)
+	fmt.Printf("Buildkit revision: %s\n", info.BuildkitVersion.Revision)
+	fmt.Printf("Buildkit package: %s\n", info.BuildkitVersion.Package)
+	fmt.Printf("Num sessions: %d\n", info.NumSessions)
+	return nil
+}
+
+func (app *earthlyApp) actionDebugBuildkitDiskUsage(cliCtx *cli.Context) error {
+	app.commandName = "debugBuildkitDiskUsage"
+
+	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	if err != nil {
+		return errors.Wrap(err, "failed to create cloud client")
+	}
+	bkClient, err := app.getBuildkitClient(cliCtx, cloudClient)
+	if err != nil {
+		return errors.Wrap(err, "build new buildkitd client")
+	}
+	defer bkClient.Close()
+
+	infos, err := bkClient.DiskUsage(cliCtx.Context)
+	if err != nil {
+		return errors.Wrap(err, "get buildkit disk usage")
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	defer w.Flush()
+	fmt.Fprintf(w, "ID\tDescription\tSize\tUsageCount\tRecordType\tMutable\tShared\tInUse\tParents\tCreatedAt\tLastUsedAt\n")
+	for _, info := range infos {
+		var rt string
+		switch info.RecordType {
+		case client.UsageRecordTypeCacheMount:
+			rt = "cache"
+		case client.UsageRecordTypeFrontend:
+			rt = "frontend"
+		case client.UsageRecordTypeGitCheckout:
+			rt = "git"
+		case client.UsageRecordTypeInternal:
+			rt = "internal"
+		case client.UsageRecordTypeLocalSource:
+			rt = "local-source"
+		case client.UsageRecordTypeRegular:
+			rt = "regular"
+		}
+		fmt.Fprintf(
+			w, "%s\t%s\t%d\t%d\t%s\t%t\t%t\t%t\t%s\t%s\t%s\n",
+			info.ID, info.Description, info.Size, info.UsageCount,
+			rt, info.Mutable, info.Shared, info.InUse,
+			strings.Join(info.Parents, ","),
+			info.CreatedAt.Format(time.RFC3339), info.LastUsedAt.Format(time.RFC3339),
+		)
+	}
+	return nil
+}
+
+func (app *earthlyApp) actionDebugBuildkitWorkers(cliCtx *cli.Context) error {
+	app.commandName = "debugBuildkitWorkers"
+
+	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	if err != nil {
+		return errors.Wrap(err, "failed to create cloud client")
+	}
+	bkClient, err := app.getBuildkitClient(cliCtx, cloudClient)
+	if err != nil {
+		return errors.Wrap(err, "build new buildkitd client")
+	}
+	defer bkClient.Close()
+
+	workers, err := bkClient.ListWorkers(cliCtx.Context)
+	if err != nil {
+		return errors.Wrap(err, "get buildkit workers")
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	defer w.Flush()
+	fmt.Fprintf(w, "ID\tLabels\tPlatforms\tVersion\tPackage\tRevision\tParallelism current\tParallelism max\tParallelism waiting\n")
+	for _, info := range workers {
+		ps := make([]string, 0, len(info.Platforms))
+		for _, p := range info.Platforms {
+			ps = append(ps, platforms.Format(p))
+		}
+		ls := make([]string, 0, len(info.Labels))
+		for lk, lv := range info.Labels {
+			ls = append(ls, fmt.Sprintf("%s=%s", lk, lv))
+		}
+
+		fmt.Fprintf(
+			w, "%s\t%s\t%s\t%s\t%s\t%s\t%d\t%d\t%d\n",
+			info.ID, strings.Join(ls, ","), strings.Join(ps, ","),
+			info.BuildkitVersion.Version, info.BuildkitVersion.Package,
+			info.BuildkitVersion.Revision,
+			info.ParallelismCurrent, info.ParallelismMax,
+			info.ParallelismWaiting)
+	}
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,6 @@ replace (
 
 	github.com/jessevdk/go-flags => github.com/alexcb/go-flags v0.0.0-20210722203016-f11d7ecb5ee5
 
-	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.1-0.20220708213613-e5e5399956f0
+	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.1-0.20220708224117-04bab2d652be
 	github.com/tonistiigi/fsutil => github.com/earthly/fsutil v0.0.0-20220707234217-feae5c0ecda9
 )

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,6 @@ replace (
 
 	github.com/jessevdk/go-flags => github.com/alexcb/go-flags v0.0.0-20210722203016-f11d7ecb5ee5
 
-	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.1-0.20220708171740-f9b1fc160d49
+	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.1-0.20220708213613-e5e5399956f0
 	github.com/tonistiigi/fsutil => github.com/earthly/fsutil v0.0.0-20220707234217-feae5c0ecda9
 )

--- a/go.sum
+++ b/go.sum
@@ -370,8 +370,8 @@ github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
-github.com/earthly/buildkit v0.0.1-0.20220708171740-f9b1fc160d49 h1:HTPDPbV3WMdxQvnv7+CKSwmNz0IusVb43Mo8O89py4A=
-github.com/earthly/buildkit v0.0.1-0.20220708171740-f9b1fc160d49/go.mod h1:jt1heLmQjKCZBBJJ8i1iTenQGjY1eK3xx2aO3Wf51Mc=
+github.com/earthly/buildkit v0.0.1-0.20220708213613-e5e5399956f0 h1:TbYJD+FPO+iqr2gABENMkJWWsD6blufmx0llMpdgcv8=
+github.com/earthly/buildkit v0.0.1-0.20220708213613-e5e5399956f0/go.mod h1:jt1heLmQjKCZBBJJ8i1iTenQGjY1eK3xx2aO3Wf51Mc=
 github.com/earthly/cloud-api v1.0.1-0.20220629195532-0fc4354d2fbf h1:tAuK7QOjF+nGOCdaY44jjd8+NOlBVMRlvuVGfkTrgco=
 github.com/earthly/cloud-api v1.0.1-0.20220629195532-0fc4354d2fbf/go.mod h1:JhlHsW6o8zYa+XsM0nMAevRQtES35KE5R2G8tJALsnI=
 github.com/earthly/fsutil v0.0.0-20220707234217-feae5c0ecda9 h1:sUOTTlEFlgQiNdX1/ZY0S3fSwnT/qe8AEuNhQG+AaG4=

--- a/go.sum
+++ b/go.sum
@@ -370,8 +370,8 @@ github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
-github.com/earthly/buildkit v0.0.1-0.20220708213613-e5e5399956f0 h1:TbYJD+FPO+iqr2gABENMkJWWsD6blufmx0llMpdgcv8=
-github.com/earthly/buildkit v0.0.1-0.20220708213613-e5e5399956f0/go.mod h1:jt1heLmQjKCZBBJJ8i1iTenQGjY1eK3xx2aO3Wf51Mc=
+github.com/earthly/buildkit v0.0.1-0.20220708224117-04bab2d652be h1:UetQvNr/ZpixroptpEQt1cGhXCMKSxL3LctOROg3FXw=
+github.com/earthly/buildkit v0.0.1-0.20220708224117-04bab2d652be/go.mod h1:jt1heLmQjKCZBBJJ8i1iTenQGjY1eK3xx2aO3Wf51Mc=
 github.com/earthly/cloud-api v1.0.1-0.20220629195532-0fc4354d2fbf h1:tAuK7QOjF+nGOCdaY44jjd8+NOlBVMRlvuVGfkTrgco=
 github.com/earthly/cloud-api v1.0.1-0.20220629195532-0fc4354d2fbf/go.mod h1:JhlHsW6o8zYa+XsM0nMAevRQtES35KE5R2G8tJALsnI=
 github.com/earthly/fsutil v0.0.0-20220707234217-feae5c0ecda9 h1:sUOTTlEFlgQiNdX1/ZY0S3fSwnT/qe8AEuNhQG+AaG4=


### PR DESCRIPTION
Depends on https://github.com/earthly/buildkit/pull/82

This adds the following functionality:

* Buildkit binary is now tagged with the same version as Earthly. This version is reported in Buildkit's info call.
* `earthly prune` works now with satellites
* The following debug commands have been added to introspect buildkit's state:
  * `earthly debug buildkit-info` - prints version and number of active sessions
     
     Example output:
     ```
     Buildkit version: dev-main
     Buildkit revision: f9b1fc160d49dd40f859123b91674784fd19e845.m
     Buildkit package: github.com/earthly/buildkit
     Num sessions: 2
     ```
     
     * **Buildkit version** is set to any string we want - this PR sets it to the exact same version of Earthly itself during release.
     * **Buildkit revision** is the git SHA of buildkit.
     * **Buildkit package** is set to the repository address (notice that we've replaced this with earthly's fork, to indicate that this is not a vanilla buildkit)
     * **Num sessions** is the number of currently active builds running against this buildkit.
  * `earthly debug buildkit-disk-usage`
     
     Example output:
     ```
     ID                         Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                Size        UsageCount  RecordType    Mutable  Shared  InUse  Parents                    CreatedAt             LastUsedAt
     yym6p5ivf0atjfl8vkadcl7dn  mount / from exec /bin/sh -c GOLANG_VERSION=1.17.10 GOPATH=/go PATH=/go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin /usr/bin/earth_debugger /bin/sh -c 'go mod download'                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            1625034752  1           regular       false    false   false  q7ve1b95vveavpzzqsqsl68lh  2022-07-08T21:50:22Z  2022-07-08T21:52:14Z
     u0pxvuuagju5qvkzu4kt9mltf  pulled from docker.io/arm64v8/openjdk:19-slim@sha256:658b7d32f06f5f80351aa4ed20c1c4c0b52405a6b8a7f35b2b479101871fae24                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      536692597   1           regular       false    false   false  nd7d8o8osryg7642mrgctzf5c  2022-07-08T21:49:18Z  2022-07-08T21:52:14Z
     ifowq5go650vdhnn7kxk2b9p4  pulled from docker.io/library/golang:1.18-alpine@sha256:7cc62574fcf9c5fb87ad42a9789d5539a6a085971d58ee75dd2ee146cb8a8695                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   467752592   1           regular       false    false   false  4g942w7ambl1v200ojcfovav9  2022-07-08T21:50:25Z  2022-07-08T21:50:25Z
     5880uzl282v521kzizagjqd8a  pulled from docker.io/library/golang:1.17-alpine3.14@sha256:7dee28aaabcbd25c4dcd0fa6663c01157c1cca061f903b69ecf0e6f0524634d1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               443741878   1           regular       false    false   false  5xkzxaynp1unkermyqt9l25j2  2022-07-08T21:49:20Z  2022-07-08T21:49:20Z
     ...
     ```
  * `earthly debug buildkit-workers`
     
     Example output:
     ```
     Worker iyroro15hn3f509pcn0hi9wqx
             Labels: org.mobyproject.buildkit.worker.network=cni,org.mobyproject.buildkit.worker.hostname=98d0db9d24bd,org.mobyproject.buildkit.worker.snapshotter=overlayfs,org.mobyproject.buildkit.worker.executor=oci,org.mobyproject.buildkit.worker.oci.process-mode=sandbox
             Platforms: linux/arm64,linux/amd64,linux/amd64/v2,linux/riscv64,linux/ppc64le,linux/s390x,linux/386,linux/mips64le,linux/mips64,linux/arm/v7,linux/arm/v6
             Version: dev-vlad_buildkit-status
             Package: github.com/earthly/buildkit
             Revision: e5e5399956f09960775cd2892e60917db8afaace.m
             Parallelism current: 0
             Parallelism max: 20
             Parallelism waiting: 0
     ```
     
     To note:
     * **Platforms** - the first platform is the native one
     * **Version**, **Package** and **Revision** - the same as the ones reported by `earthly debug buildkit-info`
     * **Parallelism current** - the number of currently running parallel tasks
     * **Parallelism max** - the maximum allows parallel tasks (as configured during buildkit startup)
     * **Parallelism waiting** - the number of tasks waiting to be started (you can think of this as queue length)