### PR TITLE
Use email instead of user ID for all new projects/secrets commands

### DIFF
--- a/cloud/client.go
+++ b/cloud/client.go
@@ -73,16 +73,16 @@ type Client interface {
 	ListProjects(ctx context.Context, orgName string) ([]*Project, error)
 	GetProject(ctx context.Context, orgName, name string) (*Project, error)
 	DeleteProject(ctx context.Context, orgName, name string) error
-	AddProjectMember(ctx context.Context, orgName, name, idOrEmail, permission string) error
-	UpdateProjectMember(ctx context.Context, orgName, name, userID, permission string) error
+	AddProjectMember(ctx context.Context, orgName, name, userEmail, permission string) error
+	UpdateProjectMember(ctx context.Context, orgName, name, userEmail, permission string) error
 	ListProjectMembers(ctx context.Context, orgName, name string) ([]*ProjectMember, error)
-	RemoveProjectMember(ctx context.Context, orgName, name, userID string) error
+	RemoveProjectMember(ctx context.Context, orgName, name, userEmail string) error
 	ListSecrets(ctx context.Context, path string) ([]*Secret, error)
 	SetSecret(ctx context.Context, path string, secret []byte) error
 	RemoveSecret(ctx context.Context, path string) error
 	ListSecretPermissions(ctx context.Context, path string) ([]*SecretPermission, error)
-	SetSecretPermission(ctx context.Context, path, userID, permission string) error
-	RemoveSecretPermission(ctx context.Context, path, userID string) error
+	SetSecretPermission(ctx context.Context, path, userEmail, permission string) error
+	RemoveSecretPermission(ctx context.Context, path, userEmail string) error
 }
 
 type request struct {

--- a/cloud/secret_new.go
+++ b/cloud/secret_new.go
@@ -23,7 +23,7 @@ type Secret struct {
 // permission override.
 type SecretPermission struct {
 	Path       string
-	UserID     string
+	UserEmail  string
 	Permission string
 	CreatedAt  time.Time
 	ModifiedAt time.Time
@@ -129,7 +129,7 @@ func (c *client) ListSecretPermissions(ctx context.Context, path string) ([]*Sec
 
 	for _, perm := range res.SecretPermissions {
 		secretPerms = append(secretPerms, &SecretPermission{
-			UserID:     perm.UserId,
+			UserEmail:  perm.UserEmail,
 			Path:       perm.Path,
 			Permission: perm.Permission,
 			CreatedAt:  perm.CreatedAt.AsTime(),
@@ -141,14 +141,14 @@ func (c *client) ListSecretPermissions(ctx context.Context, path string) ([]*Sec
 }
 
 // SetSecretPermission is used to set a user permission on a given secret path.
-func (c *client) SetSecretPermission(ctx context.Context, path, userID, permission string) error {
+func (c *client) SetSecretPermission(ctx context.Context, path, userEmail, permission string) error {
 	if !strings.HasPrefix(path, "/") {
 		path = "/" + path
 	}
 	u := "/api/v1/secrets/permissions" + path
 
 	req := &secretsapi.UpdateSecretPermissionRequest{
-		UserId:     userID,
+		UserEmail:  userEmail,
 		Permission: permission,
 	}
 
@@ -165,11 +165,11 @@ func (c *client) SetSecretPermission(ctx context.Context, path, userID, permissi
 }
 
 // RemoveSecretPermission removes a secret permission for the user and path.
-func (c *client) RemoveSecretPermission(ctx context.Context, path, userID string) error {
+func (c *client) RemoveSecretPermission(ctx context.Context, path, userEmail string) error {
 	if !strings.HasPrefix(path, "/") {
 		path = "/" + path
 	}
-	u := "/api/v1/secrets/permissions" + path + "/" + userID
+	u := "/api/v1/secrets/permissions" + path + "/" + userEmail
 
 	status, body, err := c.doCall(ctx, http.MethodDelete, u, withAuth())
 	if err != nil {

--- a/cmd/earthly/project_cmds.go
+++ b/cmd/earthly/project_cmds.go
@@ -46,14 +46,14 @@ func (app *earthlyApp) projectCmds() []*cli.Command {
 					Name:        "add",
 					Usage:       "Add a new member to the specified project",
 					Description: "Add a new member to the specified project",
-					UsageText:   "earthly project [--org <organization-name>] member add <project-name> <user-id-or-email> <permission>",
+					UsageText:   "earthly project [--org <organization-name>] member add <project-name> <user-email> <permission>",
 					Action:      app.actionProjectMemberAdd,
 				},
 				{
 					Name:        "rm",
 					Usage:       "Remove a member from the specified project",
 					Description: "Remove a member from the specified project",
-					UsageText:   "earthly project [--org <organization-name>] member rm <project-name> <user-id>",
+					UsageText:   "earthly project [--org <organization-name>] member rm <project-name> <user-email>",
 					Action:      app.actionProjectMemberRemove,
 				},
 				{
@@ -67,7 +67,7 @@ func (app *earthlyApp) projectCmds() []*cli.Command {
 					Name:        "update",
 					Usage:       "Update the project member's permission",
 					Description: "Update the project member's permission",
-					UsageText:   "earthly project [--org <organization-name>] member update <project-name> <user-id> <permission>",
+					UsageText:   "earthly project [--org <organization-name>] member update <project-name> <user-email> <permission>",
 					Action:      app.actionProjectMemberUpdate,
 				},
 			},
@@ -188,9 +188,9 @@ func (app *earthlyApp) actionProjectMemberList(cliCtx *cli.Context) error {
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintf(w, "User ID\tEmail\tPermission\tCreated\n")
+	fmt.Fprintf(w, "User Email\tPermission\tCreated\n")
 	for _, m := range members {
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", m.UserID, m.UserEmail, m.Permission, m.CreatedAt.Format(dateFormat))
+		fmt.Fprintf(w, "%s\t%s\t%s\n", m.UserEmail, m.Permission, m.CreatedAt.Format(dateFormat))
 	}
 	w.Flush()
 
@@ -219,12 +219,12 @@ func (app *earthlyApp) actionProjectMemberRemove(cliCtx *cli.Context) error {
 		return errors.New("project name is required")
 	}
 
-	userID := cliCtx.Args().Get(1)
+	userEmail := cliCtx.Args().Get(1)
 	if projectName == "" {
-		return errors.New("user ID is required")
+		return errors.New("user email is required")
 	}
 
-	err = cloudClient.RemoveProjectMember(cliCtx.Context, orgName, projectName, userID)
+	err = cloudClient.RemoveProjectMember(cliCtx.Context, orgName, projectName, userEmail)
 	if err != nil {
 		return errors.Wrap(err, "failed to remove project member")
 	}
@@ -254,9 +254,9 @@ func (app *earthlyApp) actionProjectMemberAdd(cliCtx *cli.Context) error {
 		return errors.New("project name is required")
 	}
 
-	userID := cliCtx.Args().Get(1)
-	if userID == "" {
-		return errors.New("user ID is required")
+	userEmail := cliCtx.Args().Get(1)
+	if userEmail == "" {
+		return errors.New("user email is required")
 	}
 
 	permission := cliCtx.Args().Get(2)
@@ -264,7 +264,7 @@ func (app *earthlyApp) actionProjectMemberAdd(cliCtx *cli.Context) error {
 		return errors.New("permission is required")
 	}
 
-	err = cloudClient.AddProjectMember(cliCtx.Context, orgName, projectName, userID, permission)
+	err = cloudClient.AddProjectMember(cliCtx.Context, orgName, projectName, userEmail, permission)
 	if err != nil {
 		return errors.Wrap(err, "failed to add project member")
 	}
@@ -294,9 +294,9 @@ func (app *earthlyApp) actionProjectMemberUpdate(cliCtx *cli.Context) error {
 		return errors.New("project name is required")
 	}
 
-	userID := cliCtx.Args().Get(1)
-	if userID == "" {
-		return errors.New("user ID is required")
+	userEmail := cliCtx.Args().Get(1)
+	if userEmail == "" {
+		return errors.New("user email is required")
 	}
 
 	permission := cliCtx.Args().Get(2)
@@ -304,7 +304,7 @@ func (app *earthlyApp) actionProjectMemberUpdate(cliCtx *cli.Context) error {
 		return errors.New("permission is required")
 	}
 
-	err = cloudClient.UpdateProjectMember(cliCtx.Context, orgName, projectName, userID, permission)
+	err = cloudClient.UpdateProjectMember(cliCtx.Context, orgName, projectName, userEmail, permission)
 	if err != nil {
 		return errors.Wrap(err, "failed to update project member")
 	}

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/docker/cli v20.10.14+incompatible
 	github.com/docker/distribution v2.8.1+incompatible
 	github.com/dustin/go-humanize v1.0.0
-	github.com/earthly/cloud-api v1.0.1-0.20220629195532-0fc4354d2fbf
+	github.com/earthly/cloud-api v1.0.1-0.20220712175328-2801d1e2bcb4
 	github.com/elastic/go-sysinfo v1.7.1
 	github.com/fatih/color v1.9.0
 	github.com/golang/protobuf v1.5.2

--- a/go.sum
+++ b/go.sum
@@ -372,8 +372,8 @@ github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/earthly/buildkit v0.0.1-0.20220708224117-04bab2d652be h1:UetQvNr/ZpixroptpEQt1cGhXCMKSxL3LctOROg3FXw=
 github.com/earthly/buildkit v0.0.1-0.20220708224117-04bab2d652be/go.mod h1:jt1heLmQjKCZBBJJ8i1iTenQGjY1eK3xx2aO3Wf51Mc=
-github.com/earthly/cloud-api v1.0.1-0.20220629195532-0fc4354d2fbf h1:tAuK7QOjF+nGOCdaY44jjd8+NOlBVMRlvuVGfkTrgco=
-github.com/earthly/cloud-api v1.0.1-0.20220629195532-0fc4354d2fbf/go.mod h1:JhlHsW6o8zYa+XsM0nMAevRQtES35KE5R2G8tJALsnI=
+github.com/earthly/cloud-api v1.0.1-0.20220712175328-2801d1e2bcb4 h1:ZgyAmuEFHK3y2E2Bm6YX7zD7wTba5QnREqu0Xjwrm9E=
+github.com/earthly/cloud-api v1.0.1-0.20220712175328-2801d1e2bcb4/go.mod h1:JhlHsW6o8zYa+XsM0nMAevRQtES35KE5R2G8tJALsnI=
 github.com/earthly/fsutil v0.0.0-20220707234217-feae5c0ecda9 h1:sUOTTlEFlgQiNdX1/ZY0S3fSwnT/qe8AEuNhQG+AaG4=
 github.com/earthly/fsutil v0.0.0-20220707234217-feae5c0ecda9/go.mod h1:oPAfvw32vlUJSjyDcQ3Bu0nb2ON2B+G0dtVN/SZNJiA=
 github.com/elastic/go-sysinfo v1.7.1 h1:Wx4DSARcKLllpKT2TnFVdSUJOsybqMYCNQZq1/wO+s0=


### PR DESCRIPTION
This PR updates the Cloud client to account for a change to how project members are identified (email instead of user ID).