### PR TITLE
Add GC stats

### DIFF
--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -12,7 +12,7 @@ buildkitd:
             ARG BUILDKIT_BASE_IMAGE=$BUILDKIT_PROJECT+build
         END
     ELSE
-        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:4c3182870bc84b1f0ea4dd98824a9c20efc047ab+build
+        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:5d5cbd89c60ff69e6e7c5791420aac7bde5cd6eb+build
     END
     ARG EARTHLY_TARGET_TAG_DOCKER
     ARG TAG="dev-$EARTHLY_TARGET_TAG_DOCKER"

--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -12,7 +12,7 @@ buildkitd:
             ARG BUILDKIT_BASE_IMAGE=$BUILDKIT_PROJECT+build
         END
     ELSE
-        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:04bab2d652bea77688beb7d454abdc6b8a75907d+build
+        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:4c3182870bc84b1f0ea4dd98824a9c20efc047ab+build
     END
     ARG EARTHLY_TARGET_TAG_DOCKER
     ARG TAG="dev-$EARTHLY_TARGET_TAG_DOCKER"

--- a/buildkitd/buildkitd.go
+++ b/buildkitd/buildkitd.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/containerd/containerd/platforms"
+	"github.com/dustin/go-humanize"
 	"github.com/moby/buildkit/client"
 	_ "github.com/moby/buildkit/client/connhelper/dockercontainer" // Load "docker-container://" helper.
 	"github.com/pkg/errors"
@@ -816,6 +817,33 @@ func printBuildkitInfo(bkCons conslogging.ConsoleLogger, info *client.Info, work
 	case workerInfo.ParallelismWaiting > 0:
 		bkCons.Printf("Note: Currently under significant load. Performance will be affected")
 	default:
+	}
+	ld := time.Duration(0)
+	if workerInfo.GCAnalytics.LastEndTime != nil &&
+		workerInfo.GCAnalytics.LastStartTime != nil {
+		ld = workerInfo.GCAnalytics.LastEndTime.Sub(*workerInfo.GCAnalytics.LastStartTime)
+	}
+	printFun(
+		"GC stats: %s cache, avg GC duration %v, all-time GC duration %v, last GC duration %v, last cleared %v",
+		humanize.Bytes(uint64(workerInfo.GCAnalytics.LastSizeBefore)),
+		workerInfo.GCAnalytics.AvgDuration,
+		workerInfo.GCAnalytics.AllTimeDuration,
+		ld,
+		humanize.Bytes(uint64(workerInfo.GCAnalytics.LastSizeCleared)))
+	if workerInfo.GCAnalytics.CurrentStartTime != nil {
+		d := time.Now().Sub(*workerInfo.GCAnalytics.CurrentStartTime).Round(time.Second)
+		switch {
+		case d > 5*time.Minute:
+			bkCons.Warnf("Warning: GC has been running for a long time, started %v ago", d)
+		case d > 1*time.Minute:
+			bkCons.Printf("GC currently ongoing, started %v ago", d)
+		default:
+		}
+	}
+	if workerInfo.GCAnalytics.AllTimeMaxDuration > 5*time.Minute {
+		bkCons.Warnf(
+			"Warning: Some GC runs are very slow, max duration %v",
+			workerInfo.GCAnalytics.AllTimeMaxDuration.Round(time.Second))
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,6 @@ replace (
 
 	github.com/jessevdk/go-flags => github.com/alexcb/go-flags v0.0.0-20210722203016-f11d7ecb5ee5
 
-	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.1-0.20220708224117-04bab2d652be
+	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.1-0.20220714005053-4c3182870bc8
 	github.com/tonistiigi/fsutil => github.com/earthly/fsutil v0.0.0-20220707234217-feae5c0ecda9
 )

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,6 @@ replace (
 
 	github.com/jessevdk/go-flags => github.com/alexcb/go-flags v0.0.0-20210722203016-f11d7ecb5ee5
 
-	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.1-0.20220714005053-4c3182870bc8
+	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.1-0.20220714171911-5d5cbd89c60f
 	github.com/tonistiigi/fsutil => github.com/earthly/fsutil v0.0.0-20220707234217-feae5c0ecda9
 )

--- a/go.sum
+++ b/go.sum
@@ -370,8 +370,8 @@ github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
-github.com/earthly/buildkit v0.0.1-0.20220714005053-4c3182870bc8 h1:fvJcN3dmlOFG+H3DPnH/XBELLgubRil7ODJ4dMIfEYo=
-github.com/earthly/buildkit v0.0.1-0.20220714005053-4c3182870bc8/go.mod h1:jt1heLmQjKCZBBJJ8i1iTenQGjY1eK3xx2aO3Wf51Mc=
+github.com/earthly/buildkit v0.0.1-0.20220714171911-5d5cbd89c60f h1:GwQ6/xH/WDN99fsVDw/31sJH0FoUc/4aR/8tGvxINok=
+github.com/earthly/buildkit v0.0.1-0.20220714171911-5d5cbd89c60f/go.mod h1:jt1heLmQjKCZBBJJ8i1iTenQGjY1eK3xx2aO3Wf51Mc=
 github.com/earthly/cloud-api v1.0.1-0.20220712175328-2801d1e2bcb4 h1:ZgyAmuEFHK3y2E2Bm6YX7zD7wTba5QnREqu0Xjwrm9E=
 github.com/earthly/cloud-api v1.0.1-0.20220712175328-2801d1e2bcb4/go.mod h1:JhlHsW6o8zYa+XsM0nMAevRQtES35KE5R2G8tJALsnI=
 github.com/earthly/fsutil v0.0.0-20220707234217-feae5c0ecda9 h1:sUOTTlEFlgQiNdX1/ZY0S3fSwnT/qe8AEuNhQG+AaG4=

--- a/go.sum
+++ b/go.sum
@@ -370,8 +370,8 @@ github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
-github.com/earthly/buildkit v0.0.1-0.20220708224117-04bab2d652be h1:UetQvNr/ZpixroptpEQt1cGhXCMKSxL3LctOROg3FXw=
-github.com/earthly/buildkit v0.0.1-0.20220708224117-04bab2d652be/go.mod h1:jt1heLmQjKCZBBJJ8i1iTenQGjY1eK3xx2aO3Wf51Mc=
+github.com/earthly/buildkit v0.0.1-0.20220714005053-4c3182870bc8 h1:fvJcN3dmlOFG+H3DPnH/XBELLgubRil7ODJ4dMIfEYo=
+github.com/earthly/buildkit v0.0.1-0.20220714005053-4c3182870bc8/go.mod h1:jt1heLmQjKCZBBJJ8i1iTenQGjY1eK3xx2aO3Wf51Mc=
 github.com/earthly/cloud-api v1.0.1-0.20220712175328-2801d1e2bcb4 h1:ZgyAmuEFHK3y2E2Bm6YX7zD7wTba5QnREqu0Xjwrm9E=
 github.com/earthly/cloud-api v1.0.1-0.20220712175328-2801d1e2bcb4/go.mod h1:JhlHsW6o8zYa+XsM0nMAevRQtES35KE5R2G8tJALsnI=
 github.com/earthly/fsutil v0.0.0-20220707234217-feae5c0ecda9 h1:sUOTTlEFlgQiNdX1/ZY0S3fSwnT/qe8AEuNhQG+AaG4=

--- a/outmon/solvermon.go
+++ b/outmon/solvermon.go
@@ -282,6 +282,21 @@ func (sm *SolverMonitor) processNoOutputTick(ctx context.Context, bkClient *clie
 			"Waiting on Buildkit... Load (%d/%d)",
 			load, workerInfo.ParallelismMax)
 	}
+	if workerInfo.GCAnalytics.CurrentStartTime != nil {
+		d := now.Sub(*workerInfo.GCAnalytics.CurrentStartTime).Round(time.Second)
+		if d <= 5*time.Minute {
+			ongoingStr += fmt.Sprintf(" GC (%v ago)", d)
+		} else {
+			ongoingStr += fmt.Sprintf(" GC is slow (%v ago)", d)
+			warn = true
+		}
+	}
+	if workerInfo.GCAnalytics.AllTimeMaxDuration > 5*time.Minute {
+		ongoingStr += fmt.Sprintf(
+			" GCs historically slow (max %v)",
+			workerInfo.GCAnalytics.AllTimeMaxDuration.Round(time.Second))
+		warn = true
+	}
 	return nil
 }
 


### PR DESCRIPTION
Depends on https://github.com/earthly/buildkit/pull/83

This PR adds the following:

* GC stats as part of `earthly debug buildkit-workers` command
* Print a select few GC statistics on startup, if buildkit is remote (or satellite)
* Print warnings on startup if GC is either slow right now, or has been slow historically
* Print out GC info if GC is ongoing right now during `ongoing` output
* Print a warning if the GC is either slow right now, or has been slow historically during `ongoing` output