### PR TITLE
Remove mentions of `EARTHLY_TMP_DIR` from our docs

### DIFF
--- a/docs/ci-integration/build-an-earthly-ci-image.md
+++ b/docs/ci-integration/build-an-earthly-ci-image.md
@@ -93,10 +93,10 @@ When running the built image in your CI of choice, if you're not using a remote 
 
 {% hint style='danger' %}
 ##### Important
-We *strongly* recommend using a Docker volume for mounting `EARTHLY_TMP_DIR`. If you do not, Buildkit can consume excessive disk space, operate very slowly, or it might not function correctly.
+We *strongly* recommend using a Docker volume for mounting `/tmp/earthly`. If you do not, Buildkit can consume excessive disk space, operate very slowly, or it might not function correctly.
 {% endhint %}
 
-In some environments, not mounting `EARTHLY_TMP_DIR` as a Docker volume results in the following error:
+In some environments, not mounting `/tmp/earthly` as a Docker volume results in the following error:
 
 ```
 --> WITH DOCKER RUN --privileged ...
@@ -106,6 +106,6 @@ rm: can't remove '/var/earthly/dind/...': Resource busy
 
 In EKS, users reported that mounting an EBS volume, instead of a Kubernetes `emptyDir` worked.
 
-This part of our documentation needs improvement. If you have a Kubernetes-based setup, please [let us know](https://earthly.dev/slack) how you have mounted `EARTHLY_TMP_DIR` and whether `WITH DOCKER` worked well for you.
+This part of our documentation needs improvement. If you have a Kubernetes-based setup, please [let us know](https://earthly.dev/slack) how you have mounted `/tmp/earthly` and whether `WITH DOCKER` worked well for you.
 
 For more information, see the [documentation for `earthly/earthly` on DockerHub](https://hub.docker.com/r/earthly/earthly).

--- a/docs/ci-integration/remote-buildkit.md
+++ b/docs/ci-integration/remote-buildkit.md
@@ -31,20 +31,18 @@ To run a remote BuildKit instance, deploy and configure the image [`earthly/buil
 
 A remote daemon should be reachable by all clients intending to use it. Earthly uses ports `8371-8373` to communicate, so these should be open and available.
 
-#### Daemon
+#### Mounts
 
-To configure an `earthly/buildkitd` daemon as a remotely available daemon, you will need to start the container yourself. See our [configuration docs](../earthly-config/earthly-config.md) for more details on all the options available; but here are the ones you need to know:
+**`/tmp/earthly`**
 
-**`EARTHLY_TMP_DIR`**
-
-This will configure the location of the directory that Buildkit uses for storing the cache. Because this folder sees _a lot_ of traffic, its important that it remains fast.
+This path within the container is the location that Buildkit uses for storing the cache. Because this folder sees _a lot_ of traffic, its important that it remains fast.
 
 {% hint style='danger' %}
 ##### Important
-We *strongly* recommend using a Docker volume for mounting `EARTHLY_TMP_DIR`. If you do not, `buildkitd` can consume excessive disk space, operate very slowly, or it might not function correctly.
+We *strongly* recommend using a Docker volume for mounting `/tmp/earthly`. If you do not, `buildkitd` can consume excessive disk space, operate very slowly, or it might not function correctly.
 {% endhint %}
 
-In some environments, not mounting `EARTHLY_TMP_DIR` as a Docker volume results in the following error:
+In some environments, not mounting `/tmp/earthly` as a Docker volume results in the following error:
 
 ```
 --> WITH DOCKER RUN --privileged ...
@@ -55,6 +53,10 @@ rm: can't remove '/var/earthly/dind/...': Resource busy
 In EKS, users reported that mounting an EBS volume, instead of a Kubernetes `emptyDir` worked.
 
 This part of our documentation needs improvement. If you have a Kubernetes-based setup, please [let us know](https://earthly.dev/slack) how you have mounted `EARTHLY_TMP_DIR` and whether `WITH DOCKER` worked well for you.
+
+#### Daemon
+
+To configure an `earthly/buildkitd` daemon as a remotely available daemon, you will need to start the container yourself. See our [configuration docs](../earthly-config/earthly-config.md) for more details on all the options available; but here are the ones you need to know:
 
 **`BUILDKIT_TCP_TRANSPORT_ENABLED`**
 

--- a/docs/ci-integration/use-earthly-ci-image.md
+++ b/docs/ci-integration/use-earthly-ci-image.md
@@ -53,10 +53,10 @@ When running the built image in your CI of choice, if you're not using a remote 
 
 {% hint style='danger' %}
 ##### Important
-We *strongly* recommend using a Docker volume for mounting `EARTHLY_TMP_DIR`. If you do not, Buildkit can consume excessive disk space, operate very slowly, or it might not function correctly.
+We *strongly* recommend using a Docker volume for mounting `/tmp/earthly`. If you do not, Buildkit can consume excessive disk space, operate very slowly, or it might not function correctly.
 {% endhint %}
 
-In some environments, not mounting `EARTHLY_TMP_DIR` as a Docker volume results in the following error:
+In some environments, not mounting `/tmp/earthly` as a Docker volume results in the following error:
 
 ```
 --> WITH DOCKER RUN --privileged ...
@@ -66,6 +66,6 @@ rm: can't remove '/var/earthly/dind/...': Resource busy
 
 In EKS, users reported that mounting an EBS volume, instead of a Kubernetes `emptyDir` worked.
 
-This part of our documentation needs improvement. If you have a Kubernetes-based setup, please [let us know](https://earthly.dev/slack) how you have mounted `EARTHLY_TMP_DIR` and whether `WITH DOCKER` worked well for you.
+This part of our documentation needs improvement. If you have a Kubernetes-based setup, please [let us know](https://earthly.dev/slack) how you have mounted `/tmp/earthly` and whether `WITH DOCKER` worked well for you.
 
 For more information, see the [documentation for `earthly/earthly` on DockerHub](https://hub.docker.com/r/earthly/earthly).

--- a/docs/docker-images/all-in-one.md
+++ b/docs/docker-images/all-in-one.md
@@ -50,11 +50,11 @@ There are a couple requirements this image expects you to follow when using it. 
 
 If you are using the baked-in `buildkitd`, then this image needs to be run as a privileged container. This is because `buildkitd` needs appropriate access to use `overlayfs`.
 
-#### EARTHLY_TMP_DIR
+#### `/tmp/earthly`
 
-Because this folder sees _a lot_ of traffic, its important that it remains fast. We *strongly* recommend using a Docker volume for mounting `EARTHLY_TMP_DIR`. If you do not, `buildkitd` can consume excessive disk space, operate very slowly, or it might not function correctly.
+Because this folder sees _a lot_ of traffic, its important that it remains fast. We *strongly* recommend using a Docker volume for mounting `/tmp/earthly`. If you do not, `buildkitd` can consume excessive disk space, operate very slowly, or it might not function correctly.
 
-In some environments, not mounting `EARTHLY_TMP_DIR` as a Docker volume results in the following error:
+In some environments, not mounting `/tmp/earthly` as a Docker volume results in the following error:
 
 ```
 --> WITH DOCKER RUN --privileged ...
@@ -89,9 +89,8 @@ This is the easiest way to ensure you get the nice, colorized output from `earth
 | BUILDKIT_TCP_TRANSPORT_ENABLED      |                                | Required to be set to `true` when using an external `buildkitd` via `BUILDKIT_HOST`. `true` when using the baked-in `buildkitd`.                                                                              |
 | BUILDKIT_TLS_ENABLED                |                                | Required when using an external `buildkitd` via `BUILDKITD_HOST`, and the external `buildkitd` requires mTLS. You will also need to mount certificates into the right place (`/etc/.earthly/certs`).          |
 | CNI_MTU                             | MTU of first default interface | Set this when we autodetect the MTU incorrectly. The device used for autodetection can be shown by the command  `ip route show \| grep default \| cut -d' ' -f5 \| head -n 1`                                 |
-| EARTHLY_RESET_TMP_DIR               | `false`                        | Cleans out `EARTHLY_TMP_DIR` before running, if set to `true`. Useful when you host-mount an temporary directory across runs.                                                                                 |
+| EARTHLY_RESET_TMP_DIR               | `false`                        | Cleans out `/tmp/earthly` before running, if set to `true`. Useful when you host-mount an temporary directory across runs.                                                                                 |
 | NETWORK_MODE                        | `cni`                          | Specifies the networking mode of `buildkitd`. Default uses a CNI bridge network, configured with the `CNI_MTU`.                                                                                               |
-| EARTHLY_TMP_DIR                     | `/tmp/earthly`                 | Specifies the location of `earthly`s temporary directory. You can also mount an external volume to this path to preserve the contents across runs.                                                            |
 | CACHE_SIZE_MB                       | `0`                            | How big should the `buildkitd` cache be allowed to get, in MiB? A value of 0 sets the cache size to "adaptive", causing BuildKit to detect the available size of the system and choose a limit automatically. |
 | GIT_URL_INSTEAD_OF                  |                                | Configure `git config --global url.<url>.insteadOf` rules to be used by `buildkitd`.                                                                                                                          |
 | IP_TABLES                           |                                | Override which binary (`iptables_nft` or `iptables_legacy`) is used for configuring `ip_tables`. Only set this if autodetection fails for your platform.                                                      |

--- a/docs/docker-images/buildkit-standalone.md
+++ b/docs/docker-images/buildkit-standalone.md
@@ -48,11 +48,11 @@ Assuming you ran this on another machine named `fast-builder`, you could use thi
 
 This image needs to be run as a privileged container. This is because `buildkitd` needs appropriate access to start and run additional containers itself via `runc`.
 
-#### EARTHLY_TMP_DIR
+#### `/tmp/earthly`
 
-Because this folder sees _a lot_ of traffic, its important that it remains fast. We *strongly* recommend using a Docker volume for mounting `EARTHLY_TMP_DIR`. If you do not, `buildkitd` can consume excessive disk space, operate very slowly, or it might not function correctly.
+Because this folder sees _a lot_ of traffic, its important that it remains fast. We *strongly* recommend using a Docker volume for mounting `/tmp/earthly`. If you do not, `buildkitd` can consume excessive disk space, operate very slowly, or it might not function correctly.
 
-In some environments, not mounting `EARTHLY_TMP_DIR` as a Docker volume results in the following error:
+In some environments, not mounting `/tmp/earthly` as a Docker volume results in the following error:
 
 ```
 --> WITH DOCKER RUN --privileged ...
@@ -74,9 +74,8 @@ When using this container locally with `earthly`, please note that setting `EART
 | BUILDKIT_TCP_TRANSPORT_ENABLED      |                                | Set to `true` when the `buildkitd` instance is going to be used remotely                                                                                                      |
 | BUILDKIT_TLS_ENABLED                |                                | Set to `true` when the `buildkittd` instance will require mTLS from the clients. You will also need to mount certificates into the right place (`/etc/*.pem`).                |
 | CNI_MTU                             | MTU of first default interface | Set this when we autodetect the MTU incorrectly. The device used for autodetection can be shown by the command  `ip route show \| grep default \| cut -d' ' -f5 \| head -n 1` |
-| EARTHLY_RESET_TMP_DIR               | `false`                        | Cleans out `EARTHLY_TMP_DIR` before running, if set to `true`. Useful when you host-mount an temporary directory across runs.                                                            |
+| EARTHLY_RESET_TMP_DIR               | `false`                        | Cleans out `/tmp/earthly` before running, if set to `true`. Useful when you host-mount an temporary directory across runs.                                                            |
 | NETWORK_MODE                        | `cni`                          | Specifies the networking mode of `buildkitd`. Default uses a CNI bridge network, configured with the `CNI_MTU`.                                                               |
-| EARTHLY_TMP_DIR                     | `/tmp/earthly`                 | Specifies the location of `earthly`s temporary directory. You can also mount an external volume to this path to preserve the contents across runs.                                       |
 | CACHE_SIZE_MB                       | `0`                            | How big should the `buildkitd` cache be allowed to get, in MiB? 0 is unbounded.                                                                                               |
 | GIT_URL_INSTEAD_OF                  |                                | Configure `git config --global url.<url>.insteadOf` rules used by `buildkitd`                                                                                                 |
 | IP_TABLES                           |                                | Override which binary (`iptables_nft` or `iptables_legacy`) is used for configuring `ip_tables`. Only set this if autodetection fails for your platform.                          |


### PR DESCRIPTION
Changing the default is not supported (https://github.com/earthly/earthly/issues/2019)