### PR TITLE
Fix `WITH DOCKER` registry caching

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -403,7 +403,7 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 	onFinalArtifact := func(childCtx context.Context) (string, error) {
 		return b.tempEarthlyOutDir()
 	}
-	onPull := func(childCtx context.Context, imagesToPull []string) error {
+	onPull := func(childCtx context.Context, imagesToPull []string, resp map[string]string) error {
 		if b.opt.LocalRegistryAddr == "" {
 			return nil
 		}

--- a/builder/solver.go
+++ b/builder/solver.go
@@ -20,7 +20,6 @@ import (
 type onImageFunc func(context.Context, *errgroup.Group, string) (io.WriteCloser, error)
 type onArtifactFunc func(context.Context, int, domain.Artifact, string, string) (string, error)
 type onFinalArtifactFunc func(context.Context) (string, error)
-type onReadyForPullFunc func(context.Context, []string) error
 
 type solver struct {
 	sm              *outmon.SolverMonitor
@@ -33,7 +32,7 @@ type solver struct {
 	saveInlineCache bool
 }
 
-func (s *solver) buildMainMulti(ctx context.Context, bf gwclient.BuildFunc, onImage onImageFunc, onArtifact onArtifactFunc, onFinalArtifact onFinalArtifactFunc, onPullCallback onReadyForPullFunc, phaseText string) error {
+func (s *solver) buildMainMulti(ctx context.Context, bf gwclient.BuildFunc, onImage onImageFunc, onArtifact onArtifactFunc, onFinalArtifact onFinalArtifactFunc, onPullCallback pullping.PullCallback, phaseText string) error {
 	ch := make(chan *client.SolveStatus)
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -70,7 +69,7 @@ func (s *solver) buildMainMulti(ctx context.Context, bf gwclient.BuildFunc, onIm
 	return nil
 }
 
-func (s *solver) newSolveOptMulti(ctx context.Context, eg *errgroup.Group, onImage onImageFunc, onArtifact onArtifactFunc, onFinalArtifact onFinalArtifactFunc, onPullCallback onReadyForPullFunc) (*client.SolveOpt, error) {
+func (s *solver) newSolveOptMulti(ctx context.Context, eg *errgroup.Group, onImage onImageFunc, onArtifact onArtifactFunc, onFinalArtifact onFinalArtifactFunc, onPullCallback pullping.PullCallback) (*client.SolveOpt, error) {
 	var cacheImports []client.CacheOptionsEntry
 	for ci := range s.cacheImports.AsMap() {
 		cacheImports = append(cacheImports, newCacheImportOpt(ci))

--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -12,7 +12,7 @@ buildkitd:
             ARG BUILDKIT_BASE_IMAGE=$BUILDKIT_PROJECT+build
         END
     ELSE
-        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:8252b6eb0ca543ec9920c9e3c8c610f1b2d59521+build
+        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:a2a3e382a7782588b741932d7ee9484358bac157+build
     END
     ARG EARTHLY_TARGET_TAG_DOCKER
     ARG TAG="dev-$EARTHLY_TARGET_TAG_DOCKER"

--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -12,7 +12,7 @@ buildkitd:
             ARG BUILDKIT_BASE_IMAGE=$BUILDKIT_PROJECT+build
         END
     ELSE
-        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:e48456505a8a76032913abef0fb4ee4b5a87fb3d+build
+        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:8252b6eb0ca543ec9920c9e3c8c610f1b2d59521+build
     END
     ARG EARTHLY_TARGET_TAG_DOCKER
     ARG TAG="dev-$EARTHLY_TARGET_TAG_DOCKER"

--- a/earthfile2llb/withdockerrunlocalreg.go
+++ b/earthfile2llb/withdockerrunlocalreg.go
@@ -2,6 +2,7 @@ package earthfile2llb
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/earthly/earthly/domain"
 	"github.com/earthly/earthly/states"
@@ -81,7 +82,8 @@ func (w *withDockerRunLocalReg) Run(ctx context.Context, args []string, opt With
 	// Wait for all images to build (channel will be closed when finished).
 	for result := range res.ResultChan {
 		// Pull and then retag all images with expected tags.
-		err := w.c.containerFrontend.ImagePull(ctx, result.IntermediateImageName)
+		pullImage := fmt.Sprintf("%s/%s", buildkitRegistry, result.IntermediateImageName)
+		err := w.c.containerFrontend.ImagePull(ctx, pullImage)
 		if err != nil {
 			return err
 		}

--- a/earthfile2llb/withdockerrunlocalreg.go
+++ b/earthfile2llb/withdockerrunlocalreg.go
@@ -88,7 +88,7 @@ func (w *withDockerRunLocalReg) Run(ctx context.Context, args []string, opt With
 			return err
 		}
 		err = w.c.containerFrontend.ImageTag(ctx, containerutil.ImageTag{
-			SourceRef: result.IntermediateImageName,
+			SourceRef: pullImage,
 			TargetRef: result.FinalImageName,
 		})
 		if err != nil {

--- a/earthfile2llb/withdockerrunlocalreg.go
+++ b/earthfile2llb/withdockerrunlocalreg.go
@@ -2,7 +2,6 @@ package earthfile2llb
 
 import (
 	"context"
-	"strings"
 
 	"github.com/earthly/earthly/domain"
 	"github.com/earthly/earthly/states"
@@ -80,34 +79,18 @@ func (w *withDockerRunLocalReg) Run(ctx context.Context, args []string, opt With
 	})
 
 	// Wait for all images to build (channel will be closed when finished).
-	var pullImages []string
-	for imageName := range res.ResultChan {
-		pullImages = append(pullImages, imageName)
-	}
-
-	// Tag all images with expected tags.
-	for _, pullImage := range pullImages {
-
-		// The temporary image name we get back from BuildKit is structured like
-		// 'sess-<id>/<image-name>:<tag>'. We need to pull and retag it for use
-		// in the WITH DOCKER command.
-		parts := strings.SplitN(pullImage, "/", 2)
-		if len(parts) != 2 {
-			return errors.Errorf("image name: %q", pullImage)
-		}
-
-		fullRef := buildkitRegistry + "/" + pullImage
-		err := w.c.containerFrontend.ImagePull(ctx, fullRef)
+	for result := range res.ResultChan {
+		// Pull and then retag all images with expected tags.
+		err := w.c.containerFrontend.ImagePull(ctx, result.IntermediateImageName)
 		if err != nil {
 			return err
 		}
-
 		err = w.c.containerFrontend.ImageTag(ctx, containerutil.ImageTag{
-			SourceRef: fullRef,
-			TargetRef: parts[1],
+			SourceRef: result.IntermediateImageName,
+			TargetRef: result.FinalImageName,
 		})
 		if err != nil {
-			return errors.Wrapf(err, "tag image %q", pullImage)
+			return errors.Wrapf(err, "tag image %q", result.FinalImageName)
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,6 @@ replace (
 
 	github.com/jessevdk/go-flags => github.com/alexcb/go-flags v0.0.0-20210722203016-f11d7ecb5ee5
 
-	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.1-0.20220715210015-e48456505a8a
+	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.1-0.20220715232025-8252b6eb0ca5
 	github.com/tonistiigi/fsutil => github.com/earthly/fsutil v0.0.0-20220707234217-feae5c0ecda9
 )

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,6 @@ replace (
 
 	github.com/jessevdk/go-flags => github.com/alexcb/go-flags v0.0.0-20210722203016-f11d7ecb5ee5
 
-	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.1-0.20220715232025-8252b6eb0ca5
+	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.1-0.20220716004228-a2a3e382a778
 	github.com/tonistiigi/fsutil => github.com/earthly/fsutil v0.0.0-20220707234217-feae5c0ecda9
 )

--- a/go.sum
+++ b/go.sum
@@ -370,8 +370,8 @@ github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
-github.com/earthly/buildkit v0.0.1-0.20220715210015-e48456505a8a h1:OziRzSSGyoP6SVmdrf1gZcELU3yCdcu5h252QCStgiE=
-github.com/earthly/buildkit v0.0.1-0.20220715210015-e48456505a8a/go.mod h1:jt1heLmQjKCZBBJJ8i1iTenQGjY1eK3xx2aO3Wf51Mc=
+github.com/earthly/buildkit v0.0.1-0.20220715232025-8252b6eb0ca5 h1:UUqxnQieIdtf54XEMUZMG0PPT0rvDlASX7qBSCrd30A=
+github.com/earthly/buildkit v0.0.1-0.20220715232025-8252b6eb0ca5/go.mod h1:jt1heLmQjKCZBBJJ8i1iTenQGjY1eK3xx2aO3Wf51Mc=
 github.com/earthly/cloud-api v1.0.1-0.20220712175328-2801d1e2bcb4 h1:ZgyAmuEFHK3y2E2Bm6YX7zD7wTba5QnREqu0Xjwrm9E=
 github.com/earthly/cloud-api v1.0.1-0.20220712175328-2801d1e2bcb4/go.mod h1:JhlHsW6o8zYa+XsM0nMAevRQtES35KE5R2G8tJALsnI=
 github.com/earthly/fsutil v0.0.0-20220707234217-feae5c0ecda9 h1:sUOTTlEFlgQiNdX1/ZY0S3fSwnT/qe8AEuNhQG+AaG4=

--- a/go.sum
+++ b/go.sum
@@ -370,8 +370,8 @@ github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
-github.com/earthly/buildkit v0.0.1-0.20220715232025-8252b6eb0ca5 h1:UUqxnQieIdtf54XEMUZMG0PPT0rvDlASX7qBSCrd30A=
-github.com/earthly/buildkit v0.0.1-0.20220715232025-8252b6eb0ca5/go.mod h1:jt1heLmQjKCZBBJJ8i1iTenQGjY1eK3xx2aO3Wf51Mc=
+github.com/earthly/buildkit v0.0.1-0.20220716004228-a2a3e382a778 h1:EBbvNI50GusDlimywUogub7cOlJee3gH1YhfCdjffIs=
+github.com/earthly/buildkit v0.0.1-0.20220716004228-a2a3e382a778/go.mod h1:jt1heLmQjKCZBBJJ8i1iTenQGjY1eK3xx2aO3Wf51Mc=
 github.com/earthly/cloud-api v1.0.1-0.20220712175328-2801d1e2bcb4 h1:ZgyAmuEFHK3y2E2Bm6YX7zD7wTba5QnREqu0Xjwrm9E=
 github.com/earthly/cloud-api v1.0.1-0.20220712175328-2801d1e2bcb4/go.mod h1:JhlHsW6o8zYa+XsM0nMAevRQtES35KE5R2G8tJALsnI=
 github.com/earthly/fsutil v0.0.0-20220707234217-feae5c0ecda9 h1:sUOTTlEFlgQiNdX1/ZY0S3fSwnT/qe8AEuNhQG+AaG4=

--- a/states/builderfun.go
+++ b/states/builderfun.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/earthly/earthly/util/platutil"
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // DockerTarImageSolver can create a Docker image and make it available as a tar
@@ -15,9 +16,20 @@ type DockerTarImageSolver interface {
 // ImageSolverResults contains data and channels that allow one to act on images
 // during and after they are built.
 type ImageSolverResults struct {
-	ResultChan  chan string
+	ResultChan  chan *ImageResult
 	ErrChan     chan error
 	ReleaseFunc func()
+}
+
+// ImageResult contains data about an image that was built.
+type ImageResult struct {
+	IntermediateImageName    string
+	FinalImageName           string
+	FinalImageNameWithDigest string
+	ImageDigest              string
+	ConfigDigest             string
+	ImageDescriptor          *ocispecs.Descriptor
+	Annotations              map[string]string
 }
 
 // ImageDef includes the information required to build an image in BuildKit.

--- a/tests/with-docker-registry/Earthfile
+++ b/tests/with-docker-registry/Earthfile
@@ -65,7 +65,9 @@ docker-pull-test-long:
 
 docker-load-test-long:
     WITH DOCKER --load foo.example.com/bar/buz:abc=+a-test-image
-        RUN docker images | grep foo.example.com/bar/buz | grep abc
+        RUN echo "@# j" && \
+            docker inspect foo.example.com/bar/buz:abc && \
+            docker images | grep foo.example.com/bar/buz | grep abc
     END
 
 docker-load-shellout-test:

--- a/tests/with-docker-registry/Earthfile
+++ b/tests/with-docker-registry/Earthfile
@@ -65,9 +65,7 @@ docker-pull-test-long:
 
 docker-load-test-long:
     WITH DOCKER --load foo.example.com/bar/buz:abc=+a-test-image
-        RUN echo "@# j" && \
-            docker inspect foo.example.com/bar/buz:abc && \
-            docker images | grep foo.example.com/bar/buz | grep abc
+        RUN docker images | grep foo.example.com/bar/buz | grep abc
     END
 
 docker-load-shellout-test:


### PR DESCRIPTION
Depends on https://github.com/earthly/buildkit/pull/85

This adds the digests of the images being loaded into `WITH DOCKER` into the LLB, such that if any of them change, the cache gets busted automatically.

@alexcb - note that there are changes in the PullPing callback. I hope it doesn't impact the stuff you're working on!