### PR TITLE
Set grpc-timeout Header when using Satellites

### DIFF
--- a/buildkitd/buildkitd.go
+++ b/buildkitd/buildkitd.go
@@ -885,7 +885,8 @@ func addRequiredOpts(settings Settings, opts ...client.ClientOpt) ([]client.Clie
 		return append(opts, client.WithAdditionalMetadataContext(
 			"satellite_name", settings.SatelliteName,
 			"satellite_org", settings.SatelliteOrgID,
-			"satellite_token", settings.SatelliteToken),
+			"satellite_token", settings.SatelliteToken,
+			"grpc-timeout", "30S"), // Tolerate slow internet connections from users to Satellites
 			client.WithCredentials("", "", "", ""), // force buildkit to use a TLS connection
 		), nil
 	}


### PR DESCRIPTION
Apparently, it's a [standard field](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md) for controlling timeouts on RPC calls.  

Not sure how much, if at all, this will improve usage on slow internet but it's worth a shot. 