### PR TITLE
display detailed progress on receving files

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -420,7 +420,7 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 	if opt.PrintPhases {
 		b.opt.Console.PrintPhaseHeader(PhaseBuild, false, "")
 	}
-	err := b.s.buildMainMulti(ctx, bf, onImage, onArtifact, onFinalArtifact, onPull, PhaseBuild)
+	err := b.s.buildMainMulti(ctx, bf, onImage, onArtifact, onFinalArtifact, onPull, PhaseBuild, b.opt.Console)
 	if err != nil {
 		return nil, errors.Wrapf(err, "build main")
 	}
@@ -444,7 +444,7 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 			}
 		}
 		if hasRunPush {
-			err = b.s.buildMainMulti(ctx, bf, onImage, onArtifact, onFinalArtifact, onPull, PhasePush)
+			err = b.s.buildMainMulti(ctx, bf, onImage, onArtifact, onFinalArtifact, onPull, PhasePush, b.opt.Console)
 			if err != nil {
 				return nil, errors.Wrapf(err, "build push")
 			}

--- a/builder/solver.go
+++ b/builder/solver.go
@@ -87,10 +87,7 @@ func (s *solver) newSolveOptMulti(ctx context.Context, eg *errgroup.Group, onIma
 		cacheExports = append(cacheExports, newInlineCacheOpt())
 	}
 
-	verboseProgressConsole := console.WithPrefixAndSalt("output",
-		"local context .", // TODO this salt must be the same as the salt used in SolverMonitor.processStatus
-	)
-	progressCB := fsutilprogress.New("", verboseProgressConsole)
+	progressCB := fsutilprogress.New("", console.WithPrefix("output"))
 
 	return &client.SolveOpt{
 		Exports: []client.ExportEntry{

--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -12,7 +12,7 @@ buildkitd:
             ARG BUILDKIT_BASE_IMAGE=$BUILDKIT_PROJECT+build
         END
     ELSE
-        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:0e732b962d4a3e66ed392546ee7cb5329afbc4c9+build
+        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:7a6f9e1ab2a3a3ddec5f9e612ef390af218a32bd+build
     END
     ARG EARTHLY_TARGET_TAG_DOCKER
     ARG TAG="dev-$EARTHLY_TARGET_TAG_DOCKER"

--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -12,7 +12,7 @@ buildkitd:
             ARG BUILDKIT_BASE_IMAGE=$BUILDKIT_PROJECT+build
         END
     ELSE
-        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:47e36164897b179f905c2852259308dfac0c3f93+build
+        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:0e732b962d4a3e66ed392546ee7cb5329afbc4c9+build
     END
     ARG EARTHLY_TARGET_TAG_DOCKER
     ARG TAG="dev-$EARTHLY_TARGET_TAG_DOCKER"

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,6 @@ replace (
 
 	github.com/jessevdk/go-flags => github.com/alexcb/go-flags v0.0.0-20210722203016-f11d7ecb5ee5
 
-	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.1-0.20220719221101-47e36164897b
-	github.com/tonistiigi/fsutil => github.com/earthly/fsutil v0.0.0-20220707234217-feae5c0ecda9
+	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.1-0.20220721003858-0e732b962d4a
+	github.com/tonistiigi/fsutil => github.com/earthly/fsutil v0.0.0-20220719234708-392da7eebeb5
 )

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,6 @@ replace (
 
 	github.com/jessevdk/go-flags => github.com/alexcb/go-flags v0.0.0-20210722203016-f11d7ecb5ee5
 
-	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.1-0.20220721003858-0e732b962d4a
+	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.1-0.20220721222420-7a6f9e1ab2a3
 	github.com/tonistiigi/fsutil => github.com/earthly/fsutil v0.0.0-20220719234708-392da7eebeb5
 )

--- a/go.sum
+++ b/go.sum
@@ -370,12 +370,12 @@ github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
-github.com/earthly/buildkit v0.0.1-0.20220719221101-47e36164897b h1:zKVSFrSv0QM3EFu3KD8SKmsxdTjmtF0aHErWbcqQ7Zc=
-github.com/earthly/buildkit v0.0.1-0.20220719221101-47e36164897b/go.mod h1:jt1heLmQjKCZBBJJ8i1iTenQGjY1eK3xx2aO3Wf51Mc=
+github.com/earthly/buildkit v0.0.1-0.20220721003858-0e732b962d4a h1:NkAeJOXWBUQXcwqHr2RnsdCVC8JoPXipivm7/Ho2ptw=
+github.com/earthly/buildkit v0.0.1-0.20220721003858-0e732b962d4a/go.mod h1:Ih6/jh6JTbktkhxRID0gj6dn2GAPI6H9U6xKVxgNqBk=
 github.com/earthly/cloud-api v1.0.1-0.20220712175328-2801d1e2bcb4 h1:ZgyAmuEFHK3y2E2Bm6YX7zD7wTba5QnREqu0Xjwrm9E=
 github.com/earthly/cloud-api v1.0.1-0.20220712175328-2801d1e2bcb4/go.mod h1:JhlHsW6o8zYa+XsM0nMAevRQtES35KE5R2G8tJALsnI=
-github.com/earthly/fsutil v0.0.0-20220707234217-feae5c0ecda9 h1:sUOTTlEFlgQiNdX1/ZY0S3fSwnT/qe8AEuNhQG+AaG4=
-github.com/earthly/fsutil v0.0.0-20220707234217-feae5c0ecda9/go.mod h1:oPAfvw32vlUJSjyDcQ3Bu0nb2ON2B+G0dtVN/SZNJiA=
+github.com/earthly/fsutil v0.0.0-20220719234708-392da7eebeb5 h1:bOKRnmQd1JYrtOUdkvYraBCT0SRjYpYnhd4i85mWtQw=
+github.com/earthly/fsutil v0.0.0-20220719234708-392da7eebeb5/go.mod h1:oPAfvw32vlUJSjyDcQ3Bu0nb2ON2B+G0dtVN/SZNJiA=
 github.com/elastic/go-sysinfo v1.7.1 h1:Wx4DSARcKLllpKT2TnFVdSUJOsybqMYCNQZq1/wO+s0=
 github.com/elastic/go-sysinfo v1.7.1/go.mod h1:i1ZYdU10oLNfRzq4vq62BEwD2fH8KaWh6eh0ikPT9F0=
 github.com/elastic/go-windows v1.0.0 h1:qLURgZFkkrYyTTkvYpsZIgf83AUsdIHfvlJaqaZ7aSY=

--- a/go.sum
+++ b/go.sum
@@ -370,8 +370,8 @@ github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
-github.com/earthly/buildkit v0.0.1-0.20220721003858-0e732b962d4a h1:NkAeJOXWBUQXcwqHr2RnsdCVC8JoPXipivm7/Ho2ptw=
-github.com/earthly/buildkit v0.0.1-0.20220721003858-0e732b962d4a/go.mod h1:Ih6/jh6JTbktkhxRID0gj6dn2GAPI6H9U6xKVxgNqBk=
+github.com/earthly/buildkit v0.0.1-0.20220721222420-7a6f9e1ab2a3 h1:GlnXERW8hl9hnoujynobzjpUrGTq4BUpOeB6ZaRkLhk=
+github.com/earthly/buildkit v0.0.1-0.20220721222420-7a6f9e1ab2a3/go.mod h1:Ih6/jh6JTbktkhxRID0gj6dn2GAPI6H9U6xKVxgNqBk=
 github.com/earthly/cloud-api v1.0.1-0.20220712175328-2801d1e2bcb4 h1:ZgyAmuEFHK3y2E2Bm6YX7zD7wTba5QnREqu0Xjwrm9E=
 github.com/earthly/cloud-api v1.0.1-0.20220712175328-2801d1e2bcb4/go.mod h1:JhlHsW6o8zYa+XsM0nMAevRQtES35KE5R2G8tJALsnI=
 github.com/earthly/fsutil v0.0.0-20220719234708-392da7eebeb5 h1:bOKRnmQd1JYrtOUdkvYraBCT0SRjYpYnhd4i85mWtQw=

--- a/outmon/vertexmeta.go
+++ b/outmon/vertexmeta.go
@@ -101,8 +101,14 @@ func (vm *VertexMeta) Salt() string {
 	default:
 		name = "unknown"
 	}
+
+	overridingArgsString := vm.OverridingArgsString()
+	if vm.Platform == "" && overridingArgsString == "" {
+		return name // don't hash when unmarshalling VertexMeta failed
+	}
+
 	h := fnv.New32a()
 	h.Write([]byte(vm.Platform))
-	h.Write([]byte(vm.OverridingArgsString()))
+	h.Write([]byte(overridingArgsString))
 	return fmt.Sprintf("%s-%d", name, h.Sum32())
 }

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -230,8 +230,8 @@ copy-test-verbose-output:
     # the shared cache key.
     RUN echo "#!/bin/sh
 set -x
-earthly --config \$earthly_config --verbose +all 2>output.txt;
-earthly --config \$earthly_config --verbose +all 2>output2.txt;
+earthly --config \$earthly_config --verbose +copy 2>output.txt;
+earthly --config \$earthly_config --verbose +copy 2>output2.txt;
 " >/tmp/multiple-earthly-script && chmod +x /tmp/multiple-earthly-script
 
     DO +RUN_EARTHLY --earthfile=copy-verbose.earth --exec_cmd=/tmp/multiple-earthly-script
@@ -247,6 +247,10 @@ earthly --config \$earthly_config --verbose +all 2>output2.txt;
     RUN if grep "sent data for a.txt" output2.txt >/dev/null; then echo "a.txt should not have been sent"; exit 1; fi
     RUN if grep "sent data for alpha.txt" output2.txt >/dev/null; then echo "alpha.txt should not have been sent"; exit 1; fi
     RUN if grep "sent data for .*beta.txt" output2.txt >/dev/null; then echo "beta.txt should not have been sent"; exit 1; fi
+
+    # test SAVE ARTIFACT AS LOCAL texts is output
+    DO +RUN_EARTHLY --earthfile=copy-verbose.earth --extra_args="--verbose" --target=+save --output_contains="received data for important-data .12 B."
+    RUN ls -la important-data
 
 cache-test:
     # Test that a file can be passed between runs through the mounted cache.

--- a/tests/copy-verbose.earth
+++ b/tests/copy-verbose.earth
@@ -1,6 +1,10 @@
 VERSION --use-copy-include-patterns 0.5
 FROM alpine:3.15
 
-all:
+copy:
     COPY a.txt .
     RUN cat a.txt | md5sum - | grep 0cc175b9c0f1b6a831c399e269772661
+
+save:
+    RUN echo -n "Gobbledygook" > important-data
+    SAVE ARTIFACT important-data AS LOCAL important-data

--- a/util/fsutilprogress/progress.go
+++ b/util/fsutilprogress/progress.go
@@ -1,0 +1,72 @@
+package fsutilprogress
+
+import (
+	"path"
+	"sync"
+
+	"github.com/dustin/go-humanize"
+	"github.com/earthly/earthly/conslogging"
+	"github.com/tonistiigi/fsutil"
+)
+
+// ProgressCallback exposes two different levels of callbacks for displaying status on files being sent or received
+type ProgressCallback interface {
+	Info(numBytes int, last bool)
+	Verbose(relPath string, status fsutil.VerboseProgressStatus, numBytes int)
+}
+
+type progressCallback struct {
+	console     conslogging.ConsoleLogger
+	mutex       sync.Mutex
+	pathPrefix  string
+	numStats    int
+	numSent     int
+	numReceived int
+	filesize    map[string]int
+}
+
+// New returns a new verbose progress callback for use with fsutil
+func New(pathPrefix string, console conslogging.ConsoleLogger) ProgressCallback {
+	return &progressCallback{
+		console:    console,
+		pathPrefix: pathPrefix,
+		filesize:   map[string]int{},
+	}
+}
+
+func (s *progressCallback) Info(numBytes int, last bool) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	if last {
+		s.console.Printf("transferred %d file(s) for context %s (%s, %d file/dir stats)", s.numSent, s.pathPrefix, humanize.Bytes(uint64(numBytes)), s.numStats)
+	}
+}
+
+func (s *progressCallback) Verbose(relPath string, status fsutil.VerboseProgressStatus, numBytes int) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	fullPath := path.Join(s.pathPrefix, relPath)
+	switch status {
+	case fsutil.StatusStat:
+		s.numStats++
+		//s.console.VerbosePrintf("sent file stat for %s\n", fullPath) ignored as it is too verbose. TODO add different verbose levels to support ExtraVerbosePrintf
+	case fsutil.StatusSent:
+		s.console.VerbosePrintf("sent data for %s (%s)\n", fullPath, humanize.Bytes(uint64(numBytes)))
+		s.numSent++
+	case fsutil.StatusReceiving:
+		s.filesize[fullPath] += numBytes
+		//ignore
+	case fsutil.StatusReceived:
+		if numBytes == 0 {
+			numBytes = s.filesize[fullPath]
+		}
+		s.console.VerbosePrintf("received data for %s (%s)\n", fullPath, humanize.Bytes(uint64(numBytes)))
+		s.numReceived++
+	case fsutil.StatusFailed:
+		s.console.VerbosePrintf("sent data for %s failed\n", fullPath)
+	case fsutil.StatusSkipped:
+		s.console.VerbosePrintf("ignoring %s\n", fullPath)
+	default:
+		s.console.Warnf("unhandled progress status %v (path=%s, numBytes=%d)\n", status, fullPath, numBytes)
+	}
+}


### PR DESCRIPTION
When running under `--verbose` mode, display individual files (and
filesize) being copied from containers onto the host.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>