### PR TITLE
fix python import

### DIFF
--- a/scripts/tests/interactive-debugger/test-interactive.py
+++ b/scripts/tests/interactive-debugger/test-interactive.py
@@ -6,7 +6,7 @@ import sys
 import io
 import os
 import shlex
-import importlib
+import importlib.util
 
 script_dir = os.path.dirname(os.path.realpath(__file__))
 


### PR DESCRIPTION
Not all python 3.X versions implicitly import `importlib.util` when only the
parent `importlib` is imported.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>