### PR TITLE
Add simple org invite accept command

### DIFF
--- a/cloud/client.go
+++ b/cloud/client.go
@@ -42,6 +42,7 @@ type Client interface {
 	CreateOrg(ctx context.Context, org string) error
 	Invite(ctx context.Context, org, user string, write bool) error
 	InviteToOrg(ctx context.Context, invite *OrgInvitation) (string, error)
+	AcceptInvite(ctx context.Context, inviteCode string) error
 	ListOrgs(ctx context.Context) ([]*OrgDetail, error)
 	ListOrgPermissions(ctx context.Context, path string) ([]*OrgPermissions, error)
 	RevokePermission(ctx context.Context, path, user string) error

--- a/cloud/org_new.go
+++ b/cloud/org_new.go
@@ -47,3 +47,19 @@ func (c *client) InviteToOrg(ctx context.Context, invite *OrgInvitation) (string
 
 	return res.Token, nil
 }
+
+// AcceptInvite accepts the org invitation and adds the user to the org.
+func (c *client) AcceptInvite(ctx context.Context, inviteCode string) error {
+	u := "/api/v0/invitations/" + inviteCode
+
+	status, body, err := c.doCall(ctx, http.MethodPost, u, withAuth())
+	if err != nil {
+		return err
+	}
+
+	if status != http.StatusOK {
+		return errors.Errorf("failed to accept invite: %s", body)
+	}
+
+	return nil
+}

--- a/cmd/earthly/org_cmds.go
+++ b/cmd/earthly/org_cmds.go
@@ -79,6 +79,15 @@ func (app *earthlyApp) orgCmdsPreview() []*cli.Command {
 					Required: false,
 				},
 			},
+			Subcommands: []*cli.Command{
+				{
+					Name:        "accept",
+					Usage:       "Accept an invitation to join an organization",
+					Description: "Accept an invitation to join an organization",
+					UsageText:   "earthly org invite accept <invite-code>",
+					Action:      app.actionOrgInviteAccept,
+				},
+			},
 		},
 	}
 }
@@ -177,6 +186,31 @@ func (app *earthlyApp) actionOrgInvite(cliCtx *cli.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to invite user into org")
 	}
+	return nil
+}
+
+func (app *earthlyApp) actionOrgInviteAccept(cliCtx *cli.Context) error {
+	app.commandName = "orgInviteAccept"
+
+	if cliCtx.NArg() != 1 {
+		return errors.New("invite code is required")
+	}
+
+	code := cliCtx.Args().Get(0)
+	if code == "" {
+		return errors.New("invite code is required")
+	}
+
+	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	if err != nil {
+		return errors.Wrap(err, "failed to create cloud client")
+	}
+
+	err = cloudClient.AcceptInvite(cliCtx.Context, code)
+	if err != nil {
+		return errors.Wrap(err, "failed to accept invite")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This PR adds a simple invitation accept command that can be used to complete the invitation flow from the CLI.

Here's an example:
```
$ earthly org invite accept <invite-code>
```

Perhaps we can expand the command later such that codes aren't required.

```
$ earthly org invite accept

You have a few invites. Please select one to accept:
  other-org
> cool-org
  less-cool-org
<return>
You've been added to "cool-org" as a "read-only" member.
```