### PR TITLE
account password reset

### DIFF
--- a/cloud/account.go
+++ b/cloud/account.go
@@ -272,3 +272,31 @@ func (c *client) ping(ctx context.Context) (email string, writeAccess bool, err 
 	}
 	return resp.Email, resp.WriteAccess, nil
 }
+
+func (c *client) AccountResetReqestToken(ctx context.Context, email string) error {
+	email = url.QueryEscape(email)
+	status, _, err := c.doCall(ctx, "PUT", "/api/v0/account/reset/"+email)
+	if err != nil {
+		return errors.Wrap(err, "failed executing account reset token request")
+	}
+	if status != http.StatusCreated {
+		return errors.Errorf("unexpected status code from account reset token request: %d", status)
+	}
+	return nil
+}
+
+func (c *client) AccountReset(ctx context.Context, email, token, password string) error {
+	createAccountRequest := secretsapi.ResetPasswordRequest{
+		Email:             email,
+		VerificationToken: token,
+		Password:          password,
+	}
+	status, _, err := c.doCall(ctx, "PUT", "/api/v0/account/reset", withJSONBody(&createAccountRequest))
+	if err != nil {
+		return errors.Wrap(err, "failed executing account reset request")
+	}
+	if status != http.StatusOK {
+		return errors.Errorf("unexpected status code from account reset request: %d", status)
+	}
+	return nil
+}

--- a/cloud/client.go
+++ b/cloud/client.go
@@ -83,6 +83,8 @@ type Client interface {
 	ListSecretPermissions(ctx context.Context, path string) ([]*SecretPermission, error)
 	SetSecretPermission(ctx context.Context, path, userEmail, permission string) error
 	RemoveSecretPermission(ctx context.Context, path, userEmail string) error
+	AccountResetReqestToken(ctx context.Context, userEmail string) error
+	AccountReset(ctx context.Context, userEmail, token, password string) error
 }
 
 type request struct {

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/docker/cli v20.10.14+incompatible
 	github.com/docker/distribution v2.8.1+incompatible
 	github.com/dustin/go-humanize v1.0.0
-	github.com/earthly/cloud-api v1.0.1-0.20220712175328-2801d1e2bcb4
+	github.com/earthly/cloud-api v1.0.1-0.20220728160826-b477d75c55f6
 	github.com/elastic/go-sysinfo v1.7.1
 	github.com/fatih/color v1.9.0
 	github.com/golang/protobuf v1.5.2

--- a/go.sum
+++ b/go.sum
@@ -372,8 +372,8 @@ github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/earthly/buildkit v0.0.1-0.20220721222420-7a6f9e1ab2a3 h1:GlnXERW8hl9hnoujynobzjpUrGTq4BUpOeB6ZaRkLhk=
 github.com/earthly/buildkit v0.0.1-0.20220721222420-7a6f9e1ab2a3/go.mod h1:Ih6/jh6JTbktkhxRID0gj6dn2GAPI6H9U6xKVxgNqBk=
-github.com/earthly/cloud-api v1.0.1-0.20220712175328-2801d1e2bcb4 h1:ZgyAmuEFHK3y2E2Bm6YX7zD7wTba5QnREqu0Xjwrm9E=
-github.com/earthly/cloud-api v1.0.1-0.20220712175328-2801d1e2bcb4/go.mod h1:JhlHsW6o8zYa+XsM0nMAevRQtES35KE5R2G8tJALsnI=
+github.com/earthly/cloud-api v1.0.1-0.20220728160826-b477d75c55f6 h1:4MCXNERT8+PnBJsgH/eaEdBLKKJuKbu4gb9agPUIG6o=
+github.com/earthly/cloud-api v1.0.1-0.20220728160826-b477d75c55f6/go.mod h1:JhlHsW6o8zYa+XsM0nMAevRQtES35KE5R2G8tJALsnI=
 github.com/earthly/fsutil v0.0.0-20220719234708-392da7eebeb5 h1:bOKRnmQd1JYrtOUdkvYraBCT0SRjYpYnhd4i85mWtQw=
 github.com/earthly/fsutil v0.0.0-20220719234708-392da7eebeb5/go.mod h1:oPAfvw32vlUJSjyDcQ3Bu0nb2ON2B+G0dtVN/SZNJiA=
 github.com/elastic/go-sysinfo v1.7.1 h1:Wx4DSARcKLllpKT2TnFVdSUJOsybqMYCNQZq1/wO+s0=


### PR DESCRIPTION
This adds two new calls:

    earthly account reset --email <email>

which sends a request to the server for a password reset token to be
send to the supplied email.

and:

    earthly account reset --email <email> --token <token>

which then prompts for a new password, which is then sent to the server,
to perform a password reset.

This additionally fixes the password prompt to prevent displaying a
newline before the cursor that accepts a hidden password on stdin (this
mimics the behaviour of the sudo command).

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>