### PR TITLE
Add `--cache-from` option for `build` command to import caches from registries

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -627,14 +627,14 @@ func (b *Builder) stateToRef(ctx context.Context, gwClient gwclient.Client, stat
 	noCache := b.opt.NoCache && !b.builtMain
 	return llbutil.StateToRef(
 		ctx, gwClient, state, noCache,
-		platr, b.opt.CacheImports.AsMap())
+		platr, b.opt.CacheImports.AsSlice())
 }
 
 func (b *Builder) artifactStateToRef(ctx context.Context, gwClient gwclient.Client, state pllb.State, platr *platutil.Resolver) (gwclient.Reference, error) {
 	noCache := b.opt.NoCache || b.builtMain
 	return llbutil.StateToRef(
 		ctx, gwClient, state, noCache,
-		platr, b.opt.CacheImports.AsMap())
+		platr, b.opt.CacheImports.AsSlice())
 }
 
 func (b *Builder) saveArtifactLocally(ctx context.Context, console *conslogging.BufferedLogger, artifact domain.Artifact, indexOutDir string, destPath string, salt string, opt BuildOpt, ifExists bool) error {

--- a/builder/image_solver.go
+++ b/builder/image_solver.go
@@ -51,7 +51,7 @@ func (s *tarImageSolver) newSolveOpt(img *image.Image, dockerTag string, w io.Wr
 		return nil, errors.Wrap(err, "image json marshal")
 	}
 	var cacheImports []client.CacheOptionsEntry
-	for ci := range s.cacheImports.AsMap() {
+	for _, ci := range s.cacheImports.AsSlice() {
 		cacheImports = append(cacheImports, newCacheImportOpt(ci))
 	}
 	return &client.SolveOpt{
@@ -285,7 +285,7 @@ func (m *multiImageSolver) SolveImages(ctx context.Context, imageDefs []*states.
 	)
 
 	var cacheImports []client.CacheOptionsEntry
-	for ci := range m.cacheImports.AsMap() {
+	for _, ci := range m.cacheImports.AsSlice() {
 		cacheImports = append(cacheImports, newCacheImportOpt(ci))
 	}
 
@@ -340,7 +340,7 @@ func (m *multiImageSolver) addRefToResult(ctx context.Context, gwClient gwclient
 		imageDef.ImageName += ":latest"
 	}
 
-	ref, err := llbutil.StateToRef(ctx, gwClient, saveImage.State, false, imageDef.MTS.Final.PlatformResolver, m.cacheImports.AsMap())
+	ref, err := llbutil.StateToRef(ctx, gwClient, saveImage.State, false, imageDef.MTS.Final.PlatformResolver, m.cacheImports.AsSlice())
 	if err != nil {
 		return errors.Wrap(err, "initial state to ref conversion")
 	}

--- a/builder/solver.go
+++ b/builder/solver.go
@@ -73,7 +73,7 @@ func (s *solver) buildMainMulti(ctx context.Context, bf gwclient.BuildFunc, onIm
 
 func (s *solver) newSolveOptMulti(ctx context.Context, eg *errgroup.Group, onImage onImageFunc, onArtifact onArtifactFunc, onFinalArtifact onFinalArtifactFunc, onPullCallback pullping.PullCallback, console conslogging.ConsoleLogger) (*client.SolveOpt, error) {
 	var cacheImports []client.CacheOptionsEntry
-	for ci := range s.cacheImports.AsMap() {
+	for _, ci := range s.cacheImports.AsSlice() {
 		cacheImports = append(cacheImports, newCacheImportOpt(ci))
 	}
 	var cacheExports []client.CacheOptionsEntry

--- a/cmd/earthly/build_cmd.go
+++ b/cmd/earthly/build_cmd.go
@@ -375,8 +375,10 @@ func (app *earthlyApp) actionBuildImp(cliCtx *cli.Context, flagArgs, nonFlagArgs
 	}
 
 	cacheImports := make([]string, 0)
-	if app.remoteCache != "" || len(app.cacheFrom.Value()) > 0 {
+	if app.remoteCache != "" {
 		cacheImports = append(cacheImports, app.remoteCache)
+	}
+	if len(app.cacheFrom.Value()) > 0 {
 		cacheImports = append(cacheImports, app.cacheFrom.Value()...)
 	}
 	var cacheExport string

--- a/cmd/earthly/build_cmd.go
+++ b/cmd/earthly/build_cmd.go
@@ -374,13 +374,10 @@ func (app *earthlyApp) actionBuildImp(cliCtx *cli.Context, flagArgs, nonFlagArgs
 		imageResolveMode = llb.ResolveModeForcePull
 	}
 
-	cacheImports := make(map[string]bool)
+	cacheImports := make([]string, 0)
 	if app.remoteCache != "" || len(app.cacheFrom.Value()) > 0 {
-		cacheImports[app.remoteCache] = true
-
-		for _, c := range app.cacheFrom.Value() {
-			cacheImports[c] = true
-		}
+		cacheImports = append(cacheImports, app.remoteCache)
+		cacheImports = append(cacheImports, app.cacheFrom.Value()...)
 	}
 	var cacheExport string
 	var maxCacheExport string

--- a/cmd/earthly/build_cmd.go
+++ b/cmd/earthly/build_cmd.go
@@ -375,8 +375,12 @@ func (app *earthlyApp) actionBuildImp(cliCtx *cli.Context, flagArgs, nonFlagArgs
 	}
 
 	cacheImports := make(map[string]bool)
-	if app.remoteCache != "" {
+	if app.remoteCache != "" || len(app.cacheFrom.Value()) > 0 {
 		cacheImports[app.remoteCache] = true
+
+		for _, c := range app.cacheFrom.Value() {
+			cacheImports[c] = true
+		}
 	}
 	var cacheExport string
 	var maxCacheExport string

--- a/cmd/earthly/flags.go
+++ b/cmd/earthly/flags.go
@@ -260,6 +260,13 @@ func (app *earthlyApp) buildFlags() []cli.Flag {
 			Destination: &app.buildkitdSettings.VolumeName,
 			Hidden:      true,
 		},
+		&cli.StringSliceFlag{
+			Name:    "cache-from",
+			EnvVars: []string{"EARTHLY_CACHE_FROM"},
+			Usage:   "Remote docker image tags to use as readonly explicit cache (experimental)",
+			Value:   &app.cacheFrom,
+			Hidden:  true, // Experimental
+		},
 		&cli.StringFlag{
 			Name:        "remote-cache",
 			EnvVars:     []string{"EARTHLY_REMOTE_CACHE"},

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -85,6 +85,7 @@ type cliFlags struct {
 	buildkitdImage            string
 	containerName             string
 	volumeName                string
+	cacheFrom                 cli.StringSlice
 	remoteCache               string
 	maxRemoteCache            bool
 	saveInlineCache           bool

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -946,7 +946,9 @@ func (c *Converter) SaveImage(ctx context.Context, imageNames []string, pushImag
 	if noManifestList && !c.ftrs.UseNoManifestList {
 		return fmt.Errorf("SAVE IMAGE --no-manifest-list is not supported in this version")
 	}
-	c.opt.CacheImports.Add(cacheFrom...)
+	for _, cf := range cacheFrom {
+		c.opt.CacheImports.Add(cf)
+	}
 	justCacheHint := false
 	if len(imageNames) == 0 && cacheHint {
 		imageNames = []string{""}

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -599,7 +599,7 @@ func (c *Converter) RunExitCode(ctx context.Context, opts ConvertRunOpts) (int, 
 	} else {
 		ref, err := llbutil.StateToRef(
 			ctx, c.opt.GwClient, state, c.opt.NoCache,
-			c.platr, c.opt.CacheImports.AsMap())
+			c.platr, c.opt.CacheImports.AsSlice())
 		if err != nil {
 			return 0, errors.Wrap(err, "run exit code state to ref")
 		}
@@ -689,7 +689,7 @@ func (c *Converter) runCommand(ctx context.Context, outputFileName string, isExp
 	} else {
 		ref, err := llbutil.StateToRef(
 			ctx, c.opt.GwClient, state, c.opt.NoCache,
-			c.platr, c.opt.CacheImports.AsMap())
+			c.platr, c.opt.CacheImports.AsSlice())
 		if err != nil {
 			return "", errors.Wrapf(err, "build arg state to ref")
 		}
@@ -946,9 +946,7 @@ func (c *Converter) SaveImage(ctx context.Context, imageNames []string, pushImag
 	if noManifestList && !c.ftrs.UseNoManifestList {
 		return fmt.Errorf("SAVE IMAGE --no-manifest-list is not supported in this version")
 	}
-	for _, cf := range cacheFrom {
-		c.opt.CacheImports.Add(cf)
-	}
+	c.opt.CacheImports.Add(cacheFrom...)
 	justCacheHint := false
 	if len(imageNames) == 0 && cacheHint {
 		imageNames = []string{""}
@@ -1844,7 +1842,7 @@ func (c *Converter) forceExecution(ctx context.Context, state pllb.State, platr 
 	}
 	ref, err := llbutil.StateToRef(
 		ctx, c.opt.GwClient, state, c.opt.NoCache,
-		platr, c.opt.CacheImports.AsMap())
+		platr, c.opt.CacheImports.AsSlice())
 	if err != nil {
 		return errors.Wrap(err, "force execution state to ref")
 	}
@@ -1867,7 +1865,7 @@ func (c *Converter) readArtifact(ctx context.Context, mts *states.MultiTarget, a
 	}
 	ref, err := llbutil.StateToRef(
 		ctx, c.opt.GwClient, mts.Final.ArtifactsState, c.opt.NoCache,
-		mts.Final.PlatformResolver, c.opt.CacheImports.AsMap())
+		mts.Final.PlatformResolver, c.opt.CacheImports.AsSlice())
 	if err != nil {
 		return nil, errors.Wrap(err, "state to ref solve artifact")
 	}

--- a/earthfile2llb/wait_block.go
+++ b/earthfile2llb/wait_block.go
@@ -127,7 +127,7 @@ func (wb *waitBlock) saveImages(ctx context.Context) error {
 		pullPingMap := item.c.opt.PullPingMap
 		ref, err := llbutil.StateToRef(
 			ctx, item.c.opt.GwClient, item.si.State, item.c.opt.NoCache,
-			item.c.platr, item.c.opt.CacheImports.AsMap())
+			item.c.platr, item.c.opt.CacheImports.AsSlice())
 		if err != nil {
 			return errors.Wrapf(err, "failed to solve image required for %s", item.si.DockerTag)
 		}

--- a/earthfile2llb/withdockerrunbase.go
+++ b/earthfile2llb/withdockerrunbase.go
@@ -117,7 +117,7 @@ func (w *withDockerRunBase) getComposeConfig(ctx context.Context, opt WithDocker
 	state := w.c.mts.Final.MainState.Run(runOpts...).Root()
 	ref, err := llbutil.StateToRef(
 		ctx, w.c.opt.GwClient, state, w.c.opt.NoCache,
-		w.c.platr, w.c.opt.CacheImports.AsMap())
+		w.c.platr, w.c.opt.CacheImports.AsSlice())
 	if err != nil {
 		return nil, errors.Wrap(err, "state to ref compose config")
 	}

--- a/states/cacheimports.go
+++ b/states/cacheimports.go
@@ -4,35 +4,35 @@ import "sync"
 
 // CacheImports is a synchronized set of cache imports.
 type CacheImports struct {
-	mu    sync.Mutex
-	store map[string]bool
+	mu    sync.RWMutex
+	store []string
 }
 
 // NewCacheImports creates a new cache imports structure.
-func NewCacheImports(imports map[string]bool) *CacheImports {
-	store := make(map[string]bool)
-	for k, v := range imports {
-		store[k] = v
-	}
+func NewCacheImports(imports []string) *CacheImports {
+	clone := make([]string, len(imports))
+	copy(clone, imports)
+
 	return &CacheImports{
-		store: store,
+		store: clone,
 	}
 }
 
-// Add adds an import to the set.
-func (ci *CacheImports) Add(tag string) {
+// Add adds imports to the set.
+func (ci *CacheImports) Add(tags ...string) {
 	ci.mu.Lock()
 	defer ci.mu.Unlock()
-	ci.store[tag] = true
+
+	ci.store = append(ci.store, tags...)
 }
 
-// AsMap returns the cache imports contents as a map.
-func (ci *CacheImports) AsMap() map[string]bool {
-	ci.mu.Lock()
-	defer ci.mu.Unlock()
-	copy := make(map[string]bool)
-	for k, v := range ci.store {
-		copy[k] = v
-	}
-	return copy
+// AsSlice returns the cache imports contents as a slice.
+func (ci *CacheImports) AsSlice() []string {
+	ci.mu.RLock()
+	defer ci.mu.RUnlock()
+
+	clone := make([]string, len(ci.store))
+	copy(clone, ci.store)
+
+	return clone
 }

--- a/states/cacheimports.go
+++ b/states/cacheimports.go
@@ -5,7 +5,8 @@ import "sync"
 // CacheImports is a synchronized set of cache imports.
 type CacheImports struct {
 	mu    sync.RWMutex
-	store []string
+	slice []string
+	store map[string]bool
 }
 
 // NewCacheImports creates a new cache imports structure.
@@ -13,8 +14,14 @@ func NewCacheImports(imports []string) *CacheImports {
 	clone := make([]string, len(imports))
 	copy(clone, imports)
 
+	store := make(map[string]bool)
+	for _, tag := range imports {
+		store[tag] = true
+	}
+
 	return &CacheImports{
-		store: clone,
+		slice: clone,
+		store: store,
 	}
 }
 
@@ -23,7 +30,21 @@ func (ci *CacheImports) Add(tags ...string) {
 	ci.mu.Lock()
 	defer ci.mu.Unlock()
 
-	ci.store = append(ci.store, tags...)
+	ci.slice = append(ci.slice, tags...)
+
+	for _, tag := range tags {
+		ci.store[tag] = true
+	}
+}
+
+// Has checks if a passed tag is added.
+func (ci *CacheImports) Has(tag string) bool {
+	ci.mu.RLock()
+	defer ci.mu.RUnlock()
+
+	_, ok := ci.store[tag]
+
+	return ok
 }
 
 // AsSlice returns the cache imports contents as a slice.
@@ -31,8 +52,8 @@ func (ci *CacheImports) AsSlice() []string {
 	ci.mu.RLock()
 	defer ci.mu.RUnlock()
 
-	clone := make([]string, len(ci.store))
-	copy(clone, ci.store)
+	clone := make([]string, len(ci.slice))
+	copy(clone, ci.slice)
 
 	return clone
 }

--- a/util/llbutil/statetoref.go
+++ b/util/llbutil/statetoref.go
@@ -2,7 +2,6 @@ package llbutil
 
 import (
 	"context"
-	"sort"
 
 	"github.com/earthly/earthly/util/llbutil/pllb"
 	"github.com/earthly/earthly/util/platutil"
@@ -12,18 +11,13 @@ import (
 )
 
 // StateToRef takes an LLB state, solves it using gateway and returns the ref.
-func StateToRef(ctx context.Context, gwClient gwclient.Client, state pllb.State, noCache bool, platr *platutil.Resolver, cacheImports map[string]bool) (gwclient.Reference, error) {
+func StateToRef(ctx context.Context, gwClient gwclient.Client, state pllb.State, noCache bool, platr *platutil.Resolver, cacheImports []string) (gwclient.Reference, error) {
 	platform := platr.SubPlatform(platr.Current())
 	if noCache {
 		state = state.SetMarshalDefaults(llb.IgnoreCache)
 	}
-	cacheImportsSlice := make([]string, 0, len(cacheImports))
-	for ci := range cacheImports {
-		cacheImportsSlice = append(cacheImportsSlice, ci)
-	}
-	sort.Strings(cacheImportsSlice)
 	var coes []gwclient.CacheOptionsEntry
-	for _, ci := range cacheImportsSlice {
+	for _, ci := range cacheImports {
 		coe := gwclient.CacheOptionsEntry{
 			Type:  "registry",
 			Attrs: map[string]string{"ref": ci},


### PR DESCRIPTION
Related #1693

I added `--cache-from` option as experimental to import caches from registries.
This feature leads to help us to efficiently run CI in a topic branch.

Usages:
```
earthly --cache-from=someone/image1:latest +example
```

```
earthly --remote-cache=someone/image:topic-branch \
        --cache-from=someone/image:main \
        --cache-from=someone/image:stable \ 
        +example
```