### PR TITLE
use docker compose rather than docker-compose

### DIFF
--- a/tests/local/with-docker-compose-local-reg/Earthfile
+++ b/tests/local/with-docker-compose-local-reg/Earthfile
@@ -15,5 +15,5 @@ test:
             --compose docker-compose.yml \
             --service webserver \
             --load fetch:latest=+fetch
-        RUN docker-compose up --exit-code-from fetch fetch | grep 'Hello World'
+        RUN docker compose up --exit-code-from fetch fetch | grep 'Hello World'
     END

--- a/tests/local/with-docker-compose-local/Earthfile
+++ b/tests/local/with-docker-compose-local/Earthfile
@@ -15,5 +15,5 @@ test:
             --compose docker-compose.yml \
             --service webserver \
             --load fetch:latest=+fetch
-        RUN docker-compose up --exit-code-from fetch fetch | grep 'Hello World'
+        RUN docker compose up --exit-code-from fetch fetch | grep 'Hello World'
     END


### PR DESCRIPTION
Update locally tests to use "docker compose" instead of deprecated
docker-compose.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>