### PR TITLE
Added support for passing secrets to `FROM DOCKERFILE` command

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -31,6 +31,7 @@ import (
 	"github.com/moby/buildkit/client/llb"
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/moby/buildkit/session"
+	"github.com/moby/buildkit/session/secrets"
 	"github.com/moby/buildkit/util/entitlements"
 	reccopy "github.com/otiai10/copy"
 	"github.com/pkg/errors"
@@ -76,6 +77,7 @@ type Opt struct {
 	FeatureFlagOverrides   string
 	ContainerFrontend      containerutil.ContainerFrontend
 	InternalSecretStore    *secretprovider.MutableMapStore
+	SecretProviders        []secrets.SecretStore
 }
 
 // BuildOpt is a collection of build options.
@@ -185,6 +187,7 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 				DoPushes:              opt.Push,
 				PullPingMap:           pullPingMap,
 				InternalSecretStore:   b.opt.InternalSecretStore,
+				SecretProviders:       b.opt.SecretProviders,
 			}
 			mts, err = earthfile2llb.Earthfile2LLB(childCtx, target, opt, true)
 			if err != nil {

--- a/earthfile2llb/earthfile2llb.go
+++ b/earthfile2llb/earthfile2llb.go
@@ -10,6 +10,7 @@ import (
 	"github.com/earthly/earthly/util/platutil"
 	"github.com/moby/buildkit/client/llb"
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
+	"github.com/moby/buildkit/session/secrets"
 	"github.com/pkg/errors"
 
 	"github.com/earthly/earthly/ast/spec"
@@ -133,6 +134,10 @@ type ConvertOpt struct {
 	// It is mainly used to pass along parameters to buildkit processes without
 	// invalidating the cache.
 	InternalSecretStore *secretprovider.MutableMapStore
+
+	// SecretProviders is a list of secretStores
+	// It provides access to secrets
+	SecretProviders []secrets.SecretStore
 }
 
 // Earthfile2LLB parses a earthfile and executes the statements for a given target.

--- a/earthfile2llb/flags.go
+++ b/earthfile2llb/flags.go
@@ -45,6 +45,7 @@ type fromDockerfileOpts struct {
 	Platform  string   `long:"platform" description:"The platform to use"`
 	Target    string   `long:"target" description:"The Dockerfile target to inherit from"`
 	Path      string   `short:"f" description:"The Dockerfile location on the host, relative to the current Earthfile, or as an artifact reference"`
+	Secrets   []string `long:"secret" description:"List of secrets to be pass to the dockerfile"`
 }
 
 type copyOpts struct {

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -919,6 +919,12 @@ from-dockerfile-arg:
     RUN test "$(cat ./arg-value-foo)" = "foo"
     RUN test "$(cat ./arg-value-bar)" = "bar"
 
+from-dockerfile-secrets:
+    ENV TEST_SECRET_2="this is secret from ENV"
+    DO +RUN_EARTHLY --earthfile=from-dockerfile-secrets.earth \
+    --extra_args="--secret TEST_SECRET_2 --secret SUPER_SECRET=foosecret" \
+    --target=+test
+
 cache-mount-arg:
     DO +RUN_EARTHLY --earthfile=cache-mount-arg.earth --use_tmpfs=false --target="+b-nomount --MYARG=123"
     DO +RUN_EARTHLY --earthfile=cache-mount-arg.earth --use_tmpfs=false --target="+b-nomount --MYARG=1234" --post_command="2>output-nomount.txt"

--- a/tests/from-dockerfile-secrets.earth
+++ b/tests/from-dockerfile-secrets.earth
@@ -1,0 +1,19 @@
+VERSION 0.6
+
+test:
+    FROM DOCKERFILE --secret TEST_SECRET_2 --secret TEST_SECRET_1=+secrets/SUPER_SECRET +create-dockerfile/
+    RUN test "$(cat /TEST_ENV_SECRET_1.txt)" = "foosecret"
+    RUN test "$(cat /TEST_ENV_SECRET_2.txt)" = "this is secret from ENV"
+
+create-dockerfile:
+        FROM alpine:3.15
+        RUN mkdir dist
+        RUN echo "
+FROM busybox:latest
+
+RUN --mount=type=secret,id=TEST_SECRET_1,target=/mount.txt cp /mount.txt /TEST_ENV_SECRET_1.txt
+RUN --mount=type=secret,id=TEST_SECRET_2,target=/mount.txt cp /mount.txt /TEST_ENV_SECRET_2.txt
+
+" > dist/Dockerfile
+    RUN cat dist/Dockerfile
+    SAVE ARTIFACT dist/*


### PR DESCRIPTION
Fixes: #1483

This PR allows user to pass secrets to `FROM DOCKERFILE`  earthly command/stage. secret can be pass to `FROM DOCKERFILE` with flag ```--secret```.

### example:

#### Dockerfile
```
FROM busybox:latest

RUN --mount=type=secret,id=TEST_SECRET_1,target=/mount.txt cp /mount.txt /TEST_ENV_SECRET_1.txt
RUN --mount=type=secret,id=TEST_SECRET_2,target=/mount.txt cp /mount.txt /TEST_ENV_SECRET_2.txt
```
#### Earthfile
```
test:
    FROM DOCKERFILE --secret TEST_SECRET_1 --secret TEST_SECRET_2=+secrets/SUPER_SECRET .
    RUN test "$(cat /TEST_ENV_SECRET_1.txt)" = "this is secret from env"
    RUN test "$(cat /TEST_ENV_SECRET_2.txt)" = "foo"

```

#### Set Env Locally
```
export TEST_SECRET_1="this is secret from env"
```

#### Build target test from Earthfile
```
earthly --secret TEST_SECRET_1 --secret  SUPER_SECRET="foo"  --no-cache +test
```

OUTPUT:
```
            internal | --> load metadata for docker.io/library/busybox:latest
             stage-0 | --> FROM docker.io/library/busybox:latest@sha256:ef320ff10026a50cf5f0213d35537ce0041ac1d96e9b7800bafd8bc9eff6c693
             stage-0 | [          ]   0% resolve docker.io/library/busybox:latest@sha256:ef320ff10026a50cf5f0213d35537ce0041ac1d96e9b7800bafd8bc9eff6c693 [██████████] 100% resolve docker.io/library/busybox:latest@sha256:ef320ff10026a50cf5f0213d35537ce0041ac1d96e9b7800bafd8bc9eff6c693
             stage-0 | --> RUN --mount=type=secret,id=TEST_SECRET_1,target=/mount.txt cp /mount.txt /TEST_ENV_SECRET_1.txt
             stage-0 | --> RUN --mount=type=secret,id=TEST_SECRET_2,target=/mount.txt cp /mount.txt /TEST_ENV_SECRET_2.txt
               +test | --> RUN test "$(cat /TEST_ENV_SECRET_1.txt)" = "this is secret from env"
               +test | --> RUN test "$(cat /TEST_ENV_SECRET_2.txt)" = "foo"
              output | --> exporting outputs

```

I have also added a test case under /tests/from-dockerfile-secrets.earth which can be run as 
```
./build/linux/amd64/earthly --no-cache -P ./tests+from-dockerfile-secrets --DOCKERHUB_AUTH=false
```


