### PR TITLE
increase unit-test timeout

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -195,7 +195,7 @@ unit-test:
     COPY podman-setup.sh .
     WITH DOCKER
         RUN ./podman-setup.sh && \
-            go test ./...
+            go test -timeout 20m ./...
     END
 
 changelog:


### PR DESCRIPTION
The M1 buildkite instance is struggling to complete unit-tests under the
default timeout value of 10m; this increases it to 20m.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>