### PR TITLE
Fix `WITH DOCKER` loading when image contains port number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 ### Fixed
 
 - Fixed an incompatibility with older versions of remote BuildKits and Satellites, which was resulting in Earthly crashing.
+- Fixed `WITH DOCKER` not loading correctly when the image name contained a port number under `VERSION --use-registry-for-with-docker`. [#2071](https://github.com/earthly/earthly/issues/2071)
 
 ### Changed
 

--- a/builder/image_solver.go
+++ b/builder/image_solver.go
@@ -198,6 +198,20 @@ func (m *multiImageSolver) SolveImages(ctx context.Context, imageDefs []*states.
 		return ret, nil
 	}
 
+	newInterImgFormat := false
+	info, err := m.bkClient.Info(ctx)
+	if err != nil {
+		// Maybe older buildkit.
+	} else {
+		switch info.BuildkitVersion.Version {
+		case "v0.6.19":
+		case "v0.6.20":
+		default:
+			newInterImgFormat = true
+		}
+	}
+
+	onPullMap := make(map[string]string) // intermediate image name -> final image name
 	// This func is executed when the image create/push process is complete.
 	onPull := func(ctx context.Context, images []string, resp map[string]string) error {
 		if resp == nil {
@@ -205,17 +219,15 @@ func (m *multiImageSolver) SolveImages(ctx context.Context, imageDefs []*states.
 		}
 		results := make([]*states.ImageResult, len(images))
 		for i, img := range images {
-			// Note that this img split by / algo is also repeated in the
-			// dockerd wrapper.
-			imgParts := strings.SplitN(img, "/", 2)
-			if len(imgParts) != 2 {
-				return errors.Errorf(
-					"invalid image name: %s. Was expecting sess prefix", img)
+			finalImageName, ok := onPullMap[img]
+			if !ok {
+				return errors.Errorf("image %s not found in onPullMap", img)
 			}
 			result := &states.ImageResult{
 				IntermediateImageName: img,
-				FinalImageName:        imgParts[1],
+				FinalImageName:        finalImageName,
 				Annotations:           make(map[string]string),
+				NewInterImgFormat:     newInterImgFormat,
 			}
 
 			for k, v := range resp {
@@ -270,7 +282,7 @@ func (m *multiImageSolver) SolveImages(ctx context.Context, imageDefs []*states.
 		gwCrafter := gatewaycrafter.NewGatewayCrafter()
 
 		for i, imageDef := range imageDefs {
-			err := m.addRefToResult(childCtx, gwClient, gwCrafter, imageDef, i)
+			err := m.addRefToResult(childCtx, gwClient, gwCrafter, imageDef, i, onPullMap, newInterImgFormat)
 			if err != nil {
 				return nil, err
 			}
@@ -333,7 +345,7 @@ func (m *multiImageSolver) SolveImages(ctx context.Context, imageDefs []*states.
 	return ret, nil
 }
 
-func (m *multiImageSolver) addRefToResult(ctx context.Context, gwClient gwclient.Client, gwCrafter *gatewaycrafter.GatewayCrafter, imageDef *states.ImageDef, imageIndex int) error {
+func (m *multiImageSolver) addRefToResult(ctx context.Context, gwClient gwclient.Client, gwCrafter *gatewaycrafter.GatewayCrafter, imageDef *states.ImageDef, imageIndex int, onPullMap map[string]string, newInterImgFormat bool) error {
 	saveImage := imageDef.MTS.Final.LastSaveImage()
 
 	if !strings.Contains(imageDef.ImageName, ":") {
@@ -350,8 +362,13 @@ func (m *multiImageSolver) addRefToResult(ctx context.Context, gwClient gwclient
 		return err
 	}
 
-	localRegPullID := fmt.Sprintf("sess-%s/%s", gwClient.BuildOpts().SessionID, imageDef.ImageName)
+	var localRegPullID string
+	if newInterImgFormat {
+		localRegPullID = fmt.Sprintf("sess-%s:img-%d", gwClient.BuildOpts().SessionID, imageIndex)
+	} else {
+		localRegPullID = fmt.Sprintf("sess-%s/%s", gwClient.BuildOpts().SessionID, imageDef.ImageName)
+	}
 	gwCrafter.AddMeta(fmt.Sprintf("%s/export-image-local-registry", refPrefix), []byte(localRegPullID))
-
+	onPullMap[localRegPullID] = imageDef.ImageName
 	return nil
 }

--- a/buildkitd/buildkitd.go
+++ b/buildkitd/buildkitd.go
@@ -204,6 +204,14 @@ func MaybeRestart(ctx context.Context, console conslogging.ConsoleLogger, image,
 		}
 		bkCons.Printf("Settings do not match. Restarting buildkit daemon with updated settings...\n")
 	} else {
+		if settings.NoUpdate {
+			bkCons.Printf("Updated image available. But update was inhibited.\n")
+			info, workerInfo, err := checkConnection(ctx, settings.BuildkitAddress, opts...)
+			if err != nil {
+				return nil, nil, err
+			}
+			return info, workerInfo, nil
+		}
 		bkCons.Printf("Updated image available. Restarting buildkit daemon...\n")
 	}
 

--- a/buildkitd/dockerd-wrapper.sh
+++ b/buildkitd/dockerd-wrapper.sh
@@ -195,13 +195,13 @@ load_registry_images() {
         for img in $EARTHLY_DOCKER_LOAD_REGISTRY; do
             case "$img" in
                 *'|'*)
-                    with_reg="$buildkit_docker_registry"/$(printf '%s' "$img" | cut -d'|' -f1)
-                    user_tag=$(printf '%s' "$img" | cut -d'|' -f2-)
+                    with_reg="$buildkit_docker_registry/$(printf '%s' "$img" | cut -d'|' -f1)"
+                    user_tag="$(printf '%s' "$img" | cut -d'|' -f2-)"
                     ;;
                 *)
                     # Old format before v0.6.21.
                     with_reg="$buildkit_docker_registry/$img"
-                    user_tag=$(printf '%s' "$img" | cut -d'/' -f2-)
+                    user_tag="$(printf '%s' "$img" | cut -d'/' -f2-)"
                     echo "Detected old format"
                     ;;
             esac

--- a/buildkitd/dockerd-wrapper.sh
+++ b/buildkitd/dockerd-wrapper.sh
@@ -193,8 +193,18 @@ load_registry_images() {
     if [ -n "$EARTHLY_DOCKER_LOAD_REGISTRY" ]; then
         echo "Loading images from BuildKit via embedded registry..."
         for img in $EARTHLY_DOCKER_LOAD_REGISTRY; do
-            user_tag=$(printf '%s' "$img" | cut -d'/' -f2-)
-            with_reg="$buildkit_docker_registry/$img"
+            case "$img" in
+                *'|'*)
+                    with_reg="$buildkit_docker_registry"/$(printf '%s' "$img" | cut -d'|' -f1)
+                    user_tag=$(printf '%s' "$img" | cut -d'|' -f2-)
+                    ;;
+                *)
+                    # Old format before v0.6.21.
+                    with_reg="$buildkit_docker_registry/$img"
+                    user_tag=$(printf '%s' "$img" | cut -d'/' -f2-)
+                    echo "Detected old format"
+                    ;;
+            esac
             echo "Pulling $with_reg and retagging as $user_tag"
             (docker pull "$with_reg" && docker tag "$with_reg" "$user_tag" && docker rmi "$with_reg") || (stop_dockerd; exit 1)
         done

--- a/buildkitd/settings.go
+++ b/buildkitd/settings.go
@@ -35,6 +35,7 @@ type Settings struct {
 	SatelliteOrgID       string `hash:"ignore"`
 	SatelliteToken       string `hash:"ignore"`
 	EnableProfiler       bool
+	NoUpdate             bool `hash:"ignore"`
 }
 
 // Hash returns a secure hash of the settings.

--- a/cmd/earthly/flags.go
+++ b/cmd/earthly/flags.go
@@ -87,6 +87,13 @@ func (app *earthlyApp) rootFlags() []cli.Flag {
 			Hidden:      true, // Internal.
 		},
 		&cli.BoolFlag{
+			Name:        "no-buildkit-update",
+			EnvVars:     []string{"EARTHLY_NO_BUILDKIT_UPDATE"},
+			Usage:       "Disable the automatic update of buildkitd",
+			Destination: &app.noBuildkitUpdate,
+			Hidden:      true, // Internal.
+		},
+		&cli.BoolFlag{
 			EnvVars:     []string{"EARTHLY_DISABLE_ANALYTICS", "DO_NOT_TRACK"},
 			Usage:       "Disable collection of analytics",
 			Destination: &app.disableAnalytics,

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -136,6 +136,7 @@ type cliFlags struct {
 	satelliteOrg              string
 	noSatellite               bool
 	userPermission            string
+	noBuildkitUpdate          bool
 }
 
 type analyticsMetadata struct {
@@ -455,6 +456,7 @@ func (app *earthlyApp) before(context *cli.Context) error {
 	app.buildkitdSettings.CacheSizeMb = app.cfg.Global.BuildkitCacheSizeMb
 	app.buildkitdSettings.CacheSizePct = app.cfg.Global.BuildkitCacheSizePct
 	app.buildkitdSettings.EnableProfiler = app.enableProfiler
+	app.buildkitdSettings.NoUpdate = app.noBuildkitUpdate
 
 	// ensure the MTU is something allowable in IPv4, cap enforced by type. Zero is autodetect.
 	if app.cfg.Global.CniMtu != 0 && app.cfg.Global.CniMtu < 68 {

--- a/earthfile2llb/withdockerrunbase.go
+++ b/earthfile2llb/withdockerrunbase.go
@@ -3,6 +3,7 @@ package earthfile2llb
 import (
 	"context"
 	"fmt"
+	"path"
 	"strings"
 
 	"github.com/containerd/containerd/platforms"
@@ -128,4 +129,42 @@ func (w *withDockerRunBase) getComposeConfig(ctx context.Context, opt WithDocker
 		return nil, errors.Wrap(err, "read compose config file")
 	}
 	return composeConfigDt, nil
+}
+
+func makeWithDockerdWrapFun(dindID string, tarPaths []string, imgsWithDigests []string, opt WithDockerOpt) shellWrapFun {
+	dockerRoot := path.Join("/var/earthly/dind", dindID)
+	params := []string{
+		fmt.Sprintf("EARTHLY_DOCKERD_DATA_ROOT=\"%s\"", dockerRoot),
+		fmt.Sprintf("EARTHLY_DOCKER_LOAD_FILES=\"%s\"", strings.Join(tarPaths, " ")),
+		// This is not actually used, but it is needed in order to bust the cache
+		// in case an image is updated.
+		fmt.Sprintf("EARTHLY_IMAGES_WITH_DIGESTS=\"%s\"", strings.Join(imgsWithDigests, " ")),
+	}
+	params = append(params, composeParams(opt)...)
+	return func(args []string, envVars []string, isWithShell, withDebugger, forceDebugger bool) []string {
+		envVars2 := append(params, envVars...)
+		return []string{
+			"/bin/sh", "-c",
+			strWithEnvVarsAndDocker(args, envVars2, isWithShell, withDebugger, forceDebugger, true, false, "", ""),
+		}
+	}
+}
+
+func composeParams(opt WithDockerOpt) []string {
+	return []string{
+		fmt.Sprintf("EARTHLY_START_COMPOSE=\"%t\"", (len(opt.ComposeFiles) > 0)),
+		fmt.Sprintf("EARTHLY_COMPOSE_FILES=\"%s\"", strings.Join(opt.ComposeFiles, " ")),
+		fmt.Sprintf("EARTHLY_COMPOSE_SERVICES=\"%s\"", strings.Join(opt.ComposeServices, " ")),
+		// fmt.Sprintf("EARTHLY_DEBUG=\"true\""),
+	}
+}
+
+func platformIncompatMsg(platr *platutil.Resolver) string {
+	currentPlatStr := platr.Materialize(platr.Current()).String()
+	nativePlatStr := platr.Materialize(platutil.NativePlatform).String()
+	return "running WITH DOCKER as a non-native CPU architecture. This is not supported.\n" +
+		fmt.Sprintf("Current platform: %s\n", currentPlatStr) +
+		fmt.Sprintf("Native platform of the worker: %s\n", nativePlatStr) +
+		"Try using\n\n\tFROM --platform=native earthly/dind:alpine\n\ninstead.\n" +
+		"You may still --load and --pull images of a different platform.\n"
 }

--- a/earthfile2llb/withdockerrunreg.go
+++ b/earthfile2llb/withdockerrunreg.go
@@ -207,20 +207,15 @@ func (w *withDockerRunRegistry) Run(ctx context.Context, args []string, opt With
 			"EARTHLY_DOCKER_LOAD_REGISTRY",
 			llb.SecretID(dockerLoadRegistrySecretID),
 			llb.SecretAsEnv(true),
-		),
-	)
+		))
 	err = w.c.opt.InternalSecretStore.SetSecret(
 		ctx, dockerLoadRegistrySecretID, []byte(strings.Join(pullImages, " ")))
 	if err != nil {
 		return errors.Wrap(err, "set docker load registry secret")
 	}
 	w.c.opt.CleanCollection.Add(func() error {
-		err = w.c.opt.InternalSecretStore.DeleteSecret(
+		return w.c.opt.InternalSecretStore.DeleteSecret(
 			context.TODO(), dockerLoadRegistrySecretID)
-		if err != nil {
-			return err
-		}
-		return nil
 	})
 
 	crOpts.shellWrap = makeWithDockerdWrapFun(dindID, nil, imgsWithDigests, opt)

--- a/states/builderfun.go
+++ b/states/builderfun.go
@@ -30,6 +30,7 @@ type ImageResult struct {
 	ConfigDigest             string
 	ImageDescriptor          *ocispecs.Descriptor
 	Annotations              map[string]string
+	NewInterImgFormat        bool
 }
 
 // ImageDef includes the information required to build an image in BuildKit.

--- a/tests/with-docker-registry/Earthfile
+++ b/tests/with-docker-registry/Earthfile
@@ -7,6 +7,7 @@ all:
     BUILD +docker-pull-test
     BUILD +docker-pull-test-long
     BUILD +docker-load-test-long
+    BUILD +docker-load-test-long-with-port
     BUILD +docker-load-shellout-test
     BUILD +load-parallel-test
     BUILD +docker-load-multi-test
@@ -66,6 +67,11 @@ docker-pull-test-long:
 docker-load-test-long:
     WITH DOCKER --load foo.example.com/bar/buz:abc=+a-test-image
         RUN docker images | grep foo.example.com/bar/buz | grep abc
+    END
+
+docker-load-test-long-with-port:
+    WITH DOCKER --load foo.example.com:9999/bar/buz:abc=+a-test-image
+        RUN docker images | grep foo.example.com:9999/bar/buz | grep abc
     END
 
 docker-load-shellout-test:


### PR DESCRIPTION
Fixes https://github.com/earthly/earthly/issues/2071

This PR goes the extra mile to maintain forwards-backwards compatibility given the usage of the feature flag via satellites. Besides the automated test added, I have also manually tested old earthly + new buildkit and new earthly + old buildkit (this particular bug is not fixed in these combinations, but everything else still works).

Minor hidden addition as part of this PR: a way to inhibit buildkit updating and restarting (`earthly --no-buildkit-update`) - this helps test an old buildkit with a new earthly.