### PR TITLE
Fixed issue-1986: EXPOSE parse problem

### DIFF
--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -141,6 +141,8 @@ ga:
     BUILD +escape-test
     BUILD +escape-test --EARTHFILE=escape-v0.5.earth
     BUILD +escape-dir-test
+    BUILD ./expose-test+all
+    BUILD +expose-fail-test
     BUILD +fail-invalid-artifact-test
     BUILD +target-first-line
     BUILD +absolute-reference-with-relative
@@ -567,6 +569,9 @@ escape-dir-test:
     RUN mkdir ./dir-with-+-in-it
     COPY escape-dir2.earth ./dir-with-+-in-it/Earthfile
     DO +RUN_EARTHLY --earthfile=escape-dir1.earth --extra_args="--no-output" --target=+test
+
+expose-fail-test:
+    DO +RUN_EARTHLY --earthfile=expose-fail-test.earth --should_fail=true --target=+test --output_contains="failed to parse EXPOSE 8084/idp: invalid protocol idp"
 
 eine-test-base:
     FROM docker:19.03.12-dind

--- a/tests/expose-fail-test.earth
+++ b/tests/expose-fail-test.earth
@@ -1,0 +1,9 @@
+VERSION 0.6
+FROM earthly/dind:alpine
+
+build-image:
+    EXPOSE 8084/idp
+    SAVE IMAGE expose-image:latest
+
+test:
+    BUILD +build-image

--- a/tests/expose-test/Earthfile
+++ b/tests/expose-test/Earthfile
@@ -1,0 +1,29 @@
+VERSION 0.6
+FROM earthly/dind:alpine
+
+all:
+    BUILD +test
+
+build-image:
+    FROM alpine:3.15
+    EXPOSE 8080
+    EXPOSE 8081:8082/tcp
+    EXPOSE 8083/udp
+    EXPOSE 8084-8086
+    EXPOSE 8087 8088
+    SAVE IMAGE expose-image:latest
+
+test:
+    WITH DOCKER --load=+build-image
+        RUN docker inspect expose-image:latest | jq '.[].Config.ExposedPorts' > inspect.txt
+    END
+    RUN test -f inspect.txt
+    RUN cat inspect.txt
+    RUN cat inspect.txt | grep "8080/tcp"
+    RUN cat inspect.txt | grep "8082/tcp"
+    RUN cat inspect.txt | grep "8083/udp"
+    RUN cat inspect.txt | grep "8084/tcp"
+    RUN cat inspect.txt | grep "8085/tcp"
+    RUN cat inspect.txt | grep "8086/tcp"
+    RUN cat inspect.txt | grep "8087/tcp"
+    RUN cat inspect.txt | grep "8088/tcp"


### PR DESCRIPTION
Fixes: https://github.com/earthly/earthly/issues/1986
Earthfile:
```
VERSION 0.6
FROM alpine:3.15
test:
    EXPOSE 8080:8081
    EXPOSE 8082
    EXPOSE 8083 8084
    SAVE IMAGE earthly-expose:latest
```
Dockerfile:
```
FROM alpine:3.15
EXPOSE 8080:8081
EXPOSE 8082
EXPOSE 8083 8084
```
Docker containers:
```
$ docker ps
CONTAINER ID   IMAGE                                     COMMAND                  CREATED         STATUS         PORTS                                                NAMES
dba016652adb   docker-expose:latest                      "/bin/sh"                5 seconds ago   Up 4 seconds   8081-8084/tcp                                        goofy_mestorf
4300adb49d2f   earthly-expose:latest                     "/bin/sh"                3 seconds ago    Up 2 seconds    8081-8084/tcp                                        friendly_buck
```
`docker inspect` command output on dockerfile image:
```
$ docker inspect dba016652adb | jq '.[].Config.ExposedPorts'
{
  "8081/tcp": {},
  "8082/tcp": {},
  "8083/tcp": {},
  "8084/tcp": {}
}
```
`docker inspect` command output on earthfile image:
```
$ docker inspect 4300adb49d2f | jq '.[].Config.ExposedPorts'
{
  "8081/tcp": {},
  "8082/tcp": {},
  "8083/tcp": {},
  "8084/tcp": {}
}
```