### PR TITLE
rename buildkit+update-buildkit target to avoid confusion

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -53,7 +53,7 @@ update-buildkit:
     ARG BUILDKIT_GIT_BRANCH=earthly-main
     ARG BUILDKIT_GIT_ORG=earthly
     COPY (./buildkitd+buildkit-sha/buildkit_sha --BUILDKIT_GIT_ORG="$BUILDKIT_GIT_ORG" --BUILDKIT_GIT_SHA="$BUILDKIT_GIT_SHA" --BUILDKIT_GIT_BRANCH="$BUILDKIT_GIT_BRANCH") buildkit_sha
-    BUILD  ./buildkitd+update-buildkit --BUILDKIT_GIT_ORG="$BUILDKIT_GIT_ORG" --BUILDKIT_GIT_SHA="$(cat buildkit_sha)"
+    BUILD  ./buildkitd+update-buildkit-earthfile --BUILDKIT_GIT_ORG="$BUILDKIT_GIT_ORG" --BUILDKIT_GIT_SHA="$(cat buildkit_sha)"
     RUN --no-cache go mod edit -replace "github.com/moby/buildkit=github.com/$BUILDKIT_GIT_ORG/buildkit@$(cat buildkit_sha)"
     RUN --no-cache go mod tidy
     SAVE ARTIFACT go.mod AS LOCAL go.mod

--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -88,7 +88,7 @@ buildkit-sha:
         echo "$buildkit_sha1" > buildkit_sha
     SAVE ARTIFACT buildkit_sha buildkit_sha
 
-update-buildkit:
+update-buildkit-earthfile:
     LOCALLY
     ARG --required BUILDKIT_GIT_SHA
     ARG --required BUILDKIT_GIT_ORG


### PR DESCRIPTION
This renames the buildkit+update-buildkit target, to avoid confusion
regarding which `+update-buildkit` target users should run when updating
earthly to use a different buildkit version.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>