### PR TITLE
WAIT/END support for save artifact as local

### DIFF
--- a/builder/solver.go
+++ b/builder/solver.go
@@ -3,7 +3,6 @@ package builder
 import (
 	"context"
 	"io"
-	"strconv"
 
 	"github.com/earthly/earthly/conslogging"
 	"github.com/earthly/earthly/domain"
@@ -20,7 +19,7 @@ import (
 )
 
 type onImageFunc func(context.Context, *errgroup.Group, string) (io.WriteCloser, error)
-type onArtifactFunc func(context.Context, int, domain.Artifact, string, string) (string, error)
+type onArtifactFunc func(context.Context, string, domain.Artifact, string, string) (string, error)
 type onFinalArtifactFunc func(context.Context) (string, error)
 
 type solver struct {
@@ -109,11 +108,7 @@ func (s *solver) newSolveOptMulti(ctx context.Context, eg *errgroup.Group, onIma
 					if md["final-artifact"] == "true" {
 						return onFinalArtifact(ctx)
 					}
-					indexStr := md["dir-index"]
-					index, err := strconv.Atoi(indexStr)
-					if err != nil {
-						return "", errors.Wrapf(err, "parse dir-index %s", indexStr)
-					}
+					indexStr := md["dir-id"]
 					artifactStr := md["artifact"]
 					srcPath := md["src-path"]
 					destPath := md["dest-path"]
@@ -121,7 +116,7 @@ func (s *solver) newSolveOptMulti(ctx context.Context, eg *errgroup.Group, onIma
 					if err != nil {
 						return "", errors.Wrapf(err, "parse artifact %s", artifactStr)
 					}
-					return onArtifact(ctx, index, artifact, srcPath, destPath)
+					return onArtifact(ctx, indexStr, artifact, srcPath, destPath)
 				},
 				OutputPullCallback: pullping.PullCallback(onPullCallback),
 				VerboseProgressCB:  progressCB.Verbose,

--- a/earthfile2llb/earthfile2llb.go
+++ b/earthfile2llb/earthfile2llb.go
@@ -129,10 +129,16 @@ type ConvertOpt struct {
 	// PullPingMap points to the per-connection map used by the builder's onPull callback
 	PullPingMap *gatewaycrafter.PullPingMap
 
+	// LocalArtifactWhiteList points to the per-connection list of seen SAVE ARTIFACT ... AS LOCAL entries
+	LocalArtifactWhiteList *gatewaycrafter.LocalArtifactWhiteList
+
 	// InternalSecretStore is a secret store used internally by Earthly.
 	// It is mainly used to pass along parameters to buildkit processes without
 	// invalidating the cache.
 	InternalSecretStore *secretprovider.MutableMapStore
+
+	// TempEarthlyOutDir is a path to a temp dir where artifacts are temporarily saved
+	TempEarthlyOutDir func() (string, error)
 }
 
 // Earthfile2LLB parses a earthfile and executes the statements for a given target.

--- a/earthfile2llb/interpreter.go
+++ b/earthfile2llb/interpreter.go
@@ -419,6 +419,10 @@ func (i *Interpreter) handleWait(ctx context.Context, waitStmt spec.WaitStatemen
 		return i.errorf(waitStmt.SourceLocation, "the WAIT command is not supported in this version")
 	}
 
+	if !i.converter.ftrs.ReferencedSaveOnly {
+		return i.errorf(waitStmt.SourceLocation, "the WAIT command requires the --referenced-save-only feature")
+	}
+
 	if len(waitStmt.Args) != 0 {
 		return i.errorf(waitStmt.SourceLocation, "WAIT does not accept any options")
 	}
@@ -809,6 +813,11 @@ func (i *Interpreter) handleCopy(ctx context.Context, cmd spec.Command) error {
 			if err != nil {
 				return i.wrapError(err, cmd.SourceLocation, "failed to expand COPY src %s", src)
 			}
+
+			if i.converter.opt.LocalArtifactWhiteList.Exists(expandedSrc) {
+				return i.errorf(cmd.SourceLocation, "unable to copy file %s, which has is outputted elsewhere by SAVE ARTIFACT AS LOCAL", expandedSrc)
+			}
+
 			srcs[index] = expandedSrc
 			allArtifacts = false
 		}

--- a/tests/git-webserver/Earthfile
+++ b/tests/git-webserver/Earthfile
@@ -99,7 +99,7 @@ nginx -c /root/nginx.conf
         mkdir -p /test/repo && \
         cd /test/repo && \
         git init --initial-branch=main . && \
-        echo -e "FROM alpine:3.15\nhello:\n\tRUN echo -n 98e15fb5-197c-43bf-886e-3291e65d646e | base64" > Earthfile && \
+        echo -e "VERSION 0.6\nFROM alpine:3.15\nhello:\n\tRUN echo -n 98e15fb5-197c-43bf-886e-3291e65d646e | base64" > Earthfile && \
         git add Earthfile && \
         git config --global user.email "onlyspammersemailthis@earthly.dev" && \
         git config --global user.name "test name" && \

--- a/tests/scrub-https-credentials/Earthfile
+++ b/tests/scrub-https-credentials/Earthfile
@@ -61,6 +61,7 @@ ping -c 1 selfsigned.example.com
 ping -c 1 buildkitsandbox
 
 earthly --config \$earthly_config config git \"{selfsigned.example.com: {auth: https, user: testuser, password: keepitsecret, pattern: 'selfsigned.example.com/([^/]+)'}}\"
+cat \$earthly_config
 earthly --config \$earthly_config --verbose --debug selfsigned.example.com/repo:main+hello >output.txt 2>&1
 " >/tmp/test-earthly-script && chmod +x /tmp/test-earthly-script
 
@@ -73,7 +74,7 @@ earthly --config \$earthly_config --verbose --debug selfsigned.example.com/repo:
         else \
             echo "OK: password was not leaked"; \
         fi
-    # make sure the scrubbed URL appears somewhere
+    # make sure the scrubbed URL appears somewhere (usually under llb.customname under the debug-level gwclientlogger)
     RUN grep 'https://testuser:\*\*\*@selfsigned.example.com' output.txt >/dev/null
     # echo -n 98e15fb5-197c-43bf-886e-3291e65d646e | base64
     RUN grep 'OThlMTVmYjUtMTk3Yy00M2JmLTg4NmUtMzI5MWU2NWQ2NDZl' output.txt >/dev/null

--- a/tests/wait-block/save-artifact/.gitignore
+++ b/tests/wait-block/save-artifact/.gitignore
@@ -1,0 +1,3 @@
+data
+earthly.exitcode
+earthly.log

--- a/tests/wait-block/save-artifact/Earthfile
+++ b/tests/wait-block/save-artifact/Earthfile
@@ -1,0 +1,51 @@
+VERSION --wait-block 0.6
+
+produce-file:
+    FROM alpine:3.15
+    RUN sleep 3 # to allow wait/end bugs to more easily propigate
+    RUN echo -n foo > data
+    SAVE ARTIFACT data AS LOCAL data
+
+check-file-locally:
+    LOCALLY
+    RUN md5sum data | grep acbd18db4cc2f85cedef654fccc4a4d8
+
+change-file:
+    FROM alpine:3.15
+    COPY data .
+    RUN echo -n bar >> data
+    SAVE ARTIFACT data AS LOCAL data
+
+second-copy-should-fail:
+    FROM alpine:3.15
+    COPY data . # this is should fail, as we don't allow copying in a file (with the same path) after it's already been output
+    RUN test -f data && echo dGhpcyBtYWdpYyBzdHJpbmcgc2hvdWxkIG5ldmVyIGFwcGVhcgo= | base64 -d # we should never reach this point
+
+double-check-file-locally:
+    LOCALLY
+    RUN md5sum data && md5sum data | grep 3858f62230ac3c915f300c664312c63f # should be "foobar"
+
+test:
+    WAIT
+        WAIT
+            BUILD +produce-file
+        END
+        BUILD +check-file-locally
+    END
+
+test-fail:
+    WAIT
+        WAIT
+            BUILD +change-file
+        END
+        WAIT
+            WAIT
+            END
+        END
+    END
+    WAIT
+        BUILD +double-check-file-locally
+    END
+    WAIT
+        BUILD +second-copy-should-fail
+    END

--- a/tests/wait-block/save-artifact/test.sh
+++ b/tests/wait-block/save-artifact/test.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -uex
+set -o pipefail
+
+# Unset referenced-save-only.
+export EARTHLY_VERSION_FLAG_OVERRIDES=""
+
+cd "$(dirname "$0")"
+
+earthly=${earthly-"../../../build/linux/amd64/earthly"}
+"$earthly" --version
+
+# display a pass/fail message at the end
+function finish {
+  status="$?"
+  if [ "$status" = "0" ]; then
+    echo "save-artifact test passed"
+  else
+    echo "save-artifact test failed with $status"
+  fi
+}
+trap finish EXIT
+
+# Cleanup from previous tests
+rm -f data
+
+"$earthly" $@ +test
+test "$(cat data)" = "foo"
+
+# next, check for an expected failure
+set +e
+("$earthly" $@ +test-fail; echo $? > earthly.exitcode) 2>&1 | tee earthly.log
+set -e
+test "$(cat earthly.exitcode)" = "1"
+grep 'unable to copy file data, which has is outputted elsewhere' earthly.log
+
+if grep "this magic string should never appear" earthly.log >/dev/null; then
+  echo "magic string command should never have run, but did"
+  exit 1
+fi

--- a/util/gatewaycrafter/gatewaycrafter.go
+++ b/util/gatewaycrafter/gatewaycrafter.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/earthly/earthly/states/image"
+	"github.com/earthly/earthly/util/stringutil"
 
 	"github.com/moby/buildkit/exporter/containerimage/exptypes"
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
@@ -52,6 +53,22 @@ func (gc *GatewayCrafter) AddPushImageEntry(ref gwclient.Reference, refID int, i
 		gc.AddMeta(refPrefix+"/platform", []byte(platformStr))
 	}
 	return refPrefix, nil // TODO once all earthlyoutput-metadata-related code is moved into saveimageutil, change to "return err" only
+}
+
+// AddSaveArtifactLocal adds ref and metadata required to trigger an artifact export to the local host
+func (gc *GatewayCrafter) AddSaveArtifactLocal(ref gwclient.Reference, refID int, artifact, srcPath, destPath string) (string, error) {
+	refKey := fmt.Sprintf("dir-%d", refID)
+	refPrefix := fmt.Sprintf("ref/%s", refKey)
+	gc.AddRef(refKey, ref)
+
+	dirID := stringutil.RandomAlphanumeric(32)
+	gc.AddMeta(fmt.Sprintf("%s/artifact", refPrefix), []byte(artifact))
+	gc.AddMeta(fmt.Sprintf("%s/src-path", refPrefix), []byte(srcPath))
+	gc.AddMeta(fmt.Sprintf("%s/dest-path", refPrefix), []byte(destPath))
+	gc.AddMeta(fmt.Sprintf("%s/export-dir", refPrefix), []byte("true"))
+	gc.AddMeta(fmt.Sprintf("%s/dir-id", refPrefix), []byte(dirID))
+
+	return dirID, nil
 }
 
 // AddRef adds a reference to the results to be exported.

--- a/util/gatewaycrafter/localartifactwhitelist.go
+++ b/util/gatewaycrafter/localartifactwhitelist.go
@@ -1,0 +1,44 @@
+package gatewaycrafter
+
+import (
+	"sync"
+)
+
+// LocalArtifactWhiteList is a set of paths which have been seen in a SAVE ARTIFACT ... AS LOCAL command
+type LocalArtifactWhiteList struct {
+	m     sync.Mutex
+	paths map[string]struct{}
+}
+
+// NewLocalArtifactWhiteList returns a new LocalArtifactWhiteList
+func NewLocalArtifactWhiteList() *LocalArtifactWhiteList {
+	return &LocalArtifactWhiteList{
+		paths: map[string]struct{}{},
+	}
+}
+
+// Exists returns true if the path exists in the set
+func (l *LocalArtifactWhiteList) Exists(k string) bool {
+	l.m.Lock()
+	defer l.m.Unlock()
+	_, exists := l.paths[k]
+	return exists
+}
+
+// Add adds the path to the set of paths
+func (l *LocalArtifactWhiteList) Add(path string) {
+	l.m.Lock()
+	defer l.m.Unlock()
+	l.paths[path] = struct{}{}
+}
+
+// AsList returns a copy of the set as a list
+func (l *LocalArtifactWhiteList) AsList() []string {
+	l.m.Lock()
+	defer l.m.Unlock()
+	paths := []string{}
+	for path := range l.paths {
+		paths = append(paths, path)
+	}
+	return paths
+}

--- a/util/saveartifactlocally/saveartifactlocally.go
+++ b/util/saveartifactlocally/saveartifactlocally.go
@@ -1,0 +1,123 @@
+package saveartifactlocally
+
+import (
+	"context"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/earthly/earthly/conslogging"
+	"github.com/earthly/earthly/domain"
+
+	reccopy "github.com/otiai10/copy"
+	"github.com/pkg/errors"
+)
+
+// SaveArtifactLocally handles saving artifacts to the local host, and is called from both builder and waitblock
+func SaveArtifactLocally(ctx context.Context, parentConsole conslogging.ConsoleLogger, console *conslogging.BufferedLogger, artifact domain.Artifact, indexOutDir string, destPath string, salt string, printPhases, ifExists bool) error {
+	fromPattern := filepath.Join(indexOutDir, filepath.FromSlash(artifact.Artifact))
+	// Resolve possible wildcards.
+	// TODO: Note that this is not very portable, as the glob is host-platform dependent,
+	//       while the pattern is also guest-platform dependent.
+	fromGlobMatches, err := filepath.Glob(fromPattern)
+	if err != nil {
+		return errors.Wrapf(err, "glob")
+	} else if !artifact.Target.IsRemote() && len(fromGlobMatches) <= 0 {
+		if ifExists {
+			return nil
+		}
+		return errors.Errorf("cannot save artifact %s, since it does not exist", artifact.StringCanonical())
+	}
+	isWildcard := strings.ContainsAny(fromPattern, `*?[`)
+	for _, from := range fromGlobMatches {
+		fiSrc, err := os.Stat(from)
+		if err != nil {
+			return errors.Wrapf(err, "os stat %s", from)
+		}
+		srcIsDir := fiSrc.IsDir()
+		to := destPath
+		destIsDir := strings.HasSuffix(to, "/") || to == "."
+		if artifact.Target.IsLocalExternal() && !filepath.IsAbs(to) {
+			// Place within external dir.
+			to = path.Join(artifact.Target.LocalPath, to)
+		}
+		if destIsDir {
+			// Place within dest dir.
+			to = path.Join(to, path.Base(from))
+		}
+		destExists := false
+		fiDest, err := os.Stat(to)
+		if err != nil {
+			// Ignore err. Likely dest path does not exist.
+			if isWildcard && !destIsDir {
+				return errors.New(
+					"artifact is a wildcard, but AS LOCAL destination does not end with /")
+			}
+			destIsDir = fiSrc.IsDir()
+		} else {
+			destExists = true
+			destIsDir = fiDest.IsDir()
+		}
+		if srcIsDir && !destIsDir {
+			return errors.New(
+				"artifact is a directory, but existing AS LOCAL destination is a file")
+		}
+		if destExists {
+			if !srcIsDir {
+				// Remove preexisting dest file.
+				err = os.Remove(to)
+				if err != nil {
+					return errors.Wrapf(err, "rm %s", to)
+				}
+			} else {
+				// Remove preexisting dest dir.
+				err = os.RemoveAll(to)
+				if err != nil {
+					return errors.Wrapf(err, "rm -rf %s", to)
+				}
+			}
+		}
+
+		toDir := path.Dir(to)
+		err = os.MkdirAll(toDir, 0755)
+		if err != nil {
+			return errors.Wrapf(err, "mkdir all for artifact %s", toDir)
+		}
+		err = os.Link(from, to)
+		if err != nil {
+			// Hard linking did not work. Try recursive copy.
+			errCopy := reccopy.Copy(from, to)
+			if errCopy != nil {
+				return errors.Wrapf(errCopy, "copy artifact %s", from)
+			}
+		}
+
+		// Write to console about this artifact.
+		artifactPath := trimFilePathPrefix(indexOutDir, from, parentConsole)
+		artifact2 := domain.Artifact{
+			Target:   artifact.Target,
+			Artifact: artifactPath,
+		}
+		destPath2 := filepath.FromSlash(destPath)
+		if strings.HasSuffix(destPath, "/") {
+			destPath2 = filepath.Join(destPath2, filepath.Base(artifactPath))
+		}
+		if printPhases {
+			artifactColor := parentConsole.WithPrefixAndSalt(artifact.Target.String(), salt).PrefixColor()
+			artifactStr := artifactColor.Sprintf("%s", artifact2.StringCanonical())
+			console.Printf("Artifact %s output as %s\n", artifactStr, destPath2)
+		}
+	}
+	return nil
+}
+
+func trimFilePathPrefix(prefix string, thePath string, console conslogging.ConsoleLogger) string {
+	ret, err := filepath.Rel(prefix, thePath)
+	if err != nil {
+		console.Warnf("Warning: Could not compute relative path for %s "+
+			"as being relative to %s: %s\n", thePath, prefix, err.Error())
+		return thePath
+	}
+	return ret
+}


### PR DESCRIPTION
This extends the WAIT/END code to support waiting for an artifact to be
saved locally before continuing.

This introduces a new constraint that prevents a user from copying a
file into a context after it has already been output by earthly.
Previously such a workflow was not possible as outputs always happened
at the end of an earthly build (after all copies were performed).

This changes the save artifact as local workflow to use a random
alphanumeric string rather than an index-<number>, due to the fact that
multiple wait/end blocks may now be processed in parallel, which would
lead to conflicting index-<number> entries.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>