### PR TITLE
Friendlier message on ctrl-c in satellite launch or rm

### DIFF
--- a/cmd/earthly/satellite_cmds.go
+++ b/cmd/earthly/satellite_cmds.go
@@ -162,6 +162,10 @@ func (app *earthlyApp) actionSatelliteLaunch(cliCtx *cli.Context) error {
 	app.console.Printf("Launching Satellite. This could take a moment...\n")
 	err = cloudClient.LaunchSatellite(cliCtx.Context, app.satelliteName, orgID)
 	if err != nil {
+		if errors.Cause(err) == context.Canceled {
+			app.console.Printf("Operation cancelled. Satellite will finish launching in background.\n")
+			return nil
+		}
 		return errors.Wrapf(err, "failed to create satellite %s", app.satelliteName)
 	}
 	app.console.Printf("...Done\n")
@@ -223,6 +227,10 @@ func (app *earthlyApp) actionSatelliteRemove(cliCtx *cli.Context) error {
 	app.console.Printf("Destroying Satellite. This could take a moment...\n")
 	err = cloudClient.DeleteSatellite(cliCtx.Context, app.satelliteName, orgID)
 	if err != nil {
+		if errors.Cause(err) == context.Canceled {
+			app.console.Printf("Operation cancelled. Satellite will finish destroying in background.\n")
+			return nil
+		}
 		return errors.Wrapf(err, "failed to delete satellite %s", app.satelliteName)
 	}
 	app.console.Printf("...Done\n")

--- a/cmd/earthly/satellite_cmds.go
+++ b/cmd/earthly/satellite_cmds.go
@@ -163,7 +163,7 @@ func (app *earthlyApp) actionSatelliteLaunch(cliCtx *cli.Context) error {
 	err = cloudClient.LaunchSatellite(cliCtx.Context, app.satelliteName, orgID)
 	if err != nil {
 		if errors.Cause(err) == context.Canceled {
-			app.console.Printf("Operation cancelled. Satellite will finish launching in background.\n")
+			app.console.Printf("Operation interrupted. Satellite should finish launching in background (if server received request).\n")
 			return nil
 		}
 		return errors.Wrapf(err, "failed to create satellite %s", app.satelliteName)
@@ -228,7 +228,7 @@ func (app *earthlyApp) actionSatelliteRemove(cliCtx *cli.Context) error {
 	err = cloudClient.DeleteSatellite(cliCtx.Context, app.satelliteName, orgID)
 	if err != nil {
 		if errors.Cause(err) == context.Canceled {
-			app.console.Printf("Operation cancelled. Satellite will finish destroying in background.\n")
+			app.console.Printf("Operation interrupted. Satellite should finish destroying in background (if server received request).\n")
 			return nil
 		}
 		return errors.Wrapf(err, "failed to delete satellite %s", app.satelliteName)


### PR DESCRIPTION
The operations can be long, especially the delete, and the user may not want to wait for it. The backend handles context-cancelled and allows the operation to finish gracefully. 

<img width="552" alt="Screen Shot 2022-08-11 at 11 12 13 AM" src="https://user-images.githubusercontent.com/3247216/184167335-e97d99a4-788a-4292-bd71-76d64e2f4e5f.png">
