### PR TITLE
print pass/failure message as final line on test

### DIFF
--- a/.buildkite/tests.sh
+++ b/.buildkite/tests.sh
@@ -2,6 +2,7 @@
 set -xeu
 
 function cleanup() {
+    status="$?"
     jobs="$(jobs -p)"
     if [ -n "$jobs" ]
     then
@@ -9,6 +10,11 @@ function cleanup() {
         kill $jobs
     fi
     wait
+    if [ "$status" = "0" ]; then
+      echo "buildkite-test passed"
+    else
+      echo "buildkite-test failed with $status"
+    fi
 }
 trap cleanup EXIT
 


### PR DESCRIPTION
This displays a final pass/failure on the buildkite test, to make
it obvious when the test passes.

Without this, a user may mistake the output of the fail-test (the test
that validates earthly returns a failure code on errors) as the
buildkite-test failing.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>