### PR TITLE
Fix WITH DOCKER WAIT/END related bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,6 +277,18 @@ jobs:
       - name: Execute wait-block test (Fork Only)
         run: ./tests/wait-block/test.sh --build-arg DOCKERHUB_AUTH=false
         if: github.event_name != 'push' && github.event.pull_request.head.repo.full_name != github.repository
+      - name: Execute with-docker test using wait-block override (Earthly Only)
+        run: |-
+          ./build/linux/amd64/earthly --ci -P --version-flag-overrides="wait-block,use-copy-include-patterns" \
+              --build-arg DOCKERHUB_AUTH=true \
+              --build-arg DOCKERHUB_USER_SECRET=+secrets/earthly-technologies/dockerhub-mirror/user \
+              --build-arg DOCKERHUB_TOKEN_SECRET=+secrets/earthly-technologies/dockerhub-mirror/pass \
+              --build-arg DOCKERHUB_MIRROR=registry-1.docker.io.mirror.corp.earthly.dev \
+          ./tests/with-docker+all
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+      - name: Execute wait-block test (Fork Only)
+        run: ./build/linux/amd64/earthly --ci -P --version-flag-overrides="wait-block,use-copy-include-patterns" ./tests/with-docker+all
+        if: github.event_name != 'push' && github.event.pull_request.head.repo.full_name != github.repository
       - name: Execute local buildkit with mTLS test
         run: ./tests/remote-buildkit/remote-buildkit-test.sh
       - name: Run linux-amd64 specific tests (Earthly Only)

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -1007,10 +1007,10 @@ func (c *Converter) SaveImage(ctx context.Context, imageNames []string, pushImag
 				shouldPush := pushImages && si.DockerTag != "" && c.opt.DoSaves
 				shouldExportLocally := si.DockerTag != "" && c.opt.DoSaves
 				c.waitBlock().addSaveImage(si, c, shouldPush, shouldExportLocally)
-			} else {
-				c.mts.Final.SaveImages = append(c.mts.Final.SaveImages, si)
-			}
 
+				si.SkipBuilder = true
+			}
+			c.mts.Final.SaveImages = append(c.mts.Final.SaveImages, si)
 		}
 
 		if pushImages && imageName != "" && c.opt.UseInlineCache {

--- a/earthfile2llb/wait_block.go
+++ b/earthfile2llb/wait_block.go
@@ -51,6 +51,9 @@ func newWaitBlock() *waitBlock {
 }
 
 func (wb *waitBlock) addSaveImage(si states.SaveImage, c *Converter, push, localExport bool) {
+	if !push && !localExport {
+		return
+	}
 	wb.mu.Lock()
 	defer wb.mu.Unlock()
 	item := saveImageWaitItem{

--- a/states/states.go
+++ b/states/states.go
@@ -283,6 +283,8 @@ type SaveImage struct {
 
 	Platform    platutil.Platform
 	HasPlatform bool // true when the --platform value was set (either on cli, or via FROM --platform=..., or BUILD --platform=...)
+
+	SkipBuilder bool // for use with WAIT/END
 }
 
 // RunPush is a series of RUN --push commands to be run after the build has been deemed as


### PR DESCRIPTION
This fixes a WAIT/END related bug that occured in combination with WITH DOCKER commands,
where the `--load` flag could not interpret the loaded target's docker
name, due to SAVE IMAGE not being stored in mts.

This fix introduces a new `allowDoSaves` arg to prepBuildTarget, which
WITH DOCKER commands will set to false, to prevent loaded images from
being exported to the local docker instance.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>