### PR TITLE
Improve coverage of save-artifact-after-push test

### DIFF
--- a/ast/tests/save-artifact-after-push.ast.json
+++ b/ast/tests/save-artifact-after-push.ast.json
@@ -59,7 +59,7 @@
             "args": [
               "--push",
               "echo",
-              "\"suprise\"",
+              "\"surprise\"",
               ">",
               "1"
             ],
@@ -72,7 +72,7 @@
               "1",
               "AS",
               "LOCAL",
-              "suprise"
+              "surprise"
             ],
             "name": "SAVE ARTIFACT"
           }

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -720,10 +720,13 @@ run-no-cache:
         --grep_flags="-v" --output_contains="\\\*cached\\\* --> .*motd2 \\\.\\\//"
 
 save-artifact-after-push:
-    # test that save after push is a thing
+    # test that save after push only outputs files before the RUN --push
     DO +RUN_EARTHLY --earthfile=save-artifact-after-push.earth --target=+test
+    RUN test -f 1 && test "$(cat 1)" = "1"
+    RUN ! test -f 2
+    RUN ! test -f surprise
 
-    # test that cant copy saved after push
+    # test it is not possible to copy from a target containing a RUN --push
     DO +RUN_EARTHLY --earthfile=save-artifact-after-push.earth --should_fail="true" --target=+copy-test \
         --output_contains="not found"
 

--- a/tests/save-artifact-after-push.earth
+++ b/tests/save-artifact-after-push.earth
@@ -7,9 +7,9 @@ test:
     SAVE ARTIFACT 1 AS LOCAL 1
 
     RUN --push echo "2" > 2
-    RUN --push  echo "suprise" > 1
+    RUN --push  echo "surprise" > 1
 
-    SAVE ARTIFACT 1 AS LOCAL suprise
+    SAVE ARTIFACT 1 AS LOCAL surprise
     SAVE ARTIFACT 2 AS LOCAL 2
 
 copy-test:


### PR DESCRIPTION
Signed-off-by: Alex Couture-Beil <alex@earthly.dev>