### PR TITLE
Init frontend only when actually needed

### DIFF
--- a/cmd/earthly/build_cmd.go
+++ b/cmd/earthly/build_cmd.go
@@ -199,6 +199,15 @@ func (app *earthlyApp) actionBuildImp(cliCtx *cli.Context, flagArgs, nonFlagArgs
 	app.console.PrintPhaseHeader(builder.PhaseInit, false, "")
 	app.warnIfArgContainsBuildArg(flagArgs)
 
+	// Init frontend only if we either need to run buildkit on it, or if there might be
+	// images to output to it.
+	if !app.isUsingSatellite(cliCtx) || !app.noOutput {
+		err = app.initFrontend(cliCtx)
+		if err != nil {
+			return err
+		}
+	}
+
 	err = app.configureSatellite(cliCtx, cloudClient)
 	if err != nil {
 		return errors.Wrapf(err, "could not construct new buildkit client")

--- a/cmd/earthly/build_cmd.go
+++ b/cmd/earthly/build_cmd.go
@@ -199,13 +199,9 @@ func (app *earthlyApp) actionBuildImp(cliCtx *cli.Context, flagArgs, nonFlagArgs
 	app.console.PrintPhaseHeader(builder.PhaseInit, false, "")
 	app.warnIfArgContainsBuildArg(flagArgs)
 
-	// Init frontend only if we either need to run buildkit on it, or if there might be
-	// images to output to it.
-	if !app.isUsingSatellite(cliCtx) || !app.noOutput {
-		err = app.initFrontend(cliCtx)
-		if err != nil {
-			return err
-		}
+	err = app.initFrontend(cliCtx)
+	if err != nil {
+		return err
 	}
 
 	err = app.configureSatellite(cliCtx, cloudClient)

--- a/cmd/earthly/build_cmd.go
+++ b/cmd/earthly/build_cmd.go
@@ -63,6 +63,9 @@ func (app *earthlyApp) actionBuild(cliCtx *cli.Context) error {
 			return errors.New("cannot use --no-output with image or artifact modes")
 		}
 	}
+	if app.interactiveDebugging && !termutil.IsTTY() {
+		return errors.New("A tty-terminal must be present in order to use the --interactive flag")
+	}
 
 	flagArgs, nonFlagArgs, err := variables.ParseFlagArgsWithNonFlags(cliCtx.Args().Slice())
 	if err != nil {
@@ -208,13 +211,8 @@ func (app *earthlyApp) actionBuildImp(cliCtx *cli.Context, flagArgs, nonFlagArgs
 		app.useInlineCache = false
 		app.saveInlineCache = false
 	}
-	if app.interactiveDebugging {
-		if !termutil.IsTTY() {
-			return errors.New("A tty-terminal must be present in order to the --interactive flag")
-		}
-		if !isLocal {
-			return errors.New("the --interactive flag is not currently supported with non-local buildkit servers")
-		}
+	if app.interactiveDebugging && !isLocal {
+		return errors.New("the --interactive flag is not currently supported with non-local buildkit servers")
 	}
 
 	bkClient, err := buildkitd.NewClient(cliCtx.Context, app.console, app.buildkitdImage, app.containerName, app.containerFrontend, Version, app.buildkitdSettings)

--- a/cmd/earthly/build_cmd.go
+++ b/cmd/earthly/build_cmd.go
@@ -52,14 +52,6 @@ func (app *earthlyApp) actionBuild(cliCtx *cli.Context) error {
 			return errors.New("unable to use --ci flag in combination with --interactive flag")
 		}
 	}
-	if app.interactiveDebugging {
-		if !termutil.IsTTY() {
-			return errors.New("A tty-terminal must be present in order to the --interactive flag")
-		}
-		if !containerutil.IsLocal(app.buildkitHost) {
-			return errors.New("the --interactive flag is not currently supported with non-local buildkit servers")
-		}
-	}
 
 	if app.imageMode && app.artifactMode {
 		return errors.New("both image and artifact modes cannot be active at the same time")
@@ -210,12 +202,19 @@ func (app *earthlyApp) actionBuildImp(cliCtx *cli.Context, flagArgs, nonFlagArgs
 	}
 
 	isLocal := containerutil.IsLocal(app.buildkitdSettings.BuildkitAddress)
-
 	if !isLocal && app.ci {
 		app.console.Warnf("Please note that --use-inline-cache and --save-inline-cache are currently disabled when using --ci on Satellites or remote Buildkit.")
 		app.console.Warnf("") // newline
 		app.useInlineCache = false
 		app.saveInlineCache = false
+	}
+	if app.interactiveDebugging {
+		if !termutil.IsTTY() {
+			return errors.New("A tty-terminal must be present in order to the --interactive flag")
+		}
+		if !isLocal {
+			return errors.New("the --interactive flag is not currently supported with non-local buildkit servers")
+		}
 	}
 
 	bkClient, err := buildkitd.NewClient(cliCtx.Context, app.console, app.buildkitdImage, app.containerName, app.containerFrontend, Version, app.buildkitdSettings)

--- a/cmd/earthly/buildkit.go
+++ b/cmd/earthly/buildkit.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"net/url"
+	"time"
+
 	"github.com/earthly/earthly/buildkitd"
 	"github.com/earthly/earthly/cloud"
 	"github.com/earthly/earthly/util/containerutil"
@@ -9,7 +12,83 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+func (app *earthlyApp) initFrontend(cliCtx *cli.Context) error {
+	feConfig := &containerutil.FrontendConfig{
+		BuildkitHostCLIValue:       app.buildkitHost,
+		BuildkitHostFileValue:      app.cfg.Global.BuildkitHost,
+		DebuggerHostCLIValue:       app.debuggerHost,
+		DebuggerHostFileValue:      app.cfg.Global.DebuggerHost,
+		DebuggerPortFileValue:      app.cfg.Global.DebuggerPort,
+		LocalRegistryHostFileValue: app.cfg.Global.LocalRegistryHost,
+		Console:                    app.console,
+	}
+	fe, err := containerutil.FrontendForSetting(cliCtx.Context, app.cfg.Global.ContainerFrontend, feConfig)
+	if err != nil {
+		origErr := err
+		fe, err = containerutil.NewStubFrontend(cliCtx.Context, feConfig)
+		if err != nil {
+			return errors.Wrap(err, "failed frontend initialization")
+		}
+		app.console.Warnf("%s frontend initialization failed due to %s; but will try anyway", app.cfg.Global.ContainerFrontend, origErr.Error())
+	}
+	app.containerFrontend = fe
+
+	// command line option overrides the config which overrides the default value
+	if !cliCtx.IsSet("buildkit-image") && app.cfg.Global.BuildkitImage != "" {
+		app.buildkitdImage = app.cfg.Global.BuildkitImage
+	}
+
+	// These URLs were calculated relative to the configured frontend. In the case of an automatically detected frontend,
+	// they are calculated according to the first selected one in order of precedence.
+	buildkitURLs := fe.Config().FrontendURLs
+	app.buildkitHost = buildkitURLs.BuildkitHost.String()
+	app.debuggerHost = buildkitURLs.DebuggerHost.String()
+	app.localRegistryHost = buildkitURLs.LocalRegistryHost.String()
+
+	bkURL, err := url.Parse(app.buildkitHost) // Not validated because we already did that when we calculated it.
+	if err != nil {
+		return errors.Wrap(err, "failed to parse generated buildkit URL")
+	}
+
+	if bkURL.Scheme == "tcp" {
+		app.handleTLSCertificateSettings(cliCtx)
+	}
+
+	app.buildkitdSettings.AdditionalArgs = app.cfg.Global.BuildkitAdditionalArgs
+	app.buildkitdSettings.AdditionalConfig = app.cfg.Global.BuildkitAdditionalConfig
+	app.buildkitdSettings.Timeout = time.Duration(app.cfg.Global.BuildkitRestartTimeoutS) * time.Second
+	app.buildkitdSettings.Debug = app.debug
+	app.buildkitdSettings.BuildkitAddress = app.buildkitHost
+	app.buildkitdSettings.DebuggerAddress = app.debuggerHost
+	app.buildkitdSettings.LocalRegistryAddress = app.localRegistryHost
+	app.buildkitdSettings.UseTCP = bkURL.Scheme == "tcp"
+	app.buildkitdSettings.UseTLS = app.cfg.Global.TLSEnabled
+	app.buildkitdSettings.MaxParallelism = app.cfg.Global.BuildkitMaxParallelism
+	app.buildkitdSettings.CacheSizeMb = app.cfg.Global.BuildkitCacheSizeMb
+	app.buildkitdSettings.CacheSizePct = app.cfg.Global.BuildkitCacheSizePct
+	app.buildkitdSettings.EnableProfiler = app.enableProfiler
+	app.buildkitdSettings.NoUpdate = app.noBuildkitUpdate
+
+	// ensure the MTU is something allowable in IPv4, cap enforced by type. Zero is autodetect.
+	if app.cfg.Global.CniMtu != 0 && app.cfg.Global.CniMtu < 68 {
+		return errors.New("invalid overridden MTU size")
+	}
+	app.buildkitdSettings.CniMtu = app.cfg.Global.CniMtu
+
+	if app.cfg.Global.IPTables != "" && app.cfg.Global.IPTables != "iptables-legacy" && app.cfg.Global.IPTables != "iptables-nft" {
+		return errors.New(`invalid overridden iptables name. Valid values are "iptables-legacy" or "iptables-nft"`)
+	}
+	app.buildkitdSettings.IPTables = app.cfg.Global.IPTables
+	return nil
+}
+
 func (app *earthlyApp) getBuildkitClient(cliCtx *cli.Context, cloudClient cloud.Client) (*client.Client, error) {
+	if !app.isUsingSatellite(cliCtx) {
+		err := app.initFrontend(cliCtx)
+		if err != nil {
+			return nil, err
+		}
+	}
 	err := app.configureSatellite(cliCtx, cloudClient)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not construct new buildkit client")

--- a/cmd/earthly/buildkit.go
+++ b/cmd/earthly/buildkit.go
@@ -13,6 +13,7 @@ import (
 )
 
 func (app *earthlyApp) initFrontend(cliCtx *cli.Context) error {
+	console := app.console.WithPrefix("frontend")
 	feConfig := &containerutil.FrontendConfig{
 		BuildkitHostCLIValue:       app.buildkitHost,
 		BuildkitHostFileValue:      app.cfg.Global.BuildkitHost,
@@ -20,7 +21,7 @@ func (app *earthlyApp) initFrontend(cliCtx *cli.Context) error {
 		DebuggerHostFileValue:      app.cfg.Global.DebuggerHost,
 		DebuggerPortFileValue:      app.cfg.Global.DebuggerPort,
 		LocalRegistryHostFileValue: app.cfg.Global.LocalRegistryHost,
-		Console:                    app.console,
+		Console:                    console,
 	}
 	fe, err := containerutil.FrontendForSetting(cliCtx.Context, app.cfg.Global.ContainerFrontend, feConfig)
 	if err != nil {
@@ -29,7 +30,11 @@ func (app *earthlyApp) initFrontend(cliCtx *cli.Context) error {
 		if err != nil {
 			return errors.Wrap(err, "failed frontend initialization")
 		}
-		app.console.Warnf("%s frontend initialization failed due to %s; but will try anyway", app.cfg.Global.ContainerFrontend, origErr.Error())
+
+		console.Printf("No frontend initialized.\n")
+		console.VerbosePrintf("%s frontend initialization failed due to %s", app.cfg.Global.ContainerFrontend, origErr.Error())
+	} else {
+		console.VerbosePrintf("%s frontend initialized.\n", fe.Config().Setting)
 	}
 	app.containerFrontend = fe
 

--- a/cmd/earthly/root_cmds.go
+++ b/cmd/earthly/root_cmds.go
@@ -622,7 +622,11 @@ func (app *earthlyApp) actionPrune(cliCtx *cli.Context) error {
 		if app.isUsingSatellite(cliCtx) {
 			return errors.New("Cannot prune --reset when using a satellite. Try without --reset")
 		}
-		err := buildkitd.ResetCache(cliCtx.Context, app.console, app.buildkitdImage, app.containerName, app.containerFrontend, app.buildkitdSettings)
+		err := app.initFrontend(cliCtx)
+		if err != nil {
+			return err
+		}
+		err = buildkitd.ResetCache(cliCtx.Context, app.console, app.buildkitdImage, app.containerName, app.containerFrontend, app.buildkitdSettings)
 		if err != nil {
 			return errors.Wrap(err, "reset cache")
 		}


### PR DESCRIPTION
This helps prevent those spurious warnings on unrelated commands such as `earthly account login`.

This PR also reduces the frontend initialization error output to a simple message "No frontend initialized". This can be expanded with the `--verbose` flag.