### PR TITLE
Return errors in stub frontend

### DIFF
--- a/buildkitd/buildkitd.go
+++ b/buildkitd/buildkitd.go
@@ -784,7 +784,7 @@ func isContainerRunning(ctx context.Context, containerName string, fe containeru
 }
 
 func isDockerAvailable(ctx context.Context, fe containerutil.ContainerFrontend) bool {
-	return fe.IsAvaliable(ctx)
+	return fe.IsAvailable(ctx)
 }
 
 func printBuildkitInfo(bkCons conslogging.ConsoleLogger, info *client.Info, workerInfo *client.WorkerInfo, earthlyVersion string, isLocal bool) {

--- a/util/containerutil/frontend.go
+++ b/util/containerutil/frontend.go
@@ -16,7 +16,7 @@ import (
 type ContainerFrontend interface {
 	Scheme() string
 
-	IsAvaliable(ctx context.Context) bool
+	IsAvailable(ctx context.Context) bool
 	Config() *CurrentFrontend
 	Information(ctx context.Context) (*FrontendInfo, error)
 
@@ -92,7 +92,7 @@ func frontendIfAvaliable(ctx context.Context, feType string, cfg *FrontendConfig
 	if err != nil {
 		return nil, errors.Wrapf(err, "%s frontend failed to initalize", feType)
 	}
-	if !fe.IsAvaliable(ctx) {
+	if !fe.IsAvailable(ctx) {
 		return nil, fmt.Errorf("%s frontend not avaliable", feType)
 	}
 

--- a/util/containerutil/frontend_test.go
+++ b/util/containerutil/frontend_test.go
@@ -61,7 +61,7 @@ func TestFrontendScheme(t *testing.T) {
 	}
 }
 
-func TestFrontendIsAvaliable(t *testing.T) {
+func TestFrontendIsAvailable(t *testing.T) {
 	testCases := []struct {
 		binary  string
 		newFunc func(context.Context, *containerutil.FrontendConfig) (containerutil.ContainerFrontend, error)
@@ -77,7 +77,7 @@ func TestFrontendIsAvaliable(t *testing.T) {
 			fe, err := tC.newFunc(ctx, &containerutil.FrontendConfig{Console: testLogger()})
 			assert.NoError(t, err)
 
-			avaliable := fe.IsAvaliable(ctx)
+			avaliable := fe.IsAvailable(ctx)
 			assert.True(t, avaliable)
 		})
 	}
@@ -586,7 +586,7 @@ func onlyIfBinaryIsInstalled(ctx context.Context, t *testing.T, binary string) {
 }
 
 func isBinaryInstalled(ctx context.Context, binary string) bool {
-	// This is almost a re-implementation of IsAvaliable... but relying on that presupposes the
+	// This is almost a re-implementation of IsAvailable... but relying on that presupposes the
 	// binary exists to allow the New**** to run (it gathers info from the CLI).
 	cmd := exec.CommandContext(ctx, binary, "--help")
 	return cmd.Run() == nil

--- a/util/containerutil/shell_shared.go
+++ b/util/containerutil/shell_shared.go
@@ -27,7 +27,7 @@ type shellFrontend struct {
 	urls *FrontendURLs
 }
 
-func (sf *shellFrontend) IsAvaliable(ctx context.Context) bool {
+func (sf *shellFrontend) IsAvailable(ctx context.Context) bool {
 	args := append(sf.globalCompatibilityArgs, "ps")
 	cmd := exec.CommandContext(ctx, sf.binaryName, args...)
 	err := cmd.Run()

--- a/util/containerutil/stub.go
+++ b/util/containerutil/stub.go
@@ -13,8 +13,8 @@ type stubFrontend struct {
 	*shellFrontend
 }
 
-// FrontendNotInitializedError is returned when the frontend is not initialized.
-var FrontendNotInitializedError = errors.New("frontend (e.g. docker/podman) not initialized")
+// ErrFrontendNotInitialized is returned when the frontend is not initialized.
+var ErrFrontendNotInitialized = errors.New("frontend (e.g. docker/podman) not initialized")
 
 // NewStubFrontend creates a stubbed frontend. Useful in cases where a frontend could not be detected, but we still need a frontend.
 // Examples include earthly/earthly, or integration tests. It is currently only used as a fallback when docker or other frontends are missing.
@@ -48,38 +48,38 @@ func (*stubFrontend) Information(ctx context.Context) (*FrontendInfo, error) {
 	return &FrontendInfo{}, nil
 }
 func (*stubFrontend) ContainerInfo(ctx context.Context, namesOrIDs ...string) (map[string]*ContainerInfo, error) {
-	return nil, FrontendNotInitializedError
+	return nil, ErrFrontendNotInitialized
 }
 func (*stubFrontend) ContainerRemove(ctx context.Context, force bool, namesOrIDs ...string) error {
-	return FrontendNotInitializedError
+	return ErrFrontendNotInitialized
 }
 func (*stubFrontend) ContainerStop(ctx context.Context, timeoutSec uint, namesOrIDs ...string) error {
-	return FrontendNotInitializedError
+	return ErrFrontendNotInitialized
 }
 func (*stubFrontend) ContainerLogs(ctx context.Context, namesOrIDs ...string) (map[string]*ContainerLogs, error) {
-	return nil, FrontendNotInitializedError
+	return nil, ErrFrontendNotInitialized
 }
 func (*stubFrontend) ContainerRun(ctx context.Context, containers ...ContainerRun) error {
-	return FrontendNotInitializedError
+	return ErrFrontendNotInitialized
 }
 func (*stubFrontend) ImageInfo(ctx context.Context, refs ...string) (map[string]*ImageInfo, error) {
-	return nil, FrontendNotInitializedError
+	return nil, ErrFrontendNotInitialized
 }
 func (*stubFrontend) ImagePull(ctx context.Context, refs ...string) error {
-	return FrontendNotInitializedError
+	return ErrFrontendNotInitialized
 }
 func (*stubFrontend) ImageRemove(ctx context.Context, force bool, refs ...string) error {
-	return FrontendNotInitializedError
+	return ErrFrontendNotInitialized
 }
 func (*stubFrontend) ImageTag(ctx context.Context, tags ...ImageTag) error {
-	return FrontendNotInitializedError
+	return ErrFrontendNotInitialized
 }
 func (*stubFrontend) ImageLoadFromFileCommand(filename string) string {
 	return ""
 }
 func (*stubFrontend) ImageLoad(ctx context.Context, image ...io.Reader) error {
-	return FrontendNotInitializedError
+	return ErrFrontendNotInitialized
 }
 func (*stubFrontend) VolumeInfo(ctx context.Context, volumeNames ...string) (map[string]*VolumeInfo, error) {
-	return nil, FrontendNotInitializedError
+	return nil, ErrFrontendNotInitialized
 }

--- a/util/containerutil/stub.go
+++ b/util/containerutil/stub.go
@@ -8,7 +8,6 @@ import (
 )
 
 // This is a stub for use when a proper frontend is not available.
-// Should never be used IRL.
 type stubFrontend struct {
 	*shellFrontend
 }

--- a/util/containerutil/stub.go
+++ b/util/containerutil/stub.go
@@ -7,11 +7,14 @@ import (
 	"github.com/pkg/errors"
 )
 
-// This is a stub for use in internal testing when its too much effort to provide a legitimate backend.
+// This is a stub for use when a proper frontend is not available.
 // Should never be used IRL.
 type stubFrontend struct {
 	*shellFrontend
 }
+
+// FrontendNotInitializedError is returned when the frontend is not initialized.
+var FrontendNotInitializedError = errors.New("frontend (e.g. docker/podman) not initialized")
 
 // NewStubFrontend creates a stubbed frontend. Useful in cases where a frontend could not be detected, but we still need a frontend.
 // Examples include earthly/earthly, or integration tests. It is currently only used as a fallback when docker or other frontends are missing.
@@ -32,8 +35,8 @@ func NewStubFrontend(ctx context.Context, cfg *FrontendConfig) (ContainerFronten
 func (*stubFrontend) Scheme() string {
 	return ""
 }
-func (*stubFrontend) IsAvaliable(ctx context.Context) bool {
-	return true
+func (*stubFrontend) IsAvailable(ctx context.Context) bool {
+	return false
 }
 func (sf *stubFrontend) Config() *CurrentFrontend {
 	return &CurrentFrontend{
@@ -45,38 +48,38 @@ func (*stubFrontend) Information(ctx context.Context) (*FrontendInfo, error) {
 	return &FrontendInfo{}, nil
 }
 func (*stubFrontend) ContainerInfo(ctx context.Context, namesOrIDs ...string) (map[string]*ContainerInfo, error) {
-	return make(map[string]*ContainerInfo), nil
+	return nil, FrontendNotInitializedError
 }
 func (*stubFrontend) ContainerRemove(ctx context.Context, force bool, namesOrIDs ...string) error {
-	return nil
+	return FrontendNotInitializedError
 }
 func (*stubFrontend) ContainerStop(ctx context.Context, timeoutSec uint, namesOrIDs ...string) error {
-	return nil
+	return FrontendNotInitializedError
 }
 func (*stubFrontend) ContainerLogs(ctx context.Context, namesOrIDs ...string) (map[string]*ContainerLogs, error) {
-	return make(map[string]*ContainerLogs), nil
+	return nil, FrontendNotInitializedError
 }
 func (*stubFrontend) ContainerRun(ctx context.Context, containers ...ContainerRun) error {
-	return nil
+	return FrontendNotInitializedError
 }
 func (*stubFrontend) ImageInfo(ctx context.Context, refs ...string) (map[string]*ImageInfo, error) {
-	return make(map[string]*ImageInfo), nil
+	return nil, FrontendNotInitializedError
 }
 func (*stubFrontend) ImagePull(ctx context.Context, refs ...string) error {
-	return nil
+	return FrontendNotInitializedError
 }
 func (*stubFrontend) ImageRemove(ctx context.Context, force bool, refs ...string) error {
-	return nil
+	return FrontendNotInitializedError
 }
 func (*stubFrontend) ImageTag(ctx context.Context, tags ...ImageTag) error {
-	return nil
+	return FrontendNotInitializedError
 }
 func (*stubFrontend) ImageLoadFromFileCommand(filename string) string {
 	return ""
 }
 func (*stubFrontend) ImageLoad(ctx context.Context, image ...io.Reader) error {
-	return nil
+	return FrontendNotInitializedError
 }
 func (*stubFrontend) VolumeInfo(ctx context.Context, volumeNames ...string) (map[string]*VolumeInfo, error) {
-	return make(map[string]*VolumeInfo), nil
+	return nil, FrontendNotInitializedError
 }


### PR DESCRIPTION
In an environment where Docker was not set up and the user forgot that there would be some local outputs from a satellite build they were getting this error:

```
output | WARN: (exporting outputs) failed to copy to tar: rpc error: code = Unknown desc = io: read/write on closed pipe
2022/08/17 16:41:39 http2: server connection error from localhost: connection error: PROTOCOL_ERROR
```

The issue was that the local outputs could not be loaded into Docker because the frontend was not initialized (Docker isn't available). This PR helps with a better error in such cases.