### PR TITLE
Remove WAIT/END is experimental warning

### DIFF
--- a/.earthly_version_flag_overrides
+++ b/.earthly_version_flag_overrides
@@ -1,1 +1,1 @@
-referenced-save-only,use-copy-include-patterns,earthly-version-arg,use-cache-command,use-host-command,check-duplicate-images,use-copy-link,parallel-load,shell-out-anywhere,new-platform,no-tar-build-output
+referenced-save-only,use-copy-include-patterns,earthly-version-arg,use-cache-command,use-host-command,check-duplicate-images,use-copy-link,parallel-load,shell-out-anywhere,new-platform,no-tar-build-output,wait-block

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 ### Fixed
 
 - Using `--remote-cache` on a target that contains only `BUILD` instructions caused a hang. [#1945](https://github.com/earthly/earthly/issues/1945)
+- Fixed WAIT/END related bug which prevent `WITH DOCKER --load` from building referenced target.
+- Images and artifacts which are output (or pushed), are now displayed in the final earthly output.
+
+### Changed
+
+- Removed warning stating that `WAIT/END code is experimental and may be incomplete` -- it is still experimental; however, it now has a higher degree
+  of test-coverage. It can be enabled with `VERSION --wait-block 0.6`.
 
 ## v0.6.22 - 2022-08-19
 

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -923,7 +923,6 @@ func (c *Converter) waitBlock() *waitBlock {
 
 // PushWaitBlock should be called when a WAIT block starts, all commands will be added to this new block
 func (c *Converter) PushWaitBlock(ctx context.Context) error {
-	c.opt.Console.Warnf("WAIT/END code is experimental and may be incomplete")
 	c.waitBlockStack = append(c.waitBlockStack, newWaitBlock())
 	return nil
 }

--- a/tests/push-images/test.sh
+++ b/tests/push-images/test.sh
@@ -35,18 +35,21 @@ if ! cat multi_output | grep "Did not push image earthly/sap:after-push"; then
     exit 1
 fi
 
-if ! cat multi_output | grep "Did not output image earthly/sap:after-push"; then
-    echo "Invalid push text (expected: Did not output image earthly/sap:after-push)"
-    cat multi_output
-    exit 1
-fi
-
 docker images --format "{{.Repository}}:{{.Tag}}" | grep "earthly/sap:" > multi_images
 
-if cat multi_images | grep "earthly/sap:after-push"; then
-    echo "Saved invalid image"
-    docker images --format "{{.Repository}}:{{.Tag}}" | grep "sap:"
-    exit 1
+if echo "$EARTHLY_VERSION_FLAG_OVERRIDES" | grep "wait-block" >/dev/null; then
+    echo "skipping non-output after push test; --wait-block feature does not impose such a limitation"
+else
+    if ! cat multi_output | grep "Did not output image earthly/sap:after-push"; then
+        echo "Invalid push text (expected: Did not output image earthly/sap:after-push)"
+        cat multi_output
+        exit 1
+    fi
+    if cat multi_images | grep "earthly/sap:after-push"; then
+        echo "Saved invalid image"
+        docker images --format "{{.Repository}}:{{.Tag}}" | grep "sap:"
+        exit 1
+    fi
 fi
 
 if  ! cat multi_images | grep -q "earthly/sap:empty" || \


### PR DESCRIPTION
It is still experimental; however, the code is now much more complete,
and has a higher degree of test-coverage.

The push-images test was modified due to the --wait-block feature no
longer prevents saving an image after a push, e.g.

    RUN --push ...
    SAVE IMAGE ...

is now valid when run with the `--wait-end` feature, since it roughly
translates into

    ARG EARTHLY_PUSH
    IF [ $EARTHLY_PUSH = "true" ]
        RUN --push ...
    END
    SAVE IMAGE ...

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>