### PR TITLE
Remove user name from invite command

### DIFF
--- a/cloud/org_new.go
+++ b/cloud/org_new.go
@@ -24,7 +24,6 @@ func (c *client) InviteToOrg(ctx context.Context, invite *OrgInvitation) (string
 	u := "/api/v0/invitations"
 
 	req := &secretsapi.CreateInvitationRequest{
-		Name:       invite.Name,
 		OrgName:    invite.OrgName,
 		Email:      invite.Email,
 		Permission: invite.Permission,

--- a/cmd/earthly/org_cmds.go
+++ b/cmd/earthly/org_cmds.go
@@ -281,15 +281,6 @@ func (app *earthlyApp) actionOrgInviteEmail(cliCtx *cli.Context) error {
 		OrgName: orgName,
 	}
 
-	name := cliCtx.String("name")
-	if name == "" {
-		name, err = promptInput(cliCtx.Context, "New user's name: ")
-		if err != nil {
-			return errors.Wrap(err, "failed to read name")
-		}
-	}
-	invite.Name = name
-
 	permission := cliCtx.String("permission")
 	if permission == "" {
 		permission, err = promptInput(cliCtx.Context, "New user's permission (read, write, admin): ")

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/docker/distribution v2.8.1+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/dustin/go-humanize v1.0.0
-	github.com/earthly/cloud-api v1.0.1-0.20220728160826-b477d75c55f6
+	github.com/earthly/cloud-api v1.0.1-0.20220819185746-bab168ecbbf9
 	github.com/elastic/go-sysinfo v1.7.1
 	github.com/fatih/color v1.9.0
 	github.com/golang/protobuf v1.5.2

--- a/go.sum
+++ b/go.sum
@@ -374,6 +374,8 @@ github.com/earthly/buildkit v0.0.1-0.20220818191106-3b049bfd9c25 h1:EbrX7X+65zaR
 github.com/earthly/buildkit v0.0.1-0.20220818191106-3b049bfd9c25/go.mod h1:Ih6/jh6JTbktkhxRID0gj6dn2GAPI6H9U6xKVxgNqBk=
 github.com/earthly/cloud-api v1.0.1-0.20220728160826-b477d75c55f6 h1:4MCXNERT8+PnBJsgH/eaEdBLKKJuKbu4gb9agPUIG6o=
 github.com/earthly/cloud-api v1.0.1-0.20220728160826-b477d75c55f6/go.mod h1:JhlHsW6o8zYa+XsM0nMAevRQtES35KE5R2G8tJALsnI=
+github.com/earthly/cloud-api v1.0.1-0.20220819185746-bab168ecbbf9 h1:r24RzVlEmXaJf/tX0smUEUuGYk4bkcn8TqFI5BoqR9g=
+github.com/earthly/cloud-api v1.0.1-0.20220819185746-bab168ecbbf9/go.mod h1:JhlHsW6o8zYa+XsM0nMAevRQtES35KE5R2G8tJALsnI=
 github.com/earthly/fsutil v0.0.0-20220719234708-392da7eebeb5 h1:bOKRnmQd1JYrtOUdkvYraBCT0SRjYpYnhd4i85mWtQw=
 github.com/earthly/fsutil v0.0.0-20220719234708-392da7eebeb5/go.mod h1:oPAfvw32vlUJSjyDcQ3Bu0nb2ON2B+G0dtVN/SZNJiA=
 github.com/elastic/go-sysinfo v1.7.1 h1:Wx4DSARcKLllpKT2TnFVdSUJOsybqMYCNQZq1/wO+s0=


### PR DESCRIPTION
Requiring a name doesn't necessarily add much and can slow down the invite flow.