### PR TITLE
multi4 test is failing (do not merge)

### DIFF
--- a/scripts/tests/export.sh
+++ b/scripts/tests/export.sh
@@ -10,7 +10,7 @@ echo "running tests with $earthly"
 date +%s > /tmp/last-earthly-prerelease-check
 
 # ensure earthly login works (and print out who gets logged in)
-test -n "$EARTHLY_TOKEN"
+#test -n "$EARTHLY_TOKEN"
 "$earthly" account login
 
 # Test 1: export without anything
@@ -87,7 +87,7 @@ cat >> Earthfile <<EOF
 VERSION 0.6
 
 multi4:
-    BUILD --platform=linux/amd64 --platform=linux/arm64 --platform=linux/arm/v7 +test4
+    BUILD --platform=linux/arm/v7 --platform=linux/amd64 --platform=linux/arm64 +test4
 
 test4:
     FROM busybox:latest


### PR DESCRIPTION
This can be reproduced with:

    ./earthly +for-linux && export earthly=/home/alex/gh/earthly/earthly/build/linux/amd64/earthly && scripts/tests/export.sh

(or change earthly path to match your machine)

It appears this test was passing due to our CI being amd64 and the
`--platform=linux/amd64` being listed first. When I changed the order,
this test now fails.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>