### PR TITLE
fix loadDockerManifest platform detection bug

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -605,7 +605,7 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 	outputConsole.Flush()
 
 	for parentImageName, children := range manifestLists {
-		err = loadDockerManifest(ctx, b.opt.Console, b.opt.ContainerFrontend, parentImageName, children)
+		err = loadDockerManifest(ctx, b.opt.Console, b.opt.ContainerFrontend, parentImageName, children, opt.PlatformResolver)
 		if err != nil {
 			return nil, err
 		}

--- a/scripts/tests/export.sh
+++ b/scripts/tests/export.sh
@@ -87,7 +87,9 @@ cat >> Earthfile <<EOF
 VERSION 0.6
 
 multi4:
-    BUILD --platform=linux/amd64 --platform=linux/arm64 --platform=linux/arm/v7 +test4
+    # NOTE: keep amd64 in the middle, since earthly will fallback to the first defined platform
+    # in case loadDockerManifest fails
+    BUILD --platform=linux/arm/v7 --platform=linux/amd64 --platform=linux/arm64 +test4
 
 test4:
     FROM busybox:latest


### PR DESCRIPTION
This fixes a bug where loadDockerManifest was comparing a materialized
platform with an unmaterialized platform.

Additionally, a warning is now displayed when no platform matching the
default platform is found.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>