### PR TITLE
feat(logging): less verbose headers

### DIFF
--- a/conslogging/conslogging.go
+++ b/conslogging/conslogging.go
@@ -206,7 +206,6 @@ func (cl ConsoleLogger) PrintPhaseHeader(phase string, disabled bool, special st
 	if underlineLength < barWidth {
 		underlineLength = barWidth
 	}
-	cl.errW.Write([]byte("\n"))
 	c.Fprintf(cl.errW, " %s", msg)
 	cl.errW.Write([]byte("\n"))
 	c.Fprintf(cl.errW, "%s", strings.Repeat("—", underlineLength))


### PR DESCRIPTION
Making the complete output slightly more compact. Less scrolling.

This fixes #2087.