### PR TITLE
Fix typo in go-monorepo example

### DIFF
--- a/examples/go-monorepo/services/two/Earthfile
+++ b/examples/go-monorepo/services/two/Earthfile
@@ -25,7 +25,7 @@ docker:
 release-tag:
     FROM golang:1.17-alpine
     RUN go install github.com/maykonlf/semver-cli/cmd/semver@v1.0.2
-    COPY .semver.yatwo.
+    COPY .semver.yaml .
     RUN semver get release > version
     SAVE ARTIFACT version
 


### PR DESCRIPTION
The `go-monorepo` example doesn't build because of this small typo.