### PR TITLE
Fix +examples2 on Satellites from Forks

### DIFF
--- a/.github/workflows/satellites.yml
+++ b/.github/workflows/satellites.yml
@@ -108,6 +108,13 @@ jobs:
     steps:
       - uses: earthly/actions-setup@v1.0.1
       - uses: actions/checkout@v3
+      - name: Set up QEMU (Forks Only)
+        id: qemu
+        uses: docker/setup-qemu-action@v1
+        with:
+          image: tonistiigi/binfmt:latest
+          platforms: all
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
       - name: Configure Satellites (Earthly Only)
         run: earthly satellite select core-examples
         if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository


### PR DESCRIPTION
+examples2 was failing because QEMU was not installed. The satellites tests just run local buildkit instead of actually on satellites when they are triggered by a fork.

Example of passing test from a fork https://github.com/earthly/earthly/actions/runs/2920999640