### PR TITLE
Fix Ctrl-C in Satellite Launch/Rm

### DIFF
--- a/cloud/client.go
+++ b/cloud/client.go
@@ -243,13 +243,6 @@ func shouldRetry(status int, body string, callErr error, warnFunc func(string, .
 		return false, callErr
 	case strings.Contains(callErr.Error(), "failed to connect to ssh-agent"):
 		return false, callErr
-	case strings.Contains(callErr.Error(), "context canceled"):
-		// Note the actual error caught here is not an instance of context.Canceled,
-		// but is an error message that contains the HTTP call plus the string "context canceled".
-		return false, context.Canceled
-	case strings.Contains(callErr.Error(), "context deadline exceeded"):
-		// Similarly here.
-		return false, context.DeadlineExceeded
 	default:
 		warnFunc("retrying http request due to unexpected error %v", callErr)
 		return true, nil

--- a/cmd/earthly/satellite_cmds.go
+++ b/cmd/earthly/satellite_cmds.go
@@ -162,7 +162,7 @@ func (app *earthlyApp) actionSatelliteLaunch(cliCtx *cli.Context) error {
 	app.console.Printf("Launching Satellite. This could take a moment...\n")
 	err = cloudClient.LaunchSatellite(cliCtx.Context, app.satelliteName, orgID)
 	if err != nil {
-		if errors.Cause(err) == context.Canceled {
+		if errors.Is(err, context.Canceled) {
 			app.console.Printf("Operation interrupted. Satellite should finish launching in background (if server received request).\n")
 			return nil
 		}
@@ -227,7 +227,7 @@ func (app *earthlyApp) actionSatelliteRemove(cliCtx *cli.Context) error {
 	app.console.Printf("Destroying Satellite. This could take a moment...\n")
 	err = cloudClient.DeleteSatellite(cliCtx.Context, app.satelliteName, orgID)
 	if err != nil {
-		if errors.Cause(err) == context.Canceled {
+		if errors.Is(err, context.Canceled) {
 			app.console.Printf("Operation interrupted. Satellite should finish destroying in background (if server received request).\n")
 			return nil
 		}


### PR DESCRIPTION
Apparently `errors.Is` works much better than `errors.Cause`. I suspect in these cases, the `context.Canceled` error was not necessarily the "cause" but was somewhere in the chain.

Before + after: 
![Screenshot 2022-08-24 130852](https://user-images.githubusercontent.com/3247216/186480366-5d994f82-274b-479a-9438-6066af8bf296.png)

