### PR TITLE
fix wait-end multiplatform exports

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -17,6 +17,7 @@ import (
 	"github.com/earthly/earthly/outmon"
 	"github.com/earthly/earthly/states"
 	"github.com/earthly/earthly/util/containerutil"
+	"github.com/earthly/earthly/util/dockerutil"
 	"github.com/earthly/earthly/util/gatewaycrafter"
 	"github.com/earthly/earthly/util/gwclientlogger"
 	"github.com/earthly/earthly/util/llbutil"
@@ -135,9 +136,9 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 	var (
 		sharedLocalStateCache  = earthfile2llb.NewSharedLocalStateCache()
 		featureFlagOverrides   = b.opt.FeatureFlagOverrides
-		manifestLists          = make(map[string][]manifest) // parent image -> child images
-		platformImgNames       = make(map[string]bool)       // ensure that these are unique
-		singPlatImgNames       = make(map[string]bool)       // ensure that these are unique
+		manifestLists          = make(map[string][]dockerutil.Manifest) // parent image -> child images
+		platformImgNames       = make(map[string]bool)                  // ensure that these are unique
+		singPlatImgNames       = make(map[string]bool)                  // ensure that these are unique
 		pullPingMap            = gatewaycrafter.NewPullPingMap()
 		localArtifactWhiteList = gatewaycrafter.NewLocalArtifactWhiteList()
 
@@ -284,7 +285,7 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 						}
 						singPlatImgNames[saveImage.DockerTag] = true
 					}
-					localRegPullID := pullPingMap.Insert(gwClient.BuildOpts().SessionID, saveImage.DockerTag)
+					localRegPullID := pullPingMap.Insert(gwClient.BuildOpts().SessionID, saveImage.DockerTag, nil)
 					refPrefix, err := gwCrafter.AddPushImageEntry(ref, imageIndex, saveImage.DockerTag, shouldPush, saveImage.InsecurePush, saveImage.Image, nil)
 					if err != nil {
 						return nil, err
@@ -335,7 +336,7 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 						}
 						imageIndex++
 
-						localRegPullID := pullPingMap.Insert(gwClient.BuildOpts().SessionID, platformImgName)
+						localRegPullID := pullPingMap.Insert(gwClient.BuildOpts().SessionID, platformImgName, nil)
 						if b.opt.LocalRegistryAddr != "" {
 							gwCrafter.AddMeta(fmt.Sprintf("%s/export-image-local-registry", refPrefix), []byte(localRegPullID))
 						} else {
@@ -343,9 +344,9 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 						}
 
 						manifestLists[saveImage.DockerTag] = append(
-							manifestLists[saveImage.DockerTag], manifest{
-								imageName: platformImgName,
-								platform:  resolvedPlat,
+							manifestLists[saveImage.DockerTag], dockerutil.Manifest{
+								ImageName: platformImgName,
+								Platform:  resolvedPlat,
 							})
 					}
 				}
@@ -391,7 +392,7 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 		pipeR, pipeW := io.Pipe()
 		eg.Go(func() error {
 			defer pipeR.Close()
-			err := loadDockerTar(childCtx, b.opt.ContainerFrontend, pipeR)
+			err := dockerutil.LoadDockerTar(childCtx, b.opt.ContainerFrontend, pipeR)
 			if err != nil {
 				return errors.Wrapf(err, "load docker tar")
 			}
@@ -421,15 +422,34 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 		if b.opt.LocalRegistryAddr == "" {
 			return nil
 		}
+		manifests := make(map[string][]dockerutil.Manifest)
 		pullMap := make(map[string]string)
 		for _, imgToPull := range imagesToPull {
-			finalName, ok := pullPingMap.Get(imgToPull)
+			manifest, dockerTag, ok := pullPingMap.Get(imgToPull)
 			if !ok {
 				return errors.Errorf("unrecognized image to pull %s", imgToPull)
 			}
-			pullMap[imgToPull] = finalName
+			if manifest != nil {
+				manifests[dockerTag] = append(manifests[dockerTag], *manifest)
+				pullMap[imgToPull] = manifest.ImageName
+			} else {
+				pullMap[imgToPull] = dockerTag
+			}
 		}
-		return dockerPullLocalImages(childCtx, b.opt.ContainerFrontend, b.opt.LocalRegistryAddr, pullMap)
+		err := dockerutil.DockerPullLocalImages(childCtx, b.opt.ContainerFrontend, b.opt.LocalRegistryAddr, pullMap)
+		if err != nil {
+			return err
+		}
+		for parentImageName, children := range manifests {
+			if opt.PlatformResolver == nil {
+				panic("platform resolver is nil")
+			}
+			err = dockerutil.LoadDockerManifest(ctx, b.opt.Console, b.opt.ContainerFrontend, parentImageName, children, opt.PlatformResolver)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
 	}
 	if opt.PrintPhases {
 		b.opt.Console.PrintPhaseHeader(PhaseBuild, false, "")
@@ -605,7 +625,7 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 	outputConsole.Flush()
 
 	for parentImageName, children := range manifestLists {
-		err = loadDockerManifest(ctx, b.opt.Console, b.opt.ContainerFrontend, parentImageName, children, opt.PlatformResolver)
+		err = dockerutil.LoadDockerManifest(ctx, b.opt.Console, b.opt.ContainerFrontend, parentImageName, children, opt.PlatformResolver)
 		if err != nil {
 			return nil, err
 		}

--- a/builder/solver.go
+++ b/builder/solver.go
@@ -18,7 +18,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-type onImageFunc func(context.Context, *errgroup.Group, string) (io.WriteCloser, error)
+type onImageFunc func(context.Context, *errgroup.Group, string, string, string) (io.WriteCloser, error)
 type onArtifactFunc func(context.Context, string, domain.Artifact, string, string) (string, error)
 type onFinalArtifactFunc func(context.Context) (string, error)
 
@@ -98,7 +98,9 @@ func (s *solver) newSolveOptMulti(ctx context.Context, eg *errgroup.Group, onIma
 						return nil, nil
 					}
 					imageName := md["image.name"]
-					return onImage(ctx, eg, imageName)
+					waitFor := md["export-image-wait-for"]
+					manifestKey := md["export-image-manifest-key"]
+					return onImage(ctx, eg, imageName, waitFor, manifestKey)
 				},
 				OutputDirFunc: func(md map[string]string) (string, error) {
 					if md["export-dir"] != "true" {

--- a/earthfile2llb/wait_block.go
+++ b/earthfile2llb/wait_block.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/earthly/earthly/conslogging"
@@ -147,6 +148,10 @@ func (wb *waitBlock) saveImages(ctx context.Context) error {
 
 	gwCrafter := gatewaycrafter.NewGatewayCrafter()
 
+	// these are used to pass manifest data to the onImage function in builder.go; this only applies to non-local-registry exports (e.g. satellites)
+	var tarImagesInWaitBlockRefPrefixes []string
+	var tarImagesInWaitBlock []string
+
 	refID := 0
 	for _, item := range imageWaitItems {
 		sessionID := item.c.opt.GwClient.BuildOpts().SessionID
@@ -199,15 +204,22 @@ func (wb *waitBlock) saveImages(ctx context.Context) error {
 				if err != nil {
 					return err
 				}
-				if !item.c.opt.UseLocalRegistry {
-					return errors.Errorf(
-						"the --uselocalregistry feature must also be enabled in order to use multi-platform images in combination with the --wait-block feature")
-				}
+
 				localRegPullID := pullPingMap.Insert(sessionID, item.si.DockerTag, &dockerutil.Manifest{
 					ImageName: platformImgName,
 					Platform:  item.si.Platform,
 				})
-				gwCrafter.AddMeta(fmt.Sprintf("%s/export-image-local-registry", refPrefix), []byte(localRegPullID))
+
+				if item.c.opt.UseLocalRegistry {
+					gwCrafter.AddMeta(fmt.Sprintf("%s/export-image-local-registry", refPrefix), []byte(localRegPullID))
+				} else {
+					gwCrafter.AddMeta(fmt.Sprintf("%s/export-image", refPrefix), []byte("true"))
+
+					// the tar exporter abuses the pullping map as a way to pass manifest data to the onImage function in builder.go
+					gwCrafter.AddMeta(fmt.Sprintf("%s/export-image-manifest-key", refPrefix), []byte(localRegPullID))
+					tarImagesInWaitBlockRefPrefixes = append(tarImagesInWaitBlockRefPrefixes, refPrefix)
+					tarImagesInWaitBlock = append(tarImagesInWaitBlock, localRegPullID)
+				}
 				refID++
 			} else {
 				if item.c.opt.UseLocalRegistry {
@@ -218,6 +230,13 @@ func (wb *waitBlock) saveImages(ctx context.Context) error {
 				}
 			}
 
+		}
+	}
+	if len(tarImagesInWaitBlockRefPrefixes) != 0 {
+		waitFor := strings.Join(tarImagesInWaitBlock, " ")
+		// the wait-for entry is used to know when all multiplatform images have been exported, thus making it safe to load manifests
+		for _, refPrefix := range tarImagesInWaitBlockRefPrefixes {
+			gwCrafter.AddMeta(fmt.Sprintf("%s/export-image-wait-for", refPrefix), []byte(waitFor))
 		}
 	}
 

--- a/tests/wait-block/save-multi-platform-image/Earthfile
+++ b/tests/wait-block/save-multi-platform-image/Earthfile
@@ -1,18 +1,18 @@
 VERSION --wait-block 0.6
 
-myimg-amd64:
+earthly-multiplatform-wait-test-amd64:
     FROM --platform=linux/amd64 alpine:3.15
-    RUN echo amd64 > /contrived-platform-data
+    RUN echo x86_64 > /contrived-platform-data
     ARG --required REGISTRY
     ARG --required tag
-    SAVE IMAGE $REGISTRY/myuser/myimg:$tag
+    SAVE IMAGE $REGISTRY/myuser/earthly-multiplatform-wait-test:$tag
 
-myimg-arm64:
+earthly-multiplatform-wait-test-arm64:
     FROM --platform=linux/arm64 alpine:3.15
-    RUN echo arm64 > /contrived-platform-data
+    RUN echo aarch64 > /contrived-platform-data
     ARG --required REGISTRY
     ARG --required tag
-    SAVE IMAGE $REGISTRY/myuser/myimg:$tag
+    SAVE IMAGE $REGISTRY/myuser/earthly-multiplatform-wait-test:$tag
 
 deps:
     FROM alpine:3.15
@@ -22,23 +22,28 @@ check-tag-does-not-exist-in-registry:
     FROM +deps
     ARG --required REGISTRY
     ARG --required tag
-    RUN curl -k "https://$REGISTRY/v2/myuser/myimg/manifests/$tag" > output && \
+    RUN curl -k "https://$REGISTRY/v2/myuser/earthly-multiplatform-wait-test/manifests/$tag" > output && \
         test "$(cat output | jq -r .errors[0].code)" = "MANIFEST_UNKNOWN" && echo "verified $tag was not pushed"
 
 check-tag-exists-locally:
     LOCALLY
     ARG --required REGISTRY
     ARG --required tag
-    #RUN docker images "$REGISTRY/myuser/myimg:$tag" | grep "$tag"
-    RUN docker images | grep "${tag}_linux_amd64"
-    RUN docker images | grep "${tag}_linux_arm64"
+
+    RUN docker images | grep -w "${tag}"
+    RUN docker images | grep -w "${tag}_linux_amd64"
+    RUN docker images | grep -w "${tag}_linux_arm64"
+
+    RUN test "$(docker run --rm "$REGISTRY/myuser/earthly-multiplatform-wait-test:$tag" cat /contrived-platform-data)" = "$(uname -m)"
+    RUN test "$(docker run --rm "$REGISTRY/myuser/earthly-multiplatform-wait-test:${tag}_linux_amd64" cat /contrived-platform-data)" = "x86_64"
+    RUN test "$(docker run --rm "$REGISTRY/myuser/earthly-multiplatform-wait-test:${tag}_linux_arm64" cat /contrived-platform-data)" = "aarch64"
 
 test:
     ARG --required REGISTRY
     ARG --required tag
     WAIT
-        BUILD +myimg-amd64 --REGISTRY=$REGISTRY --tag=$tag
-        BUILD +myimg-arm64 --REGISTRY=$REGISTRY --tag=$tag
+        BUILD +earthly-multiplatform-wait-test-amd64 --REGISTRY=$REGISTRY --tag=$tag
+        BUILD +earthly-multiplatform-wait-test-arm64 --REGISTRY=$REGISTRY --tag=$tag
     END
     BUILD +check-tag-does-not-exist-in-registry --REGISTRY=$REGISTRY --tag=$tag
     BUILD +check-tag-exists-locally --REGISTRY=$REGISTRY --tag=$tag

--- a/tests/wait-block/save-multi-platform-image/test.sh
+++ b/tests/wait-block/save-multi-platform-image/test.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
-set -e
 
+# clean up old images (best effort)
+docker images | grep myuser/earthly-multiplatform-wait-test | awk '{print $1 ":" $2}' | xargs -n 1 docker rmi
+
+set -e
 cd "$(dirname "$0")"
 ../common/test.sh

--- a/util/gatewaycrafter/pullpingmap.go
+++ b/util/gatewaycrafter/pullpingmap.go
@@ -4,36 +4,45 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/earthly/earthly/util/dockerutil"
 	"github.com/earthly/earthly/util/stringutil"
 )
 
 // PullPingMap is a thread-save map used for coordinating pullpings
 type PullPingMap struct {
-	m           sync.Mutex
-	localImages map[string]string
+	m       sync.Mutex
+	entries map[string]pullPingMapEntry
+}
+
+type pullPingMapEntry struct {
+	manifest   *dockerutil.Manifest
+	localImage string
 }
 
 // NewPullPingMap returns a new PullPingMap
 func NewPullPingMap() *PullPingMap {
 	return &PullPingMap{
-		localImages: map[string]string{},
+		entries: map[string]pullPingMapEntry{},
 	}
 }
 
 // Get fetches an existing entry from the map or returns false if none exists
-func (ppm *PullPingMap) Get(k string) (string, bool) {
+func (ppm *PullPingMap) Get(k string) (*dockerutil.Manifest, string, bool) {
 	ppm.m.Lock()
 	defer ppm.m.Unlock()
-	v, ok := ppm.localImages[k]
-	return v, ok
+	v, ok := ppm.entries[k]
+	return v.manifest, v.localImage, ok
 }
 
 // Insert creates a new entry for the value under sessionID/<v'>-<uuid>
 // Where v' is v without special chars
-func (ppm *PullPingMap) Insert(sessionID, v string) string {
-	k := fmt.Sprintf("sess-%s/pullping:%s-%s", sessionID, stringutil.AlphanumericOnly(v), stringutil.RandomAlphanumeric(32))
+func (ppm *PullPingMap) Insert(sessionID, localImage string, manifest *dockerutil.Manifest) string {
+	k := fmt.Sprintf("sess-%s/pullping:%s-%s", sessionID, stringutil.AlphanumericOnly(localImage), stringutil.RandomAlphanumeric(32))
 	ppm.m.Lock()
 	defer ppm.m.Unlock()
-	ppm.localImages[k] = v
+	ppm.entries[k] = pullPingMapEntry{
+		localImage: localImage,
+		manifest:   manifest,
+	}
 	return k
 }


### PR DESCRIPTION
This fixes a bug where the default platform was never exported to the
local docker instance.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>