### PR TITLE
fix: SAVE IMAGE --push in WAIT/END always happened

### DIFF
--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -1006,7 +1006,7 @@ func (c *Converter) SaveImage(ctx context.Context, imageNames []string, pushImag
 			}
 
 			if c.ftrs.WaitBlock {
-				shouldPush := pushImages && si.DockerTag != "" && c.opt.DoSaves
+				shouldPush := pushImages && si.DockerTag != "" && c.opt.DoPushes
 				shouldExportLocally := si.DockerTag != "" && c.opt.DoSaves
 				c.waitBlock().addSaveImage(si, c, shouldPush, shouldExportLocally)
 


### PR DESCRIPTION
This fixes a bug where SAVE IMAGE --push commands always pushed an
image, even when earthly was run without the --push flag.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>