### PR TITLE
remove prerelease from docs

### DIFF
--- a/docs/docker-images/all-in-one.md
+++ b/docs/docker-images/all-in-one.md
@@ -2,7 +2,6 @@ This image contains `earthly`, `buildkit`, and some extra configuration to enabl
 
 ## Tags
 
-* `prerelease`
 * `v0.6.22`, `latest`
 * `v0.6.21`
 * `v0.6.20`

--- a/docs/docker-images/buildkit-standalone.md
+++ b/docs/docker-images/buildkit-standalone.md
@@ -4,7 +4,6 @@ This image contains `buildkit` with some Earthly-specific setup. This is what Ea
 
 ## Tags
 
-* `prerelease`
 * `v0.6.22`, `latest`
 * `v0.6.21`
 * `v0.6.20`


### PR DESCRIPTION
The prerelease tag does not exist.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>