### PR TITLE
New subcommand to list invite status

### DIFF
--- a/cloud/client.go
+++ b/cloud/client.go
@@ -43,6 +43,7 @@ type Client interface {
 	Invite(ctx context.Context, org, user string, write bool) error
 	InviteToOrg(ctx context.Context, invite *OrgInvitation) (string, error)
 	AcceptInvite(ctx context.Context, inviteCode string) error
+	ListInvites(ctx context.Context, org string) ([]*OrgInvitation, error)
 	ListOrgs(ctx context.Context) ([]*OrgDetail, error)
 	ListOrgPermissions(ctx context.Context, path string) ([]*OrgPermissions, error)
 	ListOrgMembers(ctx context.Context, orgName string) ([]*OrgMember, error)

--- a/cloud/org_new.go
+++ b/cloud/org_new.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"time"
 
 	secretsapi "github.com/earthly/cloud-api/secrets"
 	"github.com/golang/protobuf/jsonpb"
@@ -17,6 +18,8 @@ type OrgInvitation struct {
 	Permission string
 	Message    string
 	OrgName    string
+	CreatedAt  time.Time
+	AcceptedAt time.Time
 }
 
 // InviteToOrg sends an email invitation to a user and asks for them to join an org.
@@ -135,4 +138,42 @@ func (c *client) AcceptInvite(ctx context.Context, inviteCode string) error {
 	}
 
 	return nil
+}
+
+// ListInvites returns a collection of organization invites and their status.
+func (c *client) ListInvites(ctx context.Context, org string) ([]*OrgInvitation, error) {
+	u := "/api/v0/invitations?org=" + org
+
+	status, body, err := c.doCall(ctx, http.MethodGet, u, withAuth())
+	if err != nil {
+		return nil, err
+	}
+
+	if status != http.StatusOK {
+		return nil, errors.Errorf("failed to remove member: %s", body)
+	}
+
+	res := &secretsapi.ListInvitationsResponse{}
+
+	err = jsonpb.UnmarshalString(body, res)
+	if err != nil {
+		return nil, err
+	}
+
+	var invites []*OrgInvitation
+
+	for _, invite := range res.Invitations {
+		in := &OrgInvitation{
+			Email:      invite.RecipientEmail,
+			OrgName:    org,
+			Permission: invite.Permission,
+			CreatedAt:  invite.CreatedAt.AsTime(),
+		}
+		if invite.AcceptedAt != nil {
+			in.AcceptedAt = invite.AcceptedAt.AsTime()
+		}
+		invites = append(invites, in)
+	}
+
+	return invites, nil
 }

--- a/cloud/org_new.go
+++ b/cloud/org_new.go
@@ -150,7 +150,7 @@ func (c *client) ListInvites(ctx context.Context, org string) ([]*OrgInvitation,
 	}
 
 	if status != http.StatusOK {
-		return nil, errors.Errorf("failed to remove member: %s", body)
+		return nil, errors.Errorf("failed to list invites: %s", body)
 	}
 
 	res := &secretsapi.ListInvitationsResponse{}

--- a/cmd/earthly/org_cmds.go
+++ b/cmd/earthly/org_cmds.go
@@ -282,6 +282,10 @@ func (app *earthlyApp) actionOrgInviteList(cliCtx *cli.Context) error {
 		return errors.Wrap(err, "failed to accept invite")
 	}
 
+	if len(invites) == 0 {
+		return nil
+	}
+
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 	fmt.Fprintf(w, "User Email\tPermission\tCreated\tAccepted\n")
 	for _, invite := range invites {

--- a/cmd/earthly/org_cmds.go
+++ b/cmd/earthly/org_cmds.go
@@ -262,11 +262,6 @@ func (app *earthlyApp) actionOrgInviteAccept(cliCtx *cli.Context) error {
 func (app *earthlyApp) actionOrgInviteList(cliCtx *cli.Context) error {
 	app.commandName = "orgInviteList"
 
-	code := cliCtx.Args().Get(0)
-	if code == "" {
-		return errors.New("invite code is required")
-	}
-
 	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
@@ -279,7 +274,7 @@ func (app *earthlyApp) actionOrgInviteList(cliCtx *cli.Context) error {
 
 	invites, err := cloudClient.ListInvites(cliCtx.Context, orgName)
 	if err != nil {
-		return errors.Wrap(err, "failed to accept invite")
+		return errors.Wrap(err, "failed to list invites")
 	}
 
 	if len(invites) == 0 {

--- a/cmd/earthly/org_cmds.go
+++ b/cmd/earthly/org_cmds.go
@@ -125,7 +125,7 @@ func (app *earthlyApp) orgCmdsPreview() []*cli.Command {
 				{
 					Name:        "ls",
 					Aliases:     []string{"list"},
-					Usage:       "List all pending and accepted invitations",
+					Usage:       "List all sent invitations (both pending and accepted)",
 					Description: "List all pending and accepted invitations",
 					UsageText:   "earthly org [--org <organization>] invite ls",
 					Action:      app.actionOrgInviteList,

--- a/go.mod
+++ b/go.mod
@@ -46,4 +46,6 @@ replace (
 
 	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.1-0.20220824153500-64d715da40d6
 	github.com/tonistiigi/fsutil => github.com/earthly/fsutil v0.0.0-20220719234708-392da7eebeb5
+
+	github.com/earthly/cloud-api => ../cloud-api
 )

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/docker/distribution v2.8.1+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/dustin/go-humanize v1.0.0
-	github.com/earthly/cloud-api v1.0.1-0.20220819185746-bab168ecbbf9
+	github.com/earthly/cloud-api v1.0.1-0.20220906171601-d9bcf2b5756f
 	github.com/elastic/go-sysinfo v1.7.1
 	github.com/fatih/color v1.9.0
 	github.com/golang/protobuf v1.5.2
@@ -46,6 +46,4 @@ replace (
 
 	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.1-0.20220824153500-64d715da40d6
 	github.com/tonistiigi/fsutil => github.com/earthly/fsutil v0.0.0-20220719234708-392da7eebeb5
-
-	github.com/earthly/cloud-api => ../cloud-api
 )

--- a/go.sum
+++ b/go.sum
@@ -372,8 +372,6 @@ github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/earthly/buildkit v0.0.1-0.20220824153500-64d715da40d6 h1:oZcbJXVZsKLv+ftz3qu6fma/vCp/Z1NZvkKmaxO3l/w=
 github.com/earthly/buildkit v0.0.1-0.20220824153500-64d715da40d6/go.mod h1:Ih6/jh6JTbktkhxRID0gj6dn2GAPI6H9U6xKVxgNqBk=
-github.com/earthly/cloud-api v1.0.1-0.20220819185746-bab168ecbbf9 h1:r24RzVlEmXaJf/tX0smUEUuGYk4bkcn8TqFI5BoqR9g=
-github.com/earthly/cloud-api v1.0.1-0.20220819185746-bab168ecbbf9/go.mod h1:JhlHsW6o8zYa+XsM0nMAevRQtES35KE5R2G8tJALsnI=
 github.com/earthly/fsutil v0.0.0-20220719234708-392da7eebeb5 h1:bOKRnmQd1JYrtOUdkvYraBCT0SRjYpYnhd4i85mWtQw=
 github.com/earthly/fsutil v0.0.0-20220719234708-392da7eebeb5/go.mod h1:oPAfvw32vlUJSjyDcQ3Bu0nb2ON2B+G0dtVN/SZNJiA=
 github.com/elastic/go-sysinfo v1.7.1 h1:Wx4DSARcKLllpKT2TnFVdSUJOsybqMYCNQZq1/wO+s0=

--- a/go.sum
+++ b/go.sum
@@ -372,6 +372,8 @@ github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/earthly/buildkit v0.0.1-0.20220824153500-64d715da40d6 h1:oZcbJXVZsKLv+ftz3qu6fma/vCp/Z1NZvkKmaxO3l/w=
 github.com/earthly/buildkit v0.0.1-0.20220824153500-64d715da40d6/go.mod h1:Ih6/jh6JTbktkhxRID0gj6dn2GAPI6H9U6xKVxgNqBk=
+github.com/earthly/cloud-api v1.0.1-0.20220906171601-d9bcf2b5756f h1:VOBbD3M3H70I5FqZpJU3g49jaXjE4gV/+YBvRB2ML7w=
+github.com/earthly/cloud-api v1.0.1-0.20220906171601-d9bcf2b5756f/go.mod h1:JhlHsW6o8zYa+XsM0nMAevRQtES35KE5R2G8tJALsnI=
 github.com/earthly/fsutil v0.0.0-20220719234708-392da7eebeb5 h1:bOKRnmQd1JYrtOUdkvYraBCT0SRjYpYnhd4i85mWtQw=
 github.com/earthly/fsutil v0.0.0-20220719234708-392da7eebeb5/go.mod h1:oPAfvw32vlUJSjyDcQ3Bu0nb2ON2B+G0dtVN/SZNJiA=
 github.com/elastic/go-sysinfo v1.7.1 h1:Wx4DSARcKLllpKT2TnFVdSUJOsybqMYCNQZq1/wO+s0=


### PR DESCRIPTION
New subcommand that helps users determine the status of previously sent invites.

```
earthly preview orgs --org earthly-technologies invite ls
User Email                     Permission  Created     Accepted
mike@earthly.dev               admin       2022-07-29  No
mikejholly@gmail.com           read        2022-08-22  2022-08-22
mikejholly+test001@gmail.com   read        2022-08-22  2022-08-22
mikejholly+test0002@gmail.com  read        2022-08-24  No
mikejholly+test0003@gmail.com  admin       2022-08-24  No
mikejholly+test0004@gmail.com  read        2022-08-25  2022-08-25
```