### PR TITLE
Brew install should not fail if buildkit startup fails

### DIFF
--- a/cmd/earthly/build_cmd.go
+++ b/cmd/earthly/build_cmd.go
@@ -214,6 +214,9 @@ func (app *earthlyApp) actionBuildImp(cliCtx *cli.Context, flagArgs, nonFlagArgs
 	if app.interactiveDebugging && !isLocal {
 		return errors.New("the --interactive flag is not currently supported with non-local buildkit servers")
 	}
+	if isLocal && !app.containerFrontend.IsAvailable(cliCtx.Context) {
+		return errors.New("Frontend is not available to perform the build. Is Docker installed and running?")
+	}
 
 	bkClient, err := buildkitd.NewClient(cliCtx.Context, app.console, app.buildkitdImage, app.containerName, app.containerFrontend, Version, app.buildkitdSettings)
 	if err != nil {

--- a/cmd/earthly/buildkit.go
+++ b/cmd/earthly/buildkit.go
@@ -28,10 +28,12 @@ func (app *earthlyApp) initFrontend(cliCtx *cli.Context) error {
 		origErr := err
 		fe, err = containerutil.NewStubFrontend(cliCtx.Context, feConfig)
 		if err != nil {
-			return errors.Wrap(err, "failed frontend initialization")
+			return errors.Wrap(err, "failed stub frontend initialization")
 		}
 
-		console.Printf("No frontend initialized.\n")
+		if !app.verbose {
+			console.Printf("No frontend initialized. Use --verbose to see details\n")
+		}
 		console.VerbosePrintf("%s frontend initialization failed due to %s", app.cfg.Global.ContainerFrontend, origErr.Error())
 	} else {
 		console.VerbosePrintf("%s frontend initialized.\n", fe.Config().Setting)

--- a/cmd/earthly/root_cmds.go
+++ b/cmd/earthly/root_cmds.go
@@ -396,9 +396,11 @@ func (app *earthlyApp) bootstrap(cliCtx *cli.Context) error {
 		// Bootstrap buildkit - pulls image and starts daemon.
 		bkClient, err := app.getBuildkitClient(cliCtx, nil)
 		if err != nil {
-			return errors.Wrap(err, "bootstrap new buildkitd client")
+			console.Warnf("Warning: Bootstrapping buildkit failed: %v", err)
+			// Keep going.
+		} else {
+			defer bkClient.Close()
 		}
-		defer bkClient.Close()
 	}
 
 	console.Printf("Bootstrapping successful.\n")


### PR DESCRIPTION
There are valid use cases for installing Earthly without a functional Buildkit. For example, using it via podman (needs to be configured), or using it only for org/account/secret management.

Before this PR, the brew installation would fail on a Mac if Docker is not available. One case is that Docker simply is not installed. But another (very common) case is that the Docker App is simply not started. We don't want to prevent the user from installing Earthly in these cases. We can always show them a more meaningful error on their first build.

In addition, this PR improves the error shown when attempting to perform a local build and Docker is not running.