### PR TITLE
correct spelling error latests -> latest

### DIFF
--- a/docs/basics/part-4-args.md
+++ b/docs/basics/part-4-args.md
@@ -32,7 +32,7 @@ In this case `my-new-image-tag` will override the default value and become the n
 
 ```bash
 earthly +docker
-# tag for image will be 'latests'
+# tag for image will be 'latest'
 ```
 
 ### Passing ARGs in FROM, BUILD, and COPY


### PR DESCRIPTION
Simply change the spelling from `latests` -> `latest`.