### PR TITLE
bootstrap: attempt multiple zsh install locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 
 ## Unreleased
 
+### Changed
+
+- Bootstraping zsh autocompletion will first attempt to install under `/usr/local/share/zsh/site-functions`, and will now
+  fallback to `/usr/share/zsh/site-functions`.
+
 ## v0.6.23 - 2022-09-06
 
 ### Fixed


### PR DESCRIPTION
A user reported having `/usr/share/zsh/site-functions` as their zsh location rather than `/usr/local/share/zsh/site-functions`; This change checks both locations rather than just the later.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>