### PR TITLE
Use gRPC Client Instead of JSON

### DIFF
--- a/cloud/auth_test.go
+++ b/cloud/auth_test.go
@@ -23,7 +23,7 @@ var testTokenExp = time.Now().Add(24 * time.Hour).UTC()
 func TestClient_Authenticate(t *testing.T) {
 	srv := mockServer(t)
 	cc := &client{
-		host:     srv.URL,
+		httpAddr: srv.URL,
 		email:    testEmail,
 		password: testPass,
 		authDir:  "/tmp",

--- a/cloud/client.go
+++ b/cloud/client.go
@@ -27,6 +27,7 @@ const (
 	satelliteMgmtTimeout = "5M" // 5 minute timeout when launching or deleting a Satellite
 )
 
+// Client contains gRPC and REST endpoints to the Earthly Cloud backend.
 type Client interface {
 	RegisterEmail(ctx context.Context, email string) error
 	CreateAccount(ctx context.Context, email, verificationToken, password, publicKey string, termsConditionsPrivacy bool) error

--- a/cloud/client.go
+++ b/cloud/client.go
@@ -131,7 +131,7 @@ func NewClient(httpAddr, grpcAddr, agentSockPath, authCredsOverride string, warn
 	tlsConfig := credentials.NewTLS(&tls.Config{})
 	ctx := context.Background()
 	retryOpts := []grpc_retry.CallOption{
-		grpc_retry.WithBackoff(grpc_retry.BackoffLinear(100 * time.Millisecond)),
+		grpc_retry.WithBackoff(grpc_retry.BackoffExponential(100 * time.Millisecond)),
 		grpc_retry.WithCodes(codes.Internal, codes.Unavailable),
 	}
 	conn, err := grpc.DialContext(ctx, grpcAddr,

--- a/cloud/client.go
+++ b/cloud/client.go
@@ -1,20 +1,18 @@
 package cloud
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
-	"fmt"
-	"io"
-	"net/http"
-	"os"
-	"strings"
+	"crypto/tls"
 	"time"
 
+	"github.com/earthly/cloud-api/pipelines"
 	"github.com/golang/protobuf/jsonpb"
-	"github.com/golang/protobuf/proto"
+	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/ssh/agent"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
 )
 
 var (
@@ -29,7 +27,6 @@ const (
 	satelliteMgmtTimeout = "5M" // 5 minute timeout when launching or deleting a Satellite
 )
 
-// Client provides a client to the shared secrets service
 type Client interface {
 	RegisterEmail(ctx context.Context, email string) error
 	CreateAccount(ctx context.Context, email, verificationToken, password, publicKey string, termsConditionsPrivacy bool) error
@@ -92,218 +89,8 @@ type Client interface {
 	AccountReset(ctx context.Context, userEmail, token, password string) error
 }
 
-type request struct {
-	hasBody bool
-	body    []byte
-	headers http.Header
-
-	hasAuth    bool
-	hasHeaders bool
-}
-
-type requestOpt func(*request) error
-
-func withAuth() requestOpt {
-	return func(r *request) error {
-		r.hasAuth = true
-		return nil
-	}
-}
-
-func withHeader(key, value string) requestOpt {
-	return func(r *request) error {
-		r.hasHeaders = true
-		r.headers = http.Header{}
-		r.headers.Add(key, value)
-		return nil
-	}
-}
-
-func withJSONBody(body proto.Message) requestOpt {
-	return func(r *request) error {
-		marshaler := jsonpb.Marshaler{}
-		encodedBody, err := marshaler.MarshalToString(body)
-		if err != nil {
-			return err
-		}
-
-		r.hasBody = true
-		r.body = []byte(encodedBody)
-		return nil
-	}
-}
-
-func withFileBody(pathOnDisk string) requestOpt {
-	return func(r *request) error {
-		_, err := os.Stat(pathOnDisk)
-		if err != nil {
-			return errors.Wrapf(err, "could not stat file at %s", pathOnDisk)
-		}
-
-		contents, err := os.ReadFile(pathOnDisk)
-		if err != nil {
-			return errors.Wrapf(err, "could not add file %s to request body", pathOnDisk)
-		}
-
-		r.hasBody = true
-		r.body = contents
-		return nil
-	}
-}
-
-func withBody(body string) requestOpt {
-	return func(r *request) error {
-		r.hasBody = true
-		r.body = []byte(body)
-		return nil
-	}
-}
-
-func (c *client) doCall(ctx context.Context, method, url string, opts ...requestOpt) (int, string, error) {
-	const maxAttempt = 10
-	const maxSleepBeforeRetry = time.Second * 3
-
-	var r request
-	for _, opt := range opts {
-		err := opt(&r)
-		if err != nil {
-			return 0, "", err
-		}
-	}
-
-	alreadyReAuthed := false
-	if r.hasAuth && time.Now().UTC().After(c.authTokenExpiry) {
-		if err := c.Authenticate(ctx); err != nil {
-			if errors.Is(err, ErrUnauthorized) {
-				return 0, "", ErrUnauthorized
-			}
-			return 0, "", errors.Wrap(err, "failed refreshing expired auth token")
-		}
-		alreadyReAuthed = true
-	}
-
-	var status int
-	var body string
-	var callErr error
-	duration := time.Millisecond * 100
-	for attempt := 0; attempt < maxAttempt; attempt++ {
-		status, body, callErr = c.doCallImp(ctx, r, method, url, opts...)
-		retry, err := shouldRetry(status, body, callErr, c.warnFunc)
-		if err != nil {
-			return status, body, err
-		}
-		if !retry {
-			return status, body, nil
-		}
-
-		if status == http.StatusUnauthorized {
-			if !r.hasAuth || alreadyReAuthed {
-				return status, body, ErrUnauthorized
-			}
-			err := c.Authenticate(ctx)
-			if err != nil {
-				return status, body, errors.Wrap(err, "auth credentials not valid")
-			}
-			alreadyReAuthed = true
-		}
-
-		if duration > maxSleepBeforeRetry {
-			duration = maxSleepBeforeRetry
-		}
-
-		time.Sleep(duration)
-		duration *= 2
-	}
-
-	return status, body, callErr
-}
-
-func shouldRetry(status int, body string, callErr error, warnFunc func(string, ...interface{})) (bool, error) {
-	if status == http.StatusUnauthorized {
-		return true, nil
-	}
-	if 500 <= status && status <= 599 {
-		msg, err := getMessageFromJSON(bytes.NewReader([]byte(body)))
-		if err != nil {
-			warnFunc("retrying http request due to unexpected status code %v", status)
-		} else {
-			warnFunc("retrying http request due to unexpected status code %v: %v", status, msg)
-		}
-		return true, nil
-	}
-	switch {
-	case callErr == nil:
-		return false, nil
-	case errors.Is(callErr, ErrNoAuthorizedPublicKeys):
-		return false, callErr
-	case errors.Is(callErr, ErrNoSSHAgent):
-		return false, callErr
-	case errors.Is(callErr, context.Canceled):
-		return false, callErr
-	case errors.Is(callErr, context.DeadlineExceeded):
-		return false, callErr
-	case strings.Contains(callErr.Error(), "failed to connect to ssh-agent"):
-		return false, callErr
-	default:
-		warnFunc("retrying http request due to unexpected error %v", callErr)
-		return true, nil
-	}
-}
-
-func (c *client) doCallImp(ctx context.Context, r request, method, url string, opts ...requestOpt) (int, string, error) {
-	var bodyReader io.Reader
-	var bodyLen int64
-	if r.hasBody {
-		bodyReader = bytes.NewReader(r.body)
-		bodyLen = int64(len(r.body))
-	}
-
-	req, err := http.NewRequestWithContext(ctx, method, c.host+url, bodyReader)
-	if err != nil {
-		return 0, "", err
-	}
-	if bodyReader != nil {
-		req.ContentLength = bodyLen
-	}
-	if r.hasHeaders {
-		req.Header = r.headers.Clone()
-	}
-	if r.hasAuth {
-		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.authToken))
-	}
-
-	client := &http.Client{}
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return 0, "", err
-	}
-
-	respBody, err := readAllWithContext(ctx, resp.Body)
-	if err != nil {
-		return 0, "", err
-	}
-	return resp.StatusCode, string(respBody), nil
-}
-
-func readAllWithContext(ctx context.Context, r io.Reader) ([]byte, error) {
-	var dt []byte
-	var readErr error
-	ch := make(chan struct{})
-	go func() {
-		dt, readErr = io.ReadAll(r)
-		close(ch)
-	}()
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case <-ch:
-		return dt, readErr
-	}
-}
-
 type client struct {
-	host                  string
+	httpAddr              string
 	sshKeyBlob            []byte // sshKey to use
 	forceSSHKey           bool   // if true only use the above ssh key, don't attempt to guess others
 	sshAgent              agent.ExtendedAgent
@@ -316,14 +103,15 @@ type client struct {
 	authDir               string
 	disableSSHKeyGuessing bool
 	jm                    *jsonpb.Unmarshaler
+	pipelines             pipelines.PipelinesClient
 }
 
 var _ Client = &client{}
 
 // NewClient provides a new Earthly Cloud client
-func NewClient(host, agentSockPath, authCredsOverride string, warnFunc func(string, ...interface{})) (Client, error) {
+func NewClient(httpAddr, grpcAddr, agentSockPath, authCredsOverride string, warnFunc func(string, ...interface{})) (Client, error) {
 	c := &client{
-		host: host,
+		httpAddr: httpAddr,
 		sshAgent: &lazySSHAgent{
 			sockPath: agentSockPath,
 		},
@@ -339,17 +127,19 @@ func NewClient(host, agentSockPath, authCredsOverride string, warnFunc func(stri
 			return nil, err
 		}
 	}
-	return c, nil
-}
-
-func getMessageFromJSON(r io.Reader) (string, error) {
-	decoder := json.NewDecoder(r)
-	msg := struct {
-		Message string `json:"message"`
-	}{}
-	err := decoder.Decode(&msg)
-	if err != nil {
-		return "", err
+	tlsConfig := credentials.NewTLS(&tls.Config{})
+	ctx := context.Background()
+	retryOpts := []grpc_retry.CallOption{
+		grpc_retry.WithBackoff(grpc_retry.BackoffLinear(100 * time.Millisecond)),
+		grpc_retry.WithCodes(codes.Internal, codes.Unavailable),
 	}
-	return msg.Message, nil
+	conn, err := grpc.DialContext(ctx, grpcAddr,
+		grpc.WithTransportCredentials(tlsConfig),
+		grpc.WithChainStreamInterceptor(grpc_retry.StreamClientInterceptor(retryOpts...), c.StreamAuthInterceptor()),
+		grpc.WithChainUnaryInterceptor(grpc_retry.UnaryClientInterceptor(retryOpts...), c.UnaryAuthInterceptor()))
+	if err != nil {
+		return nil, errors.Wrap(err, "failed dialing pipelines grpc")
+	}
+	c.pipelines = pipelines.NewPipelinesClient(conn)
+	return c, nil
 }

--- a/cloud/grpc.go
+++ b/cloud/grpc.go
@@ -38,8 +38,6 @@ func (c *client) UnaryAuthInterceptor() grpc.UnaryClientInterceptor {
 				}
 				md.Delete("authorization")
 				ctx = metadata.NewOutgoingContext(ctx, md)
-				ctx = c.withAuth(ctx)
-				md, _ = metadata.FromOutgoingContext(ctx)
 				return invoker(c.withAuth(ctx), method, req, reply, cc, opts...)
 			}
 		}

--- a/cloud/grpc.go
+++ b/cloud/grpc.go
@@ -1,0 +1,79 @@
+package cloud
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/pkg/errors"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+func (c *client) withAuth(ctx context.Context) context.Context {
+	return metadata.AppendToOutgoingContext(ctx, "authorization", fmt.Sprintf("Bearer %s", c.authToken))
+}
+
+func (c *client) UnaryAuthInterceptor() grpc.UnaryClientInterceptor {
+	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		if time.Now().UTC().After(c.authTokenExpiry) {
+			err := c.Authenticate(ctx)
+			if err != nil {
+				return errors.Wrap(err, "failed refreshing expired token")
+			}
+		}
+		err := invoker(ctx, method, req, reply, cc, opts...)
+		if err != nil {
+			s, ok := status.FromError(err)
+			if ok && s.Code() == codes.Unauthenticated {
+				err = c.Authenticate(ctx)
+				if err != nil {
+					return errors.Wrap(err, "failed re-authenticating")
+				}
+				md, ok := metadata.FromOutgoingContext(ctx)
+				if !ok {
+					return errors.New("could not parse metadata")
+				}
+				md.Delete("authorization")
+				ctx = metadata.NewOutgoingContext(ctx, md)
+				ctx = c.withAuth(ctx)
+				md, _ = metadata.FromOutgoingContext(ctx)
+				return invoker(c.withAuth(ctx), method, req, reply, cc, opts...)
+			}
+		}
+		return nil
+	}
+}
+
+func (c *client) StreamAuthInterceptor() grpc.StreamClientInterceptor {
+	return func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+		if time.Now().UTC().After(c.authTokenExpiry) {
+			err := c.Authenticate(ctx)
+			if err != nil {
+				return nil, errors.Wrap(err, "failed refreshing expired token")
+			}
+		}
+		newStreamer, err := streamer(ctx, desc, cc, method, opts...)
+		if err != nil {
+			s, ok := status.FromError(err)
+			if ok && s.Code() == codes.Unauthenticated {
+				err = c.Authenticate(ctx)
+				if err != nil {
+					return nil, errors.Wrap(err, "failed re-authenticating")
+				}
+				md, ok := metadata.FromOutgoingContext(ctx)
+				if !ok {
+					return nil, errors.New("could not parse metadata")
+				}
+				md.Delete("authorization")
+				ctx = metadata.NewOutgoingContext(ctx, md)
+				// TODO not sure if newStreamer(...) should be called here instead
+				return streamer(c.withAuth(ctx), desc, cc, method, opts...)
+			}
+			return newStreamer, err
+		}
+		return newStreamer, nil
+	}
+}

--- a/cloud/http.go
+++ b/cloud/http.go
@@ -1,0 +1,239 @@
+package cloud
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/golang/protobuf/jsonpb"
+	"github.com/golang/protobuf/proto"
+	"github.com/pkg/errors"
+)
+
+type request struct {
+	hasBody bool
+	body    []byte
+	headers http.Header
+
+	hasAuth    bool
+	hasHeaders bool
+}
+
+type requestOpt func(*request) error
+
+func withAuth() requestOpt {
+	return func(r *request) error {
+		r.hasAuth = true
+		return nil
+	}
+}
+
+func withHeader(key, value string) requestOpt {
+	return func(r *request) error {
+		r.hasHeaders = true
+		r.headers = http.Header{}
+		r.headers.Add(key, value)
+		return nil
+	}
+}
+
+func withJSONBody(body proto.Message) requestOpt {
+	return func(r *request) error {
+		marshaler := jsonpb.Marshaler{}
+		encodedBody, err := marshaler.MarshalToString(body)
+		if err != nil {
+			return err
+		}
+
+		r.hasBody = true
+		r.body = []byte(encodedBody)
+		return nil
+	}
+}
+
+func withFileBody(pathOnDisk string) requestOpt {
+	return func(r *request) error {
+		_, err := os.Stat(pathOnDisk)
+		if err != nil {
+			return errors.Wrapf(err, "could not stat file at %s", pathOnDisk)
+		}
+
+		contents, err := os.ReadFile(pathOnDisk)
+		if err != nil {
+			return errors.Wrapf(err, "could not add file %s to request body", pathOnDisk)
+		}
+
+		r.hasBody = true
+		r.body = contents
+		return nil
+	}
+}
+
+func withBody(body string) requestOpt {
+	return func(r *request) error {
+		r.hasBody = true
+		r.body = []byte(body)
+		return nil
+	}
+}
+
+func (c *client) doCall(ctx context.Context, method, url string, opts ...requestOpt) (int, string, error) {
+	const maxAttempt = 10
+	const maxSleepBeforeRetry = time.Second * 3
+
+	var r request
+	for _, opt := range opts {
+		err := opt(&r)
+		if err != nil {
+			return 0, "", err
+		}
+	}
+
+	alreadyReAuthed := false
+	if r.hasAuth && time.Now().UTC().After(c.authTokenExpiry) {
+		if err := c.Authenticate(ctx); err != nil {
+			if errors.Is(err, ErrUnauthorized) {
+				return 0, "", ErrUnauthorized
+			}
+			return 0, "", errors.Wrap(err, "failed refreshing expired auth token")
+		}
+		alreadyReAuthed = true
+	}
+
+	var status int
+	var body string
+	var callErr error
+	duration := time.Millisecond * 100
+	for attempt := 0; attempt < maxAttempt; attempt++ {
+		status, body, callErr = c.doCallImp(ctx, r, method, url, opts...)
+		retry, err := shouldRetry(status, body, callErr, c.warnFunc)
+		if err != nil {
+			return status, body, err
+		}
+		if !retry {
+			return status, body, nil
+		}
+
+		if status == http.StatusUnauthorized {
+			if !r.hasAuth || alreadyReAuthed {
+				return status, body, ErrUnauthorized
+			}
+			err := c.Authenticate(ctx)
+			if err != nil {
+				return status, body, errors.Wrap(err, "auth credentials not valid")
+			}
+			alreadyReAuthed = true
+		}
+
+		if duration > maxSleepBeforeRetry {
+			duration = maxSleepBeforeRetry
+		}
+
+		time.Sleep(duration)
+		duration *= 2
+	}
+
+	return status, body, callErr
+}
+
+func shouldRetry(status int, body string, callErr error, warnFunc func(string, ...interface{})) (bool, error) {
+	if status == http.StatusUnauthorized {
+		return true, nil
+	}
+	if 500 <= status && status <= 599 {
+		msg, err := getMessageFromJSON(bytes.NewReader([]byte(body)))
+		if err != nil {
+			warnFunc("retrying http request due to unexpected status code %v", status)
+		} else {
+			warnFunc("retrying http request due to unexpected status code %v: %v", status, msg)
+		}
+		return true, nil
+	}
+	switch {
+	case callErr == nil:
+		return false, nil
+	case errors.Is(callErr, ErrNoAuthorizedPublicKeys):
+		return false, callErr
+	case errors.Is(callErr, ErrNoSSHAgent):
+		return false, callErr
+	case errors.Is(callErr, context.Canceled):
+		return false, callErr
+	case errors.Is(callErr, context.DeadlineExceeded):
+		return false, callErr
+	case strings.Contains(callErr.Error(), "failed to connect to ssh-agent"):
+		return false, callErr
+	default:
+		warnFunc("retrying http request due to unexpected error %v", callErr)
+		return true, nil
+	}
+}
+
+func (c *client) doCallImp(ctx context.Context, r request, method, url string, opts ...requestOpt) (int, string, error) {
+	var bodyReader io.Reader
+	var bodyLen int64
+	if r.hasBody {
+		bodyReader = bytes.NewReader(r.body)
+		bodyLen = int64(len(r.body))
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, c.httpAddr+url, bodyReader)
+	if err != nil {
+		return 0, "", err
+	}
+	if bodyReader != nil {
+		req.ContentLength = bodyLen
+	}
+	if r.hasHeaders {
+		req.Header = r.headers.Clone()
+	}
+	if r.hasAuth {
+		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.authToken))
+	}
+
+	client := &http.Client{}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, "", err
+	}
+
+	respBody, err := readAllWithContext(ctx, resp.Body)
+	if err != nil {
+		return 0, "", err
+	}
+	return resp.StatusCode, string(respBody), nil
+}
+
+func readAllWithContext(ctx context.Context, r io.Reader) ([]byte, error) {
+	var dt []byte
+	var readErr error
+	ch := make(chan struct{})
+	go func() {
+		dt, readErr = io.ReadAll(r)
+		close(ch)
+	}()
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-ch:
+		return dt, readErr
+	}
+}
+
+func getMessageFromJSON(r io.Reader) (string, error) {
+	decoder := json.NewDecoder(r)
+	msg := struct {
+		Message string `json:"message"`
+	}{}
+	err := decoder.Decode(&msg)
+	if err != nil {
+		return "", err
+	}
+	return msg.Message, nil
+}

--- a/cmd/earthly/account_cmds.go
+++ b/cmd/earthly/account_cmds.go
@@ -12,12 +12,13 @@ import (
 	"time"
 
 	"github.com/dustin/go-humanize"
-	"github.com/earthly/earthly/cloud"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
 	"golang.org/x/term"
+
+	"github.com/earthly/earthly/cloud"
 )
 
 var (
@@ -190,7 +191,7 @@ func (app *earthlyApp) actionAccountRegister(cliCtx *cli.Context) error {
 		return errors.New("email is invalid")
 	}
 
-	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -324,7 +325,7 @@ func promptPassword() (string, error) {
 
 func (app *earthlyApp) actionAccountListKeys(cliCtx *cli.Context) error {
 	app.commandName = "accountListKeys"
-	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -340,7 +341,7 @@ func (app *earthlyApp) actionAccountListKeys(cliCtx *cli.Context) error {
 
 func (app *earthlyApp) actionAccountAddKey(cliCtx *cli.Context) error {
 	app.commandName = "accountAddKey"
-	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -410,7 +411,7 @@ func (app *earthlyApp) actionAccountAddKey(cliCtx *cli.Context) error {
 
 func (app *earthlyApp) actionAccountRemoveKey(cliCtx *cli.Context) error {
 	app.commandName = "accountRemoveKey"
-	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -424,7 +425,7 @@ func (app *earthlyApp) actionAccountRemoveKey(cliCtx *cli.Context) error {
 }
 func (app *earthlyApp) actionAccountListTokens(cliCtx *cli.Context) error {
 	app.commandName = "accountListTokens"
-	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -486,7 +487,7 @@ func (app *earthlyApp) actionAccountCreateToken(cliCtx *cli.Context) error {
 		}
 	}
 
-	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -505,7 +506,7 @@ func (app *earthlyApp) actionAccountRemoveToken(cliCtx *cli.Context) error {
 		return errors.New("invalid number of arguments provided")
 	}
 	name := cliCtx.Args().First()
-	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -541,7 +542,7 @@ func (app *earthlyApp) actionAccountLogin(cliCtx *cli.Context) error {
 	if token != "" && (email != "" || pass != "") {
 		return errors.New("--token cannot be used in conjuction with --email or --password")
 	}
-	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -682,7 +683,7 @@ func (app *earthlyApp) actionAccountLogout(cliCtx *cli.Context) error {
 		return errLogoutHasNoEffectWhenAuthTokenSet
 	}
 
-	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return err
 	}
@@ -700,7 +701,7 @@ func (app *earthlyApp) actionAccountReset(cliCtx *cli.Context) error {
 		return errors.New("no email given")
 	}
 
-	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return err
 	}

--- a/cmd/earthly/account_cmds.go
+++ b/cmd/earthly/account_cmds.go
@@ -191,7 +191,7 @@ func (app *earthlyApp) actionAccountRegister(cliCtx *cli.Context) error {
 		return errors.New("email is invalid")
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -325,7 +325,7 @@ func promptPassword() (string, error) {
 
 func (app *earthlyApp) actionAccountListKeys(cliCtx *cli.Context) error {
 	app.commandName = "accountListKeys"
-	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -341,7 +341,7 @@ func (app *earthlyApp) actionAccountListKeys(cliCtx *cli.Context) error {
 
 func (app *earthlyApp) actionAccountAddKey(cliCtx *cli.Context) error {
 	app.commandName = "accountAddKey"
-	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -411,7 +411,7 @@ func (app *earthlyApp) actionAccountAddKey(cliCtx *cli.Context) error {
 
 func (app *earthlyApp) actionAccountRemoveKey(cliCtx *cli.Context) error {
 	app.commandName = "accountRemoveKey"
-	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -425,7 +425,7 @@ func (app *earthlyApp) actionAccountRemoveKey(cliCtx *cli.Context) error {
 }
 func (app *earthlyApp) actionAccountListTokens(cliCtx *cli.Context) error {
 	app.commandName = "accountListTokens"
-	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -487,7 +487,7 @@ func (app *earthlyApp) actionAccountCreateToken(cliCtx *cli.Context) error {
 		}
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -506,7 +506,7 @@ func (app *earthlyApp) actionAccountRemoveToken(cliCtx *cli.Context) error {
 		return errors.New("invalid number of arguments provided")
 	}
 	name := cliCtx.Args().First()
-	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -542,7 +542,7 @@ func (app *earthlyApp) actionAccountLogin(cliCtx *cli.Context) error {
 	if token != "" && (email != "" || pass != "") {
 		return errors.New("--token cannot be used in conjuction with --email or --password")
 	}
-	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -683,7 +683,7 @@ func (app *earthlyApp) actionAccountLogout(cliCtx *cli.Context) error {
 		return errLogoutHasNoEffectWhenAuthTokenSet
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return err
 	}
@@ -701,7 +701,7 @@ func (app *earthlyApp) actionAccountReset(cliCtx *cli.Context) error {
 		return errors.New("no email given")
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return err
 	}

--- a/cmd/earthly/build_cmd.go
+++ b/cmd/earthly/build_cmd.go
@@ -161,7 +161,7 @@ func (app *earthlyApp) actionBuildImp(cliCtx *cli.Context, flagArgs, nonFlagArgs
 	cleanCollection := cleanup.NewCollection()
 	defer cleanCollection.Close()
 
-	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}

--- a/cmd/earthly/build_cmd.go
+++ b/cmd/earthly/build_cmd.go
@@ -11,6 +11,17 @@ import (
 
 	"github.com/containerd/containerd/platforms"
 	"github.com/docker/cli/cli/config"
+	"github.com/joho/godotenv"
+	"github.com/moby/buildkit/client/llb"
+	"github.com/moby/buildkit/session"
+	"github.com/moby/buildkit/session/auth/authprovider"
+	"github.com/moby/buildkit/session/localhost/localhostprovider"
+	"github.com/moby/buildkit/session/socketforward/socketprovider"
+	"github.com/moby/buildkit/session/sshforward/sshprovider"
+	"github.com/moby/buildkit/util/entitlements"
+	"github.com/pkg/errors"
+	"github.com/urfave/cli/v2"
+
 	"github.com/earthly/earthly/analytics"
 	"github.com/earthly/earthly/buildcontext"
 	"github.com/earthly/earthly/buildcontext/provider"
@@ -28,16 +39,6 @@ import (
 	"github.com/earthly/earthly/util/syncutil/semutil"
 	"github.com/earthly/earthly/util/termutil"
 	"github.com/earthly/earthly/variables"
-	"github.com/joho/godotenv"
-	"github.com/moby/buildkit/client/llb"
-	"github.com/moby/buildkit/session"
-	"github.com/moby/buildkit/session/auth/authprovider"
-	"github.com/moby/buildkit/session/localhost/localhostprovider"
-	"github.com/moby/buildkit/session/socketforward/socketprovider"
-	"github.com/moby/buildkit/session/sshforward/sshprovider"
-	"github.com/moby/buildkit/util/entitlements"
-	"github.com/pkg/errors"
-	"github.com/urfave/cli/v2"
 )
 
 func (app *earthlyApp) actionBuild(cliCtx *cli.Context) error {
@@ -160,7 +161,7 @@ func (app *earthlyApp) actionBuildImp(cliCtx *cli.Context, flagArgs, nonFlagArgs
 	cleanCollection := cleanup.NewCollection()
 	defer cleanCollection.Close()
 
-	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}

--- a/cmd/earthly/debug_cmds.go
+++ b/cmd/earthly/debug_cmds.go
@@ -85,7 +85,7 @@ func (app *earthlyApp) actionDebugAst(cliCtx *cli.Context) error {
 func (app *earthlyApp) actionDebugBuildkitInfo(cliCtx *cli.Context) error {
 	app.commandName = "debugBuildkitInfo"
 
-	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -110,7 +110,7 @@ func (app *earthlyApp) actionDebugBuildkitInfo(cliCtx *cli.Context) error {
 func (app *earthlyApp) actionDebugBuildkitDiskUsage(cliCtx *cli.Context) error {
 	app.commandName = "debugBuildkitDiskUsage"
 
-	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -161,7 +161,7 @@ func (app *earthlyApp) actionDebugBuildkitDiskUsage(cliCtx *cli.Context) error {
 func (app *earthlyApp) actionDebugBuildkitWorkers(cliCtx *cli.Context) error {
 	app.commandName = "debugBuildkitWorkers"
 
-	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -234,7 +234,7 @@ func (app *earthlyApp) actionDebugBuildkitWorkers(cliCtx *cli.Context) error {
 func (app *earthlyApp) actionDebugBuildkitShutdownIfIdle(cliCtx *cli.Context) error {
 	app.commandName = "debugBuildkitShutdownIfIdle"
 
-	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}

--- a/cmd/earthly/debug_cmds.go
+++ b/cmd/earthly/debug_cmds.go
@@ -85,7 +85,7 @@ func (app *earthlyApp) actionDebugAst(cliCtx *cli.Context) error {
 func (app *earthlyApp) actionDebugBuildkitInfo(cliCtx *cli.Context) error {
 	app.commandName = "debugBuildkitInfo"
 
-	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -110,7 +110,7 @@ func (app *earthlyApp) actionDebugBuildkitInfo(cliCtx *cli.Context) error {
 func (app *earthlyApp) actionDebugBuildkitDiskUsage(cliCtx *cli.Context) error {
 	app.commandName = "debugBuildkitDiskUsage"
 
-	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -161,7 +161,7 @@ func (app *earthlyApp) actionDebugBuildkitDiskUsage(cliCtx *cli.Context) error {
 func (app *earthlyApp) actionDebugBuildkitWorkers(cliCtx *cli.Context) error {
 	app.commandName = "debugBuildkitWorkers"
 
-	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -234,7 +234,7 @@ func (app *earthlyApp) actionDebugBuildkitWorkers(cliCtx *cli.Context) error {
 func (app *earthlyApp) actionDebugBuildkitShutdownIfIdle(cliCtx *cli.Context) error {
 	app.commandName = "debugBuildkitShutdownIfIdle"
 
-	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}

--- a/cmd/earthly/flags.go
+++ b/cmd/earthly/flags.go
@@ -76,7 +76,7 @@ func (app *earthlyApp) rootFlags() []cli.Flag {
 			Value:       "https://api.earthly.dev",
 			EnvVars:     []string{"EARTHLY_SERVER_ADDRESS"},
 			Usage:       "API server override for dev purposes",
-			Destination: &app.cloudHttpAddr,
+			Destination: &app.cloudHTTPAddr,
 			Hidden:      true, // Internal.
 		},
 		&cli.StringFlag{
@@ -84,7 +84,7 @@ func (app *earthlyApp) rootFlags() []cli.Flag {
 			Value:       "ci.earthly.dev:443",
 			EnvVars:     []string{"EARTHLY_GRPC_ADDRESS"},
 			Usage:       "gRPC server override for dev purposes",
-			Destination: &app.cloudGrpcAddr,
+			Destination: &app.cloudGRPCAddr,
 			Hidden:      true, // Internal.
 		},
 		&cli.StringFlag{

--- a/cmd/earthly/flags.go
+++ b/cmd/earthly/flags.go
@@ -3,8 +3,9 @@ package main
 import (
 	"os"
 
-	"github.com/earthly/earthly/util/containerutil"
 	"github.com/urfave/cli/v2"
+
+	"github.com/earthly/earthly/util/containerutil"
 )
 
 func (app *earthlyApp) rootFlags() []cli.Flag {
@@ -75,7 +76,15 @@ func (app *earthlyApp) rootFlags() []cli.Flag {
 			Value:       "https://api.earthly.dev",
 			EnvVars:     []string{"EARTHLY_SERVER_ADDRESS"},
 			Usage:       "API server override for dev purposes",
-			Destination: &app.apiServer,
+			Destination: &app.cloudHttpAddr,
+			Hidden:      true, // Internal.
+		},
+		&cli.StringFlag{
+			Name:        "grpc",
+			Value:       "ci.earthly.dev:443",
+			EnvVars:     []string{"EARTHLY_GRPC_ADDRESS"},
+			Usage:       "gRPC server override for dev purposes",
+			Destination: &app.cloudGrpcAddr,
 			Hidden:      true, // Internal.
 		},
 		&cli.StringFlag{

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -106,7 +106,8 @@ type cliFlags struct {
 	disableNewLine            bool
 	secretFile                string
 	secretStdin               bool
-	apiServer                 string
+	cloudHttpAddr             string
+	cloudGrpcAddr             string
 	satelliteAddress          string
 	writePermission           bool
 	registrationPublicKey     string
@@ -270,7 +271,7 @@ func main() {
 		ctxTimeout, cancel := context.WithTimeout(context.Background(), time.Second)
 		defer cancel()
 		displayErrors := app.verbose
-		cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+		cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 		if err != nil && displayErrors {
 			app.console.Warnf("unable to start cloud client: %s", err)
 		} else if err == nil {

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -106,8 +106,8 @@ type cliFlags struct {
 	disableNewLine            bool
 	secretFile                string
 	secretStdin               bool
-	cloudHttpAddr             string
-	cloudGrpcAddr             string
+	cloudHTTPAddr             string
+	cloudGRPCAddr             string
 	satelliteAddress          string
 	writePermission           bool
 	registrationPublicKey     string
@@ -271,7 +271,7 @@ func main() {
 		ctxTimeout, cancel := context.WithTimeout(context.Background(), time.Second)
 		defer cancel()
 		displayErrors := app.verbose
-		cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+		cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 		if err != nil && displayErrors {
 			app.console.Warnf("unable to start cloud client: %s", err)
 		} else if err == nil {

--- a/cmd/earthly/org_cmds.go
+++ b/cmd/earthly/org_cmds.go
@@ -142,7 +142,7 @@ func (app *earthlyApp) actionOrgCreate(cliCtx *cli.Context) error {
 		return errors.New("invalid number of arguments provided")
 	}
 	org := cliCtx.Args().Get(0)
-	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -155,7 +155,7 @@ func (app *earthlyApp) actionOrgCreate(cliCtx *cli.Context) error {
 
 func (app *earthlyApp) actionOrgList(cliCtx *cli.Context) error {
 	app.commandName = "orgList"
-	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -188,7 +188,7 @@ func (app *earthlyApp) actionOrgListPermissions(cliCtx *cli.Context) error {
 	if !strings.HasSuffix(path, "/") {
 		path += "/"
 	}
-	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -221,7 +221,7 @@ func (app *earthlyApp) actionOrgInvite(cliCtx *cli.Context) error {
 		return errors.New("invitation paths must end with a slash (/)")
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -245,7 +245,7 @@ func (app *earthlyApp) actionOrgInviteAccept(cliCtx *cli.Context) error {
 		return errors.New("invite code is required")
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -263,7 +263,7 @@ func (app *earthlyApp) actionOrgInviteAccept(cliCtx *cli.Context) error {
 func (app *earthlyApp) actionOrgInviteList(cliCtx *cli.Context) error {
 	app.commandName = "orgInviteList"
 
-	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -303,7 +303,7 @@ func (app *earthlyApp) actionOrgInviteEmail(cliCtx *cli.Context) error {
 	}
 	emails := cliCtx.Args().Slice()
 
-	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -369,7 +369,7 @@ func (app *earthlyApp) actionOrgRevoke(cliCtx *cli.Context) error {
 		return errors.New("revoked paths must end with a slash (/)")
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -388,7 +388,7 @@ func (app *earthlyApp) actionOrgMemberList(cliCtx *cli.Context) error {
 		return errors.New("expected no arguments")
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -428,7 +428,7 @@ func (app *earthlyApp) actionOrgMemberUpdate(cliCtx *cli.Context) error {
 		return errors.New("too many arguments provided")
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -464,7 +464,7 @@ func (app *earthlyApp) actionOrgMemberRemove(cliCtx *cli.Context) error {
 		return errors.New("member email required")
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}

--- a/cmd/earthly/org_cmds.go
+++ b/cmd/earthly/org_cmds.go
@@ -6,9 +6,10 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	"github.com/earthly/earthly/cloud"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"
+
+	"github.com/earthly/earthly/cloud"
 )
 
 func (app *earthlyApp) orgCmds() []*cli.Command {
@@ -141,7 +142,7 @@ func (app *earthlyApp) actionOrgCreate(cliCtx *cli.Context) error {
 		return errors.New("invalid number of arguments provided")
 	}
 	org := cliCtx.Args().Get(0)
-	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -154,7 +155,7 @@ func (app *earthlyApp) actionOrgCreate(cliCtx *cli.Context) error {
 
 func (app *earthlyApp) actionOrgList(cliCtx *cli.Context) error {
 	app.commandName = "orgList"
-	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -187,7 +188,7 @@ func (app *earthlyApp) actionOrgListPermissions(cliCtx *cli.Context) error {
 	if !strings.HasSuffix(path, "/") {
 		path += "/"
 	}
-	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -220,7 +221,7 @@ func (app *earthlyApp) actionOrgInvite(cliCtx *cli.Context) error {
 		return errors.New("invitation paths must end with a slash (/)")
 	}
 
-	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -244,7 +245,7 @@ func (app *earthlyApp) actionOrgInviteAccept(cliCtx *cli.Context) error {
 		return errors.New("invite code is required")
 	}
 
-	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -262,7 +263,7 @@ func (app *earthlyApp) actionOrgInviteAccept(cliCtx *cli.Context) error {
 func (app *earthlyApp) actionOrgInviteList(cliCtx *cli.Context) error {
 	app.commandName = "orgInviteList"
 
-	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -302,7 +303,7 @@ func (app *earthlyApp) actionOrgInviteEmail(cliCtx *cli.Context) error {
 	}
 	emails := cliCtx.Args().Slice()
 
-	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -368,7 +369,7 @@ func (app *earthlyApp) actionOrgRevoke(cliCtx *cli.Context) error {
 		return errors.New("revoked paths must end with a slash (/)")
 	}
 
-	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -387,7 +388,7 @@ func (app *earthlyApp) actionOrgMemberList(cliCtx *cli.Context) error {
 		return errors.New("expected no arguments")
 	}
 
-	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -427,7 +428,7 @@ func (app *earthlyApp) actionOrgMemberUpdate(cliCtx *cli.Context) error {
 		return errors.New("too many arguments provided")
 	}
 
-	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -463,7 +464,7 @@ func (app *earthlyApp) actionOrgMemberRemove(cliCtx *cli.Context) error {
 		return errors.New("member email required")
 	}
 
-	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}

--- a/cmd/earthly/project_cmds.go
+++ b/cmd/earthly/project_cmds.go
@@ -6,9 +6,10 @@ import (
 	"os"
 	"text/tabwriter"
 
-	"github.com/earthly/earthly/cloud"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"
+
+	"github.com/earthly/earthly/cloud"
 )
 
 const dateFormat = "2006-01-02"
@@ -79,7 +80,7 @@ func (app *earthlyApp) projectCmds() []*cli.Command {
 func (app *earthlyApp) actionProjectList(cliCtx *cli.Context) error {
 	app.commandName = "projectList"
 
-	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -108,7 +109,7 @@ func (app *earthlyApp) actionProjectRemove(cliCtx *cli.Context) error {
 		return errors.New("project name is required")
 	}
 
-	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -145,7 +146,7 @@ func (app *earthlyApp) actionProjectCreate(cliCtx *cli.Context) error {
 		return errors.New("project name is required")
 	}
 
-	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -168,7 +169,7 @@ func (app *earthlyApp) actionProjectCreate(cliCtx *cli.Context) error {
 func (app *earthlyApp) actionProjectMemberList(cliCtx *cli.Context) error {
 	app.commandName = "projectMemberList"
 
-	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -209,7 +210,7 @@ func (app *earthlyApp) actionProjectMemberRemove(cliCtx *cli.Context) error {
 		return errors.New("user email are required")
 	}
 
-	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -245,7 +246,7 @@ func (app *earthlyApp) actionProjectMemberAdd(cliCtx *cli.Context) error {
 		return errors.New("user email and permission arguments are required")
 	}
 
-	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -286,7 +287,7 @@ func (app *earthlyApp) actionProjectMemberUpdate(cliCtx *cli.Context) error {
 		return errors.New("user email and permission arguments are required")
 	}
 
-	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}

--- a/cmd/earthly/project_cmds.go
+++ b/cmd/earthly/project_cmds.go
@@ -80,7 +80,7 @@ func (app *earthlyApp) projectCmds() []*cli.Command {
 func (app *earthlyApp) actionProjectList(cliCtx *cli.Context) error {
 	app.commandName = "projectList"
 
-	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -109,7 +109,7 @@ func (app *earthlyApp) actionProjectRemove(cliCtx *cli.Context) error {
 		return errors.New("project name is required")
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -146,7 +146,7 @@ func (app *earthlyApp) actionProjectCreate(cliCtx *cli.Context) error {
 		return errors.New("project name is required")
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -169,7 +169,7 @@ func (app *earthlyApp) actionProjectCreate(cliCtx *cli.Context) error {
 func (app *earthlyApp) actionProjectMemberList(cliCtx *cli.Context) error {
 	app.commandName = "projectMemberList"
 
-	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -210,7 +210,7 @@ func (app *earthlyApp) actionProjectMemberRemove(cliCtx *cli.Context) error {
 		return errors.New("user email are required")
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -246,7 +246,7 @@ func (app *earthlyApp) actionProjectMemberAdd(cliCtx *cli.Context) error {
 		return errors.New("user email and permission arguments are required")
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -287,7 +287,7 @@ func (app *earthlyApp) actionProjectMemberUpdate(cliCtx *cli.Context) error {
 		return errors.New("user email and permission arguments are required")
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}

--- a/cmd/earthly/root_cmds.go
+++ b/cmd/earthly/root_cmds.go
@@ -652,7 +652,7 @@ func (app *earthlyApp) actionPrune(cliCtx *cli.Context) error {
 	}
 
 	// Prune via API.
-	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}

--- a/cmd/earthly/root_cmds.go
+++ b/cmd/earthly/root_cmds.go
@@ -10,6 +10,12 @@ import (
 	"strings"
 
 	"github.com/dustin/go-humanize"
+	"github.com/moby/buildkit/client"
+	gwclient "github.com/moby/buildkit/frontend/gateway/client"
+	"github.com/pkg/errors"
+	"github.com/urfave/cli/v2"
+	"golang.org/x/sync/errgroup"
+
 	"github.com/earthly/earthly/buildcontext"
 	"github.com/earthly/earthly/buildkitd"
 	"github.com/earthly/earthly/cloud"
@@ -20,11 +26,6 @@ import (
 	"github.com/earthly/earthly/util/cliutil"
 	"github.com/earthly/earthly/util/fileutil"
 	"github.com/earthly/earthly/util/termutil"
-	"github.com/moby/buildkit/client"
-	gwclient "github.com/moby/buildkit/frontend/gateway/client"
-	"github.com/pkg/errors"
-	"github.com/urfave/cli/v2"
-	"golang.org/x/sync/errgroup"
 )
 
 func (app *earthlyApp) rootCmds() []*cli.Command {
@@ -651,7 +652,7 @@ func (app *earthlyApp) actionPrune(cliCtx *cli.Context) error {
 	}
 
 	// Prune via API.
-	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}

--- a/cmd/earthly/satellite_cmds.go
+++ b/cmd/earthly/satellite_cmds.go
@@ -159,7 +159,7 @@ func (app *earthlyApp) actionSatelliteLaunch(cliCtx *cli.Context) error {
 
 	app.satelliteName = cliCtx.Args().Get(0)
 
-	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -196,7 +196,7 @@ func (app *earthlyApp) actionSatelliteList(cliCtx *cli.Context) error {
 		return errors.New("command does not accept any arguments")
 	}
 
-	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -224,7 +224,7 @@ func (app *earthlyApp) actionSatelliteRemove(cliCtx *cli.Context) error {
 
 	app.satelliteName = cliCtx.Args().Get(0)
 
-	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -265,7 +265,7 @@ func (app *earthlyApp) actionSatelliteInspect(cliCtx *cli.Context) error {
 	satelliteToInspect := cliCtx.Args().Get(0)
 	selectedSatellite := app.cfg.Satellite.Name
 
-	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -317,7 +317,7 @@ func (app *earthlyApp) actionSatelliteSelect(cliCtx *cli.Context) error {
 
 	app.satelliteName = cliCtx.Args().Get(0)
 
-	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}

--- a/cmd/earthly/satellite_cmds.go
+++ b/cmd/earthly/satellite_cmds.go
@@ -159,7 +159,7 @@ func (app *earthlyApp) actionSatelliteLaunch(cliCtx *cli.Context) error {
 
 	app.satelliteName = cliCtx.Args().Get(0)
 
-	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -196,7 +196,7 @@ func (app *earthlyApp) actionSatelliteList(cliCtx *cli.Context) error {
 		return errors.New("command does not accept any arguments")
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -224,7 +224,7 @@ func (app *earthlyApp) actionSatelliteRemove(cliCtx *cli.Context) error {
 
 	app.satelliteName = cliCtx.Args().Get(0)
 
-	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -265,7 +265,7 @@ func (app *earthlyApp) actionSatelliteInspect(cliCtx *cli.Context) error {
 	satelliteToInspect := cliCtx.Args().Get(0)
 	selectedSatellite := app.cfg.Satellite.Name
 
-	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -317,7 +317,7 @@ func (app *earthlyApp) actionSatelliteSelect(cliCtx *cli.Context) error {
 
 	app.satelliteName = cliCtx.Args().Get(0)
 
-	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}

--- a/cmd/earthly/secret_cmds.go
+++ b/cmd/earthly/secret_cmds.go
@@ -170,7 +170,7 @@ func (app *earthlyApp) actionSecretsList(cliCtx *cli.Context) error {
 	if !strings.HasSuffix(path, "/") {
 		path += "/"
 	}
-	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -190,7 +190,7 @@ func (app *earthlyApp) actionSecretsGet(cliCtx *cli.Context) error {
 		return errors.New("invalid number of arguments provided")
 	}
 	path := cliCtx.Args().Get(0)
-	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -211,7 +211,7 @@ func (app *earthlyApp) actionSecretsRemove(cliCtx *cli.Context) error {
 		return errors.New("invalid number of arguments provided")
 	}
 	path := cliCtx.Args().Get(0)
-	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -257,7 +257,7 @@ func (app *earthlyApp) actionSecretsSet(cliCtx *cli.Context) error {
 		value = string(data)
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -289,7 +289,7 @@ func (app *earthlyApp) actionSecretsListV2(cliCtx *cli.Context) error {
 
 	path = app.fullSecretPath(path)
 
-	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -325,7 +325,7 @@ func (app *earthlyApp) actionSecretsGetV2(cliCtx *cli.Context) error {
 
 	path := cliCtx.Args().Get(0)
 
-	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -358,7 +358,7 @@ func (app *earthlyApp) actionSecretsRemoveV2(cliCtx *cli.Context) error {
 
 	path := cliCtx.Args().Get(0)
 
-	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -410,7 +410,7 @@ func (app *earthlyApp) actionSecretsSetV2(cliCtx *cli.Context) error {
 		value = string(data)
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -454,7 +454,7 @@ func (app *earthlyApp) actionSecretPermsList(cliCtx *cli.Context) error {
 		return errors.New("user secrets don't support permissions")
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -498,7 +498,7 @@ func (app *earthlyApp) actionSecretPermsRemove(cliCtx *cli.Context) error {
 		return errors.New("user email is required")
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -537,7 +537,7 @@ func (app *earthlyApp) actionSecretPermsSet(cliCtx *cli.Context) error {
 		return errors.New("permission is required")
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -574,7 +574,7 @@ func (app *earthlyApp) actionSecretsMigrate(cliCtx *cli.Context) error {
 		return errors.New("destination project is required")
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}

--- a/cmd/earthly/secret_cmds.go
+++ b/cmd/earthly/secret_cmds.go
@@ -8,9 +8,10 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	"github.com/earthly/earthly/cloud"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"
+
+	"github.com/earthly/earthly/cloud"
 )
 
 func (app *earthlyApp) secretCmds() []*cli.Command {
@@ -169,7 +170,7 @@ func (app *earthlyApp) actionSecretsList(cliCtx *cli.Context) error {
 	if !strings.HasSuffix(path, "/") {
 		path += "/"
 	}
-	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -189,7 +190,7 @@ func (app *earthlyApp) actionSecretsGet(cliCtx *cli.Context) error {
 		return errors.New("invalid number of arguments provided")
 	}
 	path := cliCtx.Args().Get(0)
-	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -210,7 +211,7 @@ func (app *earthlyApp) actionSecretsRemove(cliCtx *cli.Context) error {
 		return errors.New("invalid number of arguments provided")
 	}
 	path := cliCtx.Args().Get(0)
-	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -256,7 +257,7 @@ func (app *earthlyApp) actionSecretsSet(cliCtx *cli.Context) error {
 		value = string(data)
 	}
 
-	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -288,7 +289,7 @@ func (app *earthlyApp) actionSecretsListV2(cliCtx *cli.Context) error {
 
 	path = app.fullSecretPath(path)
 
-	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -324,7 +325,7 @@ func (app *earthlyApp) actionSecretsGetV2(cliCtx *cli.Context) error {
 
 	path := cliCtx.Args().Get(0)
 
-	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -357,7 +358,7 @@ func (app *earthlyApp) actionSecretsRemoveV2(cliCtx *cli.Context) error {
 
 	path := cliCtx.Args().Get(0)
 
-	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -409,7 +410,7 @@ func (app *earthlyApp) actionSecretsSetV2(cliCtx *cli.Context) error {
 		value = string(data)
 	}
 
-	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -453,7 +454,7 @@ func (app *earthlyApp) actionSecretPermsList(cliCtx *cli.Context) error {
 		return errors.New("user secrets don't support permissions")
 	}
 
-	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -497,7 +498,7 @@ func (app *earthlyApp) actionSecretPermsRemove(cliCtx *cli.Context) error {
 		return errors.New("user email is required")
 	}
 
-	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -536,7 +537,7 @@ func (app *earthlyApp) actionSecretPermsSet(cliCtx *cli.Context) error {
 		return errors.New("permission is required")
 	}
 
-	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -573,7 +574,7 @@ func (app *earthlyApp) actionSecretsMigrate(cliCtx *cli.Context) error {
 		return errors.New("destination project is required")
 	}
 
-	cloudClient, err := cloud.NewClient(app.apiServer, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHttpAddr, app.cloudGrpcAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/fatih/color v1.9.0
 	github.com/golang/protobuf v1.5.2
 	github.com/google/uuid v1.3.0
+	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/jdxcode/netrc v0.0.0-20210204082910-926c7f70242a
 	github.com/jessevdk/go-flags v1.5.0


### PR DESCRIPTION
I was running into some issues with the JSON-to-protobuf unmarshaller we've been using. In particular with enums, where existing enums can not be added to on the server without breaking old clients versions - i.e. the JSON unmarshaller throws an error if it encounters an enum value it doesn't recognize. Traditional gRPC does not have this limitation.

Unsurprisingly, the code is also much simpler now in gRPC than it was before using REST calls.

Note: this switches the Pipelines endpoints only, as other endpoints don't support gRPC yet. In due time, we can convert the other endpoints too (after we've converted them on the server first).