### PR TITLE
Fix remote docker host running x86 platform. Fixes https://github.com/earthly/earthly/issues/1895

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
   fallback to `/usr/share/zsh/site-functions`.
 
 ### Fixed
-Fixed Earthly failing when using a remote docker host from a machine with an incompatible architecture. Fixes (#1895)[https://github.com/earthly/earthly/issues/1895]
+- Fixed Earthly failing when using a remote docker host from a machine with an incompatible architecture. Fixes (#1895)[https://github.com/earthly/earthly/issues/1895]
 
 ## v0.6.23 - 2022-09-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
   fallback to `/usr/share/zsh/site-functions`.
 
 ### Fixed
-- Fixed Earthly failing when using a remote docker host from a machine with an incompatible architecture. Fixes (#1895)[https://github.com/earthly/earthly/issues/1895]
+
+- Fixed Earthly failing when using a remote docker host from a machine with an incompatible architecture. [#1895](https://github.com/earthly/earthly/issues/1895)
 
 ## v0.6.23 - 2022-09-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 - Bootstraping zsh autocompletion will first attempt to install under `/usr/local/share/zsh/site-functions`, and will now
   fallback to `/usr/share/zsh/site-functions`.
 
+### Fixed
+Fixed Earthly failing when using a remote docker host from a machine with an incompatible architecture. Fixes (#1895)[https://github.com/earthly/earthly/issues/1895]
+
 ## v0.6.23 - 2022-09-06
 
 ### Fixed

--- a/util/containerutil/docker.go
+++ b/util/containerutil/docker.go
@@ -31,6 +31,8 @@ func NewDockerShellFrontend(ctx context.Context, cfg *FrontendConfig) (Container
 			globalCompatibilityArgs: make([]string, 0),
 		},
 	}
+	// TODO: Find a cleaner way to pass down information to the shellFrontend
+	fe.FrontendInformation = fe.Information
 
 	// running `docker info --format={{.SecurityOptions}}` results in a panic() when docker is not running.
 	// To workaround this issue, first we run `docker info` to test docker is running, then again with the

--- a/util/containerutil/docker.go
+++ b/util/containerutil/docker.go
@@ -29,6 +29,7 @@ func NewDockerShellFrontend(ctx context.Context, cfg *FrontendConfig) (Container
 			binaryName:              "docker",
 			runCompatibilityArgs:    make([]string, 0),
 			globalCompatibilityArgs: make([]string, 0),
+			Console:                 cfg.Console,
 		},
 	}
 	// TODO: Find a cleaner way to pass down information to the shellFrontend

--- a/util/containerutil/podman.go
+++ b/util/containerutil/podman.go
@@ -29,6 +29,8 @@ func NewPodmanShellFrontend(ctx context.Context, cfg *FrontendConfig) (Container
 			globalCompatibilityArgs: make([]string, 0),
 		},
 	}
+	// TODO: Find a cleaner way to pass down information to the shellFrontend
+	fe.FrontendInformation = fe.Information
 
 	output, err := fe.commandContextOutput(ctx, "info", "--format={{.Host.Security.Rootless}}")
 	if err != nil {

--- a/util/containerutil/podman.go
+++ b/util/containerutil/podman.go
@@ -27,6 +27,7 @@ func NewPodmanShellFrontend(ctx context.Context, cfg *FrontendConfig) (Container
 			binaryName:              "podman",
 			runCompatibilityArgs:    []string{"--security-opt", "unmask=/sys/fs/cgroup"},
 			globalCompatibilityArgs: make([]string, 0),
+			Console:                 cfg.Console,
 		},
 	}
 	// TODO: Find a cleaner way to pass down information to the shellFrontend

--- a/util/containerutil/shell_shared.go
+++ b/util/containerutil/shell_shared.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/containerd/containerd/platforms"
 	"net"
 	"net/url"
 	"os"
 	"os/exec"
 	"strconv"
 	"strings"
+
+	"github.com/containerd/containerd/platforms"
 
 	"github.com/hashicorp/go-multierror"
 	_ "github.com/moby/buildkit/client/connhelper/dockercontainer" // Load "docker-container://" helper.

--- a/util/containerutil/shell_shared.go
+++ b/util/containerutil/shell_shared.go
@@ -187,8 +187,8 @@ func (sf *shellFrontend) ContainerRun(ctx context.Context, containers ...Contain
 		}
 
 		platform := getPlatform()
-		supportsPlatform, err := sf.supportsPlatform(ctx, platform)
-		if err != nil {
+		supportsPlatform, platformCheckErr := sf.supportsPlatform(ctx, platform)
+		if platformCheckErr != nil {
 			return errors.Wrapf(err, "failed to run container")
 		}
 		if supportsPlatform {

--- a/util/containerutil/shell_shared.go
+++ b/util/containerutil/shell_shared.go
@@ -309,6 +309,9 @@ func normalizePlatform(platform string) (string, error) {
 
 func (sf *shellFrontend) supportsPlatform(ctx context.Context, platform string) (bool, error) {
 	normalizedPlatform, err := normalizePlatform(platform)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to normalize platform")
+	}
 	frontendInfo, err := sf.FrontendInformation(ctx)
 	if err != nil {
 		return false, errors.Wrapf(err, "failed to get platform information")

--- a/util/containerutil/shell_shared.go
+++ b/util/containerutil/shell_shared.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/containerd/containerd/platforms"
 	"net"
 	"net/url"
 	"os"
@@ -298,11 +299,17 @@ func (sf *shellFrontend) commandContextOutput(ctx context.Context, args ...strin
 }
 
 func (sf *shellFrontend) supportsPlatform(ctx context.Context, platform string) (bool, error) {
+	parsedPlatform, err := platforms.Parse(platform)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to parse platform %s", platform)
+	}
+	platformSpec := platforms.Normalize(parsedPlatform)
+	platformNormalized := platforms.Format(platformSpec)
 	frontendInfo, err := sf.FrontendInformation(ctx)
 	if err != nil {
 		return false, errors.Wrapf(err, "failed to get platform information")
 	}
-	return frontendInfo.ServerPlatform == platform, nil
+	return frontendInfo.ServerPlatform == platformNormalized, nil
 }
 
 func (sf *shellFrontend) setupAndValidateAddresses(feType string, cfg *FrontendConfig) (*FrontendURLs, error) {

--- a/util/containerutil/shell_shared.go
+++ b/util/containerutil/shell_shared.go
@@ -187,7 +187,7 @@ func (sf *shellFrontend) ContainerRun(ctx context.Context, containers ...Contain
 		}
 
 		platform := getPlatform()
-		supportsPlatform, err := sf.supportsPlatformArg(ctx, platform)
+		supportsPlatform, err := sf.supportsPlatform(ctx, platform)
 		if err != nil {
 			return errors.Wrapf(err, "failed in run container")
 		}
@@ -297,7 +297,7 @@ func (sf *shellFrontend) commandContextOutput(ctx context.Context, args ...strin
 	return output, nil
 }
 
-func (sf *shellFrontend) supportsPlatformArg(ctx context.Context, platform string) (bool, error) {
+func (sf *shellFrontend) supportsPlatform(ctx context.Context, platform string) (bool, error) {
 	frontendInfo, err := sf.FrontendInformation(ctx)
 	if err != nil {
 		return false, errors.Wrapf(err, "failed to get platform information")

--- a/util/containerutil/shell_shared.go
+++ b/util/containerutil/shell_shared.go
@@ -189,7 +189,7 @@ func (sf *shellFrontend) ContainerRun(ctx context.Context, containers ...Contain
 		platform := getPlatform()
 		supportsPlatform, err := sf.supportsPlatform(ctx, platform)
 		if err != nil {
-			return errors.Wrapf(err, "failed in run container")
+			return errors.Wrapf(err, "failed to run container")
 		}
 		if supportsPlatform {
 			args = append(args, "--platform", platform)

--- a/util/containerutil/shell_shared.go
+++ b/util/containerutil/shell_shared.go
@@ -185,8 +185,10 @@ func (sf *shellFrontend) ContainerRun(ctx context.Context, containers ...Contain
 			args = append(args, "--publish", port)
 		}
 
-		if sf.supportsPlatformArg(ctx) {
-			args = append(args, "--platform", getPlatform())
+		// TODO rlaforge: this is wrong - we should instead be checking the platform / arch for the frontend host
+		platform := getPlatform()
+		if sf.supportsPlatformArg(ctx, platform) {
+			args = append(args, "--platform", platform)
 		}
 
 		args = append(args, "-d") // Run detached, this feels implied by the API
@@ -291,11 +293,12 @@ func (sf *shellFrontend) commandContextOutput(ctx context.Context, args ...strin
 	return output, nil
 }
 
-func (sf *shellFrontend) supportsPlatformArg(ctx context.Context) bool {
+func (sf *shellFrontend) supportsPlatformArg(ctx context.Context, platform string) bool {
 	// We can't run scratch, but the error is different depending on whether
 	// --platform is supported or not. This is faster than attempting to run
 	// an actual image which may require downloading.
-	output, _ := sf.commandContextOutput(ctx, "run", "--rm", "--platform", getPlatform(), "scratch")
+
+	output, _ := sf.commandContextOutput(ctx, "run", "--rm", "--platform", platform, "scratch")
 	return strings.Contains(output.string(), "Unable to find image")
 }
 

--- a/util/containerutil/shell_shared.go
+++ b/util/containerutil/shell_shared.go
@@ -189,7 +189,7 @@ func (sf *shellFrontend) ContainerRun(ctx context.Context, containers ...Contain
 		platform := getPlatform()
 		supportsPlatform, platformCheckErr := sf.supportsPlatform(ctx, platform)
 		if platformCheckErr != nil {
-			return errors.Wrapf(err, "failed to run container")
+			err = multierror.Append(err, platformCheckErr)
 		}
 		if supportsPlatform {
 			args = append(args, "--platform", platform)

--- a/util/containerutil/stub.go
+++ b/util/containerutil/stub.go
@@ -19,7 +19,7 @@ var ErrFrontendNotInitialized = errors.New("frontend (e.g. docker/podman) not in
 // Examples include earthly/earthly, or integration tests. It is currently only used as a fallback when docker or other frontends are missing.
 func NewStubFrontend(ctx context.Context, cfg *FrontendConfig) (ContainerFrontend, error) {
 	fe := &stubFrontend{
-		shellFrontend: &shellFrontend{},
+		shellFrontend: &shellFrontend{Console: cfg.Console},
 	}
 	fe.shellFrontend.FrontendInformation = fe.Information
 

--- a/util/containerutil/stub.go
+++ b/util/containerutil/stub.go
@@ -21,6 +21,7 @@ func NewStubFrontend(ctx context.Context, cfg *FrontendConfig) (ContainerFronten
 	fe := &stubFrontend{
 		shellFrontend: &shellFrontend{},
 	}
+	fe.shellFrontend.FrontendInformation = fe.Information
 
 	var err error
 	fe.urls, err = fe.setupAndValidateAddresses(FrontendStub, cfg)


### PR DESCRIPTION
fixes https://github.com/earthly/earthly/issues/1895

Running Earthly from an M1 mac to a remote docker host running x86 was broken as described in the issue.
We need to ensure an appropriate image is pulled that is. compatible with the architecture the docker host itself.

The solution is to use the frontend information we collect via the `Information` call to determine if the current client's platform also works on the server. 

If it is supported, this acts as a sort of preference to the client's platform.
If not, it will default to the server platform to allow the buildkitd container to run.

@alexcb @vladaionescu 