### PR TITLE
dont display errors during autocompletion

### DIFF
--- a/features/features.go
+++ b/features/features.go
@@ -158,7 +158,7 @@ func GetFeatures(version *spec.Version) (*Features, bool, error) {
 		return nil, false, errUnexpectedArgs
 	}
 
-	parsedArgs, err := flagutil.ParseArgsWithValueModifier("VERSION", &ftrs, version.Args, instrumentVersion)
+	parsedArgs, err := flagutil.ParseArgsWithValueModifierAndOptions("VERSION", &ftrs, version.Args, instrumentVersion, goflags.PassDoubleDash|goflags.PassAfterNonOption|goflags.AllowBoolValues)
 	if err != nil {
 		return nil, false, err
 	}

--- a/tests/autocompletion/Earthfile
+++ b/tests/autocompletion/Earthfile
@@ -216,6 +216,13 @@ test-targets-in-two-subdirs-that-are-similar:
     RUN COMP_LINE="earthly ./foo" COMP_POINT=13 earthly > actual
     RUN diff expected actual
 
+test-no-errors-are-displayed:
+    COPY bad-version-flag.earth ./Earthfile
+
+    RUN > expected
+    RUN ! COMP_LINE="earthly +" COMP_POINT=9 earthly > actual
+    RUN diff expected actual
+
 test-all:
     BUILD +test-root-commands
     BUILD +test-hidden-root-commands
@@ -232,3 +239,4 @@ test-all:
     BUILD +test-no-parent-at-root-from-home
     BUILD +test-targets-in-dir-and-subdir
     BUILD +test-targets-in-two-subdirs-that-are-similar
+    BUILD +test-no-errors-are-displayed

--- a/tests/autocompletion/bad-version-flag.earth
+++ b/tests/autocompletion/bad-version-flag.earth
@@ -1,0 +1,5 @@
+VERSION --this-flag-does-not-exist 0.6
+
+test:
+    FROM alpine
+    RUN echo "auto-completion shouldn't work here, but don't display errors when a user hits tab-tab"

--- a/util/flagutil/parse.go
+++ b/util/flagutil/parse.go
@@ -29,7 +29,12 @@ func ParseArgs(command string, data interface{}, args []string) ([]string, error
 // which is called before each flag value is parsed, and allows one to change the value.
 // if the flag value
 func ParseArgsWithValueModifier(command string, data interface{}, args []string, argumentModFunc ArgumentModFunc) ([]string, error) {
-	p := flags.NewNamedParser("", flags.PrintErrors|flags.PassDoubleDash|flags.PassAfterNonOption|flags.AllowBoolValues)
+	return ParseArgsWithValueModifierAndOptions(command, data, args, argumentModFunc, flags.PrintErrors|flags.PassDoubleDash|flags.PassAfterNonOption|flags.AllowBoolValues)
+}
+
+// ParseArgsWithValueModifierAndOptions is similar to ParseArgsWithValueModifier, but allows changing the parser options.
+func ParseArgsWithValueModifierAndOptions(command string, data interface{}, args []string, argumentModFunc ArgumentModFunc, parserOptions flags.Options) ([]string, error) {
+	p := flags.NewNamedParser("", parserOptions)
 	var modFuncErr error
 	modFunc := func(flagName string, opt *flags.Option, flagVal *string) *string {
 		p, err := argumentModFunc(flagName, opt, flagVal)
@@ -45,7 +50,9 @@ func ParseArgsWithValueModifier(command string, data interface{}, args []string,
 	}
 	res, err := p.ParseArgs(args)
 	if err != nil {
-		p.WriteHelp(os.Stderr)
+		if parserOptions&flags.PrintErrors != flags.None {
+			p.WriteHelp(os.Stderr)
+		}
 		return nil, err
 	}
 	if modFuncErr != nil {


### PR DESCRIPTION
Dont display errors (and help text) if the autocompletion code fails due to an unknown VERSION flag.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>