### PR TITLE
Use New Satellite Reserve Endpoint

### DIFF
--- a/buildkitd/buildkitd.go
+++ b/buildkitd/buildkitd.go
@@ -594,17 +594,6 @@ func checkConnection(ctx context.Context, address string, opts ...client.ClientO
 			return
 		}
 		defer bkClient.Close()
-		err = bkClient.Reserve(ctxTimeout)
-		if err != nil {
-			s, ok := status.FromError(errors.Cause(err))
-			// Note that if err is codes.Unimplemented,
-			// we assume it's an older version of buildkit and continue to call ListWorkers.
-			if !ok || s.Code() != codes.Unimplemented {
-				mu.Lock()
-				connErr = err
-				mu.Unlock()
-			}
-		}
 		// Use ListWorkers for backwards compatibility. (Info is relatively new)
 		ws, err := bkClient.ListWorkers(ctxTimeout)
 		if err != nil {

--- a/cloud/client.go
+++ b/cloud/client.go
@@ -72,6 +72,7 @@ type Client interface {
 	ListSatellites(ctx context.Context, orgID string) ([]SatelliteInstance, error)
 	GetSatellite(ctx context.Context, name, orgID string) (*SatelliteInstance, error)
 	DeleteSatellite(ctx context.Context, name, orgID string) error
+	ReserveSatellite(ctx context.Context, name, orgID string, out chan<- string) error
 	CreateProject(ctx context.Context, name, orgName string) (*Project, error)
 	ListProjects(ctx context.Context, orgName string) ([]*Project, error)
 	GetProject(ctx context.Context, orgName, name string) (*Project, error)
@@ -131,6 +132,7 @@ func NewClient(httpAddr, grpcAddr, agentSockPath, authCredsOverride string, warn
 	tlsConfig := credentials.NewTLS(&tls.Config{})
 	ctx := context.Background()
 	retryOpts := []grpc_retry.CallOption{
+		grpc_retry.WithMax(10),
 		grpc_retry.WithBackoff(grpc_retry.BackoffExponential(100 * time.Millisecond)),
 		grpc_retry.WithCodes(codes.Internal, codes.Unavailable),
 	}

--- a/cloud/satellite.go
+++ b/cloud/satellite.go
@@ -10,14 +10,22 @@ import (
 )
 
 const (
+	// SatelliteStatusOperational indicates an on satellite that is ready to accept connections.
 	SatelliteStatusOperational = "Operational"
-	SatelliteStatusSleep       = "Sleeping"
-	SatelliteStatusStarting    = "Starting"
-	SatelliteStatusCreating    = "Creating"
-	SatelliteStatusFailed      = "Failed"
-	SatelliteStatusDestroying  = "Destroying"
-	SatelliteStatusOffline     = "Offline"
-	SatelliteStatusUnknown     = "Unknown"
+	// SatelliteStatusSleep indicates a satellite that is in a sleep state.
+	SatelliteStatusSleep = "Sleeping"
+	// SatelliteStatusStarting indicates a satellite that is waking from a sleep state.
+	SatelliteStatusStarting = "Starting"
+	// SatelliteStatusCreating indicates a new satellite that is currently being launched.
+	SatelliteStatusCreating = "Creating"
+	// SatelliteStatusFailed indicates a satellite that has crashed and cannot be used.
+	SatelliteStatusFailed = "Failed"
+	// SatelliteStatusDestroying indicates a satellite that is actively being deleted.
+	SatelliteStatusDestroying = "Destroying"
+	// SatelliteStatusOffline indicates a satellite that has been stopped and will not be woken up normally via build.
+	SatelliteStatusOffline = "Offline"
+	// SatelliteStatusUnknown is used when an unexpected satellite status is returned by the server.
+	SatelliteStatusUnknown = "Unknown"
 )
 
 // SatelliteInstance contains details about a remote Buildkit instance.

--- a/cloud/satellite.go
+++ b/cloud/satellite.go
@@ -115,7 +115,11 @@ func (c *client) ReserveSatellite(ctx context.Context, name, orgID string, out c
 		if err != nil {
 			return errors.Wrap(err, "failed receiving satellite reserve update")
 		}
-		out <- satelliteStatus(update.Status)
+		status := satelliteStatus(update.Status)
+		if status == SatelliteStatusFailed {
+			return errors.New("satellite is in failed state")
+		}
+		out <- status
 	}
 }
 

--- a/cmd/earthly/buildkit.go
+++ b/cmd/earthly/buildkit.go
@@ -214,7 +214,7 @@ func (app *earthlyApp) reserveSatellite(ctx context.Context, cloudClient cloud.C
 		switch status {
 		case cloud.SatelliteStatusSleep:
 			wasAsleep = true
-			console.Printf("%s is starting. Please wait...", name)
+			console.Printf("%s is booting up. Please wait...", name)
 		case cloud.SatelliteStatusStarting:
 			var msg string
 			msg, loadingMsgs = nextSatelliteLoadingMessage(loadingMsgs)

--- a/cmd/earthly/buildkit.go
+++ b/cmd/earthly/buildkit.go
@@ -214,7 +214,7 @@ func (app *earthlyApp) reserveSatellite(ctx context.Context, cloudClient cloud.C
 		switch status {
 		case cloud.SatelliteStatusSleep:
 			wasAsleep = true
-			console.Printf("%s is booting up. Please wait...", name)
+			console.Printf("%s is waking up. Please wait...", name)
 		case cloud.SatelliteStatusStarting:
 			var msg string
 			msg, loadingMsgs = nextSatelliteLoadingMessage(loadingMsgs)

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/docker/distribution v2.8.1+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/dustin/go-humanize v1.0.0
-	github.com/earthly/cloud-api v1.0.1-0.20220913124428-8736f7614ec8
+	github.com/earthly/cloud-api v1.0.1-0.20220916153800-ea892d6eecde
 	github.com/earthly/earthly/ast v0.0.0-00010101000000-000000000000
 	github.com/elastic/go-sysinfo v1.7.1
 	github.com/fatih/color v1.9.0

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/docker/distribution v2.8.1+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/dustin/go-humanize v1.0.0
-	github.com/earthly/cloud-api v1.0.1-0.20220916153800-ea892d6eecde
+	github.com/earthly/cloud-api v1.0.1-0.20220922190850-93cd2eef4241
 	github.com/earthly/earthly/ast v0.0.0-00010101000000-000000000000
 	github.com/elastic/go-sysinfo v1.7.1
 	github.com/fatih/color v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -372,8 +372,8 @@ github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/earthly/buildkit v0.0.1-0.20220913002628-9c256c19c539 h1:m0Q93OE9h9s8JY7kTDe7Mhsdy6KcYB5ncHjKGX7m6OE=
 github.com/earthly/buildkit v0.0.1-0.20220913002628-9c256c19c539/go.mod h1:Ih6/jh6JTbktkhxRID0gj6dn2GAPI6H9U6xKVxgNqBk=
-github.com/earthly/cloud-api v1.0.1-0.20220913124428-8736f7614ec8 h1:ogVB0Go3KFbQ3QOdD+7/UIb1UedLYmbEO56TaVvm3vQ=
-github.com/earthly/cloud-api v1.0.1-0.20220913124428-8736f7614ec8/go.mod h1:JhlHsW6o8zYa+XsM0nMAevRQtES35KE5R2G8tJALsnI=
+github.com/earthly/cloud-api v1.0.1-0.20220916153800-ea892d6eecde h1:C10i/OotdFPzJwxkWlY4D1YqU3QqcR9MHXochczZI6I=
+github.com/earthly/cloud-api v1.0.1-0.20220916153800-ea892d6eecde/go.mod h1:JhlHsW6o8zYa+XsM0nMAevRQtES35KE5R2G8tJALsnI=
 github.com/earthly/fsutil v0.0.0-20220719234708-392da7eebeb5 h1:bOKRnmQd1JYrtOUdkvYraBCT0SRjYpYnhd4i85mWtQw=
 github.com/earthly/fsutil v0.0.0-20220719234708-392da7eebeb5/go.mod h1:oPAfvw32vlUJSjyDcQ3Bu0nb2ON2B+G0dtVN/SZNJiA=
 github.com/elastic/go-sysinfo v1.7.1 h1:Wx4DSARcKLllpKT2TnFVdSUJOsybqMYCNQZq1/wO+s0=

--- a/go.sum
+++ b/go.sum
@@ -372,8 +372,8 @@ github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/earthly/buildkit v0.0.1-0.20220913002628-9c256c19c539 h1:m0Q93OE9h9s8JY7kTDe7Mhsdy6KcYB5ncHjKGX7m6OE=
 github.com/earthly/buildkit v0.0.1-0.20220913002628-9c256c19c539/go.mod h1:Ih6/jh6JTbktkhxRID0gj6dn2GAPI6H9U6xKVxgNqBk=
-github.com/earthly/cloud-api v1.0.1-0.20220916153800-ea892d6eecde h1:C10i/OotdFPzJwxkWlY4D1YqU3QqcR9MHXochczZI6I=
-github.com/earthly/cloud-api v1.0.1-0.20220916153800-ea892d6eecde/go.mod h1:JhlHsW6o8zYa+XsM0nMAevRQtES35KE5R2G8tJALsnI=
+github.com/earthly/cloud-api v1.0.1-0.20220922190850-93cd2eef4241 h1:4kyj9C81+Kmb/MjtwA7iHtRKNheaU7lY6KoKCPWcQqE=
+github.com/earthly/cloud-api v1.0.1-0.20220922190850-93cd2eef4241/go.mod h1:JhlHsW6o8zYa+XsM0nMAevRQtES35KE5R2G8tJALsnI=
 github.com/earthly/fsutil v0.0.0-20220719234708-392da7eebeb5 h1:bOKRnmQd1JYrtOUdkvYraBCT0SRjYpYnhd4i85mWtQw=
 github.com/earthly/fsutil v0.0.0-20220719234708-392da7eebeb5/go.mod h1:oPAfvw32vlUJSjyDcQ3Bu0nb2ON2B+G0dtVN/SZNJiA=
 github.com/elastic/go-sysinfo v1.7.1 h1:Wx4DSARcKLllpKT2TnFVdSUJOsybqMYCNQZq1/wO+s0=


### PR DESCRIPTION
The new [satellite reserve endpoint](https://github.com/earthly/cloud/pull/344) wakes up a satellite if it's asleep, and calls buildkit Reserve().  It's a streaming RPC call, which returns periodic updates until the instance is awake.

<img width="1054" alt="Screen Shot 2022-09-21 at 12 16 30 PM" src="https://user-images.githubusercontent.com/3247216/191557350-85fdbb30-da27-46af-a526-733d247b7f74.png">

