### PR TITLE
Don't output secret list result to stderr

### DIFF
--- a/cmd/earthly/project_cmds.go
+++ b/cmd/earthly/project_cmds.go
@@ -96,7 +96,7 @@ func (app *earthlyApp) actionProjectList(cliCtx *cli.Context) error {
 	}
 
 	for _, project := range projects {
-		app.console.Printf("%s\n", project.Name)
+		fmt.Println(project.Name)
 	}
 
 	return nil

--- a/cmd/earthly/secret_cmds.go
+++ b/cmd/earthly/secret_cmds.go
@@ -310,7 +310,7 @@ func (app *earthlyApp) actionSecretsListV2(cliCtx *cli.Context) error {
 			prefix := fmt.Sprintf("/%s/%s/", app.orgName, app.projectName)
 			display = strings.TrimPrefix(display, prefix)
 		}
-		app.console.Printf(display)
+		fmt.Println(display)
 	}
 
 	return nil


### PR DESCRIPTION
It seems like `app.console.Printf` writes to stderr. This was causing some issues with grepping, etc. 