### PR TITLE
chore: removed custom error

### DIFF
--- a/buildcontext/detectbuildfile.go
+++ b/buildcontext/detectbuildfile.go
@@ -12,6 +12,16 @@ import (
 	"github.com/pkg/errors"
 )
 
+// ErrNotExist is the struct indicating that file does not exist.
+type ErrEarthfileNotExist struct {
+	Target string
+}
+
+// Error is function required by error interface.
+func (err ErrEarthfileNotExist) Error() string {
+	return "No Earthfile nor build.earth file found for target " + err.Target
+}
+
 // detectBuildFile detects whether to use Earthfile, build.earth or Dockerfile.
 func detectBuildFile(ref domain.Reference, localDir string) (string, error) {
 	if strings.HasPrefix(ref.GetName(), DockerfileMetaTarget) {
@@ -23,8 +33,7 @@ func detectBuildFile(ref domain.Reference, localDir string) (string, error) {
 		buildEarthPath := filepath.Join(localDir, "build.earth")
 		_, err := os.Stat(buildEarthPath)
 		if os.IsNotExist(err) {
-			return "", errors.Errorf(
-				"No Earthfile nor build.earth file found for target %s", ref.String())
+			return "", ErrEarthfileNotExist{Target: ref.String()}
 		} else if err != nil {
 			return "", errors.Wrapf(err, "stat file %s", buildEarthPath)
 		}

--- a/cmd/earthly/root_cmds.go
+++ b/cmd/earthly/root_cmds.go
@@ -598,14 +598,22 @@ func (app *earthlyApp) actionListTargets(cliCtx *cli.Context) error {
 	// it's expensive to create this gwclient, so we need to implement a lazy eval which returns it when required.
 
 	target, err := domain.ParseTarget(fmt.Sprintf("%s+base", targetToParse)) // the +base is required to make ParseTarget work; however is ignored by GetTargets
-	if err != nil {
+	if errors.Is(err, buildcontext.ErrEarthfileNotExist{}) {
 		return errors.Errorf("unable to locate Earthfile under %s", targetToDisplay)
+	} else if err != nil {
+		return err
 	}
 
 	targets, err := earthfile2llb.GetTargets(cliCtx.Context, resolver, gwClient, target)
 	if err != nil {
-		return errors.Errorf("unable to locate Earthfile under %s", targetToDisplay)
+		switch err := errors.Cause(err).(type) {
+		case *buildcontext.ErrEarthfileNotExist:
+			return errors.Errorf("unable to locate Earthfile under %s", targetToDisplay)
+		default:
+			return err
+		}
 	}
+
 	targets = append(targets, "base")
 	sort.Strings(targets)
 	for _, t := range targets {


### PR DESCRIPTION
This is a proof of concept, that aims to improve error presented to end user, when we encounter syntax error when executing `earthly ls`.

I would love to get some feedback, or suggestions what else could be fixed under this PR, as the change now is minimal, and probably not worth merging yet.

Closes #2223