### PR TITLE
remove dead link from release readme

### DIFF
--- a/release/README.md
+++ b/release/README.md
@@ -33,7 +33,6 @@
 * Merge branch `main` into `next`, then merge branch `next` into `main`.
 * Update the version for the installation command in the following places:
 <!-- vale HouseStyle.Spelling = NO -->
-  * [ci-integration.md](../docs/ci-integration.md)
   * [circle-integration.md](../docs/ci-integration/guides/circle-integration.md)
   * [gh-actions-integration.md](../docs/ci-integration/guides/gh-actions-integration.md)
   * [codebuild-integration.md](../docs/ci-integration/guides/codebuild-integration.md)


### PR DESCRIPTION
ci-integration.md was deleted in d6c4467ae401c14c0fd7b10e8df29437389fc556

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>