### PR TITLE
Support for all ssh key types (e.g. ssh-ed25519)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 
 ## Unreleased
 
+### Changed
+- Support for all ssh-based key types (e.g. ssh-ed25519), and not only ssh-rsa. [#1783](https://github.com/earthly/earthly/issues/1783)
+
+### Fixed
+- Unable to specify public key to add via the command-line, e.g. running `earthly account add-key <key>` ignored the key and fellback to an interactive prompt.
+
 ## v0.6.26 - 2022-10-13
 
 ### Added

--- a/cloud/account.go
+++ b/cloud/account.go
@@ -45,7 +45,7 @@ func (c *client) ListPublicKeys(ctx context.Context) ([]string, error) {
 	return keys, nil
 }
 
-func (c *client) AddPublickKey(ctx context.Context, key string) error {
+func (c *client) AddPublicKey(ctx context.Context, key string) error {
 	key = strings.TrimSpace(key) + "\n"
 	status, body, err := c.doCall(ctx, "PUT", "/api/v0/account/keys", withAuth(), withBody([]byte(key)))
 	if err != nil {
@@ -61,7 +61,7 @@ func (c *client) AddPublickKey(ctx context.Context, key string) error {
 	return nil
 }
 
-func (c *client) RemovePublickKey(ctx context.Context, key string) error {
+func (c *client) RemovePublicKey(ctx context.Context, key string) error {
 	key = strings.TrimSpace(key) + "\n"
 	status, body, err := c.doCall(ctx, "DELETE", "/api/v0/account/keys", withAuth(), withBody([]byte(key)))
 	if err != nil {

--- a/cloud/client.go
+++ b/cloud/client.go
@@ -50,8 +50,8 @@ type Client interface {
 	RemoveOrgMember(ctx context.Context, orgName, userEmail string) error
 	RevokePermission(ctx context.Context, path, user string) error
 	ListPublicKeys(ctx context.Context) ([]string, error)
-	AddPublickKey(ctx context.Context, key string) error
-	RemovePublickKey(ctx context.Context, key string) error
+	AddPublicKey(ctx context.Context, key string) error
+	RemovePublicKey(ctx context.Context, key string) error
 	CreateToken(context.Context, string, bool, *time.Time) (string, error)
 	ListTokens(ctx context.Context) ([]*TokenDetail, error)
 	RemoveToken(ctx context.Context, token string) error

--- a/cmd/earthly/account_cmds.go
+++ b/cmd/earthly/account_cmds.go
@@ -243,7 +243,7 @@ func (app *earthlyApp) actionAccountRegister(cliCtx *cli.Context) error {
 	var publicKey string
 	if app.registrationPublicKey == "" {
 		if len(publicKeys) > 0 {
-			rawIsRegisterSSHKey, err := promptInput(cliCtx.Context, "Would you like to register an SSH key to be used as a form of login? [Y/n]: ")
+			rawIsRegisterSSHKey, err := promptInput(cliCtx.Context, "Would you like to enable password-less login using public key authentication (https://earthly.dev/public-key-auth)? [Y/n]: ")
 			if err != nil {
 				return err
 			}
@@ -345,9 +345,9 @@ func (app *earthlyApp) actionAccountAddKey(cliCtx *cli.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
-	if cliCtx.NArg() > 1 {
+	if cliCtx.NArg() > 0 {
 		for _, k := range cliCtx.Args().Slice() {
-			err := cloudClient.AddPublickKey(cliCtx.Context, k)
+			err := cloudClient.AddPublicKey(cliCtx.Context, k)
 			if err != nil {
 				return errors.Wrap(err, "failed to add public key to account")
 			}
@@ -367,7 +367,7 @@ func (app *earthlyApp) actionAccountAddKey(cliCtx *cli.Context) error {
 	// as there's no way to pass app.ctx to stdin read calls.
 	signal.Reset(syscall.SIGINT, syscall.SIGTERM)
 
-	fmt.Printf("Which of the following keys do you want to register?\n")
+	fmt.Printf("Which of the following public keys do you want to register (your private key is never sent or even read by earthly)?\n")
 	for i, key := range publicKeys {
 		fmt.Printf("%d) %s\n", i+1, key.String())
 	}
@@ -387,7 +387,7 @@ func (app *earthlyApp) actionAccountAddKey(cliCtx *cli.Context) error {
 	}
 	publicKey := publicKeys[i-1].String()
 
-	err = cloudClient.AddPublickKey(cliCtx.Context, publicKey)
+	err = cloudClient.AddPublicKey(cliCtx.Context, publicKey)
 	if err != nil {
 		return errors.Wrap(err, "failed to add public key to account")
 	}
@@ -416,7 +416,7 @@ func (app *earthlyApp) actionAccountRemoveKey(cliCtx *cli.Context) error {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
 	for _, k := range cliCtx.Args().Slice() {
-		err := cloudClient.RemovePublickKey(cliCtx.Context, k)
+		err := cloudClient.RemovePublicKey(cliCtx.Context, k)
 		if err != nil {
 			return errors.Wrap(err, "failed to add public key to account")
 		}


### PR DESCRIPTION
Extend client-side support for all ssh key types.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>