### PR TITLE
Retry on docker info calls

### DIFF
--- a/util/containerutil/docker.go
+++ b/util/containerutil/docker.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/alessio/shellescape"
 	"github.com/dustin/go-humanize"
@@ -40,12 +41,12 @@ func NewDockerShellFrontend(ctx context.Context, cfg *FrontendConfig) (Container
 	// `--format` option.
 	// This is to prevent displaying panic() errors to our users (even though the panic() occurred in the
 	// docker cli binary and not earthly).
-	_, err := fe.commandContextOutput(ctx, "info")
+	_, err := fe.commandContextOutputRetry(ctx, 10, 30*time.Second, "info")
 	if err != nil {
 		return nil, err
 	}
 
-	output, err := fe.commandContextOutput(ctx, "info", "--format={{.SecurityOptions}}")
+	output, err := fe.commandContextOutputRetry(ctx, 10, 30*time.Second, "info", "--format={{.SecurityOptions}}")
 	if err != nil {
 		return nil, err
 	}

--- a/util/containerutil/shell_shared.go
+++ b/util/containerutil/shell_shared.go
@@ -294,6 +294,7 @@ func (sf *shellFrontend) commandContextOutputRetry(ctx context.Context, maxRetry
 		if err == nil {
 			return output, nil
 		}
+		// TODO: This is not correct for the last iteration.
 		sf.Console.Warnf("Command %s failed: %v. Will retry\n", strings.Join(args, " "))
 	}
 	return &commmandContextOutput{}, err

--- a/util/containerutil/shell_shared.go
+++ b/util/containerutil/shell_shared.go
@@ -295,7 +295,7 @@ func (sf *shellFrontend) commandContextOutputRetry(ctx context.Context, maxRetry
 			return output, nil
 		}
 		// TODO: This is not correct for the last iteration.
-		sf.Console.Warnf("Command %s failed: %v. Will retry\n", strings.Join(args, " "))
+		sf.Console.Warnf("Command %s failed: %v. Will retry\n", strings.Join(args, " "), err)
 	}
 	return &commmandContextOutput{}, err
 }

--- a/util/containerutil/shell_shared.go
+++ b/util/containerutil/shell_shared.go
@@ -294,7 +294,7 @@ func (sf *shellFrontend) commandContextOutputRetry(ctx context.Context, maxRetry
 		if err == nil {
 			return output, nil
 		}
-		sf.Console.VerbosePrintf("Command %s failed: %v. Will retry\n", strings.Join(args, " "))
+		sf.Console.Warnf("Command %s failed: %v. Will retry\n", strings.Join(args, " "))
 	}
 	return &commmandContextOutput{}, err
 }


### PR DESCRIPTION
To test this branch, run `earthly github.com/earthly/earthly:vlad/info-retry+for-darwin-m1` and then use the binary under ./build/darwin/arm64/earthly.

Attempts to fix https://github.com/earthly/earthly/issues/2247