### PR TITLE
Fix link in podman guide

### DIFF
--- a/docs/guides/podman.md
+++ b/docs/guides/podman.md
@@ -5,7 +5,7 @@ Podman also works on Mac using a [podman machine](https://docs.podman.io/en/late
 
 ## Prerequisites
  - [Install podman](https://podman.io/getting-started/installation)
- - Mac: ensure a [podman machine](podman machine) is running.
+ - Mac: ensure a [podman machine](https://docs.podman.io/en/latest/markdown/podman-machine.1.html) is running.
  - Linux: for [multi-platform builds](https://docs.earthly.dev/docs/guides/multi-platform), install [qemu-user-static](https://github.com/multiarch/qemu-user-static).
  - [WITH DOCKER](https://docs.earthly.dev/docs/earthfile#with-docker) requires rootful mode.
    - Linux: run with `sudo` (i.e., `sudo earthly -P +with-docker-target`)


### PR DESCRIPTION
Link wasn't properly formatted. It may be nicer to change it to something like:

```markdown
[podman machine][podman_machine]

[podman_machine]: https://docs.podman.io/en/latest/markdown/podman-machine.1.html
```

And reuse the link across the document, I just wasn't sure about the style/practices for these docs.