### PR TITLE
Fix cache size unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 
 - Fixed outputting images with long names [#2053](https://github.com/earthly/earthly/issues/2053)
 - Fixed buildkit connection timing out occasionally [#2229](https://github.com/earthly/earthly/issues/2229)
+- Cache size was incorrectly displayed (magnitude of 1024 higher)
 
 ## v0.6.24 - 2022-09-22
 

--- a/buildkitd/buildkitd.go
+++ b/buildkitd/buildkitd.go
@@ -522,14 +522,14 @@ ContainerRunningLoop:
 			return nil, nil, err
 		}
 		// We timed out. Check if the user has a lot of cache and give buildkit another chance.
-		cacheSize, cacheSizeErr := getCacheSize(ctx, volumeName, fe)
+		cacheSizeBytes, cacheSizeErr := getCacheSize(ctx, volumeName, fe)
 		if cacheSizeErr != nil {
 			console.
 				WithPrefix("buildkitd").
 				Printf("Warning: Could not detect buildkit cache size: %v\n", cacheSizeErr)
 			return nil, nil, err
 		}
-		cacheGigs := cacheSize / 1024 / 1024
+		cacheGigs := cacheSizeBytes / 1024 / 1024 / 1024
 		if cacheGigs >= 30 || (cacheGigs >= 10 && runtime.GOOS == "darwin") {
 			console.
 				WithPrefix("buildkitd").
@@ -889,14 +889,14 @@ func printBuildkitInfo(bkCons conslogging.ConsoleLogger, info *client.Info, work
 	}
 }
 
-// getCacheSize returns the size of the earthly cache in KiB.
+// getCacheSize returns the size of the earthly cache in bytes.
 func getCacheSize(ctx context.Context, volumeName string, fe containerutil.ContainerFrontend) (int, error) {
 	infos, err := fe.VolumeInfo(ctx, volumeName)
 	if err != nil {
 		return 0, errors.Wrapf(err, "failed to get volume info for cache size %s", volumeName)
 	}
 
-	return int(infos[volumeName].Size), nil
+	return int(infos[volumeName].SizeBytes), nil
 }
 
 func makeTLSPath(path string) (string, error) {

--- a/util/containerutil/docker.go
+++ b/util/containerutil/docker.go
@@ -201,7 +201,7 @@ func (dsf *dockerShellFrontend) VolumeInfo(ctx context.Context, volumeNames ...s
 				} else {
 					results[name] = &VolumeInfo{
 						Name:       volumeInfo.Name,
-						Size:       bytes,
+						SizeBytes:  bytes,
 						Mountpoint: volumeInfo.Mountpoint,
 					}
 				}

--- a/util/containerutil/podman.go
+++ b/util/containerutil/podman.go
@@ -230,7 +230,7 @@ func (psf *podmanShellFrontend) VolumeInfo(ctx context.Context, volumeNames ...s
 
 				results[volumeName] = &VolumeInfo{
 					Name:       volumeName,
-					Size:       bytes,
+					SizeBytes:  bytes,
 					Mountpoint: string(mountpoint.string()),
 				}
 				break

--- a/util/containerutil/types.go
+++ b/util/containerutil/types.go
@@ -71,7 +71,7 @@ type ImageInfo struct {
 type VolumeInfo struct {
 	Name       string
 	Mountpoint string
-	Size       uint64
+	SizeBytes  uint64
 }
 
 // ImageTag contains a source and target ref, used for tagging an image. It means that the SourceRef is tagged as the value in TargetRef.


### PR DESCRIPTION
Cache size was being returned as Bytes, but was treated as if it were KiB.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>