### PR TITLE
fix copyop merging without cwd

### DIFF
--- a/ast/tests/git-clone.ast.json
+++ b/ast/tests/git-clone.ast.json
@@ -41,6 +41,15 @@
         {
           "command": {
             "args": [
+              "ls",
+              ".git"
+            ],
+            "name": "RUN"
+          }
+        },
+        {
+          "command": {
+            "args": [
               "git",
               "status"
             ],
@@ -71,6 +80,7 @@
   ],
   "version": {
     "args": [
+      "--use-copy-link",
       "0.6"
     ]
   }

--- a/buildcontext/git.go
+++ b/buildcontext/git.go
@@ -77,9 +77,13 @@ func (gr *gitResolver) resolveEarthProject(ctx context.Context, gwClient gwclien
 				TargetName: ref.String(),
 				Internal:   true,
 			}
-			buildContextFactory = llbfactory.PreconstructedState(llbutil.CopyOp(
+			copyState, err := llbutil.CopyOp(ctx,
 				rgp.state, []string{subDir}, platr.Scratch(), "./", false, false, false, "root:root", nil, false, false, false,
-				llb.WithCustomNamef("%sCOPY git context %s", vm.ToVertexPrefix(), ref.String())))
+				llb.WithCustomNamef("%sCOPY git context %s", vm.ToVertexPrefix(), ref.String()))
+			if err != nil {
+				return nil, errors.Wrap(err, "copyOp failed in resolveEarthProject")
+			}
+			buildContextFactory = llbfactory.PreconstructedState(copyState)
 		}
 	}
 	// Else not needed: Commands don't come with a build context.

--- a/tests/git-clone.earth
+++ b/tests/git-clone.earth
@@ -1,9 +1,11 @@
-VERSION 0.6
+VERSION --use-copy-link 0.6
+
 FROM alpine/git:1.0.7
 test:
     WORKDIR /test
     GIT CLONE https://github.com/moby/buildkit.git buildkit
     WORKDIR /test/buildkit
+    RUN ls .git
     RUN git status
     RUN git branch
     RUN test -f README.md


### PR DESCRIPTION
CopyOp was ignoring the current working directory when merging.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>