### PR TITLE
[contrib]: check for jq + update release cmd in docs

### DIFF
--- a/release/README.md
+++ b/release/README.md
@@ -28,7 +28,7 @@
   | Windows (WSL) | [![Build status](https://badge.buildkite.com/19d9cf7fcfb3e0ee45adcb29abb5ef3cfcd994fba2d6dc148c.svg)](https://buildkite.com/earthly-technologies/earthly-windows-scheduled)
 * Run
   ```bash
-  env -i HOME="$HOME" PATH="$PATH" SSH_AUTH_SOCK="$SSH_AUTH_SOCK" RELEASE_TAG="$RELEASE_TAG" ./release.sh
+  env -i HOME="$HOME" PATH="$PATH" SSH_AUTH_SOCK="$SSH_AUTH_SOCK" RELEASE_TAG="$RELEASE_TAG" USER="$USER" ./release.sh
   ```
 * Merge branch `main` into `next`, then merge branch `next` into `main`.
 * Update the version for the installation command in the following places:

--- a/release/release.sh
+++ b/release/release.sh
@@ -45,6 +45,8 @@ test -n "$HOME" || (echo "ERROR: HOME is not set"; exit 1);
 test -n "$RELEASE_TAG" || (echo "ERROR: RELEASE_TAG is not set" && exit 1);
 (echo "$RELEASE_TAG" | grep '^v[0-9]\+.[0-9]\+.[0-9]\+\(-rc[0-9]\+\)\?$' > /dev/null) || (echo "ERROR: RELEASE_TAG must be formatted as v1.2.3 (or v1.2.3-RC1); instead got \"$RELEASE_TAG\""; exit 1);
 
+command -v jq || (echo "ERROR: jq is not installed"; exit 1);
+
 # Set default values
 export GITHUB_USER=${GITHUB_USER:-earthly}
 export DOCKERHUB_USER=${DOCKERHUB_USER:-earthly}


### PR DESCRIPTION
We should check for `jq` + update the release.sh run command to also pass $USER.