### PR TITLE
Support for leading Docker `ARG`s in `docker2earthly`

### DIFF
--- a/docker2earthly/convert.go
+++ b/docker2earthly/convert.go
@@ -14,6 +14,10 @@ import (
 	"github.com/pkg/errors"
 )
 
+// Ideally this would point to "the current version" rather than being hard-coded, but the single
+// "source of truth" (in ast/validator) isn't currently exported.
+const earthlyCurrentVersion = "0.6"
+
 func getArtifactName(s string) string {
 	split := strings.Split(s, "/")
 	n := len(split)
@@ -41,10 +45,11 @@ func Docker2Earthly(dockerfilePath, earthfilePath, imageTag string) error {
 
 	targets := [][]string{
 		{
+			fmt.Sprintf("VERSION %s\n", earthlyCurrentVersion),
 			"# This Earthfile was generated using docker2earthly",
 			"# the conversion is done on a best-effort basis",
 			"# and might not follow best practices, please",
-			"# visit http://docs.earthly.dev for Earthfile guides",
+			"# visit https://docs.earthly.dev for Earthfile guides",
 		},
 	}
 

--- a/docker2earthly/convert.go
+++ b/docker2earthly/convert.go
@@ -124,8 +124,6 @@ func Docker2Earthly(dockerfilePath, earthfilePath, imageTag string) error {
 		out = out2
 	}
 
-	fmt.Fprintf(out, "\n")
-
 	for i, lines := range targets {
 		for j, l := range lines {
 			if i == 0 {

--- a/tests/docker2earth/args-before-from.Dockerfile
+++ b/tests/docker2earth/args-before-from.Dockerfile
@@ -1,0 +1,21 @@
+ARG BASE
+ARG GO_MAJOR
+ARG GO_MINOR=16
+ARG GO_VERSION="${GO_MAJOR}.${GO_MINOR}"
+FROM "${BASE}:${GO_VERSION}"
+WORKDIR /go/src/github.com/alexellis/href-counter/
+RUN go get -d -v golang.org/x/net/html
+COPY app.go .
+RUN go mod init
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
+
+FROM alpine:latest as greet
+WORKDIR /root/
+RUN echo greetings > /root/hello.txt
+
+FROM alpine:latest
+RUN apk --no-cache add ca-certificates
+WORKDIR /root/
+COPY --from=0 /go/src/github.com/alexellis/href-counter/app .
+COPY --from=greet /root/hello.txt .
+CMD ["./app"]

--- a/tests/docker2earth/test.sh
+++ b/tests/docker2earth/test.sh
@@ -1,21 +1,21 @@
 #!/bin/bash
 set -eu
 
-earthly=`pwd`/build/linux/amd64/earthly
+earthly=$(pwd)/build/linux/amd64/earthly
 dockerfiles="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-echo === Testing Dockerfile1 ===
-cd $(mktemp -d)
+echo "=== Testing Dockerfile1 ==="
+cd "$(mktemp -d)"
 echo "working out of $(pwd)"
-cp $dockerfiles/Dockerfile1 Dockerfile
+cp "$dockerfiles"/Dockerfile1 Dockerfile
 $earthly docker2earthly --tag=myimage:latest
 $earthly +build
 docker run --rm myimage:latest say-hi | grep hello
 
-echo === Testing Dockerfile2 ===
-cd $(mktemp -d)
+echo "=== Testing Dockerfile2 ==="
+cd "$(mktemp -d)"
 echo "working out of $(pwd)"
-cat $dockerfiles/Dockerfile2 | $earthly docker2earthly --dockerfile - --tag myotherimage:test
-cp $dockerfiles/app.go .
+cat "$dockerfiles"/Dockerfile2 | $earthly docker2earthly --dockerfile - --tag myotherimage:test
+cp "$dockerfiles"/app.go .
 $earthly +build
 docker run --rm myotherimage:test | grep greetings

--- a/tests/docker2earth/test.sh
+++ b/tests/docker2earth/test.sh
@@ -19,3 +19,11 @@ cat "$dockerfiles"/Dockerfile2 | $earthly docker2earthly --dockerfile - --tag my
 cp "$dockerfiles"/app.go .
 $earthly +build
 docker run --rm myotherimage:test | grep greetings
+
+echo "=== Testing args-before-from.Dockerfile ==="
+cd "$(mktemp -d)"
+echo "working out of $(pwd)"
+$earthly docker2earthly --dockerfile - --tag onemoreimage:test < "$dockerfiles"/args-before-from.Dockerfile
+cp "$dockerfiles"/app.go .
+$earthly +build --BASE=golang --GO_MAJOR=1
+docker run --rm onemoreimage:test | grep greetings


### PR DESCRIPTION
Given a trivial (but valid) Dockerfile:
```Dockerfile
ARG img
FROM $img
```
the conversion results in an unusable Earthfile:
```
$ earthly docker2earthly --tag foo --earthfile - 2>/dev/null

# This Earthfile was generated using docker2earthly
# the conversion is done on a best-effort basis
# and might not follow best practices, please
# visit http://docs.earthly.dev for Earthfile guides
subbuild1:
    FROM $img
    SAVE IMAGE foo

build:
    BUILD +subbuild1
```

This change results in a file that's buildable (and has the equivalent docker behavior):
```
$ earthly-dev docker2earthly --tag foo --earthfile - 2>/dev/null
VERSION 0.6

# This Earthfile was generated using docker2earthly
# the conversion is done on a best-effort basis
# and might not follow best practices, please
# visit https://docs.earthly.dev for Earthfile guides
subbuild1:
    ARG img
    FROM $img
    SAVE IMAGE foo

build:
    BUILD +subbuild1
```