### PR TITLE
Satellite Wake-up Command

### DIFF
--- a/cloud/client.go
+++ b/cloud/client.go
@@ -74,6 +74,7 @@ type Client interface {
 	GetSatellite(ctx context.Context, name, orgID string) (*SatelliteInstance, error)
 	DeleteSatellite(ctx context.Context, name, orgID string) error
 	ReserveSatellite(ctx context.Context, name, orgID, gitAuthor string, isCI bool, out chan<- string) error
+	WakeSatellite(ctx context.Context, name, orgID string, out chan<- string) error
 	CreateProject(ctx context.Context, name, orgName string) (*Project, error)
 	ListProjects(ctx context.Context, orgName string) ([]*Project, error)
 	GetProject(ctx context.Context, orgName, name string) (*Project, error)

--- a/cloud/client.go
+++ b/cloud/client.go
@@ -73,8 +73,8 @@ type Client interface {
 	ListSatellites(ctx context.Context, orgID string) ([]SatelliteInstance, error)
 	GetSatellite(ctx context.Context, name, orgID string) (*SatelliteInstance, error)
 	DeleteSatellite(ctx context.Context, name, orgID string) error
-	ReserveSatellite(ctx context.Context, name, orgID, gitAuthor string, isCI bool, out chan<- string) error
-	WakeSatellite(ctx context.Context, name, orgID string, out chan<- string) error
+	ReserveSatellite(ctx context.Context, name, orgID, gitAuthor string, isCI bool) chan SatelliteStatusUpdate
+	WakeSatellite(ctx context.Context, name, orgID string) chan SatelliteStatusUpdate
 	CreateProject(ctx context.Context, name, orgName string) (*Project, error)
 	ListProjects(ctx context.Context, orgName string) ([]*Project, error)
 	GetProject(ctx context.Context, orgName, name string) (*Project, error)

--- a/cloud/satellite.go
+++ b/cloud/satellite.go
@@ -117,6 +117,7 @@ func (c *client) ReserveSatellite(ctx context.Context, name, orgID, gitAuthor, g
 		})
 		if err != nil {
 			out <- SatelliteStatusUpdate{Err: errors.Wrap(err, "failed opening satellite reserve stream")}
+			return
 		}
 		var update *pb.ReserveSatelliteResponse
 		for {
@@ -126,10 +127,12 @@ func (c *client) ReserveSatellite(ctx context.Context, name, orgID, gitAuthor, g
 			}
 			if err != nil {
 				out <- SatelliteStatusUpdate{Err: errors.Wrap(err, "failed receiving satellite reserve update")}
+				return
 			}
 			status := satelliteStatus(update.Status)
 			if status == SatelliteStatusFailed {
 				out <- SatelliteStatusUpdate{Err: errors.New("satellite is in a failed state")}
+				return
 			}
 			out <- SatelliteStatusUpdate{State: satelliteStatus(update.Status)}
 		}
@@ -149,6 +152,7 @@ func (c *client) WakeSatellite(ctx context.Context, name, orgID string) (out cha
 		})
 		if err != nil {
 			out <- SatelliteStatusUpdate{Err: errors.Wrap(err, "failed opening satellite wake stream")}
+			return
 		}
 		var update *pb.WakeSatelliteResponse
 		for {
@@ -158,10 +162,12 @@ func (c *client) WakeSatellite(ctx context.Context, name, orgID string) (out cha
 			}
 			if err != nil {
 				out <- SatelliteStatusUpdate{Err: errors.Wrap(err, "failed receiving satellite wake update")}
+				return
 			}
 			status := satelliteStatus(update.Status)
 			if status == SatelliteStatusFailed {
 				out <- SatelliteStatusUpdate{Err: errors.New("satellite is in a failed state")}
+				return
 			}
 			out <- SatelliteStatusUpdate{State: satelliteStatus(update.Status)}
 		}

--- a/cmd/earthly/buildkit.go
+++ b/cmd/earthly/buildkit.go
@@ -208,13 +208,11 @@ func (app *earthlyApp) isUsingSatellite(cliCtx *cli.Context) bool {
 
 func (app *earthlyApp) reserveSatellite(ctx context.Context, cloudClient cloud.Client, name, orgID, gitAuthor string) error {
 	console := app.console.WithPrefix("satellite")
-	out := make(chan string)
-	var reserveErr error
 	_, isCI := analytics.DetectCI()
-	go func() { reserveErr = cloudClient.ReserveSatellite(ctx, name, orgID, gitAuthor, isCI, out) }()
-	showSatelliteLoading(console, out, name)
-	if reserveErr != nil {
-		return errors.Wrap(reserveErr, "failed reserving satellite for build")
+	out := cloudClient.ReserveSatellite(ctx, name, orgID, gitAuthor, isCI)
+	err := showSatelliteLoading(console, name, out)
+	if err != nil {
+		return errors.Wrap(err, "failed reserving satellite for build")
 	}
 	return nil
 }

--- a/cmd/earthly/buildkit.go
+++ b/cmd/earthly/buildkit.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"math/rand"
 	"net/url"
 	"path/filepath"
 	"time"
@@ -213,91 +212,9 @@ func (app *earthlyApp) reserveSatellite(ctx context.Context, cloudClient cloud.C
 	var reserveErr error
 	_, isCI := analytics.DetectCI()
 	go func() { reserveErr = cloudClient.ReserveSatellite(ctx, name, orgID, gitAuthor, isCI, out) }()
-	loadingMsgs := getSatelliteLoadingMessages()
-	var (
-		loggedSleep      bool
-		loggedStop       bool
-		loggedStart      bool
-		shouldLogLoading bool
-	)
-	for status := range out {
-		shouldLogLoading = true
-		switch status {
-		case cloud.SatelliteStatusSleep:
-			if !loggedSleep {
-				console.Printf("%s is waking up. Please wait...", name)
-				loggedSleep = true
-				shouldLogLoading = false
-			}
-		case cloud.SatelliteStatusStopping:
-			if !loggedStop {
-				console.Printf("%s is falling asleep. Please wait...", name)
-				loggedStop = true
-				shouldLogLoading = false
-			}
-		case cloud.SatelliteStatusStarting:
-			if !loggedStart && !loggedSleep {
-				console.Printf("%s is starting. Please wait...", name)
-				loggedStart = true
-				shouldLogLoading = false
-			}
-		case cloud.SatelliteStatusOperational:
-			// Should be last update received at this point.
-			console.Printf("...System online.")
-			shouldLogLoading = false
-		default:
-			// In case there's a new state later which we didn't expect here,
-			// we'll still try to inform the user as best we can.
-			// Note the state might just be "Unknown" if it maps to an gRPC enum we don't know about.
-			console.Printf("%s state is: %s", name, status)
-			shouldLogLoading = false
-		}
-		if shouldLogLoading {
-			var msg string
-			msg, loadingMsgs = nextSatelliteLoadingMessage(loadingMsgs)
-			console.Printf("...%s...", msg)
-		}
-	}
+	showSatelliteLoading(console, out, name)
 	if reserveErr != nil {
 		return errors.Wrap(reserveErr, "failed reserving satellite for build")
 	}
 	return nil
-}
-
-func nextSatelliteLoadingMessage(msgs []string) (nextMsg string, remainingMsgs []string) {
-	if len(msgs) == 0 {
-		msgs = getSatelliteLoadingMessages()
-	}
-	return msgs[0], msgs[1:]
-}
-
-func getSatelliteLoadingMessages() []string {
-	baseMessages := []string{
-		"tracking orbit",
-		"adjusting course",
-		"deploying solar array",
-		"aligning solar panels",
-		"calibrating guidance system",
-		"establishing transponder uplink",
-		"testing signal quality",
-		"fueling thrusters",
-		"amplifying transmission signal",
-		"checking thermal controls",
-		"stabilizing trajectory",
-		"contacting mission control",
-		"testing antennas",
-		"reporting fuel levels",
-		"scanning surroundings",
-		"avoiding debris",
-		"taking solar reading",
-		"reporting thermal conditions",
-		"testing system integrity",
-		"checking battery levels",
-		"calibrating transponders",
-		"modifying downlink frequency",
-	}
-	msgs := baseMessages
-	rand.Seed(time.Now().UnixNano())
-	rand.Shuffle(len(msgs), func(i, j int) { msgs[i], msgs[j] = msgs[j], msgs[i] })
-	return msgs
 }

--- a/cmd/earthly/satellite_cmds.go
+++ b/cmd/earthly/satellite_cmds.go
@@ -459,7 +459,7 @@ func showSatelliteLoading(console conslogging.ConsoleLogger, satName string, out
 			}
 		case cloud.SatelliteStatusStopping:
 			if !loggedStop {
-				console.Printf("%s is falling asleep. Please wait...", satName)
+				console.Printf("%s is currently falling asleep. Waiting to send wake up signal...", satName)
 				loggedStop = true
 				shouldLogLoading = false
 			}

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/docker/distribution v2.8.1+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/dustin/go-humanize v1.0.0
-	github.com/earthly/cloud-api v1.0.1-0.20221020142037-a1531a0a332d
+	github.com/earthly/cloud-api v1.0.1-0.20221024144755-4fbecec92cbc
 	github.com/earthly/earthly/ast v0.0.0-00010101000000-000000000000
 	github.com/elastic/go-sysinfo v1.7.1
 	github.com/fatih/color v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -85,8 +85,8 @@ github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/earthly/buildkit v0.0.1-0.20220913002628-9c256c19c539 h1:m0Q93OE9h9s8JY7kTDe7Mhsdy6KcYB5ncHjKGX7m6OE=
 github.com/earthly/buildkit v0.0.1-0.20220913002628-9c256c19c539/go.mod h1:Ih6/jh6JTbktkhxRID0gj6dn2GAPI6H9U6xKVxgNqBk=
-github.com/earthly/cloud-api v1.0.1-0.20221020142037-a1531a0a332d h1:eikmeuwuh7r4+q/c91Cf2ibLkTIa91L38B7YiZ++wxw=
-github.com/earthly/cloud-api v1.0.1-0.20221020142037-a1531a0a332d/go.mod h1:JhlHsW6o8zYa+XsM0nMAevRQtES35KE5R2G8tJALsnI=
+github.com/earthly/cloud-api v1.0.1-0.20221024144755-4fbecec92cbc h1:l4drYtVwk9DZOb8NBgzFkGFQK3GLSFfUi8rsi3ox2Mc=
+github.com/earthly/cloud-api v1.0.1-0.20221024144755-4fbecec92cbc/go.mod h1:JhlHsW6o8zYa+XsM0nMAevRQtES35KE5R2G8tJALsnI=
 github.com/earthly/fsutil v0.0.0-20220719234708-392da7eebeb5 h1:bOKRnmQd1JYrtOUdkvYraBCT0SRjYpYnhd4i85mWtQw=
 github.com/earthly/fsutil v0.0.0-20220719234708-392da7eebeb5/go.mod h1:oPAfvw32vlUJSjyDcQ3Bu0nb2ON2B+G0dtVN/SZNJiA=
 github.com/elastic/go-sysinfo v1.7.1 h1:Wx4DSARcKLllpKT2TnFVdSUJOsybqMYCNQZq1/wO+s0=


### PR DESCRIPTION
The satellite wake command will start a satellite that is asleep. This can be useful for using the `inspect` command, since it will not show much info when the satellite is asleep. 

The wake command will also use more "force" in trying to start a satellite than a normal Reserve call will do, so it can be usef to debug or attempt to recover a satellite that has failed or ended up in a bad state for some reason.

Examples below 👇 

Satellite wake command, when satellite is asleep:
![Screenshot 2022-10-24 164539](https://user-images.githubusercontent.com/3247216/197627000-68c29f36-a685-4b26-b015-fde1729f6554.png)

Satellite wake when already awake:
![Screenshot 2022-10-24 164607](https://user-images.githubusercontent.com/3247216/197627042-e91bf3be-7228-4aa5-9412-e12fc1a16eb1.png)

`inspect` prompts user to run `wake` if the satellite is asleep:
![Screenshot 2022-10-24 165652](https://user-images.githubusercontent.com/3247216/197627858-23d64022-b74a-4810-9e26-a4fac35ea0c3.png)

