### PR TITLE
rename Load to current utilization

### DIFF
--- a/buildkitd/buildkitd.go
+++ b/buildkitd/buildkitd.go
@@ -22,6 +22,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/earthly/earthly/conslogging"
+	"github.com/earthly/earthly/util/buildkitutil"
 	"github.com/earthly/earthly/util/cliutil"
 	"github.com/earthly/earthly/util/containerutil"
 	"github.com/earthly/earthly/util/fileutil"
@@ -859,9 +860,7 @@ func printBuildkitInfo(bkCons conslogging.ConsoleLogger, info *client.Info, work
 		printFun("Platforms: %s (native) %s", ps[0], strings.Join(ps[1:], " "))
 	}
 	load := workerInfo.ParallelismCurrent + workerInfo.ParallelismWaiting
-	printFun(
-		"Utilization: %d other builds, %d/%d op load",
-		info.NumSessions, load, workerInfo.ParallelismMax)
+	printFun(buildkitutil.FormatUtilization(info.NumSessions, load, workerInfo.ParallelismMax))
 	switch {
 	case workerInfo.ParallelismWaiting > 5:
 		bkCons.Warnf("Warning: Currently under heavy load. Performance will be affected")

--- a/outmon/solvermon.go
+++ b/outmon/solvermon.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/dustin/go-humanize"
 	"github.com/earthly/earthly/conslogging"
+	"github.com/earthly/earthly/util/buildkitutil"
 	"github.com/moby/buildkit/client"
 	"github.com/opencontainers/go-digest"
 )
@@ -260,6 +261,11 @@ func (sm *SolverMonitor) processNoOutputTick(ctx context.Context, bkClient *clie
 		warn = true
 		return nil // no need to crash
 	}
+	numOtherSessions := -1 // default to unknown (since Info is a newer call and might not be implemented)
+	if info, err := bkClient.Info(ctx); err == nil {
+		numOtherSessions = info.NumSessions - 1 // don't count current session
+	}
+
 	if len(workers) == 0 {
 		ongoingStr = "error getting buildkit worker info: no workers"
 		warn = true
@@ -270,17 +276,14 @@ func (sm *SolverMonitor) processNoOutputTick(ctx context.Context, bkClient *clie
 	switch {
 	case workerInfo.ParallelismWaiting > 5:
 		ongoingStr = fmt.Sprintf(
-			"Waiting... Buildkit is currently under heavy load (%d/%d)",
-			load, workerInfo.ParallelismMax)
+			"Waiting... Buildkit is currently under heavy load (%s)", buildkitutil.FormatUtilization(numOtherSessions, load, workerInfo.ParallelismMax))
 		warn = true
 	case workerInfo.ParallelismWaiting > 0:
 		ongoingStr = fmt.Sprintf(
-			"Waiting... Buildkit is currently under significant load (%d/%d)",
-			load, workerInfo.ParallelismMax)
+			"Waiting... Buildkit is currently under significant load (%s)", buildkitutil.FormatUtilization(numOtherSessions, load, workerInfo.ParallelismMax))
 	default:
 		ongoingStr = fmt.Sprintf(
-			"Waiting on Buildkit... Load (%d/%d)",
-			load, workerInfo.ParallelismMax)
+			"Waiting on Buildkit... (%s)", buildkitutil.FormatUtilization(numOtherSessions, load, workerInfo.ParallelismMax))
 	}
 	if workerInfo.GCAnalytics.CurrentStartTime != nil {
 		d := now.Sub(*workerInfo.GCAnalytics.CurrentStartTime).Round(time.Second)

--- a/util/buildkitutil/utilization.go
+++ b/util/buildkitutil/utilization.go
@@ -1,0 +1,12 @@
+package buildkitutil
+
+import "fmt"
+
+// FormatUtilization returns a string representing utilization
+func FormatUtilization(numOtherSessions, load, maxParallelism int) string {
+	otherSessions := "unknown"
+	if numOtherSessions >= 0 {
+		otherSessions = fmt.Sprintf("%d", numOtherSessions)
+	}
+	return fmt.Sprintf("Utilization: %s other builds, %d/%d op load", otherSessions, load, maxParallelism)
+}


### PR DESCRIPTION
This is to avoid load being misinterpreted as "loading data".

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>