### PR TITLE
Run builds on two Satellites

### DIFF
--- a/.github/workflows/ci-docker-satellites.yml
+++ b/.github/workflows/ci-docker-satellites.yml
@@ -34,7 +34,7 @@ jobs:
       SUDO: ""
       EXAMPLE_NAME: "+examples1"
       USE_SATELLITE: true
-      SATELLITE_NAME: "core-test"
+      SATELLITE_NAME: "core-examples"
       EARTHLY_ORG: "earthly-technologies"
     secrets: inherit
 
@@ -49,7 +49,7 @@ jobs:
       SUDO: ""
       EXAMPLE_NAME: "+examples2"
       USE_SATELLITE: true
-      SATELLITE_NAME: "core-test"
+      SATELLITE_NAME: "core-examples"
       EARTHLY_ORG: "earthly-technologies"
     secrets: inherit
 


### PR DESCRIPTION
The example targets should run on the satellite `core-examples`

This helps balance the load when there's lots of PR builds. Also a proof-of-concept for splitting load on multiple satellites