### PR TITLE
increased buildkit source cache limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,14 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 
 ## Unreleased
 
+### Changed
+
+- Increases the cache limit for local and git sources from 10% to 50% to support copying large files (e.g. binary assets).
+
 ### Fixed
 
 - `CACHE` command was not being correctly used in `IF`, `FOR`, `ARG` and other commands. [#2330](https://github.com/earthly/earthly/issues/2330)
+- Fixed buildkit gckeepstorage config value which was was set to 1000 times larger than the cache size, now it is set to the cache size.
 
 ## v0.6.28 - 2022-10-26
 

--- a/buildkitd/buildkitd.cache.template
+++ b/buildkitd/buildkitd.cache.template
@@ -1,12 +1,11 @@
   # Please note the required indentation to fit in buildkit.toml.template accordingly.
 
-  # 1/100 of total cache size.
-  gckeepstorage = ${CACHE_SIZE_MB}0000
+  # gckeepstorage sets storage limit for default gc profile, in MB.
+  gckeepstorage = ${CACHE_SIZE_MB}
+
   [[worker.oci.gcpolicy]]
-    # 1/10 of total cache size.
-    keepBytes = ${CACHE_SIZE_MB}00000
+    keepBytes = ${SOURCE_FILE_KEEP_BYTES}
     filters = [ "type==source.local", "type==source.git.checkout"]
   [[worker.oci.gcpolicy]]
     all = true
-    # Cache size MB with 6 zeros, to turn it into bytes.
-    keepBytes = ${CACHE_SIZE_MB}000000
+    keepBytes = ${CATCH_ALL_KEEP_BYTES}

--- a/buildkitd/entrypoint.sh
+++ b/buildkitd/entrypoint.sh
@@ -191,6 +191,10 @@ fi
 # set (or not), but we'll continue setting to "0" in case anyone has become dependent on that behavior.
 CACHE_SIZE_MB="${EFFECTIVE_CACHE_SIZE_MB:-0}"
 if [ "$CACHE_SIZE_MB" -gt "0" ]; then
+    SOURCE_FILE_KEEP_BYTES="$(echo "($CACHE_SIZE_MB * 1024 * 1024 * 0.5) / 1" | bc)" # Note /1 division truncates to int
+    export SOURCE_FILE_KEEP_BYTES
+    CATCH_ALL_KEEP_BYTES="$(echo "$CACHE_SIZE_MB * 1024 * 1024" | bc)"
+    export CATCH_ALL_KEEP_BYTES
     CACHE_SETTINGS="$(envsubst </etc/buildkitd.cache.template)"
 fi
 export CACHE_SETTINGS


### PR DESCRIPTION
This increases the cache limit for local and git sources from 10% to 50% to support copying large files (e.g. binary assets). This additionally fixes the `gckeepstorage` value which expects MB and not bytes.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>