### PR TITLE
Use correct user platform on Darwin and on Windows

### DIFF
--- a/util/platutil/resolver.go
+++ b/util/platutil/resolver.go
@@ -158,10 +158,5 @@ func (r *Resolver) ToLLBPlatform(in Platform) specs.Platform {
 
 // GetUserPlatform returns the user platform.
 func GetUserPlatform() specs.Platform {
-	p := platforms.DefaultSpec()
-	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
-		// Use linux so that this works with Docker Desktop app.
-		p.OS = "linux"
-	}
-	return platforms.Normalize(p)
+	return platforms.Normalize(platforms.DefaultSpec())
 }

--- a/util/platutil/resolver.go
+++ b/util/platutil/resolver.go
@@ -1,8 +1,6 @@
 package platutil
 
 import (
-	"runtime"
-
 	"github.com/containerd/containerd/platforms"
 	"github.com/earthly/earthly/util/llbutil/pllb"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"


### PR DESCRIPTION
This was being overridden because in the past we didn't have distinct platforms for user vs target vs native. This no longer makes sense now, however.