### PR TITLE
Satellite sleep command

### DIFF
--- a/cloud/client.go
+++ b/cloud/client.go
@@ -75,6 +75,7 @@ type Client interface {
 	DeleteSatellite(ctx context.Context, name, orgID string) error
 	ReserveSatellite(ctx context.Context, name, orgID, gitAuthor, gitConfigEmail string, isCI bool) chan SatelliteStatusUpdate
 	WakeSatellite(ctx context.Context, name, orgID string) chan SatelliteStatusUpdate
+	SleepSatellite(ctx context.Context, name, orgID string) chan SatelliteStatusUpdate
 	CreateProject(ctx context.Context, name, orgName string) (*Project, error)
 	ListProjects(ctx context.Context, orgName string) ([]*Project, error)
 	GetProject(ctx context.Context, orgName, name string) (*Project, error)

--- a/cloud/satellite.go
+++ b/cloud/satellite.go
@@ -120,9 +120,8 @@ func (c *client) ReserveSatellite(ctx context.Context, name, orgID, gitAuthor, g
 			out <- SatelliteStatusUpdate{Err: errors.Wrap(err, "failed opening satellite reserve stream")}
 			return
 		}
-		var update *pb.ReserveSatelliteResponse
 		for {
-			update, err = stream.Recv()
+			update, err := stream.Recv()
 			if err == io.EOF {
 				return
 			}
@@ -155,9 +154,8 @@ func (c *client) WakeSatellite(ctx context.Context, name, orgID string) (out cha
 			out <- SatelliteStatusUpdate{Err: errors.Wrap(err, "failed opening satellite wake stream")}
 			return
 		}
-		var update *pb.WakeSatelliteResponse
 		for {
-			update, err = stream.Recv()
+			update, err := stream.Recv()
 			if err == io.EOF {
 				return
 			}
@@ -191,9 +189,8 @@ func (c *client) SleepSatellite(ctx context.Context, name, orgID string) (out ch
 			out <- SatelliteStatusUpdate{Err: errors.Wrap(err, "failed opening satellite sleep stream")}
 			return
 		}
-		var update *pb.SleepSatelliteResponse
 		for {
-			update, err = stream.Recv()
+			update, err := stream.Recv()
 			if err == io.EOF {
 				return
 			}

--- a/cloud/satellite.go
+++ b/cloud/satellite.go
@@ -7,6 +7,7 @@ import (
 
 	pb "github.com/earthly/cloud-api/compute"
 	"github.com/pkg/errors"
+	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 const (
@@ -162,6 +163,42 @@ func (c *client) WakeSatellite(ctx context.Context, name, orgID string) (out cha
 			}
 			if err != nil {
 				out <- SatelliteStatusUpdate{Err: errors.Wrap(err, "failed receiving satellite wake update")}
+				return
+			}
+			status := satelliteStatus(update.Status)
+			if status == SatelliteStatusFailed {
+				out <- SatelliteStatusUpdate{Err: errors.New("satellite is in a failed state")}
+				return
+			}
+			out <- SatelliteStatusUpdate{State: satelliteStatus(update.Status)}
+		}
+	}()
+	return out
+}
+
+func (c *client) SleepSatellite(ctx context.Context, name, orgID string) (out chan SatelliteStatusUpdate) {
+	out = make(chan SatelliteStatusUpdate)
+	go func() {
+		ctxTimeout, cancel := context.WithTimeout(ctx, 5*time.Minute)
+		defer cancel()
+		defer close(out)
+		stream, err := c.compute.SleepSatellite(c.withAuth(ctxTimeout), &pb.SleepSatelliteRequest{
+			OrgId:          orgID,
+			Name:           name,
+			UpdateInterval: durationpb.New(10 * time.Second),
+		})
+		if err != nil {
+			out <- SatelliteStatusUpdate{Err: errors.Wrap(err, "failed opening satellite sleep stream")}
+			return
+		}
+		var update *pb.SleepSatelliteResponse
+		for {
+			update, err = stream.Recv()
+			if err == io.EOF {
+				return
+			}
+			if err != nil {
+				out <- SatelliteStatusUpdate{Err: errors.Wrap(err, "failed receiving satellite sleep update")}
 				return
 			}
 			status := satelliteStatus(update.Status)

--- a/cmd/earthly/satellite_cmds.go
+++ b/cmd/earthly/satellite_cmds.go
@@ -172,8 +172,11 @@ func (app *earthlyApp) getSatelliteOrgID(ctx context.Context, cloudClient cloud.
 func (app *earthlyApp) actionSatelliteLaunch(cliCtx *cli.Context) error {
 	app.commandName = "satelliteLaunch"
 
-	if cliCtx.NArg() != 1 {
+	if cliCtx.NArg() == 0 {
 		return errors.New("satellite name is required")
+	}
+	if cliCtx.NArg() > 1 {
+		return errors.New("only a single satellite name is supported")
 	}
 
 	app.satelliteName = cliCtx.Args().Get(0)
@@ -211,8 +214,11 @@ func (app *earthlyApp) actionSatelliteLaunch(cliCtx *cli.Context) error {
 func (app *earthlyApp) actionSatelliteList(cliCtx *cli.Context) error {
 	app.commandName = "satelliteList"
 
-	if cliCtx.NArg() != 0 {
-		return errors.New("command does not accept any arguments")
+	if cliCtx.NArg() == 0 {
+		return errors.New("satellite name is required")
+	}
+	if cliCtx.NArg() > 1 {
+		return errors.New("only a single satellite name is supported")
 	}
 
 	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
@@ -237,8 +243,11 @@ func (app *earthlyApp) actionSatelliteList(cliCtx *cli.Context) error {
 func (app *earthlyApp) actionSatelliteRemove(cliCtx *cli.Context) error {
 	app.commandName = "satelliteRemove"
 
-	if cliCtx.NArg() != 1 {
+	if cliCtx.NArg() == 0 {
 		return errors.New("satellite name is required")
+	}
+	if cliCtx.NArg() > 1 {
+		return errors.New("only a single satellite name is supported")
 	}
 
 	app.satelliteName = cliCtx.Args().Get(0)
@@ -277,8 +286,11 @@ func (app *earthlyApp) actionSatelliteRemove(cliCtx *cli.Context) error {
 func (app *earthlyApp) actionSatelliteInspect(cliCtx *cli.Context) error {
 	app.commandName = "satelliteInspect"
 
-	if cliCtx.NArg() != 1 {
+	if cliCtx.NArg() == 0 {
 		return errors.New("satellite name is required")
+	}
+	if cliCtx.NArg() > 1 {
+		return errors.New("only a single satellite name is supported")
 	}
 
 	satelliteToInspect := cliCtx.Args().Get(0)
@@ -412,8 +424,11 @@ func (app *earthlyApp) actionSatelliteUnselect(cliCtx *cli.Context) error {
 func (app *earthlyApp) actionSatelliteWake(cliCtx *cli.Context) error {
 	app.commandName = "satelliteWake"
 
-	if cliCtx.NArg() != 1 {
+	if cliCtx.NArg() == 0 {
 		return errors.New("satellite name is required")
+	}
+	if cliCtx.NArg() > 1 {
+		return errors.New("only a single satellite name is supported")
 	}
 
 	app.satelliteName = cliCtx.Args().Get(0)
@@ -449,8 +464,11 @@ func (app *earthlyApp) actionSatelliteWake(cliCtx *cli.Context) error {
 func (app *earthlyApp) actionSatelliteSleep(cliCtx *cli.Context) error {
 	app.commandName = "satelliteSleep"
 
-	if cliCtx.NArg() != 1 {
+	if cliCtx.NArg() == 0 {
 		return errors.New("satellite name is required")
+	}
+	if cliCtx.NArg() > 1 {
+		return errors.New("only a single satellite name is supported")
 	}
 
 	app.satelliteName = cliCtx.Args().Get(0)

--- a/cmd/earthly/satellite_cmds.go
+++ b/cmd/earthly/satellite_cmds.go
@@ -82,8 +82,17 @@ func (app *earthlyApp) satelliteCmds() []*cli.Command {
 			Name:        "wake",
 			Usage:       "Manually force a Satellite to wake up from a sleep state",
 			Description: "Manually force a Satellite to wake up from a sleep state",
-			UsageText:   "earthly satellite unselect",
-			Action:      app.actionSatelliteWake,
+			UsageText: "earthly satellite wake <satellite-name>\n" +
+				"	earthly satellite [--org <organization-name>] wake <satellite-name>",
+			Action: app.actionSatelliteWake,
+		},
+		{
+			Name:        "sleep",
+			Usage:       "Manually force a Satellite to sleep from an operational state",
+			Description: "Manually force a Satellite to sleep from an operational state",
+			UsageText: "earthly satellite sleep <satellite-name>\n" +
+				"	earthly satellite [--org <organization-name>] sleep <satellite-name>",
+			Action: app.actionSatelliteSleep,
 		},
 	}
 }
@@ -437,6 +446,34 @@ func (app *earthlyApp) actionSatelliteWake(cliCtx *cli.Context) error {
 	return nil
 }
 
+func (app *earthlyApp) actionSatelliteSleep(cliCtx *cli.Context) error {
+	app.commandName = "satelliteSleep"
+
+	if cliCtx.NArg() != 1 {
+		return errors.New("satellite name is required")
+	}
+
+	app.satelliteName = cliCtx.Args().Get(0)
+
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	if err != nil {
+		return errors.Wrap(err, "failed to create cloud client")
+	}
+
+	orgID, err := app.getSatelliteOrgID(cliCtx.Context, cloudClient)
+	if err != nil {
+		return err
+	}
+
+	out := cloudClient.SleepSatellite(cliCtx.Context, app.satelliteName, orgID)
+	err = showSatelliteStopping(app.console, app.satelliteName, out)
+	if err != nil {
+		return errors.Wrap(err, "failed waiting for satellite wake")
+	}
+
+	return nil
+}
+
 func showSatelliteLoading(console conslogging.ConsoleLogger, satName string, out chan cloud.SatelliteStatusUpdate) error {
 	loadingMsgs := getSatelliteLoadingMessages()
 	var (
@@ -527,4 +564,27 @@ func getSatelliteLoadingMessages() []string {
 	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(msgs), func(i, j int) { msgs[i], msgs[j] = msgs[j], msgs[i] })
 	return msgs
+}
+
+func showSatelliteStopping(console conslogging.ConsoleLogger, satName string, out chan cloud.SatelliteStatusUpdate) error {
+	loggedStopping := false
+	for o := range out {
+		if o.Err != nil {
+			return errors.Wrap(o.Err, "failed processing satellite status")
+		}
+		switch o.State {
+		case cloud.SatelliteStatusSleep:
+			if !loggedStopping {
+				console.Printf("%s is already asleep", satName)
+			} else {
+				console.Printf("...Done.")
+			}
+		case cloud.SatelliteStatusOperational:
+			console.Printf("%s is going to sleep. Please wait...", satName)
+		case cloud.SatelliteStatusStopping:
+			loggedStopping = true
+			console.Printf("...still shutting down...")
+		}
+	}
+	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/docker/distribution v2.8.1+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/dustin/go-humanize v1.0.0
-	github.com/earthly/cloud-api v1.0.1-0.20221024230239-4ca0ff886698
+	github.com/earthly/cloud-api v1.0.1-0.20221102151927-95c3ac681493
 	github.com/earthly/earthly/ast v0.0.0-00010101000000-000000000000
 	github.com/elastic/go-sysinfo v1.7.1
 	github.com/fatih/color v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -70,8 +70,8 @@ github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/earthly/buildkit v0.0.1-0.20221028205720-4d7c1301fdce h1:L5PVT0b/g/1DDNjLtDuTq9JUcDj3Se0x5szWmiAMnRM=
 github.com/earthly/buildkit v0.0.1-0.20221028205720-4d7c1301fdce/go.mod h1:rxLaGmeAh0KNTTJbiUGTTDbawKIXxL6h7imbYELNKJQ=
-github.com/earthly/cloud-api v1.0.1-0.20221024230239-4ca0ff886698 h1:qk+j5NjVgLdBlue3Duq0xN3e0j7qgtV4Zsu8itAMwBI=
-github.com/earthly/cloud-api v1.0.1-0.20221024230239-4ca0ff886698/go.mod h1:JhlHsW6o8zYa+XsM0nMAevRQtES35KE5R2G8tJALsnI=
+github.com/earthly/cloud-api v1.0.1-0.20221102151927-95c3ac681493 h1:X6bdDU8ZeZ1Wolo1MmyltHZHljumXx0BH7OBckCL5Yw=
+github.com/earthly/cloud-api v1.0.1-0.20221102151927-95c3ac681493/go.mod h1:JhlHsW6o8zYa+XsM0nMAevRQtES35KE5R2G8tJALsnI=
 github.com/earthly/fsutil v0.0.0-20221025225749-b994beadd443 h1:EjOPneKZTuUcX+S49SLC35WUhcyF95m99JIOpoU5Mzs=
 github.com/earthly/fsutil v0.0.0-20221025225749-b994beadd443/go.mod h1:F83XRhNblQsKQH9hcKEE45GAOkL9590mtw9KsD0Q4fE=
 github.com/elastic/go-sysinfo v1.7.1 h1:Wx4DSARcKLllpKT2TnFVdSUJOsybqMYCNQZq1/wO+s0=


### PR DESCRIPTION
Added a new command that manually puts a satellite to sleep. When the satellite is already asleep, this is a no-op. 

This command is very useful for us internally for testing, but also could be of use to users who want more fine-grain control over their satellite's up-time. 

Note this will put a satellite to sleep, even if the user has manually disabled the auto-sleep feature. Hence a user could opt out of the auto-sleep feature and completely manage the satellite's state themselves, if they are so inclined. 

<img width="561" alt="Screen Shot 2022-11-02 at 1 32 26 PM" src="https://user-images.githubusercontent.com/3247216/199562462-59bcf4e6-59d1-479b-930e-a655bcb3f84f.png">
