### PR TITLE
Add period to .earthly_version_flag_overrides warning

### DIFF
--- a/earthly
+++ b/earthly
@@ -127,7 +127,7 @@ case "$1" in
         if [ -z "$COMP_LINE" ]; then
             update="false"
             if [ "$last_flag_hash" != "$flagoverride_hash" ]; then
-                echo ".earthly_version_flag_overrides has changed since last run, checking for prerelease binaries" \
+                echo ".earthly_version_flag_overrides has changed since last run, checking for prerelease binaries." \
                      "If you see an \"unable to set <flag-name>: invalid flag\" error, you may have to wait for the" \
                      "prerelease binary to be built by GHA on the main branch, before re-attempting a ./earthly upgrade" | fold >&2
                 update="true"

--- a/earthly
+++ b/earthly
@@ -127,7 +127,7 @@ case "$1" in
         if [ -z "$COMP_LINE" ]; then
             update="false"
             if [ "$last_flag_hash" != "$flagoverride_hash" ]; then
-                echo ".earthly_version_flag_overrides has changed since last run, checking for prerelease binaries." \
+                echo ".earthly_version_flag_overrides has changed since last run, checking for prerelease binaries. " \
                      "If you see an \"unable to set <flag-name>: invalid flag\" error, you may have to wait for the" \
                      "prerelease binary to be built by GHA on the main branch, before re-attempting a ./earthly upgrade" | fold >&2
                 update="true"


### PR DESCRIPTION
Before:
```sh
% ./earthly +for-darwin-m1

.earthly_version_flag_overrides has changed since last run, checking for prerele
ase binaries If you see an "unable to set <flag-name>: invalid flag" error, you 
may have to wait for the prerelease binary to be built by GHA on the main branch
, before re-attempting a ./earthly upgrade
./earthly: line 49: none: command not found
```

After:
```sh
% ./earthly +for-darwin-m1

.earthly_version_flag_overrides has changed since last run, checking for prerele
ase binaries. If you see an "unable to set <flag-name>: invalid flag" error, you
 may have to wait for the prerelease binary to be built by GHA on the main branc
h, before re-attempting a ./earthly upgrade
```