### PR TITLE
Handle missing docker or earthly prerelease

### DIFF
--- a/earthly
+++ b/earthly
@@ -136,7 +136,11 @@ case "$1" in
 
         last_flag_hash=$(cat "$last_flag_hash_path" 2>/dev/null || echo null)
         flagoverride_hash=$(md5sum "$earthly_version_flag_overrides_path" | awk '{print $1}')
-        if [ -z "$COMP_LINE" ]; then
+        if [ ! -x "$bindir/earthly-prerelease" ]; then
+            echo "Could not find an executable '$bindir/earthly-prerelease'."
+            update="true"
+            get_latest_binary_and_update_state
+        elif [ -z "$COMP_LINE" ]; then
             update="false"
             if [ "$last_flag_hash" != "$flagoverride_hash" ]; then
                 echo ".earthly_version_flag_overrides has changed since last run, checking for prerelease binaries" \

--- a/earthly
+++ b/earthly
@@ -103,6 +103,14 @@ do_help() {
     exec -a "$scriptname" "$bindir/earthly-prerelease" --help
 }
 
+get_latest_binary_and_update_state() {
+    get_latest_binary
+    echo "Updated prerelease binary. Version:" >&2
+    "$bindir/earthly-prerelease" --version >&2
+    echo "$now" >"$last_check_state_path"
+    echo "$flagoverride_hash" >"$last_flag_hash_path"
+}
+
 case "$1" in
     reset)
         do_reset
@@ -141,11 +149,7 @@ case "$1" in
             fi
 
             if [ "$update" = "true" ] && [ "$EARTHLY_DISABLE_AUTO_UPDATE" != "true" ]; then
-                get_latest_binary
-                echo "Updated prerelease binary. Version:" >&2
-                "$bindir/earthly-prerelease" --version >&2
-                echo "$now" >"$last_check_state_path"
-                echo "$flagoverride_hash" >"$last_flag_hash_path"
+                get_latest_binary_and_update_state
             fi
 
         fi

--- a/earthly
+++ b/earthly
@@ -44,6 +44,10 @@ detect_frontend() {
 frontend_bin=$(detect_frontend)
 
 get_latest_binary() {
+    if [ "$frontend_bin" == "none" ]; then
+        echo "Could not find a frontend, perhaps the daemon isn't running?"
+        false
+    fi
     "$frontend_bin" rm --force earthly_binary 2>/dev/null >&2 || true
 
     "$frontend_bin" pull docker.io/earthly/earthlybinaries:prerelease >&2


### PR DESCRIPTION
I use Rancher Desktop (1.6.1) on an m1 (Monterey 12.6.1).

I don't always have it running, so `docker info` will sometimes exit `1` instead of `0`.

`./earthly` will set `frontend_bin` to `none` when this happens.

On the first run, it will then die trying to run `none ...`.

If one deletes `~/.earthly` without deleting some files from `/tmp`, then future runs of `./earthly` will die:
```sh
+ exec -a earthly /Users/jsoref/.earthly/earthly-prerelease +for-darwin-m1
./earthly: line 156: /Users/jsoref/.earthly/earthly-prerelease: No such file or directory
```