### PR TITLE
Buildkit graceful shutdown on SIGTERM

### DIFF
--- a/.github/workflows/reusable-misc-tests.yml
+++ b/.github/workflows/reusable-misc-tests.yml
@@ -81,11 +81,9 @@ jobs:
           max_attempts: 2
           command: |-
             ${{inputs.SUDO}} ${{inputs.BINARY}} stop earthly-buildkitd && \
-            sleep 2 && \
-            ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} github.com/earthly/hello-world+hello & \
-            ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} github.com/earthly/hello-world+hello & \
-            ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} github.com/earthly/hello-world+hello & \
-            ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} github.com/earthly/hello-world+hello
+            ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} ./examples/go+build & \
+            ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} ./examples/go+build & \
+            ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} ./examples/go+build
       - name: Execute interactive debugger test
         uses: nick-fields/retry@v2
         with:

--- a/.github/workflows/reusable-misc-tests.yml
+++ b/.github/workflows/reusable-misc-tests.yml
@@ -81,6 +81,7 @@ jobs:
           max_attempts: 2
           command: |-
             ${{inputs.SUDO}} ${{inputs.BINARY}} stop earthly-buildkitd && \
+            sleep 2 && \
             ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} github.com/earthly/hello-world+hello & \
             ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} github.com/earthly/hello-world+hello & \
             ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} github.com/earthly/hello-world+hello & \

--- a/.github/workflows/reusable-misc-tests.yml
+++ b/.github/workflows/reusable-misc-tests.yml
@@ -80,6 +80,7 @@ jobs:
           timeout_minutes: 10
           max_attempts: 2
           command: |-
+            ${{inputs.SUDO}} ${{inputs.BINARY}} stop earthly-buildkitd && \
             ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} github.com/earthly/hello-world+hello & \
             ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} github.com/earthly/hello-world+hello & \
             ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} github.com/earthly/hello-world+hello & \

--- a/.github/workflows/reusable-misc-tests.yml
+++ b/.github/workflows/reusable-misc-tests.yml
@@ -81,6 +81,7 @@ jobs:
           max_attempts: 2
           command: |-
             ${{inputs.SUDO}} ${{inputs.BINARY}} stop earthly-buildkitd && \
+            ${{inputs.SUDO}} ${{inputs.BINARY}} ps && \
             ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} github.com/earthly/hello-world+hello & \
             ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} github.com/earthly/hello-world+hello & \
             ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} github.com/earthly/hello-world+hello & \

--- a/.github/workflows/reusable-misc-tests.yml
+++ b/.github/workflows/reusable-misc-tests.yml
@@ -80,12 +80,12 @@ jobs:
           timeout_minutes: 10
           max_attempts: 2
           command: |-
-            ${{inputs.SUDO}} ${{inputs.BINARY}} stop earthly-buildkitd && \
-            ${{inputs.SUDO}} ${{inputs.BINARY}} ps && \
+            ${{inputs.SUDO}} ${{inputs.BINARY}} stop earthly-buildkitd && ( \
             ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} github.com/earthly/hello-world+hello & \
             ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} github.com/earthly/hello-world+hello & \
             ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} github.com/earthly/hello-world+hello & \
-            ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} github.com/earthly/hello-world+hello
+            ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} github.com/earthly/hello-world+hello) && \
+            wait
       - name: Execute interactive debugger test
         uses: nick-fields/retry@v2
         with:

--- a/.github/workflows/reusable-misc-tests.yml
+++ b/.github/workflows/reusable-misc-tests.yml
@@ -80,10 +80,10 @@ jobs:
           timeout_minutes: 10
           max_attempts: 2
           command: |-
-            ${{inputs.SUDO}} ${{inputs.BINARY}} stop earthly-buildkitd && \
-            ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} ./examples/go+build & \
-            ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} ./examples/go+build & \
-            ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} ./examples/go+build
+            ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} github.com/earthly/hello-world+hello & \
+            ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} github.com/earthly/hello-world+hello & \
+            ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} github.com/earthly/hello-world+hello & \
+            ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} github.com/earthly/hello-world+hello
       - name: Execute interactive debugger test
         uses: nick-fields/retry@v2
         with:

--- a/buildkitd/entrypoint.sh
+++ b/buildkitd/entrypoint.sh
@@ -253,11 +253,11 @@ echo "Detected container architecture is $(uname -m)"
 execpid=$!
 
 stop_buildkit() {
-  echo "SIGTERM received. Shutting down buildkit..."
+  echo "Shutdown signal received. Stopping buildkit..."
   kill -SIGTERM "$execpid"
 }
 
-trap stop_buildkit SIGTERM
+trap stop_buildkit TERM QUIT INT
 
 # quit if buildkit dies
 set +x

--- a/buildkitd/entrypoint.sh
+++ b/buildkitd/entrypoint.sh
@@ -252,6 +252,13 @@ echo "Detected container architecture is $(uname -m)"
 "$@" &
 execpid=$!
 
+stop_buildkit() {
+  echo "SIGTERM received. Shutting down buildkit..."
+  kill -SIGTERM "$execpid"
+}
+
+trap stop_buildkit SIGTERM
+
 # quit if buildkit dies
 set +x
 while true


### PR DESCRIPTION
Uses a `trap` to relay the SIGTERM to buildkit in the entrypoint script.

<img width="777" alt="Screen Shot 2022-11-03 at 12 00 20 PM" src="https://user-images.githubusercontent.com/3247216/199771827-b4357c71-0469-4c6e-850c-dd7397dee677.png">
