### PR TITLE
Use 'core-test-2' satellite

### DIFF
--- a/.github/workflows/ci-docker-satellites.yml
+++ b/.github/workflows/ci-docker-satellites.yml
@@ -19,7 +19,7 @@ jobs:
       BINARY: "docker"
       SUDO: ""
       USE_SATELLITE: true
-      SATELLITE_NAME: "core-test"
+      SATELLITE_NAME: "core-test-2"
       EARTHLY_ORG: "earthly-technologies"
     secrets: inherit
 
@@ -65,6 +65,6 @@ jobs:
       BINARY_COMPOSE: "\"docker compose\""
       SUDO: ""
       USE_SATELLITE: true
-      SATELLITE_NAME: "core-test"
+      SATELLITE_NAME: "core-test-2"
       EARTHLY_ORG: "earthly-technologies"
     secrets: inherit


### PR DESCRIPTION
This is temporary, while the original `core-test` satellite is in a weird state that we want to continue debugging. 