### PR TITLE
Add documentation for woodpecker-ci

### DIFF
--- a/docs/ci-integration/guides/woodpecker-integration.md
+++ b/docs/ci-integration/guides/woodpecker-integration.md
@@ -1,0 +1,30 @@
+
+# Woodpecker CI integration
+
+This example uses [Woodpecker CI](https://woodpecker-ci.org/) to build the Earthly target `+build`.
+
+
+## Configuration
+
+The project needs to be [trusted](https://woodpecker-ci.org/docs/usage/project-settings#trusted) to grant the capabilities like mounting volumes (required for the docker socket). We also need to include the `earthly/earthly` image in the list of images that are allowed to run in [privileged mode](https://woodpecker-ci.org/docs/administration/server-config#woodpecker_escalate)
+
+
+
+```yml
+#.woodpecker.yml
+pipeline:
+  earthly:
+    image: earthly/earthly:v0.6.28
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      - FORCE_COLOR=1
+      - EARTHLY_EXEC_CMD="/bin/sh" 
+    secrets: [REGISTRY, REGISTRY_USER, REGISTRY_PASSWORD]
+    commands:
+     - docker login -u $${REGISTRY_USER} -p $${REGISTRY_PASSWORD} $${REGISTRY}
+     - earthly bootstrap
+     - earthly --ci --push -P +build
+```
+
+For a complete guide on CI integration see the [CI integration guide](../overview.md).

--- a/docs/ci-integration/overview.md
+++ b/docs/ci-integration/overview.md
@@ -104,3 +104,4 @@ Below are links to CI systems that we have more specific information for. If you
  * [GitHub Actions](guides/gh-actions-integration.md)
  * [Google Cloud Build](guides/google-cloud-build.md)
  * [GitLab CI/CD](guides/gitlab-integration.md)
+ * [Woodpecker CI](guides/woodpecker-integration.md)


### PR DESCRIPTION
There was no documentation yet about how to use earthly with woodpecker-ci. It took me some time to get it working (the combination of trusted project, adding the image to the list of privileged images and the volume mount in a ci file).

It might be helpful for others too.