### PR TITLE
Only display declared ARGs in failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 ### Fixed
 
 - Fixed Earthly on Mac would randomly hang on `1. Init` if Earthly was installed from Homebrew or the Earthly homebrew tap. [#2247](https://github.com/earthly/earthly/issues/2247)
+- Only referenced ARGs from .env are displayed on failures, this prevents secrets contained in .env from being displayed. [#1736](https://github.com/earthly/earthly/issues/1736)
 
 ## v0.6.29 - 2022-11-07
 

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -163,7 +163,7 @@ func (c *Converter) From(ctx context.Context, imageName string, platform platuti
 	if err != nil {
 		return err
 	}
-	c.varCollection.SetArg(reserved.EarthlyLocally, "false") // FIXME this will have to change once https://github.com/earthly/earthly/issues/2044 is fixed
+	c.varCollection.SetLocally(false) // FIXME this will have to change once https://github.com/earthly/earthly/issues/2044 is fixed
 	platform = c.setPlatform(platform)
 	if strings.Contains(imageName, "+") {
 		// Target-based FROM.
@@ -399,7 +399,7 @@ func (c *Converter) Locally(ctx context.Context) error {
 		return errors.Wrapf(err, "unable to get abs path of %s", c.localWorkingDir)
 	}
 
-	c.varCollection.SetArg(reserved.EarthlyLocally, "true")
+	c.varCollection.SetLocally(true)
 
 	// reset WORKDIR to current directory where Earthfile is
 	c.mts.Final.MainState = c.mts.Final.MainState.Dir(workingDir)

--- a/earthfile2llb/interpreter.go
+++ b/earthfile2llb/interpreter.go
@@ -39,8 +39,6 @@ type Interpreter struct {
 	local           bool
 	allowPrivileged bool
 
-	stack string
-
 	withDocker    *WithDockerOpt
 	withDockerRan bool
 
@@ -55,7 +53,6 @@ func newInterpreter(c *Converter, t domain.Target, allowPrivileged, parallelConv
 	return &Interpreter{
 		converter:          c,
 		target:             t,
-		stack:              c.StackString(),
 		allowPrivileged:    allowPrivileged,
 		parallelConversion: parallelConversion,
 		console:            console,
@@ -1897,7 +1894,6 @@ func (i *Interpreter) handleDoUserCommand(ctx context.Context, command domain.Co
 	}
 	prevAllowPrivileged := i.allowPrivileged
 	i.allowPrivileged = allowPrivileged
-	i.stack = i.converter.StackString()
 	err = i.handleBlock(ctx, uc.Recipe[1:])
 	if err != nil {
 		return err
@@ -1906,7 +1902,6 @@ func (i *Interpreter) handleDoUserCommand(ctx context.Context, command domain.Co
 	if err != nil {
 		return i.wrapError(err, uc.SourceLocation, "exit scope")
 	}
-	i.stack = i.converter.StackString()
 	i.allowPrivileged = prevAllowPrivileged
 	return nil
 }
@@ -1925,12 +1920,16 @@ func (i *Interpreter) expandArgsSlice(ctx context.Context, words []string, keepP
 	return ret, nil
 }
 
+func (i *Interpreter) stack() string {
+	return i.converter.varCollection.StackString()
+}
+
 func (i *Interpreter) errorf(sl *spec.SourceLocation, format string, args ...interface{}) *InterpreterError {
-	return Errorf(sl, i.stack, format, args...)
+	return Errorf(sl, i.stack(), format, args...)
 }
 
 func (i *Interpreter) wrapError(cause error, sl *spec.SourceLocation, format string, args ...interface{}) *InterpreterError {
-	return WrapError(cause, sl, i.stack, format, args...)
+	return WrapError(cause, sl, i.stack(), format, args...)
 }
 
 func (i *Interpreter) pushOnlyErr(sl *spec.SourceLocation) error {

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -143,6 +143,8 @@ ga-no-qemu:
     BUILD +chown-test
     BUILD +dotenv-test
     BUILD +env-test
+    BUILD +stack-failure-test
+    BUILD +multi-stack-failure-test
     BUILD +no-cache-local-artifact-test
     BUILD +empty-git-test
     BUILD +escape-test
@@ -569,6 +571,7 @@ dotenv-test:
     RUN echo "TEST_ENV_2=foo" >>.env
     RUN echo "TEST_ENV_3=bar" >>.env
     DO +RUN_EARTHLY --earthfile=dotenv.earth --extra_args="--no-output" --target=+test
+
     # Smoke test that no .env file does not result in an error.
     RUN mv .env .some-other-env
     DO +RUN_EARTHLY --earthfile=dotenv.earth --extra_args="--no-output" --target=+test-no-dotenv
@@ -580,6 +583,32 @@ dotenv-test:
     # --env-file takes precedence
     DO +RUN_EARTHLY --earthfile=dotenv.earth --extra_args="--no-output --env-file .some-other-env" --pre_command="export EARTHLY_ENV_FILE=.this-should-be-ignored" --target=+test
 
+stack-failure-test:
+    RUN echo "TEST_ENV_1=abracadabra" >.env
+    RUN echo "TEST_ENV_2=foo" >>.env
+    RUN echo "THIS_IS_SECRET=dont-display-this" >>.env
+
+    # test that only declared ARGs are displayed in output (and non-referenced .env values which may actually be secrets aren't)
+    DO +RUN_EARTHLY --earthfile=stack-failure.earth --extra_args="--no-output" --output_contains="unknown flag .cause-interpreter-failure." --should_fail="true" --target=+fail
+    RUN if grep dont-display-this earthly.output; then echo "secret was leaked!"; exit 1; fi
+    RUN grep 'in.*+fail --TEST_ENV_1=abracadabra --TEST_ENV_2=foo' earthly.output
+
+    # test missing target doesn't leak secret
+    DO +RUN_EARTHLY --earthfile=stack-failure.earth --extra_args="--no-output" --output_contains="target this-does-not-exist not found" --should_fail="true" --target=+this-does-not-exist
+    RUN if grep dont-display-this earthly.output; then echo "secret was leaked!"; exit 1; fi
+
+multi-stack-failure-test:
+    RUN echo "FOO=foo" >.env
+    RUN echo "THIS_IS_SECRET=dont-display-this" >>.env
+
+    DO +RUN_EARTHLY --earthfile=multi-stack-failure.earth --extra_args="--no-output --build-arg BAR=bar" --output_contains="unknown flag .cause-interpreter-failure." --should_fail="true" --target=+fail
+    RUN if grep dont-display-this earthly.output; then echo "secret was leaked!"; exit 1; fi
+    RUN grep 'in.*+fail --BAR=bar --EMPTY= --FOO=foo' earthly.output
+
+    DO +RUN_EARTHLY --earthfile=multi-stack-failure.earth --extra_args="--no-output --build-arg BAR=bar --build-arg ANOTHER_ARG=another-value" --output_contains="unknown flag .cause-interpreter-failure." --should_fail="true" --target=+from-fail
+    RUN if grep dont-display-this earthly.output; then echo "secret was leaked!"; exit 1; fi
+    RUN grep 'in.*+fail --BAR=bar --EMPTY= --FOO=foo' earthly.output
+    RUN grep 'in.*+from-fail --ANOTHER_ARG=another-value' earthly.output
 
 env-test:
     DO +RUN_EARTHLY --earthfile=env.earth --extra_args="--no-output" --target=+test

--- a/tests/multi-stack-failure.earth
+++ b/tests/multi-stack-failure.earth
@@ -1,0 +1,20 @@
+VERSION 0.6
+FROM alpine:3.15
+
+ARG GLOBAL_ARG
+ARG GLOBAL_ARG_DEFAULT="mydefault"
+
+mybase:
+  ARG MYBASE_ARG
+  ARG MYBASE_ARG_DEFAULT="mybasedefault"
+
+fail:
+  FROM +mybase
+  ARG --required FOO
+  ARG --required BAR
+  ARG EMPTY
+  RUN --cause-interpreter-failure true
+
+from-fail:
+  ARG ANOTHER_ARG
+  FROM +fail

--- a/tests/stack-failure.earth
+++ b/tests/stack-failure.earth
@@ -1,0 +1,7 @@
+VERSION 0.6
+FROM alpine:3.15
+
+fail:
+    ARG TEST_ENV_1
+    ARG TEST_ENV_2=override
+    RUN --cause-interpreter-failure true

--- a/variables/builtin.go
+++ b/variables/builtin.go
@@ -48,7 +48,7 @@ func BuiltinArgs(target domain.Target, platr *platutil.Resolver, gitMeta *gituti
 	}
 
 	if ftrs.EarthlyLocallyArg {
-		ret.AddInactive(arg.EarthlyLocally, "false")
+		SetLocally(ret, false)
 	}
 
 	if gitMeta != nil {
@@ -109,6 +109,11 @@ func setNativePlatformArgs(s *Scope, platr *platutil.Resolver) {
 	s.AddInactive(arg.NativeOS, platform.OS)
 	s.AddInactive(arg.NativeArch, platform.Architecture)
 	s.AddInactive(arg.NativeVariant, platform.Variant)
+}
+
+// SetLocally sets the locally built-in arg value
+func SetLocally(s *Scope, locally bool) {
+	s.AddInactive(arg.EarthlyLocally, fmt.Sprintf("%v", locally))
 }
 
 // getProjectName returns the deprecated PROJECT_NAME value

--- a/variables/collection.go
+++ b/variables/collection.go
@@ -143,6 +143,12 @@ func (c *Collection) SetPlatform(platr *platutil.Resolver) {
 	c.effectiveCache = nil
 }
 
+// SetLocally sets the locally flag, updating the builtin args.
+func (c *Collection) SetLocally(locally bool) {
+	SetLocally(c.builtin, locally)
+	c.effectiveCache = nil
+}
+
 // GetActive returns an active variable by name.
 func (c *Collection) GetActive(name string) (string, bool) {
 	return c.effective().GetActive(name)
@@ -263,10 +269,10 @@ func (c *Collection) IsStackAtBase() bool {
 func (c *Collection) StackString() string {
 	builder := make([]string, 0, len(c.stack))
 	for i := len(c.stack) - 1; i >= 0; i-- {
-		overridingNames := c.stack[i].overriding.SortedAny()
-		row := make([]string, 0, len(overridingNames)+1)
+		activeNames := c.stack[i].args.SortedActive()
+		row := make([]string, 0, len(activeNames)+1)
 		row = append(row, c.stack[i].frameName)
-		for _, k := range overridingNames {
+		for _, k := range activeNames {
 			v, _ := c.stack[i].overriding.GetAny(k)
 			row = append(row, fmt.Sprintf("--%s=%s", k, v))
 		}


### PR DESCRIPTION
This fixes an issue where all .env values are displayed during failures, which could potentially print a secret value (since secrets can also read from .env).

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>