### PR TITLE
Fix registry caching issue (#2337, #2288)

### DIFF
--- a/builder/image_solver.go
+++ b/builder/image_solver.go
@@ -231,10 +231,14 @@ func (m *multiImageSolver) SolveImages(ctx context.Context, imageDefs []*states.
 			}
 
 			for k, v := range resp {
-				if !strings.HasPrefix(k, result.FinalImageName+"|") {
+				// discarded prefix is likely a registry/repository from its canonical name, i.e.
+				// 1. user asks for 'busybox'
+				// 2. result.FinalImageName is calculated as 'busybox:latest'
+				// 3. BK response has keys 'docker.io/library/busybox:latest|<type>'
+				_, k2, found := strings.Cut(k, result.FinalImageName+"|")
+				if !found {
 					continue
 				}
-				k2 := strings.TrimPrefix(k, result.FinalImageName+"|")
 				switch k2 {
 				case exptypes.ExporterImageDescriptorKey:
 					vdec, err := base64.StdEncoding.DecodeString(v)


### PR DESCRIPTION
This improves on b35afd1b; images that are pulled/loaded by abbreviated (but common/accepted) names, and then normalized/canonicalized by earthly/buildkit, are not processed correctly.

I was looking to see if #2288 was within my reach to address, and in the process, discovered it's directly related to #2337.

When using `WITH DOCKER`, if an image specified via `--pull` or `--load` doesn't *exactly* match what earthly/buildkit returns (simplest example being adding `:latest` to an unqualified image)
https://github.com/earthly/earthly/blob/696c9e2e618ba4fe70695d6d22fd4de33991b0a3/builder/image_solver.go#L234-L236
then the warning from #2288 shows up
https://github.com/earthly/earthly/blob/696c9e2e618ba4fe70695d6d22fd4de33991b0a3/builder/image_solver.go#L258-L261

While the warning is an annoyance, it is also impactful.  A side effect of the `.ImageDigest` not being set is that `.FinalImageNameWithDigest` is also unset
https://github.com/earthly/earthly/blob/696c9e2e618ba4fe70695d6d22fd4de33991b0a3/builder/image_solver.go#L249-L251
and they are used
https://github.com/earthly/earthly/blob/696c9e2e618ba4fe70695d6d22fd4de33991b0a3/earthfile2llb/withdockerrunreg.go#L173
to intentionally break the cache
https://github.com/earthly/earthly/blob/696c9e2e618ba4fe70695d6d22fd4de33991b0a3/earthfile2llb/withdockerrunbase.go#L139-L141

Thus, if that metadata isn't processed, the `.FinalImageNameWithDigest` is always the empty string, regardless of any structural changes (which leads to #2337).