### PR TITLE
Add `SAVE IMAGE` warning to Earthfile reference

### DIFF
--- a/docs/earthfile/earthfile.md
+++ b/docs/earthfile/earthfile.md
@@ -677,6 +677,14 @@ SAVE IMAGE my-example-registry.com/another-image:latest
 ```
 {% endhint %}
 
+{% hint style='danger' %}
+##### Important
+
+Since the introduction of the `--referenced-save-only` feature flag, Images are only saved if they are connected to the initial target through a chain of `BUILD` commands. [See the `--referenced-save-only` flag documentation for more details](./features.md#referenced-save-only).
+{% endhint %}
+
+
+
 #### Options
 
 ##### `--push`


### PR DESCRIPTION
A user brought up that this behavior was not well documented. I added it to our documentation for `SAVE IMAGE` to make it more apparent.