### PR TITLE
remove `earthly+for-linux` from the target example

### DIFF
--- a/docs/guides/target-ref.md
+++ b/docs/guides/target-ref.md
@@ -21,7 +21,6 @@ Here are some examples:
 * `+build`
 * `./js+deps`
 * `github.com/earthly/earthly:v0.1.0+earthly`
-* `earthly+for-linux`
 
 ## Artifact reference
 


### PR DESCRIPTION
All other three examples can be used directly on the cli, or via a `BUILD`, the `earthly+for-linux` can only be used in an Earthfile, which is confusing for new users.