### PR TITLE
Explicitly set `CGO_ENABLED=0`

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -207,6 +207,7 @@ lint-changelog:
 
 debugger:
     FROM +code
+    ENV CGO_ENABLED=0
     ARG GOCACHE=/go-cache
     ARG GO_EXTRA_LDFLAGS="-linkmode external -extldflags -static"
     ARG EARTHLY_TARGET_TAG
@@ -222,6 +223,7 @@ debugger:
 
 earthly:
     FROM +code
+    ENV CGO_ENABLED=0
     ARG GOOS=linux
     ARG TARGETARCH
     ARG TARGETVARIANT


### PR DESCRIPTION
This is normally not necessary, but in some cases, it does default to 1, and that can be problematic sometimes (an example: https://github.com/earthly/earthly/issues/2247).