### PR TITLE
Improvements related to logstream integration

### DIFF
--- a/.buildkite/tests.sh
+++ b/.buildkite/tests.sh
@@ -75,10 +75,7 @@ do
     sleep $(( att_num++ ))
 done
 
-"$earthly" config global.conversion_parallelism 5
-
 export EARTHLY_VERSION_FLAG_OVERRIDES="referenced-save-only"
-"$earthly" config global.local_registry_host 'tcp://127.0.0.1:8371'
 
 # Yes, there is a bug in the upstream YAML parser. Sorry about the jank here.
 # https://github.com/go-yaml/yaml/issues/423

--- a/.github/workflows/ci-docker-ubuntu.yml
+++ b/.github/workflows/ci-docker-ubuntu.yml
@@ -145,8 +145,6 @@ jobs:
         if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
       - name: Build latest earthly/buildkitd image using released earthly
         run: earthly --use-inline-cache ./buildkitd+buildkitd --TAG=race-test
-      - name: Configure Earthly Conversion Parallelism
-        run: go run ./cmd/earthly/*.go config global.conversion_parallelism 5
       - name: Execute tests (Earthly Only)
         run: |-
           GORACE="halt_on_error=1" go run -race ./cmd/earthly/*.go --buildkit-image earthly/buildkitd:race-test -P --no-output \
@@ -195,10 +193,6 @@ jobs:
           set -euo pipefail
           EARTHLY_VERSION_FLAG_OVERRIDES="$(tr -d '\n' < .earthly_version_flag_overrides)"
           echo "EARTHLY_VERSION_FLAG_OVERRIDES=$EARTHLY_VERSION_FLAG_OVERRIDES" >> "$GITHUB_ENV"
-      - name: Enable local registry-based exporter
-        run: ./build/linux/amd64/earthly config global.local_registry_host 'tcp://127.0.0.1:8371'
-      - name: Configure Earthly Conversion Parallelism
-        run: ./build/linux/amd64/earthly config global.conversion_parallelism 5
       - name: Build tutorial part 1
         run: ./build/linux/amd64/earthly -P ./examples/tutorial+test-part1 --earthly=$(realpath ./build/linux/amd64/earthly)
       - name: Build tutorial part 2
@@ -259,10 +253,6 @@ jobs:
           set -euo pipefail
           EARTHLY_VERSION_FLAG_OVERRIDES="$(tr -d '\n' < .earthly_version_flag_overrides)"
           echo "EARTHLY_VERSION_FLAG_OVERRIDES=$EARTHLY_VERSION_FLAG_OVERRIDES" >> "$GITHUB_ENV"
-      - name: Enable local registry-based exporter
-        run: ./build/linux/amd64/earthly config global.local_registry_host 'tcp://127.0.0.1:8371'
-      - name: Configure Earthly Conversion Parallelism
-        run: ./build/linux/amd64/earthly config global.conversion_parallelism 5
       - name: Build linux/amd64 +buildkitd
         run: |-
           ./build/linux/amd64/earthly --ci  --platform=linux/amd64 ./buildkitd+buildkitd --BUILDKIT_PROJECT="$BUILDKIT_PROJECT"
@@ -314,10 +304,6 @@ jobs:
           set -euo pipefail
           EARTHLY_VERSION_FLAG_OVERRIDES="$(tr -d '\n' < .earthly_version_flag_overrides)"
           echo "EARTHLY_VERSION_FLAG_OVERRIDES=$EARTHLY_VERSION_FLAG_OVERRIDES" >> "$GITHUB_ENV"
-      - name: Enable local registry-based exporter
-        run: ./build/linux/amd64/earthly config global.local_registry_host 'tcp://127.0.0.1:8371'
-      - name: Configure Earthly Conversion Parallelism
-        run: ./build/linux/amd64/earthly config global.conversion_parallelism 5
       - name: Build linux/arm64 +buildkitd
         run: |-
           ./build/linux/amd64/earthly --ci  --platform=linux/arm64 ./buildkitd+buildkitd --BUILDKIT_PROJECT="$BUILDKIT_PROJECT"
@@ -369,10 +355,6 @@ jobs:
           set -euo pipefail
           EARTHLY_VERSION_FLAG_OVERRIDES="$(tr -d '\n' < .earthly_version_flag_overrides)"
           echo "EARTHLY_VERSION_FLAG_OVERRIDES=$EARTHLY_VERSION_FLAG_OVERRIDES" >> "$GITHUB_ENV"
-      - name: Enable local registry-based exporter
-        run: ./build/linux/amd64/earthly config global.local_registry_host 'tcp://127.0.0.1:8371'
-      - name: Configure Earthly Conversion Parallelism
-        run: ./build/linux/amd64/earthly config global.conversion_parallelism 5
       - name: Build +all-dind
         run: ./build/linux/amd64/earthly --ci +all-dind
       - name: Buildkit logs (runs on failure)
@@ -423,10 +405,6 @@ jobs:
           set -euo pipefail
           EARTHLY_VERSION_FLAG_OVERRIDES="$(tr -d '\n' < .earthly_version_flag_overrides)"
           echo "EARTHLY_VERSION_FLAG_OVERRIDES=$EARTHLY_VERSION_FLAG_OVERRIDES" >> "$GITHUB_ENV"
-      - name: Enable local registry-based exporter
-        run: ./build/linux/amd64/earthly config global.local_registry_host 'tcp://127.0.0.1:8371'
-      - name: Configure Earthly Conversion Parallelism
-        run: ./build/linux/amd64/earthly config global.conversion_parallelism 5
       - name: Build +earthly-all
         run: ./build/linux/amd64/earthly --ci +earthly-all
       - name: Build +earthly-docker
@@ -479,10 +457,6 @@ jobs:
           set -euo pipefail
           EARTHLY_VERSION_FLAG_OVERRIDES="$(tr -d '\n' < .earthly_version_flag_overrides)"
           echo "EARTHLY_VERSION_FLAG_OVERRIDES=$EARTHLY_VERSION_FLAG_OVERRIDES" >> "$GITHUB_ENV"
-      - name: Enable local registry-based exporter
-        run: ./build/linux/amd64/earthly config global.local_registry_host 'tcp://127.0.0.1:8371'
-      - name: Configure Earthly Conversion Parallelism
-        run: ./build/linux/amd64/earthly config global.conversion_parallelism 5
       - name: Build +prerelease
         run: ./build/linux/amd64/earthly --ci +prerelease
       - name: Buildkit logs (runs on failure)
@@ -554,10 +528,6 @@ jobs:
           set -euo pipefail
           EARTHLY_VERSION_FLAG_OVERRIDES="$(tr -d '\n' < .earthly_version_flag_overrides)"
           echo "EARTHLY_VERSION_FLAG_OVERRIDES=$EARTHLY_VERSION_FLAG_OVERRIDES" >> "$GITHUB_ENV"
-      - name: Enable local registry-based exporter
-        run: ./build/linux/amd64/earthly config global.local_registry_host 'tcp://127.0.0.1:8371'
-      - name: Configure Earthly Conversion Parallelism
-        run: ./build/linux/amd64/earthly config global.conversion_parallelism 5
       - name: Build and push +prerelease
         run: ./build/linux/amd64/earthly --ci --push +prerelease
       - name: Update DockerHub description for earthly/earthly

--- a/.github/workflows/ci-scheduled-podman-mac.yml
+++ b/.github/workflows/ci-scheduled-podman-mac.yml
@@ -66,10 +66,6 @@ jobs:
           set -euo pipefail
           EARTHLY_VERSION_FLAG_OVERRIDES="$(tr -d '\n' < .earthly_version_flag_overrides)"
           echo "EARTHLY_VERSION_FLAG_OVERRIDES=$EARTHLY_VERSION_FLAG_OVERRIDES" >> "$GITHUB_ENV"
-      - name: Enable local registry-based exporter
-        run: ${{ env.BUILT_EARTHLY_PATH }} config global.local_registry_host 'tcp://127.0.0.1:8371'
-      - name: Configure Earthly Conversion Parallelism
-        run: ${{ env.BUILT_EARTHLY_PATH }} config global.conversion_parallelism 5
       # Note - we only run the non-qemu tests here because we have not figured out cross-compilation on Mac using Podman yet
       - name: Execute tests-no-qemu (Earthly Only)
         run: |-

--- a/.github/workflows/reusable-bootstrap-integrations.yml
+++ b/.github/workflows/reusable-bootstrap-integrations.yml
@@ -61,8 +61,8 @@ jobs:
         run: |-
           earthly config global.buildkit_additional_config "'[registry.\"docker.io\"]
           mirrors = [\"registry-1.docker.io.mirror.corp.earthly.dev\"]'"
-      - name: Copy Earthly dir to Earthly dev dir
-        run: mkdir -p ~/.earthly && cp -r ~/.earthly ~/.earthly-dev
+      - name: Link Earthly dir to Earthly dev dir
+        run: mkdir -p ~/.earthly && ln -s ~/.earthly ~/.earthly-dev
       - name: Build latest earthly using released earthly
         run: ${{inputs.SUDO}} $(which earthly) -P --use-inline-cache ${{inputs.BUILD_EARTHLY_TARGET}}
       - name: Set EARTHLY_VERSION_FLAG_OVERRIDES env

--- a/.github/workflows/reusable-bootstrap-integrations.yml
+++ b/.github/workflows/reusable-bootstrap-integrations.yml
@@ -61,6 +61,8 @@ jobs:
         run: |-
           earthly config global.buildkit_additional_config "'[registry.\"docker.io\"]
           mirrors = [\"registry-1.docker.io.mirror.corp.earthly.dev\"]'"
+      - name: Copy Earthly dir to Earthly dev dir
+        run: mkdir -p ~/.earthly && cp -r ~/.earthly ~/.earthly-dev
       - name: Build latest earthly using released earthly
         run: ${{inputs.SUDO}} $(which earthly) -P --use-inline-cache ${{inputs.BUILD_EARTHLY_TARGET}}
       - name: Set EARTHLY_VERSION_FLAG_OVERRIDES env

--- a/.github/workflows/reusable-bootstrap-integrations.yml
+++ b/.github/workflows/reusable-bootstrap-integrations.yml
@@ -68,10 +68,6 @@ jobs:
             set -euo pipefail
             EARTHLY_VERSION_FLAG_OVERRIDES="$(tr -d '\n' < .earthly_version_flag_overrides)"
             echo "EARTHLY_VERSION_FLAG_OVERRIDES=$EARTHLY_VERSION_FLAG_OVERRIDES" >> "$GITHUB_ENV"
-      - name: Enable local registry-based exporter
-        run: ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} config global.local_registry_host 'tcp://127.0.0.1:8371'
-      - name: Configure Earthly Conversion Parallelism
-        run: ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} config global.conversion_parallelism 5
       - name: Run bootstrap-integration
         run: frontend=${{inputs.BINARY}} ./tests/bootstrap/test-bootstrap.sh
       - name: Buildkit logs (runs on failure)

--- a/.github/workflows/reusable-example.yml
+++ b/.github/workflows/reusable-example.yml
@@ -90,8 +90,8 @@ jobs:
       - name: Docker Login (main build)
         run: ${{inputs.SUDO}} ${{inputs.BINARY}} login --username "${{ secrets.DOCKERHUB_USERNAME }}" --password "${{ secrets.DOCKERHUB_TOKEN }}"
         if: github.event_name == 'push'
-      - name: Copy Earthly dir to Earthly dev dir
-        run: mkdir -p ~/.earthly && cp -r ~/.earthly ~/.earthly-dev
+      - name: Link Earthly dir to Earthly dev dir
+        run: mkdir -p ~/.earthly && ln -s ~/.earthly ~/.earthly-dev
       - name: Build latest earthly using released earthly
         run: ${{inputs.SUDO}} $(which earthly) ${{inputs.BUILD_EARTHLY_ARGS}} ${{inputs.BUILD_EARTHLY_TARGET}}
       - name: Set EARTHLY_VERSION_FLAG_OVERRIDES env

--- a/.github/workflows/reusable-example.yml
+++ b/.github/workflows/reusable-example.yml
@@ -90,6 +90,8 @@ jobs:
       - name: Docker Login (main build)
         run: ${{inputs.SUDO}} ${{inputs.BINARY}} login --username "${{ secrets.DOCKERHUB_USERNAME }}" --password "${{ secrets.DOCKERHUB_TOKEN }}"
         if: github.event_name == 'push'
+      - name: Copy Earthly dir to Earthly dev dir
+        run: mkdir -p ~/.earthly && cp -r ~/.earthly ~/.earthly-dev
       - name: Build latest earthly using released earthly
         run: ${{inputs.SUDO}} $(which earthly) ${{inputs.BUILD_EARTHLY_ARGS}} ${{inputs.BUILD_EARTHLY_TARGET}}
       - name: Set EARTHLY_VERSION_FLAG_OVERRIDES env

--- a/.github/workflows/reusable-example.yml
+++ b/.github/workflows/reusable-example.yml
@@ -97,10 +97,6 @@ jobs:
           set -euo pipefail
           EARTHLY_VERSION_FLAG_OVERRIDES="$(tr -d '\n' < .earthly_version_flag_overrides)"
           echo "EARTHLY_VERSION_FLAG_OVERRIDES=$EARTHLY_VERSION_FLAG_OVERRIDES" >> "$GITHUB_ENV"
-      - name: Enable local registry-based exporter
-        run: ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} config global.local_registry_host 'tcp://127.0.0.1:8371'
-      - name: Configure Earthly Conversion Parallelism
-        run: ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} config global.conversion_parallelism 5
       - name: Build ${{inputs.EXAMPLE_NAME}} (PR build)
         run: ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} --ci -P ${{inputs.EXAMPLE_NAME}}
         if: github.event_name != 'push'

--- a/.github/workflows/reusable-export-test.yml
+++ b/.github/workflows/reusable-export-test.yml
@@ -71,8 +71,8 @@ jobs:
         # qemu-user-static needed for cross-compilation (--platform) targets
         run: ${{inputs.SUDO}} apt-get update && ${{inputs.SUDO}} apt-get install -y qemu-user-static
         if: inputs.BINARY == 'podman'
-      - name: Copy Earthly dir to Earthly dev dir
-        run: mkdir -p ~/.earthly && cp -r ~/.earthly ~/.earthly-dev
+      - name: Link Earthly dir to Earthly dev dir
+        run: mkdir -p ~/.earthly && ln -s ~/.earthly ~/.earthly-dev
       - name: Build latest earthly using released earthly
         run: ${{inputs.SUDO}} $(which earthly) -P --use-inline-cache ${{inputs.BUILD_EARTHLY_TARGET}}
       - name: Set EARTHLY_VERSION_FLAG_OVERRIDES env

--- a/.github/workflows/reusable-export-test.yml
+++ b/.github/workflows/reusable-export-test.yml
@@ -71,6 +71,8 @@ jobs:
         # qemu-user-static needed for cross-compilation (--platform) targets
         run: ${{inputs.SUDO}} apt-get update && ${{inputs.SUDO}} apt-get install -y qemu-user-static
         if: inputs.BINARY == 'podman'
+      - name: Copy Earthly dir to Earthly dev dir
+        run: mkdir -p ~/.earthly && cp -r ~/.earthly ~/.earthly-dev
       - name: Build latest earthly using released earthly
         run: ${{inputs.SUDO}} $(which earthly) -P --use-inline-cache ${{inputs.BUILD_EARTHLY_TARGET}}
       - name: Set EARTHLY_VERSION_FLAG_OVERRIDES env

--- a/.github/workflows/reusable-export-test.yml
+++ b/.github/workflows/reusable-export-test.yml
@@ -78,10 +78,6 @@ jobs:
             set -euo pipefail
             EARTHLY_VERSION_FLAG_OVERRIDES="$(tr -d '\n' < .earthly_version_flag_overrides)"
             echo "EARTHLY_VERSION_FLAG_OVERRIDES=$EARTHLY_VERSION_FLAG_OVERRIDES" >> "$GITHUB_ENV"
-      - name: Enable local registry-based exporter
-        run: ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} config global.local_registry_host 'tcp://127.0.0.1:8371'
-      - name: Configure Earthly Conversion Parallelism
-        run: ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} config global.conversion_parallelism 5
       - name: run export tests
         run: env earthly=${{inputs.BUILT_EARTHLY_PATH}} frontend=${{inputs.BINARY}} scripts/tests/export.sh
       - name: Buildkit logs (runs on failure)

--- a/.github/workflows/reusable-misc-tests.yml
+++ b/.github/workflows/reusable-misc-tests.yml
@@ -61,6 +61,8 @@ jobs:
           earthly config global.buildkit_additional_config "'[registry.\"docker.io\"]
           mirrors = [\"registry-1.docker.io.mirror.corp.earthly.dev\"]'"
         if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+      - name: Copy Earthly dir to Earthly dev dir
+        run: mkdir -p ~/.earthly && cp -r ~/.earthly ~/.earthly-dev
       - name: Build latest earthly using released earthly
         run: ${{inputs.SUDO}} $(which earthly) -P --use-inline-cache ${{inputs.BUILD_EARTHLY_TARGET}}
       - name: rebuild earthly using latest earthly build

--- a/.github/workflows/reusable-misc-tests.yml
+++ b/.github/workflows/reusable-misc-tests.yml
@@ -70,10 +70,6 @@ jobs:
             set -euo pipefail
             EARTHLY_VERSION_FLAG_OVERRIDES="$(tr -d '\n' < .earthly_version_flag_overrides)"
             echo "EARTHLY_VERSION_FLAG_OVERRIDES=$EARTHLY_VERSION_FLAG_OVERRIDES" >> "$GITHUB_ENV"
-      - name: Enable local registry-based exporter
-        run: ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} config global.local_registry_host 'tcp://127.0.0.1:8371'
-      - name: Configure Earthly Conversion Parallelism
-        run: ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} config global.conversion_parallelism 5
       - name: Run parallel buildkit start test. It ensures that earthly starting up buildkit does not race with itself.
         uses: nick-fields/retry@v2
         with:

--- a/.github/workflows/reusable-misc-tests.yml
+++ b/.github/workflows/reusable-misc-tests.yml
@@ -61,8 +61,8 @@ jobs:
           earthly config global.buildkit_additional_config "'[registry.\"docker.io\"]
           mirrors = [\"registry-1.docker.io.mirror.corp.earthly.dev\"]'"
         if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-      - name: Copy Earthly dir to Earthly dev dir
-        run: mkdir -p ~/.earthly && cp -r ~/.earthly ~/.earthly-dev
+      - name: Link Earthly dir to Earthly dev dir
+        run: mkdir -p ~/.earthly && ln -s ~/.earthly ~/.earthly-dev
       - name: Build latest earthly using released earthly
         run: ${{inputs.SUDO}} $(which earthly) -P --use-inline-cache ${{inputs.BUILD_EARTHLY_TARGET}}
       - name: rebuild earthly using latest earthly build

--- a/.github/workflows/reusable-push-integrations.yml
+++ b/.github/workflows/reusable-push-integrations.yml
@@ -54,10 +54,6 @@ jobs:
           set -euo pipefail
           EARTHLY_VERSION_FLAG_OVERRIDES="$(tr -d '\n' < .earthly_version_flag_overrides)"
           echo "EARTHLY_VERSION_FLAG_OVERRIDES=$EARTHLY_VERSION_FLAG_OVERRIDES" >> "$GITHUB_ENV"
-      - name: Enable local registry-based exporter
-        run: ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} config global.local_registry_host 'tcp://127.0.0.1:8371'
-      - name: Configure Earthly Conversion Parallelism
-        run: ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} config global.conversion_parallelism 5
       - name: Push and Pull Cloud Images
         run: |-
           ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} --ci -P  \

--- a/.github/workflows/reusable-push-integrations.yml
+++ b/.github/workflows/reusable-push-integrations.yml
@@ -47,8 +47,8 @@ jobs:
       - name: Docker mirror login via ${{inputs.BINARY}} (Earthly Only)
         run: ${{inputs.SUDO}} ${{inputs.BINARY}} login registry-1.docker.io.mirror.corp.earthly.dev --username "${{ secrets.DOCKERHUB_MIRROR_USERNAME }}" --password "${{ secrets.DOCKERHUB_MIRROR_PASSWORD }}"
         if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-      - name: Copy Earthly dir to Earthly dev dir
-        run: mkdir -p ~/.earthly && cp -r ~/.earthly ~/.earthly-dev
+      - name: Link Earthly dir to Earthly dev dir
+        run: mkdir -p ~/.earthly && ln -s ~/.earthly ~/.earthly-dev
       - name: Build latest earthly using released earthly
         run: ${{inputs.SUDO}} $(which earthly) -P --use-inline-cache ${{inputs.BUILD_EARTHLY_TARGET}}
       - name: Set EARTHLY_VERSION_FLAG_OVERRIDES env

--- a/.github/workflows/reusable-push-integrations.yml
+++ b/.github/workflows/reusable-push-integrations.yml
@@ -47,6 +47,8 @@ jobs:
       - name: Docker mirror login via ${{inputs.BINARY}} (Earthly Only)
         run: ${{inputs.SUDO}} ${{inputs.BINARY}} login registry-1.docker.io.mirror.corp.earthly.dev --username "${{ secrets.DOCKERHUB_MIRROR_USERNAME }}" --password "${{ secrets.DOCKERHUB_MIRROR_PASSWORD }}"
         if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+      - name: Copy Earthly dir to Earthly dev dir
+        run: mkdir -p ~/.earthly && cp -r ~/.earthly ~/.earthly-dev
       - name: Build latest earthly using released earthly
         run: ${{inputs.SUDO}} $(which earthly) -P --use-inline-cache ${{inputs.BUILD_EARTHLY_TARGET}}
       - name: Set EARTHLY_VERSION_FLAG_OVERRIDES env

--- a/.github/workflows/reusable-repo-auth-tests.yml
+++ b/.github/workflows/reusable-repo-auth-tests.yml
@@ -59,6 +59,8 @@ jobs:
         run: |-
           earthly config global.buildkit_additional_config "'[registry.\"docker.io\"]
           mirrors = [\"registry-1.docker.io.mirror.corp.earthly.dev\"]'"
+      - name: Copy Earthly dir to Earthly dev dir
+        run: mkdir -p ~/.earthly && cp -r ~/.earthly ~/.earthly-dev
       - name: Build latest earthly using released earthly
         run: ${{inputs.SUDO}} $(which earthly) -P --use-inline-cache ${{inputs.BUILD_EARTHLY_TARGET}}
       - name: Set EARTHLY_VERSION_FLAG_OVERRIDES env

--- a/.github/workflows/reusable-repo-auth-tests.yml
+++ b/.github/workflows/reusable-repo-auth-tests.yml
@@ -59,8 +59,8 @@ jobs:
         run: |-
           earthly config global.buildkit_additional_config "'[registry.\"docker.io\"]
           mirrors = [\"registry-1.docker.io.mirror.corp.earthly.dev\"]'"
-      - name: Copy Earthly dir to Earthly dev dir
-        run: mkdir -p ~/.earthly && cp -r ~/.earthly ~/.earthly-dev
+      - name: Link Earthly dir to Earthly dev dir
+        run: mkdir -p ~/.earthly && ln -s ~/.earthly ~/.earthly-dev
       - name: Build latest earthly using released earthly
         run: ${{inputs.SUDO}} $(which earthly) -P --use-inline-cache ${{inputs.BUILD_EARTHLY_TARGET}}
       - name: Set EARTHLY_VERSION_FLAG_OVERRIDES env

--- a/.github/workflows/reusable-repo-auth-tests.yml
+++ b/.github/workflows/reusable-repo-auth-tests.yml
@@ -66,10 +66,6 @@ jobs:
             set -euo pipefail
             EARTHLY_VERSION_FLAG_OVERRIDES="$(tr -d '\n' < .earthly_version_flag_overrides)"
             echo "EARTHLY_VERSION_FLAG_OVERRIDES=$EARTHLY_VERSION_FLAG_OVERRIDES" >> "$GITHUB_ENV"
-      - name: Enable local registry-based exporter
-        run: ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} config global.local_registry_host 'tcp://127.0.0.1:8371'
-      - name: Configure Earthly Conversion Parallelism
-        run: ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} config global.conversion_parallelism 5
 # to regenerate the entries below; run earthly ./scripts/tests/auth+generate-github-tasks
 # auto-generated-entries start;
       - name: run test-hello-world-no-ssh-agent.sh

--- a/.github/workflows/reusable-secrets-integrations.yml
+++ b/.github/workflows/reusable-secrets-integrations.yml
@@ -58,10 +58,6 @@ jobs:
             set -euo pipefail
             EARTHLY_VERSION_FLAG_OVERRIDES="$(tr -d '\n' < .earthly_version_flag_overrides)"
             echo "EARTHLY_VERSION_FLAG_OVERRIDES=$EARTHLY_VERSION_FLAG_OVERRIDES" >> "$GITHUB_ENV"
-      - name: Enable local registry-based exporter
-        run: ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} config global.local_registry_host 'tcp://127.0.0.1:8371'
-      - name: Configure Earthly Conversion Parallelism
-        run: ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} config global.conversion_parallelism 5
       - name: run secrets-integration
         run: env earthly=${{inputs.BUILT_EARTHLY_PATH}} scripts/tests/secrets-integration.sh
       - name: Buildkit logs (runs on failure)

--- a/.github/workflows/reusable-secrets-integrations.yml
+++ b/.github/workflows/reusable-secrets-integrations.yml
@@ -51,6 +51,8 @@ jobs:
         run: |-
           earthly config global.buildkit_additional_config "'[registry.\"docker.io\"]
           mirrors = [\"registry-1.docker.io.mirror.corp.earthly.dev\"]'"
+      - name: Copy Earthly dir to Earthly dev dir
+        run: mkdir -p ~/.earthly && cp -r ~/.earthly ~/.earthly-dev
       - name: Build latest earthly using released earthly
         run: ${{inputs.SUDO}} $(which earthly) -P --use-inline-cache ${{inputs.BUILD_EARTHLY_TARGET}}
       - name: Set EARTHLY_VERSION_FLAG_OVERRIDES env

--- a/.github/workflows/reusable-secrets-integrations.yml
+++ b/.github/workflows/reusable-secrets-integrations.yml
@@ -51,8 +51,8 @@ jobs:
         run: |-
           earthly config global.buildkit_additional_config "'[registry.\"docker.io\"]
           mirrors = [\"registry-1.docker.io.mirror.corp.earthly.dev\"]'"
-      - name: Copy Earthly dir to Earthly dev dir
-        run: mkdir -p ~/.earthly && cp -r ~/.earthly ~/.earthly-dev
+      - name: Link Earthly dir to Earthly dev dir
+        run: mkdir -p ~/.earthly && ln -s ~/.earthly ~/.earthly-dev
       - name: Build latest earthly using released earthly
         run: ${{inputs.SUDO}} $(which earthly) -P --use-inline-cache ${{inputs.BUILD_EARTHLY_TARGET}}
       - name: Set EARTHLY_VERSION_FLAG_OVERRIDES env

--- a/.github/workflows/reusable-test-local.yml
+++ b/.github/workflows/reusable-test-local.yml
@@ -74,6 +74,8 @@ jobs:
       - name: Configure Satellites (Earthly Only)
         run: earthly sat ls && earthly satellite select ${{inputs.SATELLITE_NAME}}
         if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) && inputs.USE_SATELLITE
+      - name: Copy Earthly dir to Earthly dev dir
+        run: mkdir -p ~/.earthly && cp -r ~/.earthly ~/.earthly-dev
       - name: Build latest earthly using released earthly
         run: ${{inputs.SUDO}} $(which earthly) ${{inputs.BUILD_EARTHLY_ARGS}} ${{inputs.BUILD_EARTHLY_TARGET}}
       - name: Set EARTHLY_VERSION_FLAG_OVERRIDES env

--- a/.github/workflows/reusable-test-local.yml
+++ b/.github/workflows/reusable-test-local.yml
@@ -81,10 +81,6 @@ jobs:
             set -euo pipefail
             EARTHLY_VERSION_FLAG_OVERRIDES="$(tr -d '\n' < .earthly_version_flag_overrides)"
             echo "EARTHLY_VERSION_FLAG_OVERRIDES=$EARTHLY_VERSION_FLAG_OVERRIDES" >> "$GITHUB_ENV"
-      - name: Enable local registry-based exporter
-        run: ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} config global.local_registry_host 'tcp://127.0.0.1:8371'
-      - name: Configure Earthly Conversion Parallelism
-        run: ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} config global.conversion_parallelism 5
       - name: Execute test-local
         uses: nick-fields/retry@v2
         with:

--- a/.github/workflows/reusable-test-local.yml
+++ b/.github/workflows/reusable-test-local.yml
@@ -74,8 +74,8 @@ jobs:
       - name: Configure Satellites (Earthly Only)
         run: earthly sat ls && earthly satellite select ${{inputs.SATELLITE_NAME}}
         if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) && inputs.USE_SATELLITE
-      - name: Copy Earthly dir to Earthly dev dir
-        run: mkdir -p ~/.earthly && cp -r ~/.earthly ~/.earthly-dev
+      - name: Link Earthly dir to Earthly dev dir
+        run: mkdir -p ~/.earthly && ln -s ~/.earthly ~/.earthly-dev
       - name: Build latest earthly using released earthly
         run: ${{inputs.SUDO}} $(which earthly) ${{inputs.BUILD_EARTHLY_ARGS}} ${{inputs.BUILD_EARTHLY_TARGET}}
       - name: Set EARTHLY_VERSION_FLAG_OVERRIDES env

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -88,10 +88,6 @@ jobs:
           set -euo pipefail
           EARTHLY_VERSION_FLAG_OVERRIDES="$(tr -d '\n' < .earthly_version_flag_overrides)"
           echo "EARTHLY_VERSION_FLAG_OVERRIDES=$EARTHLY_VERSION_FLAG_OVERRIDES" >> "$GITHUB_ENV"
-      - name: Enable local registry-based exporter
-        run: ${{ inputs.BUILT_EARTHLY_PATH }} config global.local_registry_host 'tcp://127.0.0.1:8371'
-      - name: Configure Earthly Conversion Parallelism
-        run: ${{ inputs.BUILT_EARTHLY_PATH }} config global.conversion_parallelism 5
       - name: Execute lint (Earthly Only)
         run: |-
           ${{inputs.SUDO}} ${{ inputs.BUILT_EARTHLY_PATH }} --ci -P \

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -79,8 +79,8 @@ jobs:
           earthly config global.buildkit_additional_config "'[registry.\"docker.io\"]
           mirrors = [\"registry-1.docker.io.mirror.corp.earthly.dev\"]'"
         if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-      - name: Copy Earthly dir to Earthly dev dir
-        run: mkdir -p ~/.earthly && cp -r ~/.earthly ~/.earthly-dev
+      - name: Link Earthly dir to Earthly dev dir
+        run: mkdir -p ~/.earthly && ln -s ~/.earthly ~/.earthly-dev
       - name: Build latest earthly using released earthly
         run: ${{inputs.SUDO}} $(which earthly) ${{inputs.BUILD_EARTHLY_ARGS}} ${{inputs.BUILD_EARTHLY_TARGET}}
       - name: rebuild earthly using latest earthly build

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -79,6 +79,8 @@ jobs:
           earthly config global.buildkit_additional_config "'[registry.\"docker.io\"]
           mirrors = [\"registry-1.docker.io.mirror.corp.earthly.dev\"]'"
         if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+      - name: Copy Earthly dir to Earthly dev dir
+        run: mkdir -p ~/.earthly && cp -r ~/.earthly ~/.earthly-dev
       - name: Build latest earthly using released earthly
         run: ${{inputs.SUDO}} $(which earthly) ${{inputs.BUILD_EARTHLY_ARGS}} ${{inputs.BUILD_EARTHLY_TARGET}}
       - name: rebuild earthly using latest earthly build

--- a/Earthfile
+++ b/Earthfile
@@ -20,10 +20,6 @@ RUN apk add --update --no-cache \
 
 WORKDIR /earthly
 
-t:
-    # TODO @# Remove
-    RUN --no-cache echo "hello world"
-
 deps:
     FROM +base
     RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.50.0
@@ -235,6 +231,7 @@ earthly:
     ARG VARIANT=$TARGETVARIANT
     ARG GO_EXTRA_LDFLAGS="-linkmode external -extldflags -static"
     ARG EXECUTABLE_NAME="earthly"
+    ARG DEFAULT_INSTALLATION_NAME="earthly-dev"
     RUN test -n "$GOOS" && test -n "$GOARCH"
     RUN test "$GOARCH" != "arm" || test -n "$VARIANT"
     ARG EARTHLY_TARGET_TAG_DOCKER
@@ -248,6 +245,7 @@ earthly:
     RUN printf '-X main.DefaultBuildkitdImage='"$DEFAULT_BUILDKITD_IMAGE" > ./build/ldflags && \
         printf ' -X main.Version='"$VERSION" >> ./build/ldflags && \
         printf ' -X main.GitSha='"$EARTHLY_GIT_HASH" >> ./build/ldflags && \
+        printf ' -X main.DefaultInstallationName='"$DEFAULT_INSTALLATION_NAME" >> ./build/ldflags && \
         printf ' '"$GO_EXTRA_LDFLAGS" >> ./build/ldflags && \
         echo "$(cat ./build/ldflags)"
     # Important! If you change the go build options, you may need to also change them
@@ -324,7 +322,7 @@ earthly-docker:
     WORKDIR /workspace
     ARG EARTHLY_TARGET_TAG_DOCKER
     ARG TAG="dev-$EARTHLY_TARGET_TAG_DOCKER"
-    COPY (+earthly/earthly --VERSION=$TAG) /usr/bin/earthly
+    COPY (+earthly/earthly --VERSION=$TAG --DEFAULT_INSTALLATION_NAME="earthly") /usr/bin/earthly
     SAVE IMAGE --push --cache-from=earthly/earthly:main earthly/earthly:$TAG
 
 earthly-integration-test-base:

--- a/Earthfile
+++ b/Earthfile
@@ -315,7 +315,7 @@ earthly-all:
 earthly-docker:
     ARG BUILDKIT_PROJECT
     FROM ./buildkitd+buildkitd --BUILDKIT_PROJECT="$BUILDKIT_PROJECT"
-    RUN apk add --update --no-cache docker-cli libcap-ng-utils
+    RUN apk add --update --no-cache docker-cli libcap-ng-utils git
     ENV EARTHLY_IMAGE=true
     COPY earthly-entrypoint.sh /usr/bin/earthly-entrypoint.sh
     ENTRYPOINT ["/usr/bin/earthly-entrypoint.sh"]

--- a/Earthfile
+++ b/Earthfile
@@ -20,6 +20,10 @@ RUN apk add --update --no-cache \
 
 WORKDIR /earthly
 
+t:
+    # TODO @# Remove
+    RUN --no-cache echo "hello world"
+
 deps:
     FROM +base
     RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.50.0

--- a/analytics/analytics.go
+++ b/analytics/analytics.go
@@ -127,8 +127,8 @@ func RepoHashFromCloneURL(repo string) string {
 	return fmt.Sprintf("%x", sha256.Sum256([]byte(repo)))
 }
 
-func getInstallID() (string, error) {
-	earthlyDir, err := cliutil.GetOrCreateEarthlyDir()
+func getInstallID(installationName string) (string, error) {
+	earthlyDir, err := cliutil.GetOrCreateEarthlyDir(installationName)
 	if err != nil {
 		return "", err
 	}
@@ -190,7 +190,7 @@ type Meta struct {
 }
 
 // CollectAnalytics sends analytics to api.earthly.dev
-func CollectAnalytics(ctx context.Context, cloudClient cloud.Client, displayErrors bool, meta Meta) {
+func CollectAnalytics(ctx context.Context, cloudClient cloud.Client, displayErrors bool, meta Meta, installationName string) {
 	var err error
 	ciName, ci := DetectCI()
 	repoHash := getRepoHash()
@@ -203,7 +203,7 @@ func CollectAnalytics(ctx context.Context, cloudClient cloud.Client, displayErro
 				installID = fmt.Sprintf("%x", sha256.Sum256([]byte(ciName+repoHash)))
 			}
 		} else {
-			installID, err = getInstallID()
+			installID, err = getInstallID(installationName)
 			if err != nil {
 				if displayErrors {
 					fmt.Fprintf(os.Stderr, "Failed to get install ID: %s\n", err.Error())

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -193,6 +193,7 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 				NoCache:                              b.opt.NoCache,
 				ContainerFrontend:                    b.opt.ContainerFrontend,
 				UseLocalRegistry:                     (b.opt.LocalRegistryAddr != ""),
+				LocalRegistryAddr:                    b.opt.LocalRegistryAddr,
 				DoSaves:                              !opt.NoOutput,
 				OnlyFinalTargetImages:                opt.OnlyFinalTargetImages,
 				DoPushes:                             opt.Push,

--- a/buildkitd/settings.go
+++ b/buildkitd/settings.go
@@ -15,7 +15,6 @@ type Settings struct {
 	CacheSizePct         int
 	Debug                bool
 	BuildkitAddress      string
-	DebuggerAddress      string
 	LocalRegistryAddress string
 	AdditionalArgs       []string
 	AdditionalConfig     string

--- a/cloud/auth.go
+++ b/cloud/auth.go
@@ -257,12 +257,12 @@ func (c *client) getCredentialsPath(create bool) (string, error) {
 	if confDirPath == "" {
 		if create {
 			var err error
-			confDirPath, err = cliutil.GetOrCreateEarthlyDir()
+			confDirPath, err = cliutil.GetOrCreateEarthlyDir(c.installationName)
 			if err != nil {
 				return "", errors.Wrap(err, "cannot get .earthly dir")
 			}
 		} else {
-			confDirPath = cliutil.GetEarthlyDir()
+			confDirPath = cliutil.GetEarthlyDir(c.installationName)
 		}
 	}
 	credPath := filepath.Join(confDirPath, "auth.credentials")
@@ -272,7 +272,7 @@ func (c *client) getCredentialsPath(create bool) (string, error) {
 func (c *client) migrateOldToken() error {
 	confDirPath := c.authDir
 	if confDirPath == "" {
-		confDirPath = cliutil.GetEarthlyDir()
+		confDirPath = cliutil.GetEarthlyDir(c.installationName)
 	}
 	tokenPath := filepath.Join(confDirPath, "auth.token")
 	newPath := filepath.Join(confDirPath, "auth.credentials")
@@ -289,12 +289,12 @@ func (c *client) getTokenPath(create bool) (string, error) {
 	if confDirPath == "" {
 		if create {
 			var err error
-			confDirPath, err = cliutil.GetOrCreateEarthlyDir()
+			confDirPath, err = cliutil.GetOrCreateEarthlyDir(c.installationName)
 			if err != nil {
 				return "", errors.Wrap(err, "cannot get .earthly dir")
 			}
 		} else {
-			confDirPath = cliutil.GetEarthlyDir()
+			confDirPath = cliutil.GetEarthlyDir(c.installationName)
 		}
 	}
 	tokenPath := filepath.Join(confDirPath, "auth.jwt")

--- a/cloud/client.go
+++ b/cloud/client.go
@@ -114,19 +114,21 @@ type client struct {
 	pipelines             pipelines.PipelinesClient
 	compute               compute.ComputeClient
 	logstream             logstream.LogStreamClient
+	installationName      string
 }
 
 var _ Client = &client{}
 
 // NewClient provides a new Earthly Cloud client
-func NewClient(httpAddr, grpcAddr string, useInsecure bool, agentSockPath, authCredsOverride string, warnFunc func(string, ...interface{})) (Client, error) {
+func NewClient(httpAddr, grpcAddr string, useInsecure bool, agentSockPath, authCredsOverride, installationName string, warnFunc func(string, ...interface{})) (Client, error) {
 	c := &client{
 		httpAddr: httpAddr,
 		sshAgent: &lazySSHAgent{
 			sockPath: agentSockPath,
 		},
-		warnFunc: warnFunc,
-		jum:      &protojson.UnmarshalOptions{DiscardUnknown: true},
+		warnFunc:         warnFunc,
+		jum:              &protojson.UnmarshalOptions{DiscardUnknown: true},
+		installationName: installationName,
 	}
 	if authCredsOverride != "" {
 		c.authCredToken = authCredsOverride

--- a/cloud/logstream.go
+++ b/cloud/logstream.go
@@ -2,6 +2,7 @@ package cloud
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/earthly/cloud-api/logstream"
@@ -25,11 +26,13 @@ func (c *client) StreamLogs(ctx context.Context, buildID string, deltasCh chan [
 				return errors.Wrap(err, "failed to read log stream response")
 			}
 			if resp.GetEofAck() {
+				fmt.Printf("@# received eof ack\n")
 				mu.Lock()
 				defer mu.Unlock()
 				if !finished {
 					return errors.New("unexpected EOF ack")
 				}
+				fmt.Printf("@# closing send\n")
 				err := streamClient.CloseSend()
 				if err != nil {
 					return errors.Wrap(err, "failed to close log stream")
@@ -45,6 +48,7 @@ func (c *client) StreamLogs(ctx context.Context, buildID string, deltasCh chan [
 				return ctx.Err()
 			case deltas, ok := <-deltasCh:
 				if !ok {
+					fmt.Printf("@# sending eof\n")
 					err := streamClient.Send(&logstream.StreamLogRequest{
 						BuildId: buildID,
 						Eof:     true,
@@ -57,6 +61,7 @@ func (c *client) StreamLogs(ctx context.Context, buildID string, deltasCh chan [
 					mu.Unlock()
 					return nil
 				}
+				fmt.Printf("@# sending deltas %v\n", deltas)
 				err := streamClient.Send(&logstream.StreamLogRequest{
 					BuildId: buildID,
 					Deltas:  deltas,

--- a/cloud/logstream.go
+++ b/cloud/logstream.go
@@ -5,12 +5,13 @@ import (
 	"sync"
 
 	"github.com/earthly/cloud-api/logstream"
+	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 )
 
 func (c *client) StreamLogs(ctx context.Context, buildID string, deltasCh chan []*logstream.Delta) error {
-	streamClient, err := c.logstream.StreamLogs(c.withAuth(ctx))
+	streamClient, err := c.logstream.StreamLogs(c.withAuth(ctx), grpc_retry.Disable())
 	if err != nil {
 		return errors.Wrap(err, "failed to create log stream client")
 	}

--- a/cloud/logstream.go
+++ b/cloud/logstream.go
@@ -2,7 +2,6 @@ package cloud
 
 import (
 	"context"
-	"fmt"
 	"sync"
 
 	"github.com/earthly/cloud-api/logstream"
@@ -26,13 +25,11 @@ func (c *client) StreamLogs(ctx context.Context, buildID string, deltasCh chan [
 				return errors.Wrap(err, "failed to read log stream response")
 			}
 			if resp.GetEofAck() {
-				fmt.Printf("@# received eof ack\n")
 				mu.Lock()
 				defer mu.Unlock()
 				if !finished {
 					return errors.New("unexpected EOF ack")
 				}
-				fmt.Printf("@# closing send\n")
 				err := streamClient.CloseSend()
 				if err != nil {
 					return errors.Wrap(err, "failed to close log stream")
@@ -48,7 +45,6 @@ func (c *client) StreamLogs(ctx context.Context, buildID string, deltasCh chan [
 				return ctx.Err()
 			case deltas, ok := <-deltasCh:
 				if !ok {
-					fmt.Printf("@# sending eof\n")
 					err := streamClient.Send(&logstream.StreamLogRequest{
 						BuildId: buildID,
 						Eof:     true,
@@ -61,7 +57,6 @@ func (c *client) StreamLogs(ctx context.Context, buildID string, deltasCh chan [
 					mu.Unlock()
 					return nil
 				}
-				fmt.Printf("@# sending deltas %v\n", deltas)
 				err := streamClient.Send(&logstream.StreamLogRequest{
 					BuildId: buildID,
 					Deltas:  deltas,

--- a/cmd/earthly/account_cmds.go
+++ b/cmd/earthly/account_cmds.go
@@ -191,7 +191,7 @@ func (app *earthlyApp) actionAccountRegister(cliCtx *cli.Context) error {
 		return errors.New("email is invalid")
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -325,7 +325,7 @@ func promptPassword() (string, error) {
 
 func (app *earthlyApp) actionAccountListKeys(cliCtx *cli.Context) error {
 	app.commandName = "accountListKeys"
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -341,7 +341,7 @@ func (app *earthlyApp) actionAccountListKeys(cliCtx *cli.Context) error {
 
 func (app *earthlyApp) actionAccountAddKey(cliCtx *cli.Context) error {
 	app.commandName = "accountAddKey"
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -411,7 +411,7 @@ func (app *earthlyApp) actionAccountAddKey(cliCtx *cli.Context) error {
 
 func (app *earthlyApp) actionAccountRemoveKey(cliCtx *cli.Context) error {
 	app.commandName = "accountRemoveKey"
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -425,7 +425,7 @@ func (app *earthlyApp) actionAccountRemoveKey(cliCtx *cli.Context) error {
 }
 func (app *earthlyApp) actionAccountListTokens(cliCtx *cli.Context) error {
 	app.commandName = "accountListTokens"
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -487,7 +487,7 @@ func (app *earthlyApp) actionAccountCreateToken(cliCtx *cli.Context) error {
 		}
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -506,7 +506,7 @@ func (app *earthlyApp) actionAccountRemoveToken(cliCtx *cli.Context) error {
 		return errors.New("invalid number of arguments provided")
 	}
 	name := cliCtx.Args().First()
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -542,7 +542,7 @@ func (app *earthlyApp) actionAccountLogin(cliCtx *cli.Context) error {
 	if token != "" && (email != "" || pass != "") {
 		return errors.New("--token cannot be used in conjuction with --email or --password")
 	}
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -683,7 +683,7 @@ func (app *earthlyApp) actionAccountLogout(cliCtx *cli.Context) error {
 		return errLogoutHasNoEffectWhenAuthTokenSet
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return err
 	}
@@ -701,7 +701,7 @@ func (app *earthlyApp) actionAccountReset(cliCtx *cli.Context) error {
 		return errors.New("no email given")
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return err
 	}

--- a/cmd/earthly/account_cmds.go
+++ b/cmd/earthly/account_cmds.go
@@ -191,9 +191,9 @@ func (app *earthlyApp) actionAccountRegister(cliCtx *cli.Context) error {
 		return errors.New("email is invalid")
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := app.newCloudClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to create cloud client")
+		return err
 	}
 
 	if app.token == "" {
@@ -325,9 +325,9 @@ func promptPassword() (string, error) {
 
 func (app *earthlyApp) actionAccountListKeys(cliCtx *cli.Context) error {
 	app.commandName = "accountListKeys"
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := app.newCloudClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to create cloud client")
+		return err
 	}
 	keys, err := cloudClient.ListPublicKeys(cliCtx.Context)
 	if err != nil {
@@ -341,9 +341,9 @@ func (app *earthlyApp) actionAccountListKeys(cliCtx *cli.Context) error {
 
 func (app *earthlyApp) actionAccountAddKey(cliCtx *cli.Context) error {
 	app.commandName = "accountAddKey"
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := app.newCloudClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to create cloud client")
+		return err
 	}
 	if cliCtx.NArg() > 0 {
 		for _, k := range cliCtx.Args().Slice() {
@@ -411,9 +411,9 @@ func (app *earthlyApp) actionAccountAddKey(cliCtx *cli.Context) error {
 
 func (app *earthlyApp) actionAccountRemoveKey(cliCtx *cli.Context) error {
 	app.commandName = "accountRemoveKey"
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := app.newCloudClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to create cloud client")
+		return err
 	}
 	for _, k := range cliCtx.Args().Slice() {
 		err := cloudClient.RemovePublicKey(cliCtx.Context, k)
@@ -425,9 +425,9 @@ func (app *earthlyApp) actionAccountRemoveKey(cliCtx *cli.Context) error {
 }
 func (app *earthlyApp) actionAccountListTokens(cliCtx *cli.Context) error {
 	app.commandName = "accountListTokens"
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := app.newCloudClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to create cloud client")
+		return err
 	}
 	tokens, err := cloudClient.ListTokens(cliCtx.Context)
 	if err != nil {
@@ -487,9 +487,9 @@ func (app *earthlyApp) actionAccountCreateToken(cliCtx *cli.Context) error {
 		}
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := app.newCloudClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to create cloud client")
+		return err
 	}
 	name := cliCtx.Args().First()
 	token, err := cloudClient.CreateToken(cliCtx.Context, name, app.writePermission, &expiry)
@@ -506,9 +506,9 @@ func (app *earthlyApp) actionAccountRemoveToken(cliCtx *cli.Context) error {
 		return errors.New("invalid number of arguments provided")
 	}
 	name := cliCtx.Args().First()
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := app.newCloudClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to create cloud client")
+		return err
 	}
 	err = cloudClient.RemoveToken(cliCtx.Context, name)
 	if err != nil {
@@ -542,9 +542,9 @@ func (app *earthlyApp) actionAccountLogin(cliCtx *cli.Context) error {
 	if token != "" && (email != "" || pass != "") {
 		return errors.New("--token cannot be used in conjuction with --email or --password")
 	}
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := app.newCloudClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to create cloud client")
+		return err
 	}
 
 	// special case where global auth token overrides login logic
@@ -683,7 +683,7 @@ func (app *earthlyApp) actionAccountLogout(cliCtx *cli.Context) error {
 		return errLogoutHasNoEffectWhenAuthTokenSet
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := app.newCloudClient()
 	if err != nil {
 		return err
 	}
@@ -701,7 +701,7 @@ func (app *earthlyApp) actionAccountReset(cliCtx *cli.Context) error {
 		return errors.New("no email given")
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := app.newCloudClient()
 	if err != nil {
 		return err
 	}

--- a/cmd/earthly/autocomplete.go
+++ b/cmd/earthly/autocomplete.go
@@ -33,7 +33,7 @@ func (app *earthlyApp) autoComplete(ctx context.Context) {
 	err := app.autoCompleteImp(ctx)
 	if err != nil {
 		errToLog := err
-		logDir, err := cliutil.GetOrCreateEarthlyDir()
+		logDir, err := cliutil.GetOrCreateEarthlyDir(app.installationName)
 		if err != nil {
 			os.Exit(1)
 		}

--- a/cmd/earthly/build_cmd.go
+++ b/cmd/earthly/build_cmd.go
@@ -183,7 +183,9 @@ func (app *earthlyApp) actionBuildImp(cliCtx *cli.Context, flagArgs, nonFlagArgs
 	if !app.cfg.Global.DisableLogSharing {
 		if cloudClient.IsLoggedIn(cliCtx.Context) {
 			if app.logstreamUpload {
-				app.logbusSetup.StartLogStreamer(cliCtx.Context, cloudClient, "my-org", "projectName TODO")
+				earthfileOrgName := "my-org" // TODO (vladaionescu): Detect this.
+				earthfileProjectName := ""   // TODO (vladaionescu): Detect this.
+				app.logbusSetup.StartLogStreamer(cliCtx.Context, cloudClient, earthfileOrgName, earthfileProjectName)
 			} else {
 				// If you are logged in, then add the bundle builder code, and configure cleanup and post-build messages.
 				app.console = app.console.WithLogBundleWriter(target.String(), cleanCollection)

--- a/cmd/earthly/build_cmd.go
+++ b/cmd/earthly/build_cmd.go
@@ -26,7 +26,6 @@ import (
 	"github.com/earthly/earthly/builder"
 	"github.com/earthly/earthly/buildkitd"
 	"github.com/earthly/earthly/cleanup"
-	"github.com/earthly/earthly/cloud"
 	debuggercommon "github.com/earthly/earthly/debugger/common"
 	"github.com/earthly/earthly/debugger/terminal"
 	"github.com/earthly/earthly/domain"
@@ -175,9 +174,9 @@ func (app *earthlyApp) actionBuildImp(cliCtx *cli.Context, flagArgs, nonFlagArgs
 	cleanCollection := cleanup.NewCollection()
 	defer cleanCollection.Close()
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := app.newCloudClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to create cloud client")
+		return err
 	}
 
 	// Default upload logs, unless explicitly configured
@@ -237,7 +236,7 @@ func (app *earthlyApp) actionBuildImp(cliCtx *cli.Context, flagArgs, nonFlagArgs
 		return errors.New("Frontend is not available to perform the build. Is Docker installed and running?")
 	}
 
-	bkClient, err := buildkitd.NewClient(cliCtx.Context, app.console, app.buildkitdImage, app.containerName, app.containerFrontend, Version, app.buildkitdSettings)
+	bkClient, err := buildkitd.NewClient(cliCtx.Context, app.console, app.buildkitdImage, app.containerName, app.installationName, app.containerFrontend, Version, app.buildkitdSettings)
 	if err != nil {
 		return errors.Wrap(err, "build new buildkitd client")
 	}

--- a/cmd/earthly/build_cmd.go
+++ b/cmd/earthly/build_cmd.go
@@ -209,7 +209,7 @@ func (app *earthlyApp) actionBuildImp(cliCtx *cli.Context, flagArgs, nonFlagArgs
 		}
 	}
 	if app.logstreamUpload {
-		app.logbusSetup.StartLogStreamer(cliCtx.Context, cloudClient, "orgName TODO", "projectName TODO")
+		app.logbusSetup.StartLogStreamer(cliCtx.Context, cloudClient, "my-org", "projectName TODO")
 	}
 
 	app.console.PrintPhaseHeader(builder.PhaseInit, false, "")

--- a/cmd/earthly/build_cmd.go
+++ b/cmd/earthly/build_cmd.go
@@ -162,7 +162,6 @@ func (app *earthlyApp) actionBuildImp(cliCtx *cli.Context, flagArgs, nonFlagArgs
 		gitCommitAuthor string
 		gitConfigEmail  string
 	)
-
 	if !target.IsRemote() {
 		if meta, err := gitutil.Metadata(cliCtx.Context, target.GetLocalPath()); err == nil {
 			// Git commit detection here is best effort
@@ -208,6 +207,9 @@ func (app *earthlyApp) actionBuildImp(cliCtx *cli.Context, flagArgs, nonFlagArgs
 				app.console.Printf("Share your logs with an Earthly account (experimental)! Register for one at https://ci.earthly.dev.")
 			}()
 		}
+	}
+	if app.logstreamUpload {
+		app.logbusSetup.StartLogStreamer(cliCtx.Context, cloudClient, "orgName TODO", "projectName TODO")
 	}
 
 	app.console.PrintPhaseHeader(builder.PhaseInit, false, "")

--- a/cmd/earthly/common.go
+++ b/cmd/earthly/common.go
@@ -10,10 +10,19 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/earthly/earthly/cloud"
 	"github.com/earthly/earthly/util/cliutil"
 	"github.com/earthly/earthly/util/fileutil"
 	"github.com/pkg/errors"
 )
+
+func (app *earthlyApp) newCloudClient() (cloud.Client, error) {
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.installationName, app.console.Warnf)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create cloud client")
+	}
+	return cloudClient, nil
+}
 
 func wrap(s ...string) string {
 	return strings.Join(s, "\n\t")
@@ -84,8 +93,8 @@ func processSecrets(secrets, secretFiles []string, dotEnvMap map[string]string) 
 	return finalSecrets, nil
 }
 
-func defaultConfigPath() string {
-	earthlyDir := cliutil.GetEarthlyDir()
+func defaultConfigPath(installName string) string {
+	earthlyDir := cliutil.GetEarthlyDir(installName)
 	oldConfig := filepath.Join(earthlyDir, "config.yaml")
 	newConfig := filepath.Join(earthlyDir, "config.yml")
 	oldConfigExists, _ := fileutil.FileExists(oldConfig)

--- a/cmd/earthly/debug_cmds.go
+++ b/cmd/earthly/debug_cmds.go
@@ -15,7 +15,6 @@ import (
 	"github.com/urfave/cli/v2"
 
 	"github.com/earthly/earthly/ast"
-	"github.com/earthly/earthly/cloud"
 )
 
 func (app *earthlyApp) debugCmds() []*cli.Command {
@@ -85,9 +84,9 @@ func (app *earthlyApp) actionDebugAst(cliCtx *cli.Context) error {
 func (app *earthlyApp) actionDebugBuildkitInfo(cliCtx *cli.Context) error {
 	app.commandName = "debugBuildkitInfo"
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := app.newCloudClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to create cloud client")
+		return err
 	}
 	bkClient, err := app.getBuildkitClient(cliCtx, cloudClient)
 	if err != nil {
@@ -110,9 +109,9 @@ func (app *earthlyApp) actionDebugBuildkitInfo(cliCtx *cli.Context) error {
 func (app *earthlyApp) actionDebugBuildkitDiskUsage(cliCtx *cli.Context) error {
 	app.commandName = "debugBuildkitDiskUsage"
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := app.newCloudClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to create cloud client")
+		return err
 	}
 	bkClient, err := app.getBuildkitClient(cliCtx, cloudClient)
 	if err != nil {
@@ -161,9 +160,9 @@ func (app *earthlyApp) actionDebugBuildkitDiskUsage(cliCtx *cli.Context) error {
 func (app *earthlyApp) actionDebugBuildkitWorkers(cliCtx *cli.Context) error {
 	app.commandName = "debugBuildkitWorkers"
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := app.newCloudClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to create cloud client")
+		return err
 	}
 	bkClient, err := app.getBuildkitClient(cliCtx, cloudClient)
 	if err != nil {
@@ -234,9 +233,9 @@ func (app *earthlyApp) actionDebugBuildkitWorkers(cliCtx *cli.Context) error {
 func (app *earthlyApp) actionDebugBuildkitShutdownIfIdle(cliCtx *cli.Context) error {
 	app.commandName = "debugBuildkitShutdownIfIdle"
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := app.newCloudClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to create cloud client")
+		return err
 	}
 	bkClient, err := app.getBuildkitClient(cliCtx, cloudClient)
 	if err != nil {

--- a/cmd/earthly/debug_cmds.go
+++ b/cmd/earthly/debug_cmds.go
@@ -85,7 +85,7 @@ func (app *earthlyApp) actionDebugAst(cliCtx *cli.Context) error {
 func (app *earthlyApp) actionDebugBuildkitInfo(cliCtx *cli.Context) error {
 	app.commandName = "debugBuildkitInfo"
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -110,7 +110,7 @@ func (app *earthlyApp) actionDebugBuildkitInfo(cliCtx *cli.Context) error {
 func (app *earthlyApp) actionDebugBuildkitDiskUsage(cliCtx *cli.Context) error {
 	app.commandName = "debugBuildkitDiskUsage"
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -161,7 +161,7 @@ func (app *earthlyApp) actionDebugBuildkitDiskUsage(cliCtx *cli.Context) error {
 func (app *earthlyApp) actionDebugBuildkitWorkers(cliCtx *cli.Context) error {
 	app.commandName = "debugBuildkitWorkers"
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -234,7 +234,7 @@ func (app *earthlyApp) actionDebugBuildkitWorkers(cliCtx *cli.Context) error {
 func (app *earthlyApp) actionDebugBuildkitShutdownIfIdle(cliCtx *cli.Context) error {
 	app.commandName = "debugBuildkitShutdownIfIdle"
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}

--- a/cmd/earthly/flags.go
+++ b/cmd/earthly/flags.go
@@ -87,6 +87,13 @@ func (app *earthlyApp) rootFlags() []cli.Flag {
 			Destination: &app.cloudGRPCAddr,
 			Hidden:      true, // Internal.
 		},
+		&cli.BoolFlag{
+			Name:        "grpc-insecure",
+			EnvVars:     []string{"EARTHLY_GRPC_INSECURE"},
+			Usage:       "Makes gRPC connections insecure for dev purposes",
+			Destination: &app.cloudGRPCInsecure,
+			Hidden:      true, // Internal.
+		},
 		&cli.StringFlag{
 			Name:        "satellite-address",
 			Value:       containerutil.SatelliteAddress,

--- a/cmd/earthly/flags.go
+++ b/cmd/earthly/flags.go
@@ -124,8 +124,15 @@ func (app *earthlyApp) rootFlags() []cli.Flag {
 		&cli.BoolFlag{
 			Name:        "logstream",
 			EnvVars:     []string{"EARTHLY_LOGSTREAM"},
-			Usage:       "Enable log streaming",
+			Usage:       "Enable log streaming only locally",
 			Destination: &app.logstream,
+			Hidden:      true, // Internal.
+		},
+		&cli.BoolFlag{
+			Name:        "logstream-upload",
+			EnvVars:     []string{"EARTHLY_LOGSTREAM_UPLOAD"},
+			Usage:       "Enable log stream uploading",
+			Destination: &app.logstreamUpload,
 			Hidden:      true, // Internal.
 		},
 		&cli.StringFlag{
@@ -133,6 +140,13 @@ func (app *earthlyApp) rootFlags() []cli.Flag {
 			EnvVars:     []string{"EARTHLY_LOGSTREAM_DEBUG_FILE"},
 			Usage:       "Enable log streaming debugging output to a file",
 			Destination: &app.logstreamDebugFile,
+			Hidden:      true, // Internal.
+		},
+		&cli.StringFlag{
+			Name:        "build-id",
+			EnvVars:     []string{"EARTHLY_BUILD_ID"},
+			Usage:       "The build ID to use for identifying the build in Earthly Cloud. If not specified, a random ID will be generated",
+			Destination: &app.buildID,
 			Hidden:      true, // Internal.
 		},
 	}

--- a/cmd/earthly/flags.go
+++ b/cmd/earthly/flags.go
@@ -9,10 +9,14 @@ import (
 )
 
 func (app *earthlyApp) rootFlags() []cli.Flag {
+	defaultInstallationName := DefaultInstallationName
+	if defaultInstallationName == "" {
+		defaultInstallationName = "earthly"
+	}
 	return []cli.Flag{
 		&cli.StringFlag{
 			Name:        "config",
-			Value:       defaultConfigPath(),
+			Value:       defaultConfigPath(defaultInstallationName),
 			EnvVars:     []string{"EARTHLY_CONFIG"},
 			Usage:       "Path to config file",
 			Destination: &app.configPath,
@@ -160,6 +164,10 @@ func (app *earthlyApp) rootFlags() []cli.Flag {
 }
 
 func (app *earthlyApp) buildFlags() []cli.Flag {
+	defaultInstallationName := DefaultInstallationName
+	if defaultInstallationName == "" {
+		defaultInstallationName = "earthly"
+	}
 	return []cli.Flag{
 		&cli.StringSliceFlag{
 			Name:    "platform",
@@ -266,13 +274,6 @@ func (app *earthlyApp) buildFlags() []cli.Flag {
 			Destination: &app.noSatellite,
 		},
 		&cli.StringFlag{
-			Name:        "debugger-host",
-			EnvVars:     []string{"EARTHLY_DEBUGGER_HOST"},
-			Usage:       wrap("The URL to use for connecting to a debugger host. ", "If empty, earthly uses the default debugger port, combined with the desired buildkit host."),
-			Destination: &app.debuggerHost,
-			Hidden:      true,
-		},
-		&cli.StringFlag{
 			Name:        "tlscert",
 			Value:       "./certs/earthly_cert.pem",
 			EnvVars:     []string{"EARTHLY_TLS_CERT"},
@@ -297,7 +298,7 @@ func (app *earthlyApp) buildFlags() []cli.Flag {
 		},
 		&cli.StringFlag{
 			Name:        "buildkit-container-name",
-			Value:       DefaultBuildkitdContainerName,
+			Value:       defaultInstallationName + DefaultBuildkitdContainerSuffix,
 			EnvVars:     []string{"EARTHLY_CONTAINER_NAME"},
 			Usage:       "The docker container name to use for the buildkit daemon",
 			Destination: &app.containerName,
@@ -305,10 +306,18 @@ func (app *earthlyApp) buildFlags() []cli.Flag {
 		},
 		&cli.StringFlag{
 			Name:        "buildkit-volume-name",
-			Value:       DefaultBuildkitdVolumeName,
+			Value:       defaultInstallationName + DefaultBuildkitdVolumeSuffix,
 			EnvVars:     []string{"EARTHLY_VOLUME_NAME"},
 			Usage:       "The docker volume name to use for the buildkit daemon cache",
 			Destination: &app.buildkitdSettings.VolumeName,
+			Hidden:      true,
+		},
+		&cli.StringFlag{
+			Name:        "installation-name",
+			Value:       defaultInstallationName,
+			EnvVars:     []string{"EARTHLY_INSTALLATION_NAME"},
+			Usage:       "The earthly installation name to use when naming the buildkit container, the docker volume and the ~/.earthly directory",
+			Destination: &app.installationName,
 			Hidden:      true,
 		},
 		&cli.StringSliceFlag{

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -20,6 +20,7 @@ import (
 
 	gsysinfo "github.com/elastic/go-sysinfo"
 	"github.com/fatih/color"
+	"github.com/google/uuid"
 	"github.com/joho/godotenv"
 	_ "github.com/moby/buildkit/client/connhelper/dockercontainer" // Load "docker-container://" helper.
 	"github.com/pkg/errors"
@@ -146,7 +147,9 @@ type cliFlags struct {
 	invitePermission          string
 	inviteMessage             string
 	logstream                 bool
+	logstreamUpload           bool
 	logstreamDebugFile        string
+	buildID                   string
 }
 
 type analyticsMetadata struct {
@@ -383,9 +386,15 @@ func (app *earthlyApp) before(cliCtx *cli.Context) error {
 	} else if app.verbose {
 		app.console = app.console.WithLogLevel(conslogging.Verbose)
 	}
+	if app.buildID == "" {
+		app.buildID = uuid.NewString()
+	}
+	if app.logstreamUpload {
+		app.logstream = true
+	}
 	disableOngoingUpdates := !app.logstream // TODO (vladaionescu)
 	var err error
-	app.logbusSetup, err = logbussetup.New(cliCtx.Context, app.logbus, app.debug, app.verbose, disableOngoingUpdates, app.logstreamDebugFile)
+	app.logbusSetup, err = logbussetup.New(cliCtx.Context, app.logbus, app.debug, app.verbose, disableOngoingUpdates, app.logstreamDebugFile, app.buildID)
 	if err != nil {
 		return errors.Wrap(err, "logbus setup")
 	}

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -112,6 +112,7 @@ type cliFlags struct {
 	secretStdin               bool
 	cloudHTTPAddr             string
 	cloudGRPCAddr             string
+	cloudGRPCInsecure         bool
 	satelliteAddress          string
 	writePermission           bool
 	registrationPublicKey     string
@@ -282,7 +283,9 @@ func main() {
 		ctxTimeout, cancel := context.WithTimeout(context.Background(), time.Second)
 		defer cancel()
 		displayErrors := app.verbose
-		cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+		cloudClient, err := cloud.NewClient(
+			app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure,
+			app.sshAuthSock, app.authToken, app.console.Warnf)
 		if err != nil && displayErrors {
 			app.console.Warnf("unable to start cloud client: %s", err)
 		} else if err == nil {

--- a/cmd/earthly/org_cmds.go
+++ b/cmd/earthly/org_cmds.go
@@ -142,9 +142,9 @@ func (app *earthlyApp) actionOrgCreate(cliCtx *cli.Context) error {
 		return errors.New("invalid number of arguments provided")
 	}
 	org := cliCtx.Args().Get(0)
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := app.newCloudClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to create cloud client")
+		return err
 	}
 	err = cloudClient.CreateOrg(cliCtx.Context, org)
 	if err != nil {
@@ -155,9 +155,9 @@ func (app *earthlyApp) actionOrgCreate(cliCtx *cli.Context) error {
 
 func (app *earthlyApp) actionOrgList(cliCtx *cli.Context) error {
 	app.commandName = "orgList"
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := app.newCloudClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to create cloud client")
+		return err
 	}
 	orgs, err := cloudClient.ListOrgs(cliCtx.Context)
 	if err != nil {
@@ -188,9 +188,9 @@ func (app *earthlyApp) actionOrgListPermissions(cliCtx *cli.Context) error {
 	if !strings.HasSuffix(path, "/") {
 		path += "/"
 	}
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := app.newCloudClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to create cloud client")
+		return err
 	}
 	orgs, err := cloudClient.ListOrgPermissions(cliCtx.Context, path)
 	if err != nil {
@@ -223,9 +223,9 @@ func (app *earthlyApp) actionOrgInviteAccept(cliCtx *cli.Context) error {
 		return errors.New("invite code is required")
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := app.newCloudClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to create cloud client")
+		return err
 	}
 
 	err = cloudClient.AcceptInvite(cliCtx.Context, code)
@@ -241,9 +241,9 @@ func (app *earthlyApp) actionOrgInviteAccept(cliCtx *cli.Context) error {
 func (app *earthlyApp) actionOrgInviteList(cliCtx *cli.Context) error {
 	app.commandName = "orgInviteList"
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := app.newCloudClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to create cloud client")
+		return err
 	}
 
 	orgName, err := app.projectOrgName(cliCtx.Context, cloudClient)
@@ -281,9 +281,9 @@ func (app *earthlyApp) actionOrgInviteEmail(cliCtx *cli.Context) error {
 	}
 	emails := cliCtx.Args().Slice()
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := app.newCloudClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to create cloud client")
+		return err
 	}
 
 	orgName, err := app.projectOrgName(cliCtx.Context, cloudClient)
@@ -347,9 +347,9 @@ func (app *earthlyApp) actionOrgRevoke(cliCtx *cli.Context) error {
 		return errors.New("revoked paths must end with a slash (/)")
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := app.newCloudClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to create cloud client")
+		return err
 	}
 	userEmail := cliCtx.Args().Get(1)
 	err = cloudClient.RevokePermission(cliCtx.Context, path, userEmail)
@@ -366,9 +366,9 @@ func (app *earthlyApp) actionOrgMemberList(cliCtx *cli.Context) error {
 		return errors.New("expected no arguments")
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := app.newCloudClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to create cloud client")
+		return err
 	}
 
 	orgName, err := app.projectOrgName(cliCtx.Context, cloudClient)
@@ -406,9 +406,9 @@ func (app *earthlyApp) actionOrgMemberUpdate(cliCtx *cli.Context) error {
 		return errors.New("too many arguments provided")
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := app.newCloudClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to create cloud client")
+		return err
 	}
 
 	orgName, err := app.projectOrgName(cliCtx.Context, cloudClient)
@@ -442,9 +442,9 @@ func (app *earthlyApp) actionOrgMemberRemove(cliCtx *cli.Context) error {
 		return errors.New("member email required")
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := app.newCloudClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to create cloud client")
+		return err
 	}
 
 	orgName, err := app.projectOrgName(cliCtx.Context, cloudClient)

--- a/cmd/earthly/org_cmds.go
+++ b/cmd/earthly/org_cmds.go
@@ -142,7 +142,7 @@ func (app *earthlyApp) actionOrgCreate(cliCtx *cli.Context) error {
 		return errors.New("invalid number of arguments provided")
 	}
 	org := cliCtx.Args().Get(0)
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -155,7 +155,7 @@ func (app *earthlyApp) actionOrgCreate(cliCtx *cli.Context) error {
 
 func (app *earthlyApp) actionOrgList(cliCtx *cli.Context) error {
 	app.commandName = "orgList"
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -188,7 +188,7 @@ func (app *earthlyApp) actionOrgListPermissions(cliCtx *cli.Context) error {
 	if !strings.HasSuffix(path, "/") {
 		path += "/"
 	}
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -223,7 +223,7 @@ func (app *earthlyApp) actionOrgInviteAccept(cliCtx *cli.Context) error {
 		return errors.New("invite code is required")
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -241,7 +241,7 @@ func (app *earthlyApp) actionOrgInviteAccept(cliCtx *cli.Context) error {
 func (app *earthlyApp) actionOrgInviteList(cliCtx *cli.Context) error {
 	app.commandName = "orgInviteList"
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -281,7 +281,7 @@ func (app *earthlyApp) actionOrgInviteEmail(cliCtx *cli.Context) error {
 	}
 	emails := cliCtx.Args().Slice()
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -347,7 +347,7 @@ func (app *earthlyApp) actionOrgRevoke(cliCtx *cli.Context) error {
 		return errors.New("revoked paths must end with a slash (/)")
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -366,7 +366,7 @@ func (app *earthlyApp) actionOrgMemberList(cliCtx *cli.Context) error {
 		return errors.New("expected no arguments")
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -406,7 +406,7 @@ func (app *earthlyApp) actionOrgMemberUpdate(cliCtx *cli.Context) error {
 		return errors.New("too many arguments provided")
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -442,7 +442,7 @@ func (app *earthlyApp) actionOrgMemberRemove(cliCtx *cli.Context) error {
 		return errors.New("member email required")
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}

--- a/cmd/earthly/project_cmds.go
+++ b/cmd/earthly/project_cmds.go
@@ -80,7 +80,7 @@ func (app *earthlyApp) projectCmds() []*cli.Command {
 func (app *earthlyApp) actionProjectList(cliCtx *cli.Context) error {
 	app.commandName = "projectList"
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -109,7 +109,7 @@ func (app *earthlyApp) actionProjectRemove(cliCtx *cli.Context) error {
 		return errors.New("project name is required")
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -146,7 +146,7 @@ func (app *earthlyApp) actionProjectCreate(cliCtx *cli.Context) error {
 		return errors.New("project name is required")
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -169,7 +169,7 @@ func (app *earthlyApp) actionProjectCreate(cliCtx *cli.Context) error {
 func (app *earthlyApp) actionProjectMemberList(cliCtx *cli.Context) error {
 	app.commandName = "projectMemberList"
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -210,7 +210,7 @@ func (app *earthlyApp) actionProjectMemberRemove(cliCtx *cli.Context) error {
 		return errors.New("user email are required")
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -246,7 +246,7 @@ func (app *earthlyApp) actionProjectMemberAdd(cliCtx *cli.Context) error {
 		return errors.New("user email and permission arguments are required")
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -287,7 +287,7 @@ func (app *earthlyApp) actionProjectMemberUpdate(cliCtx *cli.Context) error {
 		return errors.New("user email and permission arguments are required")
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}

--- a/cmd/earthly/project_cmds.go
+++ b/cmd/earthly/project_cmds.go
@@ -80,9 +80,9 @@ func (app *earthlyApp) projectCmds() []*cli.Command {
 func (app *earthlyApp) actionProjectList(cliCtx *cli.Context) error {
 	app.commandName = "projectList"
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := app.newCloudClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to create cloud client")
+		return err
 	}
 
 	orgName, err := app.projectOrgName(cliCtx.Context, cloudClient)
@@ -109,9 +109,9 @@ func (app *earthlyApp) actionProjectRemove(cliCtx *cli.Context) error {
 		return errors.New("project name is required")
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := app.newCloudClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to create cloud client")
+		return err
 	}
 
 	orgName, err := app.projectOrgName(cliCtx.Context, cloudClient)
@@ -146,9 +146,9 @@ func (app *earthlyApp) actionProjectCreate(cliCtx *cli.Context) error {
 		return errors.New("project name is required")
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := app.newCloudClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to create cloud client")
+		return err
 	}
 
 	orgName, err := app.projectOrgName(cliCtx.Context, cloudClient)
@@ -169,9 +169,9 @@ func (app *earthlyApp) actionProjectCreate(cliCtx *cli.Context) error {
 func (app *earthlyApp) actionProjectMemberList(cliCtx *cli.Context) error {
 	app.commandName = "projectMemberList"
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := app.newCloudClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to create cloud client")
+		return err
 	}
 
 	if app.projectName == "" {
@@ -210,9 +210,9 @@ func (app *earthlyApp) actionProjectMemberRemove(cliCtx *cli.Context) error {
 		return errors.New("user email are required")
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := app.newCloudClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to create cloud client")
+		return err
 	}
 
 	orgName, err := app.projectOrgName(cliCtx.Context, cloudClient)
@@ -246,9 +246,9 @@ func (app *earthlyApp) actionProjectMemberAdd(cliCtx *cli.Context) error {
 		return errors.New("user email and permission arguments are required")
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := app.newCloudClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to create cloud client")
+		return err
 	}
 
 	orgName, err := app.projectOrgName(cliCtx.Context, cloudClient)
@@ -287,9 +287,9 @@ func (app *earthlyApp) actionProjectMemberUpdate(cliCtx *cli.Context) error {
 		return errors.New("user email and permission arguments are required")
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := app.newCloudClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to create cloud client")
+		return err
 	}
 
 	orgName, err := app.projectOrgName(cliCtx.Context, cloudClient)

--- a/cmd/earthly/root_cmds.go
+++ b/cmd/earthly/root_cmds.go
@@ -668,7 +668,7 @@ func (app *earthlyApp) actionPrune(cliCtx *cli.Context) error {
 	}
 
 	// Prune via API.
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}

--- a/cmd/earthly/satellite_cmds.go
+++ b/cmd/earthly/satellite_cmds.go
@@ -181,9 +181,9 @@ func (app *earthlyApp) actionSatelliteLaunch(cliCtx *cli.Context) error {
 
 	app.satelliteName = cliCtx.Args().Get(0)
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := app.newCloudClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to create cloud client")
+		return err
 	}
 
 	orgID, err := app.getSatelliteOrgID(cliCtx.Context, cloudClient)
@@ -218,9 +218,9 @@ func (app *earthlyApp) actionSatelliteList(cliCtx *cli.Context) error {
 		return errors.New("command does not accept any arguments")
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := app.newCloudClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to create cloud client")
+		return err
 	}
 
 	orgID, err := app.getSatelliteOrgID(cliCtx.Context, cloudClient)
@@ -249,9 +249,9 @@ func (app *earthlyApp) actionSatelliteRemove(cliCtx *cli.Context) error {
 
 	app.satelliteName = cliCtx.Args().Get(0)
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := app.newCloudClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to create cloud client")
+		return err
 	}
 
 	orgID, err := app.getSatelliteOrgID(cliCtx.Context, cloudClient)
@@ -293,9 +293,9 @@ func (app *earthlyApp) actionSatelliteInspect(cliCtx *cli.Context) error {
 	satelliteToInspect := cliCtx.Args().Get(0)
 	selectedSatellite := app.cfg.Satellite.Name
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := app.newCloudClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to create cloud client")
+		return err
 	}
 
 	orgID, err := app.getSatelliteOrgID(cliCtx.Context, cloudClient)
@@ -333,7 +333,7 @@ func (app *earthlyApp) actionSatelliteInspect(cliCtx *cli.Context) error {
 	app.console.Printf("")
 
 	if satellite.Status == cloud.SatelliteStatusOperational {
-		err = buildkitd.PrintSatelliteInfo(cliCtx.Context, app.console, Version, app.buildkitdSettings)
+		err = buildkitd.PrintSatelliteInfo(cliCtx.Context, app.console, Version, app.buildkitdSettings, app.installationName)
 		if err != nil {
 			return errors.Wrap(err, "failed checking buildkit info")
 		}
@@ -366,9 +366,9 @@ func (app *earthlyApp) actionSatelliteSelect(cliCtx *cli.Context) error {
 
 	app.satelliteName = cliCtx.Args().Get(0)
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := app.newCloudClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to create cloud client")
+		return err
 	}
 
 	orgID, err := app.getSatelliteOrgID(cliCtx.Context, cloudClient)
@@ -430,9 +430,9 @@ func (app *earthlyApp) actionSatelliteWake(cliCtx *cli.Context) error {
 
 	app.satelliteName = cliCtx.Args().Get(0)
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := app.newCloudClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to create cloud client")
+		return err
 	}
 
 	orgID, err := app.getSatelliteOrgID(cliCtx.Context, cloudClient)
@@ -470,9 +470,9 @@ func (app *earthlyApp) actionSatelliteSleep(cliCtx *cli.Context) error {
 
 	app.satelliteName = cliCtx.Args().Get(0)
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := app.newCloudClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to create cloud client")
+		return err
 	}
 
 	orgID, err := app.getSatelliteOrgID(cliCtx.Context, cloudClient)

--- a/cmd/earthly/satellite_cmds.go
+++ b/cmd/earthly/satellite_cmds.go
@@ -181,7 +181,7 @@ func (app *earthlyApp) actionSatelliteLaunch(cliCtx *cli.Context) error {
 
 	app.satelliteName = cliCtx.Args().Get(0)
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -218,7 +218,7 @@ func (app *earthlyApp) actionSatelliteList(cliCtx *cli.Context) error {
 		return errors.New("command does not accept any arguments")
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -249,7 +249,7 @@ func (app *earthlyApp) actionSatelliteRemove(cliCtx *cli.Context) error {
 
 	app.satelliteName = cliCtx.Args().Get(0)
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -293,7 +293,7 @@ func (app *earthlyApp) actionSatelliteInspect(cliCtx *cli.Context) error {
 	satelliteToInspect := cliCtx.Args().Get(0)
 	selectedSatellite := app.cfg.Satellite.Name
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -366,7 +366,7 @@ func (app *earthlyApp) actionSatelliteSelect(cliCtx *cli.Context) error {
 
 	app.satelliteName = cliCtx.Args().Get(0)
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -430,7 +430,7 @@ func (app *earthlyApp) actionSatelliteWake(cliCtx *cli.Context) error {
 
 	app.satelliteName = cliCtx.Args().Get(0)
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -470,7 +470,7 @@ func (app *earthlyApp) actionSatelliteSleep(cliCtx *cli.Context) error {
 
 	app.satelliteName = cliCtx.Args().Get(0)
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}

--- a/cmd/earthly/secret_cmds.go
+++ b/cmd/earthly/secret_cmds.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"
-
-	"github.com/earthly/earthly/cloud"
 )
 
 func (app *earthlyApp) secretCmds() []*cli.Command {
@@ -170,9 +168,9 @@ func (app *earthlyApp) actionSecretsList(cliCtx *cli.Context) error {
 	if !strings.HasSuffix(path, "/") {
 		path += "/"
 	}
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := app.newCloudClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to create cloud client")
+		return err
 	}
 	paths, err := cloudClient.List(cliCtx.Context, path)
 	if err != nil {
@@ -190,9 +188,9 @@ func (app *earthlyApp) actionSecretsGet(cliCtx *cli.Context) error {
 		return errors.New("invalid number of arguments provided")
 	}
 	path := cliCtx.Args().Get(0)
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := app.newCloudClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to create cloud client")
+		return err
 	}
 	data, err := cloudClient.Get(cliCtx.Context, path)
 	if err != nil {
@@ -211,9 +209,9 @@ func (app *earthlyApp) actionSecretsRemove(cliCtx *cli.Context) error {
 		return errors.New("invalid number of arguments provided")
 	}
 	path := cliCtx.Args().Get(0)
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := app.newCloudClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to create cloud client")
+		return err
 	}
 	err = cloudClient.Remove(cliCtx.Context, path)
 	if err != nil {
@@ -257,9 +255,9 @@ func (app *earthlyApp) actionSecretsSet(cliCtx *cli.Context) error {
 		value = string(data)
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := app.newCloudClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to create cloud client")
+		return err
 	}
 	err = cloudClient.Set(cliCtx.Context, path, []byte(value))
 	if err != nil {
@@ -289,9 +287,9 @@ func (app *earthlyApp) actionSecretsListV2(cliCtx *cli.Context) error {
 
 	path = app.fullSecretPath(path)
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := app.newCloudClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to create cloud client")
+		return err
 	}
 
 	secrets, err := cloudClient.ListSecrets(cliCtx.Context, path)
@@ -325,9 +323,9 @@ func (app *earthlyApp) actionSecretsGetV2(cliCtx *cli.Context) error {
 
 	path := cliCtx.Args().Get(0)
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := app.newCloudClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to create cloud client")
+		return err
 	}
 
 	path = app.fullSecretPath(path)
@@ -358,9 +356,9 @@ func (app *earthlyApp) actionSecretsRemoveV2(cliCtx *cli.Context) error {
 
 	path := cliCtx.Args().Get(0)
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := app.newCloudClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to create cloud client")
+		return err
 	}
 
 	path = app.fullSecretPath(path)
@@ -410,9 +408,9 @@ func (app *earthlyApp) actionSecretsSetV2(cliCtx *cli.Context) error {
 		value = string(data)
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := app.newCloudClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to create cloud client")
+		return err
 	}
 
 	path = app.fullSecretPath(path)
@@ -454,9 +452,9 @@ func (app *earthlyApp) actionSecretPermsList(cliCtx *cli.Context) error {
 		return errors.New("user secrets don't support permissions")
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := app.newCloudClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to create cloud client")
+		return err
 	}
 
 	perms, err := cloudClient.ListSecretPermissions(cliCtx.Context, path)
@@ -498,9 +496,9 @@ func (app *earthlyApp) actionSecretPermsRemove(cliCtx *cli.Context) error {
 		return errors.New("user email is required")
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := app.newCloudClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to create cloud client")
+		return err
 	}
 
 	err = cloudClient.RemoveSecretPermission(cliCtx.Context, path, userEmail)
@@ -537,9 +535,9 @@ func (app *earthlyApp) actionSecretPermsSet(cliCtx *cli.Context) error {
 		return errors.New("permission is required")
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := app.newCloudClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to create cloud client")
+		return err
 	}
 
 	err = cloudClient.SetSecretPermission(cliCtx.Context, path, userEmail, perm)
@@ -574,9 +572,9 @@ func (app *earthlyApp) actionSecretsMigrate(cliCtx *cli.Context) error {
 		return errors.New("destination project is required")
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := app.newCloudClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to create cloud client")
+		return err
 	}
 
 	_, err = cloudClient.GetProject(cliCtx.Context, destOrg, destProject)

--- a/cmd/earthly/secret_cmds.go
+++ b/cmd/earthly/secret_cmds.go
@@ -170,7 +170,7 @@ func (app *earthlyApp) actionSecretsList(cliCtx *cli.Context) error {
 	if !strings.HasSuffix(path, "/") {
 		path += "/"
 	}
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -190,7 +190,7 @@ func (app *earthlyApp) actionSecretsGet(cliCtx *cli.Context) error {
 		return errors.New("invalid number of arguments provided")
 	}
 	path := cliCtx.Args().Get(0)
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -211,7 +211,7 @@ func (app *earthlyApp) actionSecretsRemove(cliCtx *cli.Context) error {
 		return errors.New("invalid number of arguments provided")
 	}
 	path := cliCtx.Args().Get(0)
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -257,7 +257,7 @@ func (app *earthlyApp) actionSecretsSet(cliCtx *cli.Context) error {
 		value = string(data)
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -289,7 +289,7 @@ func (app *earthlyApp) actionSecretsListV2(cliCtx *cli.Context) error {
 
 	path = app.fullSecretPath(path)
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -325,7 +325,7 @@ func (app *earthlyApp) actionSecretsGetV2(cliCtx *cli.Context) error {
 
 	path := cliCtx.Args().Get(0)
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -358,7 +358,7 @@ func (app *earthlyApp) actionSecretsRemoveV2(cliCtx *cli.Context) error {
 
 	path := cliCtx.Args().Get(0)
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -410,7 +410,7 @@ func (app *earthlyApp) actionSecretsSetV2(cliCtx *cli.Context) error {
 		value = string(data)
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -454,7 +454,7 @@ func (app *earthlyApp) actionSecretPermsList(cliCtx *cli.Context) error {
 		return errors.New("user secrets don't support permissions")
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -498,7 +498,7 @@ func (app *earthlyApp) actionSecretPermsRemove(cliCtx *cli.Context) error {
 		return errors.New("user email is required")
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -537,7 +537,7 @@ func (app *earthlyApp) actionSecretPermsSet(cliCtx *cli.Context) error {
 		return errors.New("permission is required")
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}
@@ -574,7 +574,7 @@ func (app *earthlyApp) actionSecretsMigrate(cliCtx *cli.Context) error {
 		return errors.New("destination project is required")
 	}
 
-	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.sshAuthSock, app.authToken, app.console.Warnf)
+	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock, app.authToken, app.console.Warnf)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cloud client")
 	}

--- a/earthfile2llb/earthfile2llb.go
+++ b/earthfile2llb/earthfile2llb.go
@@ -103,6 +103,8 @@ type ConvertOpt struct {
 	LocalStateCache *LocalStateCache
 	// UseLocalRegistry indicates whether the BuildKit-embedded registry can be used for exports.
 	UseLocalRegistry bool
+	// LocalRegistryAddr is the address of the BuildKit-embedded registry.
+	LocalRegistryAddr string
 
 	// Features is the set of enabled features
 	Features *features.Features

--- a/earthfile2llb/withdockerrunlocalreg.go
+++ b/earthfile2llb/withdockerrunlocalreg.go
@@ -11,8 +11,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-const buildkitRegistry = "127.0.0.1:8371"
-
 type withDockerRunLocalReg struct {
 	c              *Converter
 	sem            semutil.Semaphore
@@ -82,7 +80,7 @@ func (w *withDockerRunLocalReg) Run(ctx context.Context, args []string, opt With
 	// Wait for all images to build (channel will be closed when finished).
 	for result := range res.ResultChan {
 		// Pull and then retag all images with expected tags.
-		pullImage := fmt.Sprintf("%s/%s", buildkitRegistry, result.IntermediateImageName)
+		pullImage := fmt.Sprintf("%s/%s", w.c.opt.LocalRegistryAddr, result.IntermediateImageName)
 		err := w.c.containerFrontend.ImagePull(ctx, pullImage)
 		if err != nil {
 			return err

--- a/logbus/logstreamer/logstreamer.go
+++ b/logbus/logstreamer/logstreamer.go
@@ -46,8 +46,6 @@ func New(ctx context.Context, bus *logbus.Bus, c cloud.Client, initialManifest *
 
 const maxBatchSize = 128
 
-// const maxBatchDuration = 200 * time.Millisecond
-
 func (ls *LogStreamer) retryLoop(ctx context.Context) {
 	defer close(ls.doneCh)
 	const maxRetry = 10
@@ -63,7 +61,7 @@ func (ls *LogStreamer) retryLoop(ctx context.Context) {
 			ls.errors = append(ls.errors, err)
 			return
 		}
-		fmt.Fprintf(os.Stderr, "transient error streaming logs: %v", err)
+		fmt.Fprintf(os.Stderr, "transient error streaming logs: %v\n", err)
 	}
 }
 

--- a/release/Earthfile
+++ b/release/Earthfile
@@ -88,6 +88,7 @@ release-github:
     COPY (../+earthly-all/* \
          --VERSION=$RELEASE_TAG \
          --DEFAULT_BUILDKITD_IMAGE="$DOCKERHUB_USER/buildkitd:$RELEASE_TAG" \
+         --DEFAULT_INSTALLATION_NAME="earthly" \
          ) ./release/
     RUN ls ./release
     RUN test -f ./release/earthly-linux-amd64 && \

--- a/scripts/tests/auth/setup.sh
+++ b/scripts/tests/auth/setup.sh
@@ -20,4 +20,4 @@ unset EARTHLY_TOKEN
 test -z "${SSH_AUTH_SOCK:-}"
 
 # make sure tests start without a config
-rm -f ~/.earthly/config.yml
+rm -f ~/.earthly-dev/config.yml

--- a/tests/bootstrap/test-bootstrap.sh
+++ b/tests/bootstrap/test-bootstrap.sh
@@ -113,7 +113,7 @@ if [[ $(stat --format '%G' "$HOME/.earthly-dev") != "$GRP" ]]; then
   exit 1
 fi
 
-echo "----
+echo "----"
 
 touch $HOME/.earthly-dev/config.yml
 sudo chown -R 12345:12345 $HOME/.earthly-dev

--- a/tests/bootstrap/test-bootstrap.sh
+++ b/tests/bootstrap/test-bootstrap.sh
@@ -93,7 +93,7 @@ echo "=== Test 5: Permissions ==="
 
 # @#
 ls -l "$HOME/.earthly-dev" || true
-ls -l "~/.earthly-dev" || true
+ls -l ~/.earthly-dev || true
 
 touch testfile
 USR=$(stat --format '%U' testfile)
@@ -120,20 +120,20 @@ fi
 echo "----"
 # @#
 ls -l "$HOME/.earthly-dev" || true
-ls -l "~/.earthly-dev" || true
+ls -l ~/.earthly-dev || true
 
 touch $HOME/.earthly-dev/config.yml
 sudo chown -R 12345:12345 $HOME/.earthly-dev
 
 # @#
 ls -l "$HOME/.earthly-dev" || true
-ls -l "~/.earthly-dev" || true
+ls -l ~/.earthly-dev || true
 
 sudo "$earthly" bootstrap
 
 # @#
 ls -l "$HOME/.earthly-dev" || true
-ls -l "~/.earthly-dev" || true
+ls -l ~/.earthly-dev || true
 
 if [[ $(stat --format '%U' "$HOME/.earthly-dev") != "$USR" ]]; then
   echo "earthly directory is not owned by the user"

--- a/tests/bootstrap/test-bootstrap.sh
+++ b/tests/bootstrap/test-bootstrap.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -ue
+set -uex
 set -o pipefail
 
 cd "$(dirname "$0")"
@@ -91,6 +91,10 @@ sudo rm -rf "/usr/share/bash-completion/completions/earthly"
 
 echo "=== Test 5: Permissions ==="
 
+# @#
+ls -l "$HOME/.earthly-dev" || true
+ls -l "~/.earthly-dev" || true
+
 touch testfile
 USR=$(stat --format '%U' testfile)
 GRP=$(stat --format '%G' testfile)
@@ -114,10 +118,22 @@ if [[ $(stat --format '%G' "$HOME/.earthly-dev") != "$GRP" ]]; then
 fi
 
 echo "----"
+# @#
+ls -l "$HOME/.earthly-dev" || true
+ls -l "~/.earthly-dev" || true
+
 touch $HOME/.earthly-dev/config.yml
 sudo chown -R 12345:12345 $HOME/.earthly-dev
 
+# @#
+ls -l "$HOME/.earthly-dev" || true
+ls -l "~/.earthly-dev" || true
+
 sudo "$earthly" bootstrap
+
+# @#
+ls -l "$HOME/.earthly-dev" || true
+ls -l "~/.earthly-dev" || true
 
 if [[ $(stat --format '%U' "$HOME/.earthly-dev") != "$USR" ]]; then
   echo "earthly directory is not owned by the user"

--- a/tests/bootstrap/test-bootstrap.sh
+++ b/tests/bootstrap/test-bootstrap.sh
@@ -29,7 +29,7 @@ if  cat hand_boot_output | grep -q "bootstrap |"; then
     exit 1
 fi
 
-rm -rf "$HOME/.earthly-dev/"
+rm -rf "$HOME/.earthly-dev"
 
 echo "=== Test 2: Implied Bootstrap ==="
 
@@ -48,7 +48,7 @@ if  cat imp_boot_output | grep -q "bootstrap |"; then
     exit 1
 fi
 
-rm -rf "$HOME/.earthly-dev/"
+rm -rf "$HOME/.earthly-dev"
 
 echo "=== Test 3: CI ==="
 
@@ -67,7 +67,7 @@ if  cat ci_boot_output | grep -q "bootstrap |"; then
     exit 1
 fi
 
-rm -rf "$HOME/.earthly-dev/"
+rm -rf "$HOME/.earthly-dev"
 
 echo "=== Test 4: With Autocomplete ==="
 
@@ -86,14 +86,10 @@ if [[ ! -f "/usr/share/bash-completion/completions/earthly" ]]; then
   exit 1
 fi
 
-rm -rf "$HOME/.earthly-dev/"
+rm -rf "$HOME/.earthly-dev"
 sudo rm -rf "/usr/share/bash-completion/completions/earthly"
 
 echo "=== Test 5: Permissions ==="
-
-# @#
-ls -l "$HOME/.earthly-dev" || true
-ls -l ~/.earthly-dev || true
 
 touch testfile
 USR=$(stat --format '%U' testfile)
@@ -117,23 +113,12 @@ if [[ $(stat --format '%G' "$HOME/.earthly-dev") != "$GRP" ]]; then
   exit 1
 fi
 
-echo "----"
-# @#
-ls -l "$HOME/.earthly-dev" || true
-ls -l ~/.earthly-dev || true
+echo "----
 
 touch $HOME/.earthly-dev/config.yml
 sudo chown -R 12345:12345 $HOME/.earthly-dev
 
-# @#
-ls -l "$HOME/.earthly-dev" || true
-ls -l ~/.earthly-dev || true
-
 sudo "$earthly" bootstrap
-
-# @#
-ls -l "$HOME/.earthly-dev" || true
-ls -l ~/.earthly-dev || true
 
 if [[ $(stat --format '%U' "$HOME/.earthly-dev") != "$USR" ]]; then
   echo "earthly directory is not owned by the user"
@@ -211,7 +196,7 @@ if ! DOCKER_HOST="$frontend is missing" "$earthly" bootstrap --source zsh > /dev
   exit 1
 fi
 
-rm -rf "$HOME/.earthly-dev/"
+rm -rf "$HOME/.earthly-dev"
 
 echo "=== Test 8: No Buildkit ==="
 
@@ -226,4 +211,4 @@ if ! DOCKER_HOST="$frontend is missing" "$earthly" bootstrap --no-buildkit; then
   exit 1
 fi
 
-rm -rf "$HOME/.earthly-dev/"
+rm -rf "$HOME/.earthly-dev"

--- a/tests/bootstrap/test-bootstrap.sh
+++ b/tests/bootstrap/test-bootstrap.sh
@@ -16,8 +16,8 @@ echo "=== Test 1: Hand Bootstrapped ==="
 
 "$earthly" bootstrap
 
-if [[ ! -d "$HOME/.earthly" ]]; then
-  echo ".earthly directory was missing after bootstrap"
+if [[ ! -d "$HOME/.earthly-dev" ]]; then
+  echo ".earthly-dev directory was missing after bootstrap"
   exit 1
 fi
 
@@ -29,14 +29,14 @@ if  cat hand_boot_output | grep -q "bootstrap |"; then
     exit 1
 fi
 
-rm -rf "$HOME/.earthly/"
+rm -rf "$HOME/.earthly-dev/"
 
 echo "=== Test 2: Implied Bootstrap ==="
 
 "$earthly" +test
 
-if [[ ! -d "$HOME/.earthly" ]]; then
-  echo ".earthly directory was missing after bootstrap"
+if [[ ! -d "$HOME/.earthly-dev" ]]; then
+  echo ".earthly-dev directory was missing after bootstrap"
   exit 1
 fi
 
@@ -48,14 +48,14 @@ if  cat imp_boot_output | grep -q "bootstrap |"; then
     exit 1
 fi
 
-rm -rf "$HOME/.earthly/"
+rm -rf "$HOME/.earthly-dev/"
 
 echo "=== Test 3: CI ==="
 
 "$earthly" --ci +test
 
-if [[ ! -d "$HOME/.earthly" ]]; then
-  echo ".earthly directory was missing after bootstrap"
+if [[ ! -d "$HOME/.earthly-dev" ]]; then
+  echo ".earthly-dev directory was missing after bootstrap"
   exit 1
 fi
 
@@ -67,7 +67,7 @@ if  cat ci_boot_output | grep -q "bootstrap |"; then
     exit 1
 fi
 
-rm -rf "$HOME/.earthly/"
+rm -rf "$HOME/.earthly-dev/"
 
 echo "=== Test 4: With Autocomplete ==="
 
@@ -86,7 +86,7 @@ if [[ ! -f "/usr/share/bash-completion/completions/earthly" ]]; then
   exit 1
 fi
 
-rm -rf "$HOME/.earthly/"
+rm -rf "$HOME/.earthly-dev/"
 sudo rm -rf "/usr/share/bash-completion/completions/earthly"
 
 echo "=== Test 5: Permissions ==="
@@ -101,45 +101,45 @@ echo "Group: $GRP"
 
 "$earthly" bootstrap
 
-if [[ $(stat --format '%U' "$HOME/.earthly") != "$USR" ]]; then
+if [[ $(stat --format '%U' "$HOME/.earthly-dev") != "$USR" ]]; then
   echo "earthly directory is not owned by the user"
-  stat "$HOME/.earthly"
+  stat "$HOME/.earthly-dev"
   exit 1
 fi
 
-if [[ $(stat --format '%G' "$HOME/.earthly") != "$GRP" ]]; then
+if [[ $(stat --format '%G' "$HOME/.earthly-dev") != "$GRP" ]]; then
   echo "earthly directory is not owned by the users group"
-  stat "$HOME/.earthly"
+  stat "$HOME/.earthly-dev"
   exit 1
 fi
 
 echo "----"
-touch $HOME/.earthly/config.yml
-sudo chown -R 12345:12345 $HOME/.earthly
+touch $HOME/.earthly-dev/config.yml
+sudo chown -R 12345:12345 $HOME/.earthly-dev
 
 sudo "$earthly" bootstrap
 
-if [[ $(stat --format '%U' "$HOME/.earthly") != "$USR" ]]; then
+if [[ $(stat --format '%U' "$HOME/.earthly-dev") != "$USR" ]]; then
   echo "earthly directory is not owned by the user"
-  stat "$HOME/.earthly"
+  stat "$HOME/.earthly-dev"
   exit 1
 fi
 
-if [[ $(stat --format '%G' "$HOME/.earthly") != "$GRP" ]]; then
+if [[ $(stat --format '%G' "$HOME/.earthly-dev") != "$GRP" ]]; then
   echo "earthly directory is not owned by the users group"
-  stat "$HOME/.earthly"
+  stat "$HOME/.earthly-dev"
   exit 1
 fi
 
-if [[ $(stat --format '%U' "$HOME/.earthly/config.yml") != "$USR" ]]; then
+if [[ $(stat --format '%U' "$HOME/.earthly-dev/config.yml") != "$USR" ]]; then
   echo "earthly config is not owned by the user"
-  stat "$HOME/.earthly/config.yml"
+  stat "$HOME/.earthly-dev/config.yml"
   exit 1
 fi
 
-if [[ $(stat --format '%G' "$HOME/.earthly/config.yml") != "$GRP" ]]; then
+if [[ $(stat --format '%G' "$HOME/.earthly-dev/config.yml") != "$GRP" ]]; then
   echo "earthly config is not owned by the users group"
-  stat "$HOME/.earthly/config.yml"
+  stat "$HOME/.earthly-dev/config.yml"
   exit 1
 fi
 
@@ -195,7 +195,7 @@ if ! DOCKER_HOST="$frontend is missing" "$earthly" bootstrap --source zsh > /dev
   exit 1
 fi
 
-rm -rf "$HOME/.earthly/"
+rm -rf "$HOME/.earthly-dev/"
 
 echo "=== Test 8: No Buildkit ==="
 
@@ -210,4 +210,4 @@ if ! DOCKER_HOST="$frontend is missing" "$earthly" bootstrap --no-buildkit; then
   exit 1
 fi
 
-rm -rf "$HOME/.earthly/"
+rm -rf "$HOME/.earthly-dev/"

--- a/tests/remote-buildkit/remote-buildkit-test.sh
+++ b/tests/remote-buildkit/remote-buildkit-test.sh
@@ -5,7 +5,8 @@ set -o pipefail
 cd "$(dirname "$0")"
 earthly=${earthly-"../../build/linux/amd64/earthly"}
 
-touch ~/.earthly-dev/config.yml # In case it doesn't exist
+mkdir -p ~/.earthly-dev
+touch ~/.earthly-dev/config.yml
 cp ~/.earthly-dev/config.yml ~/.earthly-dev/config.yml.bkup
 
 function finish {

--- a/tests/remote-buildkit/remote-buildkit-test.sh
+++ b/tests/remote-buildkit/remote-buildkit-test.sh
@@ -5,20 +5,20 @@ set -o pipefail
 cd "$(dirname "$0")"
 earthly=${earthly-"../../build/linux/amd64/earthly"}
 
-cp ~/.earthly/config.yml ~/.earthly/config.yml.bkup
+cp ~/.earthly-dev/config.yml ~/.earthly-dev/config.yml.bkup
 
 function finish {
-  mv ~/.earthly/config.yml.bkup ~/.earthly/config.yml
+  mv ~/.earthly-dev/config.yml.bkup ~/.earthly-dev/config.yml
 }
 trap finish EXIT
 
 
 "$earthly" config global.tls_enabled true
 
-# FIXME bootstrap is failing with "open /home/runner/.earthly/certs/ca_cert.pem: permission denied", but generates them nonetheless.
+# FIXME bootstrap is failing with "open /home/runner/.earthly-dev/certs/ca_cert.pem: permission denied", but generates them nonetheless.
 "$earthly" --verbose --buildkit-host tcp://127.0.0.1:8372 bootstrap || (echo "ignoring bootstrap failure")
 
 # bootstrapping should generate six pem files
-test $(ls ~/.earthly/certs/*.pem | wc -l) = "6"
+test $(ls ~/.earthly-dev/certs/*.pem | wc -l) = "6"
 
 "$earthly" --verbose --buildkit-host tcp://127.0.0.1:8372 +target 2>&1 | perl -pe 'BEGIN {$status=1} END {exit $status} $status=0 if /running under remote-buildkit test/;'

--- a/tests/remote-buildkit/remote-buildkit-test.sh
+++ b/tests/remote-buildkit/remote-buildkit-test.sh
@@ -5,6 +5,7 @@ set -o pipefail
 cd "$(dirname "$0")"
 earthly=${earthly-"../../build/linux/amd64/earthly"}
 
+touch ~/.earthly-dev/config.yml # In case it doesn't exist
 cp ~/.earthly-dev/config.yml ~/.earthly-dev/config.yml.bkup
 
 function finish {

--- a/util/containerutil/frontend.go
+++ b/util/containerutil/frontend.go
@@ -42,11 +42,10 @@ type FrontendConfig struct {
 	BuildkitHostCLIValue  string
 	BuildkitHostFileValue string
 
-	DebuggerHostCLIValue  string
-	DebuggerHostFileValue string
-	DebuggerPortFileValue int
-
 	LocalRegistryHostFileValue string
+
+	InstallationName string
+	DefaultPort      int
 
 	Console conslogging.ConsoleLogger
 }

--- a/util/containerutil/settings_test.go
+++ b/util/containerutil/settings_test.go
@@ -2,7 +2,6 @@ package containerutil
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -15,13 +14,11 @@ var noopArgs = parsedCLIVals{}
 
 type results struct {
 	buildkit      string
-	debugger      string
 	localRegistry string
 }
 
 type parsedCLIVals struct {
 	buildkit string
-	debugger string
 }
 
 func TestBuildArgMatrix(t *testing.T) {
@@ -35,14 +32,11 @@ func TestBuildArgMatrix(t *testing.T) {
 			"No Config, no CLI",
 			config.GlobalConfig{
 				BuildkitHost:      "",
-				DebuggerHost:      "",
-				DebuggerPort:      config.DefaultDebuggerPort,
 				LocalRegistryHost: "",
 			},
 			noopArgs,
 			results{
-				buildkit:      DockerAddress,
-				debugger:      fmt.Sprintf("tcp://127.0.0.1:%v", config.DefaultDebuggerPort),
+				buildkit:      "docker-container://earthly-buildkitd",
 				localRegistry: "",
 			},
 		},
@@ -50,14 +44,11 @@ func TestBuildArgMatrix(t *testing.T) {
 			"Remote Local in config, no CLI",
 			config.GlobalConfig{
 				BuildkitHost:      "tcp://127.0.0.1:8372",
-				DebuggerHost:      "",
-				DebuggerPort:      config.DefaultDebuggerPort,
 				LocalRegistryHost: "",
 			},
 			noopArgs,
 			results{
 				buildkit:      "tcp://127.0.0.1:8372",
-				debugger:      fmt.Sprintf("tcp://127.0.0.1:%v", config.DefaultDebuggerPort),
 				localRegistry: "",
 			},
 		},
@@ -65,14 +56,11 @@ func TestBuildArgMatrix(t *testing.T) {
 			"Remote remote in config, no CLI",
 			config.GlobalConfig{
 				BuildkitHost:      "tcp://my-cool-host:8372",
-				DebuggerHost:      "",
-				DebuggerPort:      config.DefaultDebuggerPort,
 				LocalRegistryHost: "",
 			},
 			noopArgs,
 			results{
 				buildkit:      "tcp://my-cool-host:8372",
-				debugger:      fmt.Sprintf("tcp://my-cool-host:%v", config.DefaultDebuggerPort),
 				localRegistry: "",
 			},
 		},
@@ -80,62 +68,11 @@ func TestBuildArgMatrix(t *testing.T) {
 			"Nonstandard local in config, no CLI",
 			config.GlobalConfig{
 				BuildkitHost:      "docker-container://my-container",
-				DebuggerHost:      "",
-				DebuggerPort:      config.DefaultDebuggerPort,
 				LocalRegistryHost: "",
 			},
 			noopArgs,
 			results{
 				buildkit:      "docker-container://my-container",
-				debugger:      fmt.Sprintf("tcp://127.0.0.1:%v", config.DefaultDebuggerPort),
-				localRegistry: "",
-			},
-		},
-		{
-			"Debugger port specified",
-			config.GlobalConfig{
-				BuildkitHost:      "",
-				DebuggerHost:      "",
-				DebuggerPort:      5678,
-				LocalRegistryHost: "",
-			},
-			noopArgs,
-			results{
-				buildkit:      DockerAddress,
-				debugger:      "tcp://127.0.0.1:5678",
-				localRegistry: "",
-			},
-		},
-		{
-			"Debugger host and port specified",
-			config.GlobalConfig{
-				BuildkitHost:      "",
-				DebuggerHost:      "tcp://127.0.0.1:1234",
-				DebuggerPort:      5678,
-				LocalRegistryHost: "",
-			},
-			noopArgs,
-			results{
-				buildkit:      DockerAddress,
-				debugger:      "tcp://127.0.0.1:1234",
-				localRegistry: "",
-			},
-		},
-		{
-			"No Config, buildkit and debugger on CLI",
-			config.GlobalConfig{
-				BuildkitHost:      "tcp://not-this-bk:1234",
-				DebuggerHost:      "tcp://not-this-db:1234",
-				DebuggerPort:      config.DefaultDebuggerPort,
-				LocalRegistryHost: "",
-			},
-			parsedCLIVals{
-				buildkit: "tcp://ok-bk:42",
-				debugger: "tcp://ok-db:43",
-			},
-			results{
-				buildkit:      "tcp://ok-bk:42",
-				debugger:      "tcp://ok-db:43",
 				localRegistry: "",
 			},
 		},
@@ -143,14 +80,11 @@ func TestBuildArgMatrix(t *testing.T) {
 			"Remote Local in config, no CLI, validate registry host",
 			config.GlobalConfig{
 				BuildkitHost:      "tcp://127.0.0.1:8372",
-				DebuggerHost:      "",
-				DebuggerPort:      config.DefaultDebuggerPort,
 				LocalRegistryHost: "tcp://127.0.0.1:8371",
 			},
 			noopArgs,
 			results{
 				buildkit:      "tcp://127.0.0.1:8372",
-				debugger:      fmt.Sprintf("tcp://127.0.0.1:%v", config.DefaultDebuggerPort),
 				localRegistry: "tcp://127.0.0.1:8371",
 			},
 		},
@@ -158,14 +92,11 @@ func TestBuildArgMatrix(t *testing.T) {
 			"Remote remote in config, no CLI, skip validate registry host",
 			config.GlobalConfig{
 				BuildkitHost:      "tcp://my-cool-host:8372",
-				DebuggerHost:      "",
-				DebuggerPort:      config.DefaultDebuggerPort,
 				LocalRegistryHost: "this-is-not-a-url",
 			},
 			noopArgs,
 			results{
 				buildkit:      "tcp://my-cool-host:8372",
-				debugger:      fmt.Sprintf("tcp://my-cool-host:%v", config.DefaultDebuggerPort),
 				localRegistry: "",
 			},
 		},
@@ -173,14 +104,11 @@ func TestBuildArgMatrix(t *testing.T) {
 			"Local in config, no CLI, validate registry host",
 			config.GlobalConfig{
 				BuildkitHost:      "docker-container://my-cool-container",
-				DebuggerHost:      "",
-				DebuggerPort:      config.DefaultDebuggerPort,
 				LocalRegistryHost: "tcp://127.0.0.1:8371",
 			},
 			noopArgs,
 			results{
 				buildkit:      "docker-container://my-cool-container",
-				debugger:      fmt.Sprintf("tcp://127.0.0.1:%v", config.DefaultDebuggerPort),
 				localRegistry: "tcp://127.0.0.1:8371",
 			},
 		},
@@ -202,16 +130,12 @@ func TestBuildArgMatrix(t *testing.T) {
 		urls, err := stub.setupAndValidateAddresses(FrontendDockerShell, &FrontendConfig{
 			BuildkitHostCLIValue:       tt.args.buildkit,
 			BuildkitHostFileValue:      tt.config.BuildkitHost,
-			DebuggerHostCLIValue:       tt.args.debugger,
-			DebuggerHostFileValue:      tt.config.DebuggerHost,
-			DebuggerPortFileValue:      tt.config.DebuggerPort,
 			LocalRegistryHostFileValue: tt.config.LocalRegistryHost,
 			Console:                    logger,
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, tt.expected, results{
 			buildkit:      urls.BuildkitHost.String(),
-			debugger:      urls.DebuggerHost.String(),
 			localRegistry: urls.LocalRegistryHost.String(),
 		})
 	}
@@ -228,8 +152,6 @@ func TestBuildArgMatrixValidationFailures(t *testing.T) {
 			"Invalid buildkit URL",
 			config.GlobalConfig{
 				BuildkitHost:      "http\r://foo.com/",
-				DebuggerHost:      "",
-				DebuggerPort:      config.DefaultDebuggerPort,
 				LocalRegistryHost: "",
 			},
 			errURLParseFailure,
@@ -239,8 +161,6 @@ func TestBuildArgMatrixValidationFailures(t *testing.T) {
 			"Invalid debugger URL",
 			config.GlobalConfig{
 				BuildkitHost:      "",
-				DebuggerHost:      "http\r://foo.com/",
-				DebuggerPort:      config.DefaultDebuggerPort,
 				LocalRegistryHost: "",
 			},
 			errURLParseFailure,
@@ -250,8 +170,6 @@ func TestBuildArgMatrixValidationFailures(t *testing.T) {
 			"Invalid registry URL",
 			config.GlobalConfig{
 				BuildkitHost:      "",
-				DebuggerHost:      "",
-				DebuggerPort:      config.DefaultDebuggerPort,
 				LocalRegistryHost: "http\r://foo.com/",
 			},
 			errURLParseFailure,
@@ -261,8 +179,6 @@ func TestBuildArgMatrixValidationFailures(t *testing.T) {
 			"Buildkit/Local Registry host mismatch",
 			config.GlobalConfig{
 				BuildkitHost:      "tcp://127.0.0.1:8372",
-				DebuggerHost:      "",
-				DebuggerPort:      config.DefaultDebuggerPort,
 				LocalRegistryHost: "tcp://localhost:8371",
 			},
 			nil,
@@ -272,8 +188,6 @@ func TestBuildArgMatrixValidationFailures(t *testing.T) {
 			"Buildkit/Debugger host mismatch",
 			config.GlobalConfig{
 				BuildkitHost:      "tcp://bk:1234",
-				DebuggerHost:      "tcp://db:5678",
-				DebuggerPort:      config.DefaultDebuggerPort,
 				LocalRegistryHost: "",
 			},
 			nil,
@@ -283,8 +197,6 @@ func TestBuildArgMatrixValidationFailures(t *testing.T) {
 			"Buildkit/Debugger port clash",
 			config.GlobalConfig{
 				BuildkitHost:      "tcp://cool-host:1234",
-				DebuggerHost:      "tcp://cool-host:1234",
-				DebuggerPort:      config.DefaultDebuggerPort,
 				LocalRegistryHost: "",
 			},
 			errURLValidationFailure,
@@ -294,8 +206,6 @@ func TestBuildArgMatrixValidationFailures(t *testing.T) {
 			"Homebrew test",
 			config.GlobalConfig{
 				BuildkitHost:      "127.0.0.1",
-				DebuggerHost:      "",
-				DebuggerPort:      config.DefaultDebuggerPort,
 				LocalRegistryHost: "",
 			},
 			errURLValidationFailure,
@@ -318,8 +228,6 @@ func TestBuildArgMatrixValidationFailures(t *testing.T) {
 
 		_, err = stub.setupAndValidateAddresses(FrontendDockerShell, &FrontendConfig{
 			BuildkitHostFileValue:      tt.config.BuildkitHost,
-			DebuggerHostFileValue:      tt.config.DebuggerHost,
-			DebuggerPortFileValue:      tt.config.DebuggerPort,
 			LocalRegistryHostFileValue: tt.config.LocalRegistryHost,
 			Console:                    logger,
 		})
@@ -388,8 +296,6 @@ func TestBuildArgMatrixValidationNonIssues(t *testing.T) {
 			"Buildkit/Local Registry host mismatch, schemes differ",
 			config.GlobalConfig{
 				BuildkitHost:      "docker-container://127.0.0.1:8372",
-				DebuggerHost:      "",
-				DebuggerPort:      config.DefaultDebuggerPort,
 				LocalRegistryHost: "tcp://localhost:8371",
 			},
 			"Buildkit and Local Registry URLs are pointed at different hosts",
@@ -398,8 +304,6 @@ func TestBuildArgMatrixValidationNonIssues(t *testing.T) {
 			"Buildkit/Debugger host mismatch, schemes differ",
 			config.GlobalConfig{
 				BuildkitHost:      "docker-container://bk:1234",
-				DebuggerHost:      "tcp://db:5678",
-				DebuggerPort:      config.DefaultDebuggerPort,
 				LocalRegistryHost: "",
 			},
 			"Buildkit and Debugger URLs are pointed at different hosts",
@@ -421,8 +325,6 @@ func TestBuildArgMatrixValidationNonIssues(t *testing.T) {
 
 		_, err = stub.setupAndValidateAddresses(FrontendDockerShell, &FrontendConfig{
 			BuildkitHostFileValue:      tt.config.BuildkitHost,
-			DebuggerHostFileValue:      tt.config.DebuggerHost,
-			DebuggerPortFileValue:      tt.config.DebuggerPort,
 			LocalRegistryHostFileValue: tt.config.LocalRegistryHost,
 			Console:                    logger,
 		})

--- a/util/containerutil/settings_test.go
+++ b/util/containerutil/settings_test.go
@@ -36,7 +36,7 @@ func TestBuildArgMatrix(t *testing.T) {
 			},
 			noopArgs,
 			results{
-				buildkit:      "docker-container://earthly-buildkitd",
+				buildkit:      "docker-container://test-buildkitd",
 				localRegistry: "",
 			},
 		},
@@ -121,7 +121,9 @@ func TestBuildArgMatrix(t *testing.T) {
 		logger := conslogging.Current(conslogging.NoColor, conslogging.DefaultPadding, conslogging.Info)
 		logger = logger.WithWriter(&logs)
 
-		frontend, err := NewStubFrontend(ctx, &FrontendConfig{})
+		frontend, err := NewStubFrontend(ctx, &FrontendConfig{
+			InstallationName: "test-stub",
+		})
 		assert.NoError(t, err)
 
 		stub, ok := frontend.(*stubFrontend)
@@ -131,6 +133,8 @@ func TestBuildArgMatrix(t *testing.T) {
 			BuildkitHostCLIValue:       tt.args.buildkit,
 			BuildkitHostFileValue:      tt.config.BuildkitHost,
 			LocalRegistryHostFileValue: tt.config.LocalRegistryHost,
+			InstallationName:           "test",
+			DefaultPort:                8372,
 			Console:                    logger,
 		})
 		assert.NoError(t, err)
@@ -158,48 +162,12 @@ func TestBuildArgMatrixValidationFailures(t *testing.T) {
 			"",
 		},
 		{
-			"Invalid debugger URL",
-			config.GlobalConfig{
-				BuildkitHost:      "",
-				LocalRegistryHost: "",
-			},
-			errURLParseFailure,
-			"",
-		},
-		{
 			"Invalid registry URL",
 			config.GlobalConfig{
 				BuildkitHost:      "",
 				LocalRegistryHost: "http\r://foo.com/",
 			},
 			errURLParseFailure,
-			"",
-		},
-		{
-			"Buildkit/Local Registry host mismatch",
-			config.GlobalConfig{
-				BuildkitHost:      "tcp://127.0.0.1:8372",
-				LocalRegistryHost: "tcp://localhost:8371",
-			},
-			nil,
-			"Buildkit and local registry URLs are pointed at different hosts",
-		},
-		{
-			"Buildkit/Debugger host mismatch",
-			config.GlobalConfig{
-				BuildkitHost:      "tcp://bk:1234",
-				LocalRegistryHost: "",
-			},
-			nil,
-			"Buildkit and debugger URLs are pointed at different hosts",
-		},
-		{
-			"Buildkit/Debugger port clash",
-			config.GlobalConfig{
-				BuildkitHost:      "tcp://cool-host:1234",
-				LocalRegistryHost: "",
-			},
-			errURLValidationFailure,
 			"",
 		},
 		{
@@ -220,7 +188,9 @@ func TestBuildArgMatrixValidationFailures(t *testing.T) {
 		logger := conslogging.Current(conslogging.NoColor, conslogging.DefaultPadding, conslogging.Info)
 		logger = logger.WithWriter(&logs)
 
-		frontend, err := NewStubFrontend(ctx, &FrontendConfig{})
+		frontend, err := NewStubFrontend(ctx, &FrontendConfig{
+			InstallationName: "test-stub",
+		})
 		assert.NoError(t, err)
 
 		stub, ok := frontend.(*stubFrontend)
@@ -230,6 +200,8 @@ func TestBuildArgMatrixValidationFailures(t *testing.T) {
 			BuildkitHostFileValue:      tt.config.BuildkitHost,
 			LocalRegistryHostFileValue: tt.config.LocalRegistryHost,
 			Console:                    logger,
+			InstallationName:           "test",
+			DefaultPort:                8372,
 		})
 		assert.ErrorIs(t, err, tt.expected)
 		assert.Contains(t, logs.String(), tt.log)
@@ -317,7 +289,9 @@ func TestBuildArgMatrixValidationNonIssues(t *testing.T) {
 		logger := conslogging.Current(conslogging.NoColor, conslogging.DefaultPadding, conslogging.Info)
 		logger = logger.WithWriter(&logs)
 
-		frontend, err := NewStubFrontend(ctx, &FrontendConfig{})
+		frontend, err := NewStubFrontend(ctx, &FrontendConfig{
+			InstallationName: "test-stub",
+		})
 		assert.NoError(t, err)
 
 		stub, ok := frontend.(*stubFrontend)
@@ -327,6 +301,8 @@ func TestBuildArgMatrixValidationNonIssues(t *testing.T) {
 			BuildkitHostFileValue:      tt.config.BuildkitHost,
 			LocalRegistryHostFileValue: tt.config.LocalRegistryHost,
 			Console:                    logger,
+			InstallationName:           "test",
+			DefaultPort:                8372,
 		})
 		assert.NoError(t, err)
 		assert.NotContains(t, logs.String(), tt.log)

--- a/util/containerutil/shell_shared.go
+++ b/util/containerutil/shell_shared.go
@@ -17,8 +17,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	_ "github.com/moby/buildkit/client/connhelper/dockercontainer" // Load "docker-container://" helper.
 	"github.com/pkg/errors"
-
-	"github.com/earthly/earthly/config"
 )
 
 type shellFrontend struct {
@@ -360,7 +358,7 @@ func (sf *shellFrontend) setupAndValidateAddresses(feType string, cfg *FrontendC
 			calculatedBuildkitHost = cfg.BuildkitHostFileValue
 		} else {
 			var err error
-			calculatedBuildkitHost, err = DefaultAddressForSetting(feType)
+			calculatedBuildkitHost, err = DefaultAddressForSetting(feType, cfg.InstallationName, cfg.DefaultPort)
 			if err != nil {
 				return nil, errors.Wrap(err, "could not validate default address")
 			}
@@ -373,32 +371,14 @@ func (sf *shellFrontend) setupAndValidateAddresses(feType string, cfg *FrontendC
 		return nil, err
 	}
 
-	calculatedDebuggerHost := cfg.DebuggerHostCLIValue
-	if cfg.DebuggerHostCLIValue == "" {
-		if cfg.DebuggerHostFileValue != "" {
-			calculatedDebuggerHost = cfg.DebuggerHostFileValue
-		} else {
-			if cfg.DebuggerPortFileValue == config.DefaultDebuggerPort && bkURL.Scheme == "tcp" {
-				calculatedDebuggerHost = fmt.Sprintf("tcp://%s:%v", bkURL.Hostname(), config.DefaultDebuggerPort)
-			} else {
-				calculatedDebuggerHost = fmt.Sprintf("tcp://127.0.0.1:%v", cfg.DebuggerPortFileValue)
-			}
-		}
-	}
-
-	dbURL, err := parseAndValidateURL(calculatedDebuggerHost)
-	if err != nil {
-		return nil, err
-	}
-
 	lrURL := &url.URL{}
-	if IsLocal(calculatedDebuggerHost) && cfg.LocalRegistryHostFileValue != "" {
+	if IsLocal(calculatedBuildkitHost) && cfg.LocalRegistryHostFileValue != "" {
 		// Local registry only matters when local, and specified.
 		lrURL, err = parseAndValidateURL(cfg.LocalRegistryHostFileValue)
 		if err != nil {
 			return nil, err
 		}
-		if bkURL.Scheme == dbURL.Scheme && bkURL.Hostname() != lrURL.Hostname() {
+		if !IsLocal(cfg.LocalRegistryHostFileValue) && bkURL.Hostname() != lrURL.Hostname() {
 			cfg.Console.Warnf("Buildkit and local registry URLs are pointed at different hosts (%s vs. %s)", bkURL.Hostname(), lrURL.Hostname())
 		}
 	} else {
@@ -406,33 +386,23 @@ func (sf *shellFrontend) setupAndValidateAddresses(feType string, cfg *FrontendC
 			cfg.Console.VerbosePrintf("Local registry host is specified while using remote buildkit. Local registry will not be used.")
 		}
 	}
-
-	if bkURL.Scheme == dbURL.Scheme && bkURL.Hostname() != dbURL.Hostname() {
-		cfg.Console.Warnf("Buildkit and debugger URLs are pointed at different hosts (%s vs. %s)", bkURL.Hostname(), dbURL.Hostname())
-	}
-
-	if bkURL.Hostname() == dbURL.Hostname() && bkURL.Port() == dbURL.Port() {
-		return nil, fmt.Errorf("debugger and Buildkit ports are the same: %w", errURLValidationFailure)
-	}
-
 	return &FrontendURLs{
 		BuildkitHost:      bkURL,
-		DebuggerHost:      dbURL,
 		LocalRegistryHost: lrURL,
 	}, nil
 }
 
 // DefaultAddressForSetting returns an address (signifying the desired/default transport) for a given frontend specified by setting.
-func DefaultAddressForSetting(setting string) (string, error) {
+func DefaultAddressForSetting(setting string, installationName string, defaultPort int) (string, error) {
 	switch setting {
 	case FrontendDockerShell:
-		return DockerAddress, nil
+		return fmt.Sprintf(DockerAddressFmt, installationName), nil
 
 	case FrontendPodmanShell:
-		return TCPAddress, nil // Right now, podman only works over TCP. There are weird errors when trying to use the provided helper from buildkit.
+		return fmt.Sprintf(TCPAddressFmt, defaultPort), nil // Right now, podman only works over TCP. There are weird errors when trying to use the provided helper from buildkit.
 
 	case FrontendStub:
-		return DockerAddress, nil // Maintain old behavior
+		return fmt.Sprintf(DockerAddressFmt, installationName), nil // Maintain old behavior
 	}
 
 	return "", fmt.Errorf("no default buildkit address for %s", setting)

--- a/util/containerutil/types.go
+++ b/util/containerutil/types.go
@@ -185,15 +185,15 @@ const (
 )
 
 const (
-	// TCPAddress is the address at which the daemon is available when using TCP.
-	TCPAddress = "tcp://127.0.0.1:8372"
+	// TCPAddressFmt is the address at which the daemon is available when using TCP.
+	TCPAddressFmt = "tcp://127.0.0.1:%d"
 
-	// DockerAddress is the address at which the daemon is available when using a Docker Container directly
-	DockerAddress = "docker-container://earthly-buildkitd"
+	// DockerAddressFmt is the address at which the daemon is available when using a Docker Container directly
+	DockerAddressFmt = "docker-container://%s-buildkitd"
 
-	// PodmanAddress is the address at which the daemon is available when using a Podman Container directly.
+	// PodmanAddressFmt is the address at which the daemon is available when using a Podman Container directly.
 	// Currently unused due to image export issues
-	PodmanAddress = "podman-container://earthly-buildkitd"
+	PodmanAddressFmt = "podman-container://%s-buildkitd"
 
 	// SatelliteAddress is the remote address when using a Satellite to execute your builds remotely.
 	SatelliteAddress = "tcp://satellite.earthly.dev:8372"
@@ -211,6 +211,5 @@ type FrontendURLs struct {
 	//   without a more major refactor.
 
 	BuildkitHost      *url.URL
-	DebuggerHost      *url.URL
 	LocalRegistryHost *url.URL
 }


### PR DESCRIPTION
Changes:

* Biggest change: Allow Earthly to run as a different container+volume+.earthly dir name in development. This allows the released Earthly to be logged in as one user and the dev Earthly to be logged in as a different user. This works by changing the name `earthly` in all these places to `earthly-dev`, when not building an official release. So the container `earthly-buildkitd` becomes `earthly-dev-buildkitd`, the cache volume `earthly-cache` becomes `earthly-dev-cache`, and the dir `~/.earthly` becomes `~/.earthly-dev`. The ports also shift. The release ports are the same as before, whereas the ports used in dev are based on official ports + an offset calculated based on a hash of the installation name.
* Removed debugger port as it was no longer used
* Add a flag for enabling uploading logstream: `--logstream-upload`. When set, this replaces the old log uploading feature.
* Allow grpc insecure
* Remove unnecessary logstream batching