### PR TITLE
exit with error if frontend not detected

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -120,7 +120,7 @@ earthly-script-no-stdout:
     # This script performs an explicit "docker pull earthlybinaries:prerelease" which can cause rate-limiting
     # to work-around this, we will copy an earthly binary in, and disable auto-updating (and therefore don't require a WITH DOCKER)
     COPY +earthly/earthly /root/.earthly/earthly-prerelease
-    RUN EARTHLY_DISABLE_AUTO_UPDATE=true ./earthly --version > earthly-version-output
+    RUN EARTHLY_DISABLE_FRONTEND_DETECTION=true EARTHLY_DISABLE_AUTO_UPDATE=true ./earthly --version > earthly-version-output
 
     RUN test "$(cat earthly-version-output | wc -l)" = "1"
     RUN grep '^earthly version.*$' earthly-version-output # only --version info should go to stdout

--- a/earthly
+++ b/earthly
@@ -38,10 +38,14 @@ detect_frontend() {
     return
   fi
 
-  echo "none"
+  echo >&2 "failed to detect docker/podman frontend"
+  exit 1
 }
 
-frontend_bin=$(detect_frontend)
+# some tests run ./earthly when no front-end is present; when EARTHLY_DISABLE_FRONTEND_DETECTION=true, skip detection.
+if [ "$EARTHLY_DISABLE_FRONTEND_DETECTION" != "true" ]; then
+    frontend_bin=$(detect_frontend)
+fi
 
 get_latest_binary() {
     "$frontend_bin" rm --force earthly_binary 2>/dev/null >&2 || true


### PR DESCRIPTION
If the frontend detection fails, it returns `none`, then the `./earthly` script will attempt to run commands such as `none pull docker.io/earthly/earthlybinaries:prerelease`, which results in a `none command not found` which is difficult to debug.