### PR TITLE
Simplify the docker-compose interactive debugger test

### DIFF
--- a/.github/workflows/reusable-misc-tests.yml
+++ b/.github/workflows/reusable-misc-tests.yml
@@ -93,7 +93,7 @@ jobs:
         with:
           timeout_minutes: 10
           max_attempts: 2
-          command: ./scripts/tests/interactive-debugger/test-interactive.py --earthly ${{inputs.BUILT_EARTHLY_PATH}} --timeout 300
+          command: ./scripts/tests/interactive-debugger/test-interactive.py --earthly ${{inputs.BUILT_EARTHLY_PATH}} --timeout 180
       - name: Execute version test
         run: "${{inputs.BUILT_EARTHLY_PATH}} --version"
       - name: Execute docker2earth test

--- a/scripts/tests/interactive-debugger/docker-compose/Dockerfile
+++ b/scripts/tests/interactive-debugger/docker-compose/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.15
+RUN apk add --no-cache nmap-ncat
+
+# rot13 echo server
+CMD ncat -l $LISTEN_PORT -c 'xargs -n1 -I {} sh -c "echo {} | tr \"A-Za-z\" \"N-ZA-Mn-za-m\""'

--- a/scripts/tests/interactive-debugger/docker-compose/Earthfile
+++ b/scripts/tests/interactive-debugger/docker-compose/Earthfile
@@ -1,11 +1,10 @@
 VERSION 0.6
 FROM earthly/dind:alpine
-RUN apk add --update --no-cache \
-    jq
 
 fail-with-docker-compose:
     WORKDIR /test
     RUN echo ZTg4Y2MyYjgtYzE3OS00ZWQ3LThlYWUtMjA3YTBlZjc1NDZj > /data.txt
+    COPY Dockerfile ./
     COPY docker-compose.yml ./
     WITH DOCKER --compose=docker-compose.yml
         RUN false

--- a/scripts/tests/interactive-debugger/docker-compose/docker-compose.yml
+++ b/scripts/tests/interactive-debugger/docker-compose/docker-compose.yml
@@ -1,10 +1,9 @@
 version: "3"
 
 services:
-  postgres:
-    image: aa8y/postgres-dataset:iso3166
+  rot13:
+    build: .
     ports:
       - 127.0.0.1:5432:5432
     environment:
-      - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=postgres
+      - LISTEN_PORT=5432

--- a/scripts/tests/interactive-debugger/docker-compose/test-docker-compose.py
+++ b/scripts/tests/interactive-debugger/docker-compose/test-docker-compose.py
@@ -26,14 +26,12 @@ def test_interactive(earthly_path, timeout):
             # give the shell time to startup, otherwise stdin might be lost
             time.sleep(5)
 
-            # test we can select from the postgres database that is created via docker-compose
-            # this is wrapped in an infinite retry loop which pexpect will kill after the configured timeout
-            # the retry loop is required because the container reports an UP status before all data is loaded.
-            c.sendline('while ! docker exec test_postgres_1 psql -c "select name from country WHERE two_letter = \'AF\'" iso3166; do sleep 1; done')
+            # test we can obtain decoded text from the rot13 echo server that is created via docker-compose
+            c.sendline('docker exec test_rot13_1 sh -c \'(echo Nstunavfgna; sleep 1) | ncat localhost 5432\'')
             try:
                 c.expect('Afghanistan', timeout=timeout)
             except Exception as e:
-                raise RuntimeError('failed to find Afghanistan in output (indicating we were unable to run psql in the postgres container that was started via docker compose)')
+                raise RuntimeError('failed to find Afghanistan in output (indicating we were unable to obtain decoded text from the rot13 echo server that was started via docker compose)')
 
             # decode the data.txt file to ensure the debugger is still running
             c.sendline("cat /data.txt | base64 -d")


### PR DESCRIPTION
Closes #2263.

1. Replace `aa8y/postgres-dataset` with the rot13 echo server.
2. Reduce the interactive debugger test timeout to 180 seconds.