### PR TITLE
Remove frontend commands retries

### DIFF
--- a/util/containerutil/docker.go
+++ b/util/containerutil/docker.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-	"time"
 
 	"github.com/alessio/shellescape"
 	"github.com/dustin/go-humanize"
@@ -41,12 +40,12 @@ func NewDockerShellFrontend(ctx context.Context, cfg *FrontendConfig) (Container
 	// `--format` option.
 	// This is to prevent displaying panic() errors to our users (even though the panic() occurred in the
 	// docker cli binary and not earthly).
-	_, err := fe.commandContextOutputWithRetry(ctx, 10, 10*time.Second, "info")
+	_, err := fe.commandContextOutput(ctx, "info")
 	if err != nil {
 		return nil, err
 	}
 
-	output, err := fe.commandContextOutputWithRetry(ctx, 10, 10*time.Second, "info", "--format={{.SecurityOptions}}")
+	output, err := fe.commandContextOutput(ctx, "info", "--format={{.SecurityOptions}}")
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +78,7 @@ func (dsf *dockerShellFrontend) Config() *CurrentFrontend {
 }
 
 func (dsf *dockerShellFrontend) Information(ctx context.Context) (*FrontendInfo, error) {
-	output, err := dsf.commandContextOutputWithRetry(ctx, 10, 10*time.Second, "version", "--format={{json .}}")
+	output, err := dsf.commandContextOutput(ctx, "version", "--format={{json .}}")
 	if err != nil {
 		return nil, err
 	}

--- a/util/containerutil/podman.go
+++ b/util/containerutil/podman.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/dustin/go-humanize"
 	"github.com/hashicorp/go-multierror"
@@ -34,7 +33,7 @@ func NewPodmanShellFrontend(ctx context.Context, cfg *FrontendConfig) (Container
 	// TODO: Find a cleaner way to pass down information to the shellFrontend
 	fe.FrontendInformation = fe.Information
 
-	output, err := fe.commandContextOutputWithRetry(ctx, 10, 10*time.Second, "info", "--format={{.Host.Security.Rootless}}")
+	output, err := fe.commandContextOutput(ctx, "info", "--format={{.Host.Security.Rootless}}")
 	if err != nil {
 		return nil, err
 	}
@@ -80,7 +79,7 @@ func (psf *podmanShellFrontend) Config() *CurrentFrontend {
 }
 
 func (psf *podmanShellFrontend) Information(ctx context.Context) (*FrontendInfo, error) {
-	output, err := psf.commandContextOutputWithRetry(ctx, 10, 10*time.Second, "info", "--format={{.Host.RemoteSocket.Exists}}")
+	output, err := psf.commandContextOutput(ctx, "info", "--format={{.Host.RemoteSocket.Exists}}")
 	if err != nil {
 		return nil, err
 	}
@@ -119,7 +118,7 @@ func (psf *podmanShellFrontend) Information(ctx context.Context) (*FrontendInfo,
 
 	host := "daemonless"
 	if hasRemote {
-		output, err = psf.commandContextOutputWithRetry(ctx, 10, 10*time.Second, "info", "--format={{.Host.RemoteSocket.Path}}")
+		output, err = psf.commandContextOutput(ctx, "info", "--format={{.Host.RemoteSocket.Path}}")
 		if err != nil {
 			return nil, err
 		}

--- a/util/containerutil/shell_shared.go
+++ b/util/containerutil/shell_shared.go
@@ -10,7 +10,6 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/containerd/containerd/platforms"
 	"github.com/earthly/earthly/conslogging"
@@ -287,26 +286,6 @@ func (cco *commandContextOutput) string() string {
 func (sf *shellFrontend) commandContextStrings(args ...string) (string, []string) {
 	allArgs := append(sf.globalCompatibilityArgs, args...)
 	return sf.binaryName, allArgs
-}
-
-func (sf *shellFrontend) commandContextOutputWithRetry(ctx context.Context, retries int, timeout time.Duration, args ...string) (*commandContextOutput, error) {
-	var err error
-	for i := 0; i < retries; i++ {
-		timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
-		defer cancel()
-		output, cmdErr := sf.commandContextOutput(timeoutCtx, args...)
-		if cmdErr == nil {
-			return output, nil
-		}
-		err = multierror.Append(err, cmdErr)
-		if i < retries-1 {
-			binary, args2 := sf.commandContextStrings(args...)
-			sf.Console.Printf(
-				"Command '%s %s' failed with error %v. Retrying...\n",
-				binary, strings.Join(args2, " "), cmdErr)
-		}
-	}
-	return nil, err
 }
 
 func (sf *shellFrontend) commandContextOutput(ctx context.Context, args ...string) (*commandContextOutput, error) {


### PR DESCRIPTION
No longer necessary, and they add too much output when autodetecting frontend.