### PR TITLE
Changes in vscode-syntax-highlighting-v0.0.12

### DIFF
--- a/contrib/earthfile-syntax-highlighting-intellij/README.md
+++ b/contrib/earthfile-syntax-highlighting-intellij/README.md
@@ -1,0 +1,1 @@
+Hosted on [earthly-intellij-plugin repo](https://github.com/earthly/earthly-intellij-plugin).

--- a/contrib/earthfile-syntax-highlighting/Earthfile
+++ b/contrib/earthfile-syntax-highlighting/Earthfile
@@ -1,6 +1,6 @@
-FROM node:13.10.1-alpine3.11
-
-RUN npm install -g vsce
+VERSION 0.6
+FROM node:19.1.0-alpine3.15
+RUN npm install -g vsce ovsx semver
 WORKDIR /earthfile-syntax-highlighting
 
 package:
@@ -19,6 +19,10 @@ release:
     RUN test -n "$VSCODE_RELEASE_TAG"
     COPY --build-arg VSCODE_RELEASE_TAG="$VSCODE_RELEASE_TAG" +package/earthfile-syntax-highlighting-$VSCODE_RELEASE_TAG.vsix ./
     RUN --secret VSCE_TOKEN=+secrets/earthly-technologies/vsce/token test -n "$VSCE_TOKEN"
+    RUN --secret OVSX_TOKEN=+secrets/earthly-technologies/ovsx/token test -n "$OVSX_TOKEN"
     RUN --push \
         --secret VSCE_TOKEN=+secrets/earthly-technologies/vsce/token \
         vsce publish --pat "$VSCE_TOKEN" --packagePath ./earthfile-syntax-highlighting-$VSCODE_RELEASE_TAG.vsix
+    RUN --push \
+        --secret OVSX_TOKEN=+secrets/earthly-technologies/ovsx/token \ 
+        npx ovsx publish ./earthfile-syntax-highlighting-$VSCODE_RELEASE_TAG.vsix -p "$OVSX_TOKEN"

--- a/contrib/earthfile-syntax-highlighting/LICENSE
+++ b/contrib/earthfile-syntax-highlighting/LICENSE
@@ -1,0 +1,19 @@
+Copyright 2022 Earthly Technologies
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/contrib/earthfile-syntax-highlighting/README.md
+++ b/contrib/earthfile-syntax-highlighting/README.md
@@ -8,6 +8,11 @@ For an introduction of Earthly see the [Earthly GitHub repository](https://githu
 
 ## Release Notes
 
+### 0.0.12
+
+* Fix don't allow `-` in variable names.
+* Fix arg names containing `_`
+
 ### 0.0.11
 
 * Add highlighting for `FOR` and `VERSION`.

--- a/contrib/earthfile-syntax-highlighting/syntaxes/earthfile.tmLanguage.json
+++ b/contrib/earthfile-syntax-highlighting/syntaxes/earthfile.tmLanguage.json
@@ -222,7 +222,7 @@
 		"variable": {
 			"patterns": [
 				{
-					"match": "\\$[a-zA-Z0-9_\\-]+",
+					"match": "\\$[a-zA-Z0-9_]+",
 					"name": "variable.other.earthfile"
 				},
 				{

--- a/contrib/earthfile-syntax-highlighting/syntaxes/earthfile.tmLanguage.json
+++ b/contrib/earthfile-syntax-highlighting/syntaxes/earthfile.tmLanguage.json
@@ -88,7 +88,7 @@
 				},
 				{
 					"name": "keyword.operator.flag.earthfile",
-					"match": "(\\B(-)+[a-zA-Z0-9\\-]+)"
+					"match": "(\\B(-)+[a-zA-Z0-9\\-_]+)"
 				},
 				{
 					"include": "#special-method"


### PR DESCRIPTION
- Fixes https://github.com/earthly/earthly/issues/2399
- Fixes https://github.com/earthly/earthly/issues/2417
- Adds IntelliJ reference, for completeness
- Adds `publish-to-ovsx` step on release target