### PR TITLE
More fields on satellite ls and inspect

### DIFF
--- a/cloud/satellite.go
+++ b/cloud/satellite.go
@@ -33,11 +33,13 @@ const (
 
 // SatelliteInstance contains details about a remote Buildkit instance.
 type SatelliteInstance struct {
-	Name     string
-	Org      string
-	Status   string
-	Platform string
-	Size     string
+	Name         string
+	Org          string
+	Status       string
+	Platform     string
+	Size         string
+	Version      string
+	FeatureFlags []string
 }
 
 func (c *client) ListSatellites(ctx context.Context, orgID string) ([]SatelliteInstance, error) {
@@ -55,6 +57,7 @@ func (c *client) ListSatellites(ctx context.Context, orgID string) ([]SatelliteI
 			Platform: s.Platform,
 			Size:     s.Size,
 			Status:   satelliteStatus(s.Status),
+			Version:  s.Version,
 		}
 	}
 	return instances, nil
@@ -69,11 +72,13 @@ func (c *client) GetSatellite(ctx context.Context, name, orgID string) (*Satelli
 		return nil, errors.Wrap(err, "failed getting satellite")
 	}
 	return &SatelliteInstance{
-		Name:     name,
-		Org:      orgID,
-		Status:   satelliteStatus(resp.Status),
-		Platform: resp.Platform,
-		Size:     resp.Size,
+		Name:         name,
+		Org:          orgID,
+		Status:       satelliteStatus(resp.Status),
+		Platform:     resp.Platform,
+		Size:         resp.Size,
+		Version:      resp.Version,
+		FeatureFlags: resp.FeatureFlags,
 	}, nil
 }
 

--- a/cloud/satellite.go
+++ b/cloud/satellite.go
@@ -35,7 +35,7 @@ const (
 type SatelliteInstance struct {
 	Name         string
 	Org          string
-	Status       string
+	State        string
 	Platform     string
 	Size         string
 	Version      string
@@ -56,7 +56,7 @@ func (c *client) ListSatellites(ctx context.Context, orgID string) ([]SatelliteI
 			Org:      orgID,
 			Platform: s.Platform,
 			Size:     s.Size,
-			Status:   satelliteStatus(s.Status),
+			State:    satelliteStatus(s.Status),
 			Version:  s.Version,
 		}
 	}
@@ -74,7 +74,7 @@ func (c *client) GetSatellite(ctx context.Context, name, orgID string) (*Satelli
 	return &SatelliteInstance{
 		Name:         name,
 		Org:          orgID,
-		Status:       satelliteStatus(resp.Status),
+		State:        satelliteStatus(resp.Status),
 		Platform:     resp.Platform,
 		Size:         resp.Size,
 		Version:      resp.Version,

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -141,6 +141,7 @@ type cliFlags struct {
 	satelliteFeatureFlags     cli.StringSlice
 	satellitePlatform         string
 	satelliteSize             string
+	satellitePrintJSON        bool
 	userPermission            string
 	noBuildkitUpdate          bool
 	globalWaitEnd             bool // for feature-flipping builder.go code removal

--- a/cmd/earthly/satellite_cmds.go
+++ b/cmd/earthly/satellite_cmds.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"strings"
 	"text/tabwriter"
 	"time"
 
@@ -141,13 +142,14 @@ func (app *earthlyApp) useSatellite(cliCtx *cli.Context, satelliteName, orgName 
 
 func (app *earthlyApp) printSatellites(satellites []cloud.SatelliteInstance, orgID string) {
 	t := tabwriter.NewWriter(os.Stdout, 1, 2, 2, ' ', 0)
-	fmt.Fprintf(t, " \tNAME\tPLATFORM\tSIZE\n") // The leading space is for the selection marker, leave it alone
+	fmt.Fprintf(t, " \tNAME\tPLATFORM\tSIZE\tVERSION\tSTATE\n") // The leading space is for the selection marker, leave it alone
 	for _, s := range satellites {
 		var selected = ""
 		if s.Name == app.cfg.Satellite.Name && s.Org == orgID {
 			selected = "*"
 		}
-		fmt.Fprintf(t, "%s\t%s\t%s\t%s\n", selected, s.Name, s.Platform, s.Size)
+		_, _ = fmt.Fprintf(t, "%s\t%s\t%s\t%s\t%s\t%s\n",
+			selected, s.Name, s.Platform, s.Size, s.Version, strings.ToLower(s.Status))
 	}
 	err := t.Flush()
 	if err != nil {
@@ -347,9 +349,13 @@ func (app *earthlyApp) actionSatelliteInspect(cliCtx *cli.Context) error {
 		selected = "Yes"
 	}
 
-	app.console.Printf("Instance state: %s", satellite.Status)
-	app.console.Printf("Instance platform: %s", satellite.Platform)
-	app.console.Printf("Instance size: %s", satellite.Size)
+	app.console.Printf("State: %s", satellite.Status)
+	app.console.Printf("Platform: %s", satellite.Platform)
+	app.console.Printf("Size: %s", satellite.Size)
+	app.console.Printf("Version: %s", satellite.Version)
+	if len(satellite.FeatureFlags) > 0 {
+		app.console.Printf("Feature Flags: %+v", satellite.FeatureFlags)
+	}
 	app.console.Printf("Currently selected: %s", selected)
 	app.console.Printf("")
 

--- a/cmd/earthly/satellite_cmds.go
+++ b/cmd/earthly/satellite_cmds.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"math/rand"
 	"os"
@@ -66,6 +67,14 @@ func (app *earthlyApp) satelliteCmds() []*cli.Command {
 			UsageText: "earthly satellite ls\n" +
 				"	earthly satellite [--org <organization-name>] ls",
 			Action: app.actionSatelliteList,
+			Flags: []cli.Flag{
+				&cli.BoolFlag{
+					Name:        "json",
+					Usage:       "Prints the output in JSON format.",
+					Required:    false,
+					Destination: &app.satellitePrintJSON,
+				},
+			},
 		},
 		{
 			Name:        "inspect",
@@ -140,7 +149,7 @@ func (app *earthlyApp) useSatellite(cliCtx *cli.Context, satelliteName, orgName 
 	return nil
 }
 
-func (app *earthlyApp) printSatellites(satellites []cloud.SatelliteInstance, orgID string) {
+func (app *earthlyApp) printSatellitesTable(satellites []cloud.SatelliteInstance, orgID string) {
 	t := tabwriter.NewWriter(os.Stdout, 1, 2, 2, ' ', 0)
 	fmt.Fprintf(t, " \tNAME\tPLATFORM\tSIZE\tVERSION\tSTATE\n") // The leading space is for the selection marker, leave it alone
 	for _, s := range satellites {
@@ -149,12 +158,41 @@ func (app *earthlyApp) printSatellites(satellites []cloud.SatelliteInstance, org
 			selected = "*"
 		}
 		_, _ = fmt.Fprintf(t, "%s\t%s\t%s\t%s\t%s\t%s\n",
-			selected, s.Name, s.Platform, s.Size, s.Version, strings.ToLower(s.Status))
+			selected, s.Name, s.Platform, s.Size, s.Version, strings.ToLower(s.State))
 	}
 	err := t.Flush()
 	if err != nil {
 		fmt.Printf("failed to print satellites: %s", err.Error())
 	}
+}
+
+type satelliteJSON struct {
+	Name     string `json:"name"`
+	State    string `json:"state"`
+	Platform string `json:"platform"`
+	Size     string `json:"size"`
+	Version  string `json:"version"`
+	Selected bool   `json:"selected"`
+}
+
+func (app *earthlyApp) printSatellitesJSON(satellites []cloud.SatelliteInstance, orgID string) {
+	jsonSats := make([]satelliteJSON, len(satellites))
+	for i, s := range satellites {
+		selected := s.Name == app.cfg.Satellite.Name && s.Org == orgID
+		jsonSats[i] = satelliteJSON{
+			Name:     s.Name,
+			Size:     s.Size,
+			State:    s.State,
+			Platform: s.Platform,
+			Version:  s.Version,
+			Selected: selected,
+		}
+	}
+	b, err := json.MarshalIndent(jsonSats, "", "  ")
+	if err != nil {
+		fmt.Printf("failed to parse json: %s", err.Error()) // unlikely
+	}
+	fmt.Println(string(b))
 }
 
 func (app *earthlyApp) getSatelliteOrgID(ctx context.Context, cloudClient cloud.Client) (string, error) {
@@ -254,7 +292,11 @@ func (app *earthlyApp) actionSatelliteList(cliCtx *cli.Context) error {
 		return err
 	}
 
-	app.printSatellites(satellites, orgID)
+	if app.satellitePrintJSON {
+		app.printSatellitesJSON(satellites, orgID)
+	} else {
+		app.printSatellitesTable(satellites, orgID)
+	}
 	return nil
 }
 
@@ -349,7 +391,7 @@ func (app *earthlyApp) actionSatelliteInspect(cliCtx *cli.Context) error {
 		selected = "Yes"
 	}
 
-	app.console.Printf("State: %s", satellite.Status)
+	app.console.Printf("State: %s", satellite.State)
 	app.console.Printf("Platform: %s", satellite.Platform)
 	app.console.Printf("Size: %s", satellite.Size)
 	app.console.Printf("Version: %s", satellite.Version)
@@ -359,7 +401,7 @@ func (app *earthlyApp) actionSatelliteInspect(cliCtx *cli.Context) error {
 	app.console.Printf("Currently selected: %s", selected)
 	app.console.Printf("")
 
-	if satellite.Status == cloud.SatelliteStatusOperational {
+	if satellite.State == cloud.SatelliteStatusOperational {
 		err = buildkitd.PrintSatelliteInfo(cliCtx.Context, app.console, Version, app.buildkitdSettings, app.installationName)
 		if err != nil {
 			return errors.Wrap(err, "failed checking buildkit info")
@@ -424,7 +466,7 @@ func (app *earthlyApp) actionSatelliteSelect(cliCtx *cli.Context) error {
 		return fmt.Errorf("%s is not a valid satellite", app.satelliteName)
 	}
 
-	app.printSatellites(satellites, orgID)
+	app.printSatellitesTable(satellites, orgID)
 	return nil
 }
 
@@ -472,7 +514,7 @@ func (app *earthlyApp) actionSatelliteWake(cliCtx *cli.Context) error {
 		return err
 	}
 
-	if sat.Status == cloud.SatelliteStatusOperational {
+	if sat.State == cloud.SatelliteStatusOperational {
 		app.console.Printf("%s is already awake.", app.satelliteName)
 	}
 

--- a/cmd/earthly/satellite_cmds.go
+++ b/cmd/earthly/satellite_cmds.go
@@ -190,7 +190,7 @@ func (app *earthlyApp) printSatellitesJSON(satellites []cloud.SatelliteInstance,
 	}
 	b, err := json.MarshalIndent(jsonSats, "", "  ")
 	if err != nil {
-		fmt.Printf("failed to marshal json: %s", err.Error()) // unlikely
+		fmt.Fprintf(os.Stderr, "failed to marshal json: %s", err.Error()) // unlikely
 	}
 	fmt.Println(string(b))
 }

--- a/cmd/earthly/satellite_cmds.go
+++ b/cmd/earthly/satellite_cmds.go
@@ -190,7 +190,7 @@ func (app *earthlyApp) printSatellitesJSON(satellites []cloud.SatelliteInstance,
 	}
 	b, err := json.MarshalIndent(jsonSats, "", "  ")
 	if err != nil {
-		fmt.Printf("failed to parse json: %s", err.Error()) // unlikely
+		fmt.Printf("failed to marshal json: %s", err.Error()) // unlikely
 	}
 	fmt.Println(string(b))
 }

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/docker/distribution v2.8.1+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/dustin/go-humanize v1.0.0
-	github.com/earthly/cloud-api v1.0.1-0.20221111211709-e83ad3656e80
+	github.com/earthly/cloud-api v1.0.1-0.20221115213431-878f1a947125
 	github.com/earthly/earthly/ast v0.0.0-00010101000000-000000000000
 	github.com/earthly/earthly/util/deltautil v0.0.0-00010101000000-000000000000
 	github.com/elastic/go-sysinfo v1.7.1

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/docker/distribution v2.8.1+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/dustin/go-humanize v1.0.0
-	github.com/earthly/cloud-api v1.0.1-0.20221115213431-878f1a947125
+	github.com/earthly/cloud-api v1.0.1-0.20221116192021-9627baa2c069
 	github.com/earthly/earthly/ast v0.0.0-00010101000000-000000000000
 	github.com/earthly/earthly/util/deltautil v0.0.0-00010101000000-000000000000
 	github.com/elastic/go-sysinfo v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -74,8 +74,8 @@ github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/earthly/buildkit v0.0.1-0.20221109173939-f46745e0958c h1:IUNnk35i80ptmgrbbid7HxNxMcLvyMpGOaXVjCyggRw=
 github.com/earthly/buildkit v0.0.1-0.20221109173939-f46745e0958c/go.mod h1:xjNu8+/9ds44MQXBFPaZgkvCi1C6/hOXh5sA5tgij/s=
-github.com/earthly/cloud-api v1.0.1-0.20221115213431-878f1a947125 h1:6YUamMYJiZ0YhZyj26PwqSFPRw9VFdl2kXV3jBfRiqw=
-github.com/earthly/cloud-api v1.0.1-0.20221115213431-878f1a947125/go.mod h1:38rj6sccWnuk+C981DeFFomBmAtwuuvchoPrXdKXi2I=
+github.com/earthly/cloud-api v1.0.1-0.20221116192021-9627baa2c069 h1:BMnaZOLsvS9MlpJDkrIgnJk2O8EEEUGaWJEiL15NdZM=
+github.com/earthly/cloud-api v1.0.1-0.20221116192021-9627baa2c069/go.mod h1:38rj6sccWnuk+C981DeFFomBmAtwuuvchoPrXdKXi2I=
 github.com/earthly/fsutil v0.0.0-20221025225749-b994beadd443 h1:EjOPneKZTuUcX+S49SLC35WUhcyF95m99JIOpoU5Mzs=
 github.com/earthly/fsutil v0.0.0-20221025225749-b994beadd443/go.mod h1:F83XRhNblQsKQH9hcKEE45GAOkL9590mtw9KsD0Q4fE=
 github.com/elastic/go-sysinfo v1.7.1 h1:Wx4DSARcKLllpKT2TnFVdSUJOsybqMYCNQZq1/wO+s0=

--- a/go.sum
+++ b/go.sum
@@ -74,8 +74,8 @@ github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/earthly/buildkit v0.0.1-0.20221109173939-f46745e0958c h1:IUNnk35i80ptmgrbbid7HxNxMcLvyMpGOaXVjCyggRw=
 github.com/earthly/buildkit v0.0.1-0.20221109173939-f46745e0958c/go.mod h1:xjNu8+/9ds44MQXBFPaZgkvCi1C6/hOXh5sA5tgij/s=
-github.com/earthly/cloud-api v1.0.1-0.20221111211709-e83ad3656e80 h1:ev8zjjz8BhYqN0gN2C3OQTiWtCW+BrFFizLjnX8bNj0=
-github.com/earthly/cloud-api v1.0.1-0.20221111211709-e83ad3656e80/go.mod h1:38rj6sccWnuk+C981DeFFomBmAtwuuvchoPrXdKXi2I=
+github.com/earthly/cloud-api v1.0.1-0.20221115213431-878f1a947125 h1:6YUamMYJiZ0YhZyj26PwqSFPRw9VFdl2kXV3jBfRiqw=
+github.com/earthly/cloud-api v1.0.1-0.20221115213431-878f1a947125/go.mod h1:38rj6sccWnuk+C981DeFFomBmAtwuuvchoPrXdKXi2I=
 github.com/earthly/fsutil v0.0.0-20221025225749-b994beadd443 h1:EjOPneKZTuUcX+S49SLC35WUhcyF95m99JIOpoU5Mzs=
 github.com/earthly/fsutil v0.0.0-20221025225749-b994beadd443/go.mod h1:F83XRhNblQsKQH9hcKEE45GAOkL9590mtw9KsD0Q4fE=
 github.com/elastic/go-sysinfo v1.7.1 h1:Wx4DSARcKLllpKT2TnFVdSUJOsybqMYCNQZq1/wO+s0=


### PR DESCRIPTION
Added a couple of fields to  `ls` and `inspect`. 

Buidlkit version and state are now shown in `ls`. Buildkit version only works on new satellites, as it requires a new server change to be applied as they are launched. Notice the output is also sorted now by server too.

![Screenshot 2022-11-15 171506](https://user-images.githubusercontent.com/3247216/202038011-4630baee-2025-41a1-96e7-852031931115.png)

Feature flags are shown on `inspect`, along with the new version field.

![Screenshot 2022-11-15 171631](https://user-images.githubusercontent.com/3247216/202038168-993e67cf-c377-4bf1-9a7a-45911af42b7e.png)
