### PR TITLE
Fix `time.Now().UnixNano()` stripping away the nanos

### DIFF
--- a/logbus/bus.go
+++ b/logbus/bus.go
@@ -55,7 +55,7 @@ func (b *Bus) NowUnixNanos() uint64 {
 // monotonically increasing time.
 func (b *Bus) TsUnixNanos(t2 time.Time) uint64 {
 	// The following is necessary to ensure that the time is monotonically increasing.
-	// t2.UnixNano() strips the monotonic clock reading - so that wouldn't work.
+	// t2.UnixNano() sometimes strips the monotonic clock reading (e.g. time.Now().UnixNano()).
 	// Sub maintains the monotonic clock reading https://pkg.go.dev/time#hdr-Monotonic_Clocks.
 	deltaT := t2.Sub(b.createdAt).Nanoseconds()
 	return uint64(b.CreatedAt().UnixNano()) + uint64(deltaT)

--- a/logbus/command.go
+++ b/logbus/command.go
@@ -49,7 +49,7 @@ func (c *Command) Write(dt []byte, ts time.Time, stream int32) (int, error) {
 		TargetId:           c.targetID,
 		CommandId:          c.commandID,
 		Stream:             stream,
-		TimestampUnixNanos: uint64(ts.UnixNano()),
+		TimestampUnixNanos: c.b.TsUnixNanos(ts),
 		Data:               dt,
 	})
 	return len(dt), nil
@@ -71,7 +71,7 @@ func (c *Command) SetStart(start time.Time) {
 	}
 	c.started = true
 	c.commandDelta(&logstream.DeltaCommandManifest{
-		StartedAtUnixNanos: uint64(start.UnixNano()),
+		StartedAtUnixNanos: c.b.TsUnixNanos(start),
 		Status:             logstream.RunStatus_RUN_STATUS_IN_PROGRESS,
 	})
 }
@@ -117,7 +117,7 @@ func (c *Command) SetEnd(end time.Time, success bool, canceled bool, errorStr st
 	c.commandDelta(&logstream.DeltaCommandManifest{
 		Status:           status,
 		ErrorMessage:     errorStr,
-		EndedAtUnixNanos: uint64(end.UnixNano()),
+		EndedAtUnixNanos: c.b.TsUnixNanos(end),
 	})
 }
 

--- a/logbus/formattedwriter.go
+++ b/logbus/formattedwriter.go
@@ -1,8 +1,6 @@
 package logbus
 
 import (
-	"time"
-
 	"github.com/earthly/cloud-api/logstream"
 )
 
@@ -24,15 +22,15 @@ func NewFormattedWriter(bus *Bus, targetID string) *FormattedWriter {
 func (fw *FormattedWriter) Write(dt []byte) (int, error) {
 	// TODO (vladaionescu): Can the timestamp be passed along straight
 	// 						from buildkit?
-	ts := uint64(time.Now().UnixNano())
+	now := fw.bus.NowUnixNanos()
 	fw.bus.WriteFormattedLog(&logstream.DeltaFormattedLog{
 		TargetId:           fw.targetID,
-		TimestampUnixNanos: ts,
+		TimestampUnixNanos: now,
 		Data:               dt,
 	})
 	fw.bus.WriteFormattedLog(&logstream.DeltaFormattedLog{
 		TargetId:           "_full",
-		TimestampUnixNanos: ts,
+		TimestampUnixNanos: now,
 		Data:               dt,
 	})
 	return len(dt), nil

--- a/logbus/generic.go
+++ b/logbus/generic.go
@@ -29,7 +29,7 @@ func (g *Generic) Write(dt []byte) (int, error) {
 func (g *Generic) WriteWithTimestamp(dt []byte, ts time.Time) (int, error) {
 	g.run.b.WriteRawLog(&logstream.DeltaLog{
 		CommandId:          fmt.Sprintf("_generic:%s", g.category),
-		TimestampUnixNanos: uint64(ts.UnixNano()),
+		TimestampUnixNanos: g.run.b.TsUnixNanos(ts),
 		Data:               dt,
 	})
 	return len(dt), nil

--- a/logbus/logstreamer/logstreamer.go
+++ b/logbus/logstreamer/logstreamer.go
@@ -127,7 +127,7 @@ func (ls *LogStreamer) Write(delta *logstream.Delta) {
 		// TODO (vladaionescu): We should only log this if verbose is enabled.
 		dt, err := protojson.Marshal(delta)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "failed to marshal log delta: %v", err)
+			fmt.Fprintf(os.Stderr, "log streamer closed, but failed to marshal log delta: %v", err)
 			return
 		}
 		fmt.Fprintf(os.Stderr, "log streamer closed, dropping delta %v\n", string(dt))

--- a/logbus/logstreamer/logstreamer.go
+++ b/logbus/logstreamer/logstreamer.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 // LogStreamer is a log streamer. It uses the cloud client to send
@@ -118,7 +119,19 @@ func (ls *LogStreamer) Write(delta *logstream.Delta) {
 	ls.mu.Lock()
 	ch := ls.ch // ls.ch may get replaced on retry
 	ls.mu.Unlock()
-	ch <- []*logstream.Delta{delta}
+	if ch != nil {
+		ch <- []*logstream.Delta{delta}
+	} else {
+		// TODO (vladaionescu): If these messages show up, we need to rethink
+		//						the closing sequence.
+		// TODO (vladaionescu): We should only log this if verbose is enabled.
+		dt, err := protojson.Marshal(delta)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to marshal log delta: %v", err)
+			return
+		}
+		fmt.Fprintf(os.Stderr, "log streamer closed, dropping delta %v\n", string(dt))
+	}
 }
 
 // Close closes the log streamer.
@@ -126,6 +139,7 @@ func (ls *LogStreamer) Close() error {
 	ls.mu.Lock()
 	if ls.ch != nil {
 		close(ls.ch)
+		ls.ch = nil
 	}
 	ls.cancelled = true
 	ls.mu.Unlock()

--- a/logbus/run.go
+++ b/logbus/run.go
@@ -113,7 +113,7 @@ func (run *Run) SetStart(start time.Time) {
 	defer run.mu.Unlock()
 	run.buildDelta(&logstream.DeltaManifest_FieldsDelta{
 		Status:             logstream.RunStatus_RUN_STATUS_IN_PROGRESS,
-		StartedAtUnixNanos: uint64(start.UnixNano()),
+		StartedAtUnixNanos: run.b.TsUnixNanos(start),
 	})
 }
 
@@ -134,7 +134,7 @@ func (run *Run) SetFatalError(end time.Time, targetID string, commandID string, 
 	}
 	run.buildDelta(&logstream.DeltaManifest_FieldsDelta{
 		Status:           logstream.RunStatus_RUN_STATUS_FAILURE,
-		EndedAtUnixNanos: uint64(end.UnixNano()),
+		EndedAtUnixNanos: run.b.TsUnixNanos(end),
 		HasFailure:       true,
 		Failure: &logstream.Failure{
 			Type:         failureType,
@@ -171,7 +171,7 @@ func (run *Run) SetEnd(end time.Time, success bool, canceled bool, failureOutput
 
 	run.buildDelta(&logstream.DeltaManifest_FieldsDelta{
 		Status:           status,
-		EndedAtUnixNanos: uint64(end.UnixNano()),
+		EndedAtUnixNanos: run.b.TsUnixNanos(end),
 		Failure:          f,
 	})
 }

--- a/logbus/setup/setup.go
+++ b/logbus/setup/setup.go
@@ -38,7 +38,7 @@ func New(ctx context.Context, bus *logbus.Bus, debug bool, verbose bool, disable
 		Formatter:     nil, // set below
 		SolverMonitor: nil, // set below
 		BuildID:       buildID,
-		CreatedAt:     time.Now(),
+		CreatedAt:     bus.CreatedAt(),
 	}
 	bs.Formatter = formatter.New(ctx, bs.Bus, verbose, disableOngoingUpdates)
 	bs.Bus.AddRawSubscriber(bs.Formatter)

--- a/logbus/target.go
+++ b/logbus/target.go
@@ -22,7 +22,7 @@ func newTarget(b *Bus, targetID string) *Target {
 func (target *Target) SetStart(start time.Time) {
 	target.targetDelta(&logstream.DeltaTargetManifest{
 		Status:             logstream.RunStatus_RUN_STATUS_IN_PROGRESS,
-		StartedAtUnixNanos: uint64(start.UnixNano()),
+		StartedAtUnixNanos: target.b.TsUnixNanos(start),
 	})
 }
 
@@ -30,7 +30,7 @@ func (target *Target) SetStart(start time.Time) {
 func (target *Target) SetEnd(end time.Time, status logstream.RunStatus, finalPlatform string) {
 	target.targetDelta(&logstream.DeltaTargetManifest{
 		Status:           status,
-		EndedAtUnixNanos: uint64(end.UnixNano()),
+		EndedAtUnixNanos: target.b.TsUnixNanos(end),
 		FinalPlatform:    finalPlatform,
 	})
 }


### PR DESCRIPTION
Also, fix panic due to sending on a closed channel in `Logstreamer`.