### PR TITLE
fix singlequote parsing for --shell-out-anywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 - Fixed Earthly on Mac would randomly hang on `1. Init` if Earthly was installed from Homebrew or the Earthly homebrew tap. [#2247](https://github.com/earthly/earthly/issues/2247)
 - Only referenced ARGs from .env are displayed on failures, this prevents secrets contained in .env from being displayed. [#1736](https://github.com/earthly/earthly/issues/1736)
 - Earthly now correctly detects if Podman is running but is under the disguise of the Docker CLI.
-- Improved performance when copying files. Fully-cached builds are now dramatically faster as a result [#2049](https://github.com/earthly/earthly/issues/2049)
+- Improved performance when copying files. Fully-cached builds are now dramatically faster as a result. [#2049](https://github.com/earthly/earthly/issues/2049)
+- Fixed `--shell-out-anywhere` bug where inner quotes were incorrectly removed. [#2340](https://github.com/earthly/earthly/issues/2340)
 
 ## v0.6.29 - 2022-11-07
 

--- a/tests/shell-out/new.earth
+++ b/tests/shell-out/new.earth
@@ -1,16 +1,20 @@
 VERSION --shell-out-anywhere 0.6
 
-test-all:
+test:
     BUILD +test-copyfile
-    BUILD +test
+    BUILD +test1
     BUILD +test2
     BUILD +test3
     BUILD +test4
     BUILD +test5
     BUILD +test6
+    BUILD +test7
+    BUILD +test8
+    BUILD +test9
+    BUILD +test10
 
 hasfile:
-    FROM +test
+    FROM +test1
     RUN touch valid-file
     SAVE ARTIFACT "valid-$(echo file)"
 
@@ -19,7 +23,7 @@ test-copyfile:
     COPY "+hasfile/$(echo dmFsaWQtZmlsZQ== | base64 -d)" .
     RUN test -f valid-file
 
-test:
+test1:
     FROM alpine:3.15
     RUN echo "world" > data
     ARG key="hello$(cat /data)"
@@ -59,3 +63,23 @@ test6:
     FROM alpine:3.15
     ARG mystr="hello $(echo -n one && echo -n two >/dev/null && echo -n three)."
     RUN test "$mystr" = "hello onethree."
+
+test7:
+    FROM alpine:3.15
+    ARG foo = "$(echo '()')"
+    RUN env | grep foo | tee output && base64 output | grep Zm9vPSgpCg==
+
+test8:
+    FROM alpine:3.15
+    ARG foo = "$(echo "()")"
+    RUN env | grep foo | tee output && base64 output | grep Zm9vPSgpCg==
+
+test9:
+    FROM alpine:3.15
+    ARG foo = "$(echo \\(\\))"
+    RUN env | grep foo | tee output && base64 output | grep Zm9vPSgpCg==
+
+test10:
+    FROM alpine:3.15
+    ARG foo = $(echo \\(\\))
+    RUN env | grep foo | tee output && base64 output | grep Zm9vPSgpCg==


### PR DESCRIPTION
lexer was incorrectly removing first character when parsing single quotes within a shellout. fixes https://github.com/earthly/earthly/issues/2340

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>