### PR TITLE
Fix logstream closing sequence

### DIFF
--- a/logbus/logstreamer/logstreamer.go
+++ b/logbus/logstreamer/logstreamer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"sync"
+	"time"
 
 	"github.com/earthly/cloud-api/logstream"
 	"github.com/earthly/earthly/cloud"
@@ -78,8 +79,9 @@ func (ls *LogStreamer) tryStream(ctx context.Context) (bool, error) {
 	const chSize = 10240
 	if ls.ch != nil {
 		// In case the channel is congested, this frees up any stuck writers.
+		prevCh := ls.ch
 		go func() {
-			for range ls.ch {
+			for range prevCh {
 			}
 		}()
 	}
@@ -143,7 +145,18 @@ func (ls *LogStreamer) Close() error {
 	}
 	ls.cancelled = true
 	ls.mu.Unlock()
-	<-ls.doneCh // wait for all messages to be sent (or for log streamer to error-out).
+	// wait for all messages to be sent
+	timedOut := false
+	select {
+	case <-ls.doneCh:
+	case <-time.After(60 * time.Second):
+		timedOut = true
+	}
+	ls.mu.Lock()
+	defer ls.mu.Unlock()
+	if timedOut {
+		ls.errors = append(ls.errors, errors.New("timed out waiting for log streamer to close"))
+	}
 	var retErr error
 	for _, err := range ls.errors {
 		retErr = multierror.Append(retErr, err)

--- a/logbus/logstreamer/logstreamer.go
+++ b/logbus/logstreamer/logstreamer.go
@@ -81,7 +81,15 @@ func (ls *LogStreamer) tryStream(ctx context.Context) (bool, error) {
 		// In case the channel is congested, this frees up any stuck writers.
 		prevCh := ls.ch
 		go func() {
-			for range prevCh {
+			for {
+				select {
+				case _, ok := <-prevCh:
+					if !ok {
+						return
+					}
+				default:
+					return // no more messages to consume, but channel not closed
+				}
 			}
 		}()
 	}

--- a/logbus/solvermon/solvermon.go
+++ b/logbus/solvermon/solvermon.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/earthly/earthly/logbus"
 	"github.com/earthly/earthly/util/vertexmeta"
+	"github.com/earthly/earthly/util/xcontext"
 	"github.com/moby/buildkit/client"
 	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
@@ -30,7 +31,7 @@ func New(b *logbus.Bus) *SolverMonitor {
 
 // MonitorProgress processes a channel of buildkit solve statuses.
 func (sm *SolverMonitor) MonitorProgress(ctx context.Context, ch chan *client.SolveStatus) error {
-	delayedCtx, delayedCancel := context.WithCancel(ctx)
+	delayedCtx, delayedCancel := context.WithCancel(xcontext.Detach(ctx))
 	defer delayedCancel()
 	go func() {
 		<-ctx.Done()
@@ -53,7 +54,7 @@ func (sm *SolverMonitor) MonitorProgress(ctx context.Context, ch chan *client.So
 			if !ok {
 				return nil
 			}
-			err := sm.handleBuildkitStatus(ctx, status)
+			err := sm.handleBuildkitStatus(delayedCtx, status)
 			if err != nil {
 				return err
 			}

--- a/util/xcontext/xcontext.go
+++ b/util/xcontext/xcontext.go
@@ -1,0 +1,17 @@
+package xcontext
+
+import (
+	"context"
+	"time"
+)
+
+// Detach returns a context that keeps all the values of its parent context
+// but detaches from the cancellation and error handling.
+func Detach(ctx context.Context) context.Context { return detachedContext{ctx} }
+
+type detachedContext struct{ parent context.Context }
+
+func (v detachedContext) Deadline() (time.Time, bool)       { return time.Time{}, false }
+func (v detachedContext) Done() <-chan struct{}             { return nil }
+func (v detachedContext) Err() error                        { return nil }
+func (v detachedContext) Value(key interface{}) interface{} { return v.parent.Value(key) }


### PR DESCRIPTION
This addresses some issues related to attempting to send deltas after close, plus it fixes an occasional hang on ctrl-c.