### PR TITLE
Add all the non-buildkit output to logstream too

### DIFF
--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -414,7 +414,6 @@ func (app *earthlyApp) before(cliCtx *cli.Context) error {
 		app.logstream = true
 	}
 	if app.logstream {
-		// TODO (vladaionescu): Set category correctly via the console logger.
 		app.console = app.console.WithPrefixWriter(app.logbus.Run().Generic())
 	}
 

--- a/conslogging/conslogging.go
+++ b/conslogging/conslogging.go
@@ -73,14 +73,17 @@ type ConsoleLogger struct {
 	nextColorIndex *int
 	errW           io.Writer
 	consoleErrW    io.Writer
+	prefixWriter   PrefixWriter
 	trailingLine   bool
 	prefixPadding  int
+	trailNewLine   bool
 	bb             *BundleBuilder
 }
 
 // Current returns the current console.
 func Current(colorMode ColorMode, prefixPadding int, logLevel LogLevel) ConsoleLogger {
-	return New(getCompatibleStderr(), &currentConsoleMutex, colorMode, prefixPadding, logLevel)
+	return New(getCompatibleStderr(), &currentConsoleMutex, colorMode, prefixPadding, logLevel).
+		WithTrailNewLine(true)
 }
 
 // New returns a new ConsoleLogger with a predefined target writer.
@@ -104,6 +107,7 @@ func (cl ConsoleLogger) clone() ConsoleLogger {
 	return ConsoleLogger{
 		consoleErrW:    cl.consoleErrW,
 		errW:           cl.errW,
+		prefixWriter:   cl.prefixWriter,
 		prefix:         cl.prefix,
 		metadataMode:   cl.metadataMode,
 		isLocal:        cl.isLocal,
@@ -115,19 +119,36 @@ func (cl ConsoleLogger) clone() ConsoleLogger {
 		colorMode:      cl.colorMode,
 		nextColorIndex: cl.nextColorIndex,
 		prefixPadding:  cl.prefixPadding,
+		trailNewLine:   cl.trailNewLine,
 		mu:             cl.mu,
 		bb:             cl.bb,
 	}
 }
 
+// WithTrailNewLine returns a ConsoleLogger with trailNewLine flag set accordingly.
+func (cl ConsoleLogger) WithTrailNewLine(trailNewLine bool) ConsoleLogger {
+	ret := cl.clone()
+	ret.trailNewLine = trailNewLine
+	return ret
+}
+
 // WithPrefix returns a ConsoleLogger with a prefix added.
 func (cl ConsoleLogger) WithPrefix(prefix string) ConsoleLogger {
+	return cl.WithPrefixAndSalt(prefix, prefix)
+}
+
+// WithPrefixAndSalt returns a ConsoleLogger with a prefix and a seed added.
+func (cl ConsoleLogger) WithPrefixAndSalt(prefix string, salt string) ConsoleLogger {
 	ret := cl.clone()
 	if cl.bb != nil {
 		ret.errW = io.MultiWriter(cl.consoleErrW, cl.bb.PrefixWriter(prefix))
 	}
 	ret.prefix = prefix
-	ret.salt = prefix
+	ret.salt = salt
+	if ret.prefixWriter != nil {
+		ret.prefixWriter = ret.prefixWriter.WithPrefix(prefix)
+		ret.errW = ret.prefixWriter
+	}
 	return ret
 }
 
@@ -142,17 +163,6 @@ func (cl ConsoleLogger) WithMetadataMode(metadataMode bool) ConsoleLogger {
 func (cl ConsoleLogger) WithLocal(isLocal bool) ConsoleLogger {
 	ret := cl.clone()
 	ret.isLocal = isLocal
-	return ret
-}
-
-// WithPrefixAndSalt returns a ConsoleLogger with a prefix and a seed added.
-func (cl ConsoleLogger) WithPrefixAndSalt(prefix string, salt string) ConsoleLogger {
-	ret := cl.clone()
-	if cl.bb != nil {
-		ret.errW = io.MultiWriter(cl.consoleErrW, cl.bb.PrefixWriter(prefix))
-	}
-	ret.prefix = prefix
-	ret.salt = salt
 	return ret
 }
 
@@ -187,6 +197,14 @@ func (cl ConsoleLogger) WithWriter(w io.Writer) ConsoleLogger {
 	return ret
 }
 
+// WithPrefixWriter returns a ConsoleLogger with a prefix writer.
+func (cl ConsoleLogger) WithPrefixWriter(w PrefixWriter) ConsoleLogger {
+	ret := cl.clone()
+	ret.prefixWriter = w
+	ret.errW = w
+	return ret
+}
+
 // WithLogBundleWriter returns a ConsoleLogger with a BundleWriter attached to capture output into a log bundle, for upload to log sharing.
 func (cl ConsoleLogger) WithLogBundleWriter(entrypoint string, collection *cleanup.Collection) ConsoleLogger {
 	ret := cl.clone()
@@ -215,9 +233,9 @@ func (cl ConsoleLogger) PrintPhaseHeader(phase string, disabled bool, special st
 		underlineLength = barWidth
 	}
 	c.Fprintf(cl.errW, " %s", msg)
-	_, _ = cl.errW.Write([]byte("\n"))
+	fmt.Fprintf(cl.errW, "\n")
 	c.Fprintf(cl.errW, "%s", strings.Repeat("—", underlineLength))
-	_, _ = cl.errW.Write([]byte("\n\n"))
+	fmt.Fprintf(cl.errW, "\n\n")
 }
 
 // PrintPhaseFooter prints the phase footer.
@@ -275,9 +293,9 @@ func (cl ConsoleLogger) PrintBar(c *color.Color, msg, phase string) {
 		rightBar += "="
 	}
 
-	_, _ = cl.errW.Write([]byte("\n"))
+	fmt.Fprintf(cl.errW, "\n")
 	c.Fprintf(cl.errW, "%s%s%s", leftBar, center, rightBar)
-	_, _ = cl.errW.Write([]byte("\n\n"))
+	fmt.Fprintf(cl.errW, "\n\n")
 }
 
 // Warnf prints a warning message in red to errWriter.
@@ -394,26 +412,30 @@ func (cl ConsoleLogger) DebugBytes(data []byte) {
 
 func (cl ConsoleLogger) printPrefix() {
 	// Assumes mu locked.
+	if cl.prefixWriter != nil {
+		// When the prefix writer is in use, we don't need to print the prefix.
+		return
+	}
 	if cl.prefix == "" {
 		return
 	}
 	c := cl.PrefixColor()
-	c.Fprintf(cl.errW, prettyPrefix(cl.prefixPadding, cl.prefix))
+	c.Fprintf(cl.errW, "%s", prettyPrefix(cl.prefixPadding, cl.prefix))
 	if cl.isLocal {
-		_, _ = cl.errW.Write([]byte(" *"))
+		fmt.Fprintf(cl.errW, " *")
 		cl.color(localColor).Fprintf(cl.errW, "local")
-		_, _ = cl.errW.Write([]byte("*"))
+		fmt.Fprintf(cl.errW, "*")
 	}
 	if cl.isFailed {
-		_, _ = cl.errW.Write([]byte(" *"))
+		fmt.Fprintf(cl.errW, " *")
 		cl.color(warnColor).Fprintf(cl.errW, "failed")
-		_, _ = cl.errW.Write([]byte("*"))
+		fmt.Fprintf(cl.errW, "*")
 	}
-	_, _ = cl.errW.Write([]byte(" | "))
+	fmt.Fprintf(cl.errW, " | ")
 	if cl.isCached {
-		_, _ = cl.errW.Write([]byte("*"))
+		fmt.Fprintf(cl.errW, "*")
 		cl.color(cachedColor).Fprintf(cl.errW, "cached")
-		_, _ = cl.errW.Write([]byte("* "))
+		fmt.Fprintf(cl.errW, "* ")
 	}
 }
 

--- a/conslogging/conslogging.go
+++ b/conslogging/conslogging.go
@@ -76,14 +76,12 @@ type ConsoleLogger struct {
 	prefixWriter   PrefixWriter
 	trailingLine   bool
 	prefixPadding  int
-	trailNewLine   bool
 	bb             *BundleBuilder
 }
 
 // Current returns the current console.
 func Current(colorMode ColorMode, prefixPadding int, logLevel LogLevel) ConsoleLogger {
-	return New(getCompatibleStderr(), &currentConsoleMutex, colorMode, prefixPadding, logLevel).
-		WithTrailNewLine(true)
+	return New(getCompatibleStderr(), &currentConsoleMutex, colorMode, prefixPadding, logLevel)
 }
 
 // New returns a new ConsoleLogger with a predefined target writer.
@@ -119,17 +117,9 @@ func (cl ConsoleLogger) clone() ConsoleLogger {
 		colorMode:      cl.colorMode,
 		nextColorIndex: cl.nextColorIndex,
 		prefixPadding:  cl.prefixPadding,
-		trailNewLine:   cl.trailNewLine,
 		mu:             cl.mu,
 		bb:             cl.bb,
 	}
-}
-
-// WithTrailNewLine returns a ConsoleLogger with trailNewLine flag set accordingly.
-func (cl ConsoleLogger) WithTrailNewLine(trailNewLine bool) ConsoleLogger {
-	ret := cl.clone()
-	ret.trailNewLine = trailNewLine
-	return ret
 }
 
 // WithPrefix returns a ConsoleLogger with a prefix added.

--- a/conslogging/prefixwriter.go
+++ b/conslogging/prefixwriter.go
@@ -1,0 +1,10 @@
+package conslogging
+
+import "io"
+
+// PrefixWriter is a writer that can take a prefix.
+type PrefixWriter interface {
+	io.Writer
+	// WithPrefix returns a new PrefixWriter with the given prefix.
+	WithPrefix(prefix string) PrefixWriter
+}

--- a/logbus/formatter/formatter.go
+++ b/logbus/formatter/formatter.go
@@ -382,34 +382,27 @@ func (f *Formatter) printBuildFailure() {
 }
 
 func (f *Formatter) targetConsole(targetID string, commandID string) conslogging.ConsoleLogger {
-	trailNewLine := true
 	var targetName string
-	writerTargetID := targetID
-	if targetID != "" {
+	var writerTargetID string
+	switch {
+	case targetID != "":
 		tm := f.manifest.GetTargets()[targetID]
 		targetName = tm.GetName()
-	} else {
-		if commandID != "" {
-			switch {
-			case commandID == "_generic:default":
-				targetName = ""
-				writerTargetID = commandID
-				trailNewLine = false
-			case strings.HasPrefix(commandID, "_generic:"):
-				targetName = strings.TrimPrefix(commandID, "_generic:")
-				writerTargetID = commandID
-				trailNewLine = false
-			default:
-				targetName = fmt.Sprintf("_internal:%s", commandID)
-				writerTargetID = targetName
-			}
-		} else {
-			targetName = "_unknown"
-			writerTargetID = targetName
-		}
+		writerTargetID = targetID
+	case commandID == "_generic:default":
+		targetName = ""
+		writerTargetID = commandID
+	case strings.HasPrefix(commandID, "_generic:"):
+		targetName = strings.TrimPrefix(commandID, "_generic:")
+		writerTargetID = commandID
+	case commandID != "":
+		targetName = fmt.Sprintf("_internal:%s", commandID)
+		writerTargetID = commandID
+	default:
+		targetName = "_unknown"
+		writerTargetID = "_unknown"
 	}
 	return f.console.
 		WithWriter(f.bus.FormattedWriter(writerTargetID)).
-		WithTrailNewLine(trailNewLine).
 		WithPrefixAndSalt(targetName, writerTargetID)
 }

--- a/logbus/formatter/formatter.go
+++ b/logbus/formatter/formatter.go
@@ -23,7 +23,6 @@ const (
 	durationBetweenSha256ProgressUpdate = 5 * time.Second
 	durationBetweenProgressUpdate       = 3 * time.Second
 	durationBetweenProgressUpdateIfSame = 5 * time.Millisecond
-	durationBetweenOpenLineUpdate       = time.Second
 	durationBetweenOngoingUpdates       = 5 * time.Second
 	durationBetweenOngoingUpdatesNoAnsi = 60 * time.Second
 )
@@ -44,9 +43,7 @@ type command struct {
 	lastProgress   time.Time
 	lastPercentage int32
 	// openLine is the line of output that has not yet been terminated with a \n.
-	openLine            []byte
-	lastOpenLineUpdate  time.Time
-	lastOpenLineSkipped bool
+	openLine []byte
 }
 
 // Formatter is a delta to console logger.
@@ -70,17 +67,34 @@ type Formatter struct {
 }
 
 // New creates a new Formatter.
-func New(ctx context.Context, b *logbus.Bus, verbose bool, disableOngoingUpdates bool) *Formatter {
+func New(ctx context.Context, b *logbus.Bus, debug, verbose, forceColor, noColor bool, disableOngoingUpdates bool) *Formatter {
 	ongoingTick := durationBetweenOngoingUpdatesNoAnsi
 	if ansiSupported {
 		ongoingTick = durationBetweenOngoingUpdates
 	}
 	ongoingTicker := time.NewTicker(ongoingTick)
 	ongoingTicker.Stop()
+	var logLevel conslogging.LogLevel
+	switch {
+	case debug:
+		logLevel = conslogging.Debug
+	case verbose:
+		logLevel = conslogging.Verbose
+	default:
+		logLevel = conslogging.Info
+	}
+	var colorMode conslogging.ColorMode
+	switch {
+	case forceColor:
+		colorMode = conslogging.ForceColor
+	case noColor:
+		colorMode = conslogging.NoColor
+	default:
+		colorMode = conslogging.AutoColor
+	}
 	f := &Formatter{
-		bus: b,
-		// TODO (vladaionescu): Pass in color detection and log level.
-		console:       conslogging.New(nil, nil, conslogging.AutoColor, conslogging.DefaultPadding, conslogging.Info),
+		bus:           b,
+		console:       conslogging.New(nil, nil, colorMode, conslogging.DefaultPadding, logLevel),
 		verbose:       verbose,
 		timingTable:   make(map[string]time.Duration),
 		startTime:     time.Now(),
@@ -210,13 +224,12 @@ func (f *Formatter) handleDeltaLog(dl *logstream.DeltaLog) error {
 		f.lastCommandOutput == cmd)
 	output := dl.GetData()
 	printOutput := make([]byte, 0, len(cmd.openLine)+len(output)+10)
-	if bytes.HasPrefix(output, []byte{'\n'}) && len(cmd.openLine) > 0 && !cmd.lastOpenLineSkipped {
+	if bytes.HasPrefix(output, []byte{'\n'}) && len(cmd.openLine) > 0 {
 		// Optimization for cases where ansi control sequences are not supported:
 		// if the output starts with a \n, then treat the open line as closed and
 		// just keep going after that.
 		cmd.openLine = nil
 		output = output[1:]
-		cmd.lastOpenLineUpdate = time.Time{}
 	}
 	if sameAsLast && len(cmd.openLine) > 0 {
 		// Prettiness optimization: if there is an open line and the previous print out
@@ -232,24 +245,15 @@ func (f *Formatter) handleDeltaLog(dl *logstream.DeltaLog) error {
 	if lastNewLine != -1 {
 		// Ends up being empty slice if output ends in \n.
 		cmd.openLine = printOutput[(lastNewLine + 1):]
-		// A \n exists - reset the open line timer.
-		cmd.lastOpenLineUpdate = time.Time{}
 	} else {
 		// No \n found - update cmd.openLine to append the new output.
 		cmd.openLine = append(cmd.openLine, output...)
 	}
 	if !bytes.HasSuffix(printOutput, []byte{'\n'}) {
-		if time.Since(cmd.lastOpenLineUpdate) > durationBetweenOpenLineUpdate {
-			// Skip printing if trying to update the same line too frequently.
-			cmd.lastOpenLineSkipped = true
-			return nil
-		}
-		cmd.lastOpenLineUpdate = time.Now()
 		// If output doesn't terminate in \n, add our own.
 		printOutput = append(printOutput, '\n')
 	}
 
-	cmd.lastOpenLineSkipped = false
 	c.PrintBytes(printOutput)
 	f.lastOutputWasOngoingUpdate = false
 	f.lastOutputWasProgress = false
@@ -378,20 +382,34 @@ func (f *Formatter) printBuildFailure() {
 }
 
 func (f *Formatter) targetConsole(targetID string, commandID string) conslogging.ConsoleLogger {
+	trailNewLine := true
 	var targetName string
 	writerTargetID := targetID
 	if targetID != "" {
 		tm := f.manifest.GetTargets()[targetID]
 		targetName = tm.GetName()
 	} else {
-		writerTargetID = "_internal"
-		targetName = "internal"
 		if commandID != "" {
-			writerTargetID = fmt.Sprintf("_internal:%s", commandID)
-			targetName = writerTargetID
+			switch {
+			case commandID == "_generic:default":
+				targetName = ""
+				writerTargetID = commandID
+				trailNewLine = false
+			case strings.HasPrefix(commandID, "_generic:"):
+				targetName = strings.TrimPrefix(commandID, "_generic:")
+				writerTargetID = commandID
+				trailNewLine = false
+			default:
+				targetName = fmt.Sprintf("_internal:%s", commandID)
+				writerTargetID = targetName
+			}
+		} else {
+			targetName = "_unknown"
+			writerTargetID = targetName
 		}
 	}
 	return f.console.
 		WithWriter(f.bus.FormattedWriter(writerTargetID)).
-		WithPrefixAndSalt(targetName, targetID)
+		WithTrailNewLine(trailNewLine).
+		WithPrefixAndSalt(targetName, writerTargetID)
 }

--- a/logbus/generic.go
+++ b/logbus/generic.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/earthly/cloud-api/logstream"
+	"github.com/earthly/earthly/conslogging"
 )
 
 // Generic is a generic writer for build output unrelated to a specific target.
@@ -13,9 +14,18 @@ type Generic struct {
 	category string
 }
 
-func newGeneric(run *Run, category string) *Generic {
+func newGeneric(run *Run) *Generic {
 	return &Generic{
 		run:      run,
+		category: "default",
+	}
+}
+
+// WithPrefix returns a new Generic with the given prefix. This satisfies the
+// conslogging.PrefixWriter interface.
+func (g *Generic) WithPrefix(category string) conslogging.PrefixWriter {
+	return &Generic{
+		run:      g.run,
 		category: category,
 	}
 }

--- a/logbus/logstreamer/logstreamer.go
+++ b/logbus/logstreamer/logstreamer.go
@@ -137,10 +137,10 @@ func (ls *LogStreamer) Write(delta *logstream.Delta) {
 		// TODO (vladaionescu): We should only log this if verbose is enabled.
 		dt, err := protojson.Marshal(delta)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "log streamer closed, but failed to marshal log delta: %v", err)
+			fmt.Fprintf(os.Stderr, "Log streamer closed, but failed to marshal log delta: %v", err)
 			return
 		}
-		fmt.Fprintf(os.Stderr, "log streamer closed, dropping delta %v\n", string(dt))
+		fmt.Fprintf(os.Stderr, "Log streamer closed, dropping delta %v\n", string(dt))
 	}
 }
 

--- a/logbus/run.go
+++ b/logbus/run.go
@@ -17,7 +17,6 @@ type Run struct {
 	commands map[string]*Command
 	ended    bool
 
-	gpMu    sync.Mutex
 	generic *Generic
 }
 

--- a/logbus/run.go
+++ b/logbus/run.go
@@ -17,29 +17,24 @@ type Run struct {
 	commands map[string]*Command
 	ended    bool
 
-	gpMu     sync.Mutex
-	generics map[string]*Generic
+	gpMu    sync.Mutex
+	generic *Generic
 }
 
 func newRun(b *Bus) *Run {
-	return &Run{
+	run := &Run{
 		b:        b,
 		targets:  make(map[string]*Target),
 		commands: make(map[string]*Command),
-		generics: make(map[string]*Generic),
+		generic:  nil, // set below
 	}
+	run.generic = newGeneric(run)
+	return run
 }
 
 // Generic returns a generic writer for build output unrelated to a specific target.
-func (run *Run) Generic(category string) *Generic {
-	run.gpMu.Lock()
-	defer run.gpMu.Unlock()
-	gp, ok := run.generics[category]
-	if ok {
-		return gp
-	}
-	run.generics[category] = newGeneric(run, category)
-	return run.generics[category]
+func (run *Run) Generic() *Generic {
+	return run.generic
 }
 
 // NewTarget creates a new target printer.

--- a/logbus/setup/setup.go
+++ b/logbus/setup/setup.go
@@ -31,7 +31,7 @@ type BusSetup struct {
 }
 
 // New creates a new BusSetup.
-func New(ctx context.Context, bus *logbus.Bus, debug bool, verbose bool, disableOngoingUpdates bool, busDebugFile string, buildID string) (*BusSetup, error) {
+func New(ctx context.Context, bus *logbus.Bus, debug, verbose, forceColor, noColor, disableOngoingUpdates bool, busDebugFile string, buildID string) (*BusSetup, error) {
 	bs := &BusSetup{
 		Bus:           bus,
 		ConsoleWriter: writersub.New(os.Stderr, "_full"),
@@ -40,7 +40,7 @@ func New(ctx context.Context, bus *logbus.Bus, debug bool, verbose bool, disable
 		BuildID:       buildID,
 		CreatedAt:     bus.CreatedAt(),
 	}
-	bs.Formatter = formatter.New(ctx, bs.Bus, verbose, disableOngoingUpdates)
+	bs.Formatter = formatter.New(ctx, bs.Bus, debug, verbose, forceColor, noColor, disableOngoingUpdates)
 	bs.Bus.AddRawSubscriber(bs.Formatter)
 	bs.Bus.AddFormattedSubscriber(bs.ConsoleWriter)
 	bs.SolverMonitor = solvermon.New(bs.Bus)


### PR DESCRIPTION
Known issue: There are some extra new lines in the output. Will be fixed in a future PR.