### PR TITLE
Support NETRC environmental var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 ### Changed
 
 - Updated buildkit to include changes up to [a5263dd0f990a3fe17b67e0002b76bfd1f5b433d](https://github.com/moby/buildkit/commit/a5263dd0f990a3fe17b67e0002b76bfd1f5b433d), which includes a change to speed-up buildkit startup time.
+- Added support for a custom `.netrc` file path using the standard `NETRC` environmental variable. [#2426](https://github.com/earthly/earthly/pull/2426)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,13 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 
 ## Unreleased
 
+### Added
+
+- Added support for a custom `.netrc` file path using the standard `NETRC` environmental variable. [#2426](https://github.com/earthly/earthly/pull/2426)
+
 ### Changed
 
 - Updated buildkit to include changes up to [a5263dd0f990a3fe17b67e0002b76bfd1f5b433d](https://github.com/moby/buildkit/commit/a5263dd0f990a3fe17b67e0002b76bfd1f5b433d), which includes a change to speed-up buildkit startup time.
-- Added support for a custom `.netrc` file path using the standard `NETRC` environmental variable. [#2426](https://github.com/earthly/earthly/pull/2426)
 
 ### Fixed
 

--- a/buildcontext/gitlookup.go
+++ b/buildcontext/gitlookup.go
@@ -436,8 +436,12 @@ func (gl *GitLookup) detectProtocol(host string) (protocol gitProtocol, err erro
 var errNoRCHostEntry = fmt.Errorf("no netrc host entry")
 
 func (gl *GitLookup) lookupNetRCCredential(host string) (login, password string, err error) {
-	homeDir, _ := fileutil.HomeDir()
-	n, err := netrc.Parse(filepath.Join(homeDir, ".netrc"))
+	netrcPath := os.Getenv("NETRC")
+	if netrcPath == "" {
+		homeDir, _ := fileutil.HomeDir()
+		netrcPath = filepath.Join(homeDir, ".netrc")
+	}
+	n, err := netrc.Parse(netrcPath)
 	if err != nil {
 		return "", "", errors.Wrap(err, "failed to parse .netrc")
 	}


### PR DESCRIPTION
This adds support for a custom `.netrc` file path using the (apparently) standard `NETRC` env. https://www.gnu.org/software/inetutils/manual/html_node/The-_002enetrc-file.html