### PR TITLE
homebrew-release: don't change ldflags

### DIFF
--- a/release/Earthfile
+++ b/release/Earthfile
@@ -205,7 +205,6 @@ release-homebrew:
         -e 's^\burl ".*"^url "'"$NEW_URL"'"^' \
         -e 's^\bsha256 ".*"$^sha256 "'$(cat /params/downloadsha256)'"^' \
         -e 's^\btags = ".*"^tags = "'"$(cat /params/tags)"'"^' \
-        -e 's^\bldflags = ".*"^ldflags = "'"$(cat /params/ldflags)"'"^' \
         ./Formula/earthly.rb
     RUN echo "Diff:" && git diff
     RUN version=${RELEASE_TAG#v} ;\


### PR DESCRIPTION
The homebrew earthly formula creates it's own ldflags string, replacing it via the release.sh will lead to conflicting changes.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>