### PR TITLE
prevent autocompletion from executing non-existant binary

### DIFF
--- a/earthly
+++ b/earthly
@@ -149,7 +149,9 @@ case "$1" in
                 echo "$now" >"$last_check_state_path"
                 echo "$flagoverride_hash" >"$last_flag_hash_path"
             fi
-
+        elif [ ! -x "$bindir/earthly-prerelease" ]; then
+            # prerelease doesn't exist, exit silently to avoid displaying errors during tab-completion
+            exit 0
         fi
 
         EARTHLY_VERSION_FLAG_OVERRIDES="$(tr -d '\n' < "$earthly_version_flag_overrides_path")"


### PR DESCRIPTION
This prevents bash autocompletion from attempting to execute a non-existant binary (which then displays errors to the screen, which clobbers a user's terminal).

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>