### PR TITLE
earthly script should default to ~/.earthly

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -379,7 +379,7 @@ prerelease:
         --platform=linux/amd64 \
         --platform=linux/arm64 \
         ./buildkitd+buildkitd --TAG=prerelease  --BUILDKIT_PROJECT="$BUILDKIT_PROJECT"
-    COPY (+earthly-all/* --VERSION=prerelease) ./
+    COPY (+earthly-all/* --VERSION=prerelease --DEFAULT_INSTALLATION_NAME=earthly) ./
     SAVE IMAGE --push earthly/earthlybinaries:prerelease
 
 prerelease-script:


### PR DESCRIPTION
The earthly pre-release should default to an `earthly` default installation name rather than `earthly-dev`; only locally-compiled versions of earthly should use `earthly-dev` -- this change makes the local workflow faster as `./earthly +for-<platform>` and `./build/platform.../earthly` would have unique installation names, which will prevent the need to restart buildkit when switching between the two.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>