### PR TITLE
fix wait-end SAVE IMAGE/ARTIFACT race

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -220,8 +220,12 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 			}
 		}
 		if opt.GlobalWaitBlockFtr {
-			b.opt.Console.Printf("skipping builder.go bf code due to GlobalWaitBlockFtr\n")
-			return nil, nil
+			if opt.OnlyArtifact != nil || opt.OnlyFinalTargetImages {
+				b.opt.Console.Printf("builder.go bf code is still required for OnlyArtifact or OnlyFinalTargetImages modes (GlobalWaitBlockFtr has no effect)\n")
+			} else {
+				b.opt.Console.Printf("skipping builder.go bf code due to GlobalWaitBlockFtr\n")
+				return nil, nil
+			}
 		}
 
 		// WARNING: the code below is deprecated, and will eventually be removed, in favour of wait_block.go

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -877,9 +877,9 @@ func (c *Converter) SaveArtifact(ctx context.Context, saveFrom string, saveTo st
 		}
 
 		if c.ftrs.WaitBlock {
-			if c.opt.DoSaves {
-				c.waitBlock().addSaveArtifactLocal(saveLocal, c)
-			}
+			waitItem := newSaveArtifactLocal(saveLocal, c, c.opt.DoSaves)
+			c.waitBlock().AddItem(waitItem)
+			c.mts.Final.WaitItems = append(c.mts.Final.WaitItems, waitItem)
 		} else {
 			if isPush {
 				c.mts.Final.RunPush.SaveLocals = append(c.mts.Final.RunPush.SaveLocals, saveLocal)
@@ -984,7 +984,9 @@ func (c *Converter) waitBlock() *waitBlock {
 
 // PushWaitBlock should be called when a WAIT block starts, all commands will be added to this new block
 func (c *Converter) PushWaitBlock(ctx context.Context) error {
-	c.waitBlockStack = append(c.waitBlockStack, newWaitBlock())
+	waitBlock := newWaitBlock()
+	c.waitBlockStack = append(c.waitBlockStack, waitBlock)
+	c.mts.Final.AddWaitBlock(waitBlock)
 	return nil
 }
 
@@ -999,14 +1001,14 @@ func (c *Converter) PopWaitBlock(ctx context.Context) error {
 		// an END is only ever encountered by the converter that created the WAIT block, this is the only special
 		// instance where we reference mts.Final.MainState before calling FinalizeStates; this can be done here
 		// as the waitBlock belongs to the current Converter
-		c.waitBlock().addState(&c.mts.Final.MainState, c)
+		c.waitBlock().AddItem(newStateWaitItem(&c.mts.Final.MainState, c))
 	}
 
 	i := n - 1
 	waitBlock := c.waitBlockStack[i]
 	c.waitBlockStack = c.waitBlockStack[:i]
 
-	return waitBlock.wait(ctx)
+	return waitBlock.Wait(ctx, c.opt.DoPushes, c.opt.DoSaves)
 }
 
 // SaveImage applies the earthly SAVE IMAGE command.
@@ -1068,7 +1070,9 @@ func (c *Converter) SaveImage(ctx context.Context, imageNames []string, pushImag
 			if c.ftrs.WaitBlock {
 				shouldPush := pushImages && si.DockerTag != "" && c.opt.DoPushes
 				shouldExportLocally := si.DockerTag != "" && c.opt.DoSaves
-				c.waitBlock().addSaveImage(si, c, shouldPush, shouldExportLocally)
+				waitItem := newSaveImage(si, c, shouldPush, shouldExportLocally)
+				c.waitBlock().AddItem(waitItem)
+				c.mts.Final.WaitItems = append(c.mts.Final.WaitItems, waitItem)
 				if pushImages {
 					// only add summary for `SAVE IMAGE --push` commands
 					c.opt.ExportCoordinator.AddPushedImageSummary(c.target.StringCanonical(), si.DockerTag, c.mts.Final.ID, c.opt.DoPushes)
@@ -1556,7 +1560,7 @@ func (c *Converter) FinalizeStates(ctx context.Context) (*states.MultiTarget, er
 	}
 
 	if c.ftrs.WaitBlock {
-		c.waitBlock().addState(&c.mts.Final.MainState, c)
+		c.waitBlock().AddItem(newStateWaitItem(&c.mts.Final.MainState, c))
 	}
 	close(c.mts.Final.Done())
 
@@ -1650,7 +1654,16 @@ func (c *Converter) prepBuildTarget(ctx context.Context, fullTargetName string, 
 	opt.PlatformResolver = c.platr.SubResolver(platform)
 	opt.HasDangling = isDangling
 	opt.AllowPrivileged = allowPrivileged
-	opt.waitBlock = c.waitBlock()
+
+	if cmdT == buildCmd {
+		// only BUILD commands get propigated
+		opt.waitBlock = c.waitBlock()
+	} else {
+		// FROM/COPY commands will return a llb state, which will cause a wait to occur
+		// if the wait block was passed here, calling SetDoSaves would get propigated
+		opt.waitBlock = nil
+	}
+
 	if c.opt.Features.ReferencedSaveOnly {
 		// DoSaves should only be potentially turned-off when the ReferencedSaveOnly feature is flipped
 		opt.DoSaves = (cmdT == buildCmd && c.opt.DoSaves && !c.opt.OnlyFinalTargetImages)

--- a/earthfile2llb/save_artifact_wait_item.go
+++ b/earthfile2llb/save_artifact_wait_item.go
@@ -1,0 +1,33 @@
+package earthfile2llb
+
+import (
+	"sync"
+
+	"github.com/earthly/earthly/states"
+	"github.com/earthly/earthly/util/waitutil"
+)
+
+type saveArtifactLocalWaitItem struct {
+	c           *Converter
+	saveLocal   states.SaveLocal
+	localExport bool
+	mu          sync.Mutex
+}
+
+// SetDoPush has no effect, but exists to satisfy interface
+func (salwi *saveArtifactLocalWaitItem) SetDoPush() {
+}
+
+func (salwi *saveArtifactLocalWaitItem) SetDoSave() {
+	salwi.mu.Lock()
+	defer salwi.mu.Unlock()
+	salwi.localExport = true
+}
+
+func newSaveArtifactLocal(state states.SaveLocal, c *Converter, localExport bool) waitutil.WaitItem {
+	return &saveArtifactLocalWaitItem{
+		c:           c,
+		saveLocal:   state,
+		localExport: localExport,
+	}
+}

--- a/earthfile2llb/save_image_wait_item.go
+++ b/earthfile2llb/save_image_wait_item.go
@@ -1,0 +1,39 @@
+package earthfile2llb
+
+import (
+	"sync"
+
+	"github.com/earthly/earthly/states"
+	"github.com/earthly/earthly/util/waitutil"
+)
+
+type saveImageWaitItem struct {
+	c  *Converter
+	si states.SaveImage
+
+	push        bool
+	localExport bool
+
+	mu sync.Mutex
+}
+
+func newSaveImage(si states.SaveImage, c *Converter, push, localExport bool) waitutil.WaitItem {
+	return &saveImageWaitItem{
+		c:           c,
+		si:          si,
+		push:        push,
+		localExport: localExport,
+	}
+}
+
+func (siwi *saveImageWaitItem) SetDoSave() {
+	siwi.mu.Lock()
+	defer siwi.mu.Unlock()
+	siwi.localExport = true
+}
+
+func (siwi *saveImageWaitItem) SetDoPush() {
+	siwi.mu.Lock()
+	defer siwi.mu.Unlock()
+	siwi.push = true
+}

--- a/earthfile2llb/state_wait_item.go
+++ b/earthfile2llb/state_wait_item.go
@@ -1,0 +1,26 @@
+package earthfile2llb
+
+import (
+	"github.com/earthly/earthly/util/llbutil/pllb"
+	"github.com/earthly/earthly/util/waitutil"
+)
+
+type stateWaitItem struct {
+	c     *Converter
+	state *pllb.State
+}
+
+// SetDoPush has no effect, but exists to satisfy interface
+func (swi *stateWaitItem) SetDoPush() {
+}
+
+// SetDoSave has no effect, but exists to satisfy interface
+func (swi *stateWaitItem) SetDoSave() {
+}
+
+func newStateWaitItem(state *pllb.State, c *Converter) waitutil.WaitItem {
+	return &stateWaitItem{
+		c:     c,
+		state: state,
+	}
+}

--- a/tests/wait-block/save-artifact-multi-ref/Earthfile
+++ b/tests/wait-block/save-artifact-multi-ref/Earthfile
@@ -1,0 +1,22 @@
+VERSION --wait-block 0.6
+
+produce-file:
+    FROM alpine:3.15
+    RUN echo -n 162948536bc2 > data
+    SAVE ARTIFACT data AS LOCAL data
+
+check-file-locally:
+    LOCALLY
+    RUN md5sum data | grep 916bdc548e2b088e8358632b8114a173
+
+test:
+    WAIT
+        FROM +produce-file
+        IF --no-cache sleep 3
+            RUN echo this forces the converter to wait
+        END
+        WAIT
+            BUILD +produce-file # now actually force the local output
+        END
+        BUILD +check-file-locally
+    END

--- a/tests/wait-block/save-artifact-multi-ref/test.sh
+++ b/tests/wait-block/save-artifact-multi-ref/test.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -uex
+set -o pipefail
+
+# Unset referenced-save-only.
+export EARTHLY_VERSION_FLAG_OVERRIDES=""
+
+cd "$(dirname "$0")"
+
+earthly=${earthly-"../../../build/linux/amd64/earthly"}
+"$earthly" --version
+
+# display a pass/fail message at the end
+function finish {
+  status="$?"
+  if [ "$status" = "0" ]; then
+    echo "save-artifact-multi-ref test passed"
+  else
+    echo "save-artifact-multi-ref test failed with $status"
+  fi
+}
+trap finish EXIT
+
+# Cleanup from previous tests
+rm -f data
+
+"$earthly" $@ +test
+test "$(cat data)" = "162948536bc2"

--- a/tests/wait-block/save-multi-platform-image-with-from/Earthfile
+++ b/tests/wait-block/save-multi-platform-image-with-from/Earthfile
@@ -1,0 +1,49 @@
+VERSION --wait-block 0.6
+
+earthly-multiplatform-wait-test-with-from-amd64:
+    FROM --platform=linux/amd64 alpine:latest
+    RUN echo x86_64 > /contrived-platform-data
+    SAVE IMAGE earthly-multiplatform-wait-test-with-from:latest
+
+earthly-multiplatform-wait-test-with-from-arm64:
+    FROM --platform=linux/arm64 alpine:latest
+    RUN echo aarch64 > /contrived-platform-data
+    SAVE IMAGE earthly-multiplatform-wait-test-with-from:latest
+
+earthly-multiplatform-wait-test-with-from-arm32v7:
+    FROM --platform=linux/arm/v7 alpine:latest
+    RUN echo arm/v7 > /contrived-platform-data
+    SAVE IMAGE earthly-multiplatform-wait-test-with-from:latest
+
+check-tag-exists-locally:
+    LOCALLY
+
+    RUN true
+
+    RUN docker images | grep 'earthly-multiplatform-wait-test-with-from[ ]\+latest_linux_amd64'
+    RUN docker images | grep 'earthly-multiplatform-wait-test-with-from[ ]\+latest_linux_arm_v7'
+    RUN if docker images | grep 'earthly-multiplatform-wait-test-with-from[ ]\+latest_linux_arm64'; then echo "Error: latest_linux_arm64 should not have be saved, but was" && exit 1; fi
+
+
+deps:
+    FROM alpine
+
+fake:
+    FROM +earthly-multiplatform-wait-test-with-from-arm64
+    RUN echo "this fake target uses arm64, but doesn't contain a direct SAVE IMAGE"
+
+indirect:
+    FROM +earthly-multiplatform-wait-test-with-from-amd64
+    RUN echo "this uses the same target which will be called directly under the main test"
+
+test:
+    FROM alpine
+    WAIT
+        BUILD +indirect # indirectly builds arm64, which is also built directly inside the IF
+        IF --no-cache sleep 5 # wait here in order for +indirect to be executed first
+            BUILD +earthly-multiplatform-wait-test-with-from-amd64
+            BUILD +earthly-multiplatform-wait-test-with-from-arm32v7
+            BUILD +fake # this indirectly builds arm64, which should never be saved locally
+        END
+    END
+    BUILD +check-tag-exists-locally

--- a/tests/wait-block/save-multi-platform-image-with-from/test.sh
+++ b/tests/wait-block/save-multi-platform-image-with-from/test.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -uex
+
+# Unset referenced-save-only.
+export EARTHLY_VERSION_FLAG_OVERRIDES=""
+
+# clean up old images (best effort)
+docker images | grep earthly-multiplatform-wait-test-with-from | awk '{print $1 ":" $2}' | xargs -r -n 1 docker rmi
+
+cd "$(dirname "$0")"
+
+earthly=${earthly-"../../../build/linux/amd64/earthly"}
+"$earthly" +test

--- a/tests/wait-block/with-docker-run-load/Earthfile
+++ b/tests/wait-block/with-docker-run-load/Earthfile
@@ -1,0 +1,38 @@
+VERSION --wait-block 0.6
+
+deps:
+    FROM alpine:3.15
+    RUN apk add curl jq
+
+check-tag-does-not-exist-in-registry:
+    FROM +deps
+    ARG --required REGISTRY
+    ARG --required tag
+    RUN curl -k "https://$REGISTRY/v2/myuser/myimg/manifests/$tag" > output && \
+        test "$(cat output | jq -r .errors[0].code)" = "MANIFEST_UNKNOWN" && echo "verified $tag was not pushed"
+
+check-tag-does-not-exist-locally:
+    LOCALLY
+    ARG --required REGISTRY
+    ARG --required tag
+    RUN docker images "$REGISTRY/myuser/myimg:$tag" | grep -v "$tag"
+
+a-test-image:
+    FROM alpine
+    ARG --required REGISTRY
+    ARG --required tag
+    ARG --required value
+    RUN echo $value > /data
+    SAVE IMAGE $REGISTRY/myuser/myimg:$tag
+
+test:
+    FROM earthly/dind:alpine
+    ARG --required REGISTRY
+    ARG --required tag
+    WAIT
+        WITH DOCKER --load="(+a-test-image --REGISTRY=$REGISTRY --tag=$tag --value NThlMzkwNGFhZmE3Cg==)"
+            RUN docker images && docker run --pull=never --rm $REGISTRY/myuser/myimg:$tag /bin/sh -c 'cat /data | base64 -d' # | grep "58e3904aafa7"
+        END
+    END
+    BUILD +check-tag-does-not-exist-in-registry --REGISTRY=$REGISTRY --tag=$tag
+    BUILD +check-tag-does-not-exist-locally --REGISTRY=$REGISTRY --tag=$tag

--- a/tests/wait-block/with-docker-run-load/test.sh
+++ b/tests/wait-block/with-docker-run-load/test.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+cd "$(dirname "$0")"
+../common/test.sh

--- a/util/waitutil/wait_block.go
+++ b/util/waitutil/wait_block.go
@@ -1,0 +1,11 @@
+package waitutil
+
+import "context"
+
+// WaitBlock stores items within a WAIT / END block
+type WaitBlock interface {
+	Wait(ctx context.Context, push, save bool) error
+	AddItem(item WaitItem)
+	SetDoSaves()
+	SetDoPushes()
+}

--- a/util/waitutil/wait_item.go
+++ b/util/waitutil/wait_item.go
@@ -1,0 +1,7 @@
+package waitutil
+
+// WaitItem is an item to wait for
+type WaitItem interface {
+	SetDoPush()
+	SetDoSave()
+}


### PR DESCRIPTION
This fixes a race condition where the same target is referenced from
both a FROM or COPY, then a BUILD.

When the converter is run via a FROM or COPY, it produces wait-items
which do not have a doSave (aka localExport) flag set; when it's
re-referenced from a BUILD it must scan through all wait items and set
the flag to true.