### PR TITLE
unused args should not be propagated

### DIFF
--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -114,7 +114,6 @@ func NewConverter(ctx context.Context, target domain.Target, bc *buildcontext.Da
 		Final:   sts,
 		Visited: opt.Visited,
 	}
-	sts.AddOverridingVarsAsBuildArgInputs(opt.OverridingVars)
 	newCollOpt := variables.NewCollectionOpt{
 		Console:          opt.Console,
 		Target:           target,
@@ -1624,13 +1623,9 @@ func (c *Converter) buildTarget(ctx context.Context, fullTargetName string, plat
 		// Propagate build arg inputs upwards (a child target depending on a build arg means
 		// that the parent also depends on that build arg).
 		for _, bai := range mts.Final.TargetInput().BuildArgs {
-			// Check if the build arg has been overridden. If it has, it can no longer be an input
-			// directly, so skip it.
-			_, found := opt.OverridingVars.GetAny(bai.Name)
-			if found {
-				continue
+			if !reserved.IsBuiltIn(bai.Name) {
+				c.mts.Final.AddBuildArgInput(bai)
 			}
-			c.mts.Final.AddBuildArgInput(bai)
 		}
 		if cmdT == fromCmd {
 			// Propagate globals.

--- a/states/states.go
+++ b/states/states.go
@@ -172,17 +172,6 @@ func (sts *SingleTarget) AddBuildArgInput(bai dedup.BuildArgInput) {
 	sts.targetInput = sts.targetInput.WithBuildArgInput(bai)
 }
 
-// AddOverridingVarsAsBuildArgInputs adds some vars to the sts's target input.
-func (sts *SingleTarget) AddOverridingVarsAsBuildArgInputs(overridingVars *variables.Scope) {
-	sts.tiMu.Lock()
-	defer sts.tiMu.Unlock()
-	for _, key := range overridingVars.SortedAny() {
-		ovVar, _ := overridingVars.GetAny(key)
-		sts.targetInput = sts.targetInput.WithBuildArgInput(
-			dedup.BuildArgInput{ConstantValue: ovVar, Name: key})
-	}
-}
-
 // LastSaveImage returns the last save image available (if any).
 func (sts *SingleTarget) LastSaveImage() SaveImage {
 	if len(sts.SaveImages) == 0 {

--- a/tests/wait-block/save-image-indirect-unused-args/Earthfile
+++ b/tests/wait-block/save-image-indirect-unused-args/Earthfile
@@ -1,0 +1,21 @@
+VERSION --wait-block 0.6
+
+# unused by test; however required for wait-test common.sh
+deps:
+    FROM scratch
+
+a:
+  FROM alpine:3.15
+  RUN echo a > /data
+  SAVE IMAGE earthly/testimg:f8874c9c-50bd-4634-aa5f-c53f26b69b87
+
+indirect:
+  FROM alpine:3.15
+  ARG myarg
+  BUILD +a
+
+test:
+  WAIT
+    BUILD +indirect --myarg=notused
+    BUILD +indirect --myarg=unused
+  END

--- a/tests/wait-block/save-image-indirect-unused-args/test.sh
+++ b/tests/wait-block/save-image-indirect-unused-args/test.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+cd "$(dirname "$0")"
+../common/test.sh


### PR DESCRIPTION
Propitiating all args, even unused args will cause the same target to be converted multiple times, which would lead to duplicate save image commands.