### PR TITLE
Allow files to be greater than 64kB

### DIFF
--- a/cmd/debugger/main.go
+++ b/cmd/debugger/main.go
@@ -117,7 +117,7 @@ func sendFile(ctx context.Context, sockAddr, src, dst string) error {
 		return err
 	}
 
-	err = common.WriteDataPacket(conn, len(b), b)
+	err = common.WriteFileTransfer(conn, b)
 	if err != nil {
 		return err
 	}

--- a/cmd/earthly/build_cmd.go
+++ b/cmd/earthly/build_cmd.go
@@ -549,7 +549,7 @@ func getTryCatchSaveFileHandler(localArtifactWhiteList *gatewaycrafter.LocalArti
 		}
 
 		// data
-		_, data, err := debuggercommon.ReadDataPacket(conn)
+		data, err := debuggercommon.ReadFileTransfer(conn)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Fixes #2452.

At first I tried using Read/WriteDataPacket in a loop, but this is simpler.

I have no idea about tests, sorry. But it works on my test case when I try it manually.