### PR TITLE
lint for consistent import orders

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,2 +1,15 @@
 run:
   timeout: 10m
+
+linters:
+  enable:
+  - gci
+
+linters-settings:
+  gci:
+    custom-order: true
+    sections:
+      - standard
+      - 'prefix(github.com/earthly/earthly)'
+      - 'prefix(github.com/earthly/cloud-api)'
+      - default

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/antlr/antlr4/runtime/Go/antlr"
 	"github.com/earthly/earthly/ast/antlrhandler"
 	"github.com/earthly/earthly/ast/parser"
 	"github.com/earthly/earthly/ast/spec"
+
+	"github.com/antlr/antlr4/runtime/Go/antlr"
 	"github.com/pkg/errors"
 )
 

--- a/ast/lexer.go
+++ b/ast/lexer.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/antlr/antlr4/runtime/Go/antlr"
 	"github.com/earthly/earthly/ast/parser"
+
+	"github.com/antlr/antlr4/runtime/Go/antlr"
 )
 
 // lexer is a lexer for an earthly file, which also emits indentation

--- a/ast/listener.go
+++ b/ast/listener.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/earthly/earthly/ast/parser"
 	"github.com/earthly/earthly/ast/spec"
+
 	"github.com/pkg/errors"
 )
 

--- a/ast/validator.go
+++ b/ast/validator.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/earthly/earthly/ast/spec"
+
 	"github.com/pkg/errors"
 )
 

--- a/buildcontext/detectbuildfile.go
+++ b/buildcontext/detectbuildfile.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/earthly/earthly/domain"
+
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/pkg/errors"
 )

--- a/buildcontext/excludes.go
+++ b/buildcontext/excludes.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 
 	"github.com/earthly/earthly/util/fileutil"
+
 	"github.com/moby/buildkit/frontend/dockerfile/dockerignore"
 	"github.com/pkg/errors"
 )

--- a/buildcontext/gitlookup.go
+++ b/buildcontext/gitlookup.go
@@ -15,17 +15,16 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pkg/errors"
-	"golang.org/x/crypto/ssh"
-	"golang.org/x/crypto/ssh/agent"
-	"golang.org/x/crypto/ssh/knownhosts"
-
 	"github.com/earthly/earthly/conslogging"
 	"github.com/earthly/earthly/util/fileutil"
 
 	"github.com/jdxcode/netrc"
 	"github.com/moby/buildkit/util/gitutil"
 	"github.com/moby/buildkit/util/sshutil"
+	"github.com/pkg/errors"
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
+	"golang.org/x/crypto/ssh/knownhosts"
 )
 
 type gitMatcher struct {

--- a/buildcontext/local.go
+++ b/buildcontext/local.go
@@ -13,6 +13,7 @@ import (
 	"github.com/earthly/earthly/util/llbutil/llbfactory"
 	"github.com/earthly/earthly/util/platutil"
 	"github.com/earthly/earthly/util/syncutil/synccache"
+
 	"github.com/moby/buildkit/client/llb"
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/pkg/errors"

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -30,6 +30,7 @@ import (
 	"github.com/earthly/earthly/util/saveartifactlocally"
 	"github.com/earthly/earthly/util/syncutil/semutil"
 	"github.com/earthly/earthly/variables"
+
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/client/llb"
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/earthly/earthly/cleanup"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // TestTempEarthlyOutDir tests that tempEarthlyOutDir always returns the same directory

--- a/builder/image_solver.go
+++ b/builder/image_solver.go
@@ -15,6 +15,7 @@ import (
 	"github.com/earthly/earthly/states/image"
 	"github.com/earthly/earthly/util/gatewaycrafter"
 	"github.com/earthly/earthly/util/llbutil"
+
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/exporter/containerimage/exptypes"

--- a/builder/solver.go
+++ b/builder/solver.go
@@ -10,6 +10,7 @@ import (
 	"github.com/earthly/earthly/outmon"
 	"github.com/earthly/earthly/states"
 	"github.com/earthly/earthly/util/fsutilprogress"
+
 	"github.com/moby/buildkit/client"
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/moby/buildkit/session"

--- a/buildkitd/buildkitd.go
+++ b/buildkitd/buildkitd.go
@@ -12,6 +12,13 @@ import (
 	"sync"
 	"time"
 
+	"github.com/earthly/earthly/conslogging"
+	"github.com/earthly/earthly/util/buildkitutil"
+	"github.com/earthly/earthly/util/cliutil"
+	"github.com/earthly/earthly/util/containerutil"
+	"github.com/earthly/earthly/util/fileutil"
+	"github.com/earthly/earthly/util/semverutil"
+
 	"github.com/containerd/containerd/platforms"
 	"github.com/dustin/go-humanize"
 	"github.com/gofrs/flock"
@@ -20,13 +27,6 @@ import (
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-
-	"github.com/earthly/earthly/conslogging"
-	"github.com/earthly/earthly/util/buildkitutil"
-	"github.com/earthly/earthly/util/cliutil"
-	"github.com/earthly/earthly/util/containerutil"
-	"github.com/earthly/earthly/util/fileutil"
-	"github.com/earthly/earthly/util/semverutil"
 )
 
 var (

--- a/cloud/account.go
+++ b/cloud/account.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	secretsapi "github.com/earthly/cloud-api/secrets"
+
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/ssh/agent"
 	"google.golang.org/protobuf/types/known/timestamppb"

--- a/cloud/auth.go
+++ b/cloud/auth.go
@@ -11,9 +11,11 @@ import (
 	"strings"
 	"time"
 
-	secretsapi "github.com/earthly/cloud-api/secrets"
 	"github.com/earthly/earthly/util/cliutil"
 	"github.com/earthly/earthly/util/fileutil"
+
+	secretsapi "github.com/earthly/cloud-api/secrets"
+
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/ssh/agent"
 )

--- a/cloud/auth_test.go
+++ b/cloud/auth_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	api "github.com/earthly/cloud-api/secrets"
+
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/timestamppb"

--- a/cloud/client.go
+++ b/cloud/client.go
@@ -8,6 +8,7 @@ import (
 	"github.com/earthly/cloud-api/compute"
 	"github.com/earthly/cloud-api/logstream"
 	"github.com/earthly/cloud-api/pipelines"
+
 	"github.com/google/uuid"
 	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
 	"github.com/pkg/errors"

--- a/cloud/log.go
+++ b/cloud/log.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	logsapi "github.com/earthly/cloud-api/logs"
+
 	"github.com/pkg/errors"
 )
 

--- a/cloud/logstream.go
+++ b/cloud/logstream.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/earthly/cloud-api/logstream"
+
 	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"

--- a/cloud/org.go
+++ b/cloud/org.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	secretsapi "github.com/earthly/cloud-api/secrets"
+
 	"github.com/pkg/errors"
 )
 

--- a/cloud/org_new.go
+++ b/cloud/org_new.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	secretsapi "github.com/earthly/cloud-api/secrets"
+
 	"github.com/pkg/errors"
 )
 

--- a/cloud/project.go
+++ b/cloud/project.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	secretsapi "github.com/earthly/cloud-api/secrets"
+
 	"github.com/pkg/errors"
 )
 

--- a/cloud/satellite.go
+++ b/cloud/satellite.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	pb "github.com/earthly/cloud-api/compute"
+
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/types/known/durationpb"
 )

--- a/cloud/secret_new.go
+++ b/cloud/secret_new.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	secretsapi "github.com/earthly/cloud-api/secrets"
+
 	"github.com/pkg/errors"
 )
 

--- a/cmd/earthly/account_cmds.go
+++ b/cmd/earthly/account_cmds.go
@@ -11,14 +11,14 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/earthly/earthly/cloud"
+
 	"github.com/dustin/go-humanize"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
 	"golang.org/x/term"
-
-	"github.com/earthly/earthly/cloud"
 )
 
 var (
@@ -190,7 +190,7 @@ func (app *earthlyApp) actionAccountRegister(cliCtx *cli.Context) error {
 	if !strings.Contains(app.email, "@") {
 		return errors.New("email is invalid")
 	}
-	
+
 	cloudClient, err := app.newCloudClient()
 	if err != nil {
 		return err

--- a/cmd/earthly/autocomplete.go
+++ b/cmd/earthly/autocomplete.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/adrg/xdg"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -12,14 +11,15 @@ import (
 	"strconv"
 	"strings"
 
-	gwclient "github.com/moby/buildkit/frontend/gateway/client"
-	"github.com/pkg/errors"
-
 	"github.com/earthly/earthly/autocomplete"
 	"github.com/earthly/earthly/buildcontext"
 	"github.com/earthly/earthly/conslogging"
 	"github.com/earthly/earthly/util/cliutil"
 	"github.com/earthly/earthly/util/fileutil"
+
+	"github.com/adrg/xdg"
+	gwclient "github.com/moby/buildkit/frontend/gateway/client"
+	"github.com/pkg/errors"
 )
 
 // to enable autocomplete, enter

--- a/cmd/earthly/build_cmd.go
+++ b/cmd/earthly/build_cmd.go
@@ -8,19 +8,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/containerd/containerd/platforms"
-	"github.com/docker/cli/cli/config"
-	"github.com/joho/godotenv"
-	"github.com/moby/buildkit/client/llb"
-	"github.com/moby/buildkit/session"
-	"github.com/moby/buildkit/session/auth/authprovider"
-	"github.com/moby/buildkit/session/localhost/localhostprovider"
-	"github.com/moby/buildkit/session/socketforward/socketprovider"
-	"github.com/moby/buildkit/session/sshforward/sshprovider"
-	"github.com/moby/buildkit/util/entitlements"
-	"github.com/pkg/errors"
-	"github.com/urfave/cli/v2"
-
 	"github.com/earthly/earthly/buildcontext"
 	"github.com/earthly/earthly/buildcontext/provider"
 	"github.com/earthly/earthly/builder"
@@ -40,6 +27,19 @@ import (
 	"github.com/earthly/earthly/util/syncutil/semutil"
 	"github.com/earthly/earthly/util/termutil"
 	"github.com/earthly/earthly/variables"
+
+	"github.com/containerd/containerd/platforms"
+	"github.com/docker/cli/cli/config"
+	"github.com/joho/godotenv"
+	"github.com/moby/buildkit/client/llb"
+	"github.com/moby/buildkit/session"
+	"github.com/moby/buildkit/session/auth/authprovider"
+	"github.com/moby/buildkit/session/localhost/localhostprovider"
+	"github.com/moby/buildkit/session/socketforward/socketprovider"
+	"github.com/moby/buildkit/session/sshforward/sshprovider"
+	"github.com/moby/buildkit/util/entitlements"
+	"github.com/pkg/errors"
+	"github.com/urfave/cli/v2"
 )
 
 func (app *earthlyApp) actionBuild(cliCtx *cli.Context) error {

--- a/cmd/earthly/buildkit.go
+++ b/cmd/earthly/buildkit.go
@@ -6,16 +6,16 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/moby/buildkit/client"
-	"github.com/pkg/errors"
-	"github.com/urfave/cli/v2"
-
 	"github.com/earthly/earthly/analytics"
 	"github.com/earthly/earthly/buildkitd"
 	"github.com/earthly/earthly/cloud"
 	"github.com/earthly/earthly/config"
 	"github.com/earthly/earthly/util/cliutil"
 	"github.com/earthly/earthly/util/containerutil"
+
+	"github.com/moby/buildkit/client"
+	"github.com/pkg/errors"
+	"github.com/urfave/cli/v2"
 )
 
 func (app *earthlyApp) initFrontend(cliCtx *cli.Context) error {

--- a/cmd/earthly/common.go
+++ b/cmd/earthly/common.go
@@ -10,11 +10,11 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"github.com/earthly/earthly/cloud"
 	"github.com/earthly/earthly/util/cliutil"
 	"github.com/earthly/earthly/util/fileutil"
+
+	"github.com/pkg/errors"
 )
 
 func (app *earthlyApp) newCloudClient() (cloud.Client, error) {

--- a/cmd/earthly/debug_cmds.go
+++ b/cmd/earthly/debug_cmds.go
@@ -8,13 +8,13 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/earthly/earthly/ast"
+
 	"github.com/containerd/containerd/platforms"
 	"github.com/dustin/go-humanize"
 	"github.com/moby/buildkit/client"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"
-
-	"github.com/earthly/earthly/ast"
 )
 
 func (app *earthlyApp) debugCmds() []*cli.Command {

--- a/cmd/earthly/flags.go
+++ b/cmd/earthly/flags.go
@@ -3,9 +3,9 @@ package main
 import (
 	"os"
 
-	"github.com/urfave/cli/v2"
-
 	"github.com/earthly/earthly/util/containerutil"
+
+	"github.com/urfave/cli/v2"
 )
 
 func (app *earthlyApp) rootFlags() []cli.Flag {

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -18,18 +18,6 @@ import (
 	"syscall"
 	"time"
 
-	gsysinfo "github.com/elastic/go-sysinfo"
-	"github.com/fatih/color"
-	"github.com/google/uuid"
-	"github.com/joho/godotenv"
-	_ "github.com/moby/buildkit/client/connhelper/dockercontainer" // Load "docker-container://" helper.
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
-	"github.com/urfave/cli/v2"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-
-	"github.com/earthly/cloud-api/logstream"
 	"github.com/earthly/earthly/analytics"
 	"github.com/earthly/earthly/builder"
 	"github.com/earthly/earthly/buildkitd"
@@ -42,6 +30,19 @@ import (
 	"github.com/earthly/earthly/util/containerutil"
 	"github.com/earthly/earthly/util/fileutil"
 	"github.com/earthly/earthly/util/reflectutil"
+
+	"github.com/earthly/cloud-api/logstream"
+
+	gsysinfo "github.com/elastic/go-sysinfo"
+	"github.com/fatih/color"
+	"github.com/google/uuid"
+	"github.com/joho/godotenv"
+	_ "github.com/moby/buildkit/client/connhelper/dockercontainer" // Load "docker-container://" helper.
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli/v2"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 const (

--- a/cmd/earthly/org_cmds.go
+++ b/cmd/earthly/org_cmds.go
@@ -6,10 +6,10 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/earthly/earthly/cloud"
+
 	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"
-
-	"github.com/earthly/earthly/cloud"
 )
 
 func (app *earthlyApp) orgCmds() []*cli.Command {

--- a/cmd/earthly/project_cmds.go
+++ b/cmd/earthly/project_cmds.go
@@ -6,10 +6,10 @@ import (
 	"os"
 	"text/tabwriter"
 
+	"github.com/earthly/earthly/cloud"
+
 	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"
-
-	"github.com/earthly/earthly/cloud"
 )
 
 const dateFormat = "2006-01-02"

--- a/cmd/earthly/root_cmds.go
+++ b/cmd/earthly/root_cmds.go
@@ -9,13 +9,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/dustin/go-humanize"
-	"github.com/moby/buildkit/client"
-	gwclient "github.com/moby/buildkit/frontend/gateway/client"
-	"github.com/pkg/errors"
-	"github.com/urfave/cli/v2"
-	"golang.org/x/sync/errgroup"
-
 	"github.com/earthly/earthly/buildcontext"
 	"github.com/earthly/earthly/buildkitd"
 	"github.com/earthly/earthly/config"
@@ -25,6 +18,13 @@ import (
 	"github.com/earthly/earthly/util/cliutil"
 	"github.com/earthly/earthly/util/fileutil"
 	"github.com/earthly/earthly/util/termutil"
+
+	"github.com/dustin/go-humanize"
+	"github.com/moby/buildkit/client"
+	gwclient "github.com/moby/buildkit/frontend/gateway/client"
+	"github.com/pkg/errors"
+	"github.com/urfave/cli/v2"
+	"golang.org/x/sync/errgroup"
 )
 
 func (app *earthlyApp) rootCmds() []*cli.Command {

--- a/cmd/earthly/satellite_cmds.go
+++ b/cmd/earthly/satellite_cmds.go
@@ -10,14 +10,14 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/pkg/errors"
-	"github.com/urfave/cli/v2"
-
 	"github.com/earthly/earthly/buildkitd"
 	"github.com/earthly/earthly/cloud"
 	"github.com/earthly/earthly/config"
 	"github.com/earthly/earthly/conslogging"
 	"github.com/earthly/earthly/util/containerutil"
+
+	"github.com/pkg/errors"
+	"github.com/urfave/cli/v2"
 )
 
 func (app *earthlyApp) satelliteCmds() []*cli.Command {

--- a/conslogging/bundle.go
+++ b/conslogging/bundle.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/earthly/earthly/cleanup"
+
 	"github.com/pkg/errors"
 )
 

--- a/conslogging/conslogging.go
+++ b/conslogging/conslogging.go
@@ -9,6 +9,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/earthly/earthly/cleanup"
+
 	"github.com/fatih/color"
 )
 

--- a/earthfile2llb/cachedmetaresolver.go
+++ b/earthfile2llb/cachedmetaresolver.go
@@ -3,8 +3,9 @@ package earthfile2llb
 import (
 	"context"
 
-	"github.com/containerd/containerd/platforms"
 	"github.com/earthly/earthly/util/syncutil/synccache"
+
+	"github.com/containerd/containerd/platforms"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/opencontainers/go-digest"
 )

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -18,7 +18,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/earthly/cloud-api/logstream"
 	"github.com/earthly/earthly/analytics"
 	"github.com/earthly/earthly/buildcontext"
 	debuggercommon "github.com/earthly/earthly/debugger/common"
@@ -41,8 +40,8 @@ import (
 	"github.com/earthly/earthly/util/vertexmeta"
 	"github.com/earthly/earthly/variables"
 	"github.com/earthly/earthly/variables/reserved"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
+
+	"github.com/earthly/cloud-api/logstream"
 
 	"github.com/alessio/shellescape"
 	"github.com/containerd/containerd/platforms"
@@ -55,6 +54,8 @@ import (
 	solverpb "github.com/moby/buildkit/solver/pb"
 	"github.com/moby/buildkit/util/apicaps"
 	"github.com/pkg/errors"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type cmdType int

--- a/earthfile2llb/earthfile2llb.go
+++ b/earthfile2llb/earthfile2llb.go
@@ -4,16 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/earthly/earthly/logbus"
-	"github.com/earthly/earthly/util/containerutil"
-	"github.com/earthly/earthly/util/gatewaycrafter"
-	"github.com/earthly/earthly/util/llbutil/secretprovider"
-	"github.com/earthly/earthly/util/platutil"
-	"github.com/moby/buildkit/client/llb"
-	gwclient "github.com/moby/buildkit/frontend/gateway/client"
-	"github.com/moby/buildkit/util/apicaps"
-	"github.com/pkg/errors"
-
 	"github.com/earthly/earthly/ast/spec"
 	"github.com/earthly/earthly/buildcontext"
 	"github.com/earthly/earthly/buildcontext/provider"
@@ -21,10 +11,20 @@ import (
 	"github.com/earthly/earthly/conslogging"
 	"github.com/earthly/earthly/domain"
 	"github.com/earthly/earthly/features"
+	"github.com/earthly/earthly/logbus"
 	"github.com/earthly/earthly/states"
+	"github.com/earthly/earthly/util/containerutil"
+	"github.com/earthly/earthly/util/gatewaycrafter"
+	"github.com/earthly/earthly/util/llbutil/secretprovider"
+	"github.com/earthly/earthly/util/platutil"
 	"github.com/earthly/earthly/util/syncutil/semutil"
 	"github.com/earthly/earthly/util/syncutil/serrgroup"
 	"github.com/earthly/earthly/variables"
+
+	"github.com/moby/buildkit/client/llb"
+	gwclient "github.com/moby/buildkit/frontend/gateway/client"
+	"github.com/moby/buildkit/util/apicaps"
+	"github.com/pkg/errors"
 )
 
 // ConvertOpt holds conversion parameters.

--- a/earthfile2llb/interpretererror.go
+++ b/earthfile2llb/interpretererror.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/earthly/earthly/ast/spec"
+
 	"github.com/pkg/errors"
 )
 

--- a/earthfile2llb/runmount.go
+++ b/earthfile2llb/runmount.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/earthly/earthly/states/dedup"
 	"github.com/earthly/earthly/util/llbutil/pllb"
+
 	"github.com/moby/buildkit/client/llb"
 	"github.com/pkg/errors"
 )

--- a/earthfile2llb/withdockerrun.go
+++ b/earthfile2llb/withdockerrun.go
@@ -17,6 +17,7 @@ import (
 	"github.com/earthly/earthly/util/llbutil/pllb"
 	"github.com/earthly/earthly/util/platutil"
 	"github.com/earthly/earthly/util/syncutil/semutil"
+
 	"github.com/moby/buildkit/client/llb"
 	"github.com/pkg/errors"
 )

--- a/earthfile2llb/withdockerrunbase.go
+++ b/earthfile2llb/withdockerrunbase.go
@@ -6,9 +6,10 @@ import (
 	"path"
 	"strings"
 
-	"github.com/containerd/containerd/platforms"
 	"github.com/earthly/earthly/util/llbutil"
 	"github.com/earthly/earthly/util/platutil"
+
+	"github.com/containerd/containerd/platforms"
 	"github.com/moby/buildkit/client/llb"
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/pkg/errors"

--- a/earthfile2llb/withdockerrunlocal.go
+++ b/earthfile2llb/withdockerrunlocal.go
@@ -10,6 +10,7 @@ import (
 	"github.com/earthly/earthly/domain"
 	"github.com/earthly/earthly/states"
 	"github.com/earthly/earthly/util/syncutil/semutil"
+
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/session/localhost"
 	"github.com/pkg/errors"

--- a/earthfile2llb/withdockerrunlocalreg.go
+++ b/earthfile2llb/withdockerrunlocalreg.go
@@ -8,6 +8,7 @@ import (
 	"github.com/earthly/earthly/states"
 	"github.com/earthly/earthly/util/containerutil"
 	"github.com/earthly/earthly/util/syncutil/semutil"
+
 	"github.com/pkg/errors"
 )
 

--- a/earthfile2llb/withdockerrunreg.go
+++ b/earthfile2llb/withdockerrunreg.go
@@ -11,6 +11,7 @@ import (
 	"github.com/earthly/earthly/util/llbutil/pllb"
 	"github.com/earthly/earthly/util/platutil"
 	"github.com/earthly/earthly/util/syncutil/semutil"
+
 	"github.com/moby/buildkit/client/llb"
 	"github.com/pkg/errors"
 )

--- a/examples/go-monorepo/services/one/main.go
+++ b/examples/go-monorepo/services/one/main.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/earthly/earthly/examples/go-monorepo/libs/hello"
+
 	"github.com/labstack/echo/v4"
 )
 

--- a/examples/go-monorepo/services/two/main.go
+++ b/examples/go-monorepo/services/two/main.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/earthly/earthly/examples/go-monorepo/libs/hello"
+
 	"github.com/labstack/echo/v4"
 )
 

--- a/examples/readme/proto/main.go
+++ b/examples/readme/proto/main.go
@@ -4,6 +4,7 @@ import (
 	"log"
 
 	"github.com/earthly/earthly/examples/readme/proto/pb"
+
 	"github.com/golang/protobuf/proto"
 )
 

--- a/features/features.go
+++ b/features/features.go
@@ -7,12 +7,12 @@ import (
 	"strconv"
 	"strings"
 
-	goflags "github.com/jessevdk/go-flags"
-	"github.com/pkg/errors"
-
 	"github.com/earthly/earthly/analytics"
 	"github.com/earthly/earthly/ast/spec"
 	"github.com/earthly/earthly/util/flagutil"
+
+	goflags "github.com/jessevdk/go-flags"
+	"github.com/pkg/errors"
 )
 
 // Features is used to denote which features to flip on or off; this is for use in maintaining

--- a/logbus/command.go
+++ b/logbus/command.go
@@ -4,8 +4,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/armon/circbuf"
 	"github.com/earthly/cloud-api/logstream"
+
+	"github.com/armon/circbuf"
 	"github.com/pkg/errors"
 )
 

--- a/logbus/formatter/formatter.go
+++ b/logbus/formatter/formatter.go
@@ -9,11 +9,13 @@ import (
 	"sync"
 	"time"
 
-	"github.com/earthly/cloud-api/logstream"
 	"github.com/earthly/earthly/conslogging"
 	"github.com/earthly/earthly/logbus"
 	"github.com/earthly/earthly/util/deltautil"
 	"github.com/earthly/earthly/util/progressbar"
+
+	"github.com/earthly/cloud-api/logstream"
+
 	"github.com/hashicorp/go-multierror"
 	"github.com/mattn/go-isatty"
 	"github.com/pkg/errors"

--- a/logbus/generic.go
+++ b/logbus/generic.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/earthly/cloud-api/logstream"
 	"github.com/earthly/earthly/conslogging"
+
+	"github.com/earthly/cloud-api/logstream"
 )
 
 // Generic is a generic writer for build output unrelated to a specific target.

--- a/logbus/logstreamer/logstreamer.go
+++ b/logbus/logstreamer/logstreamer.go
@@ -7,9 +7,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/earthly/cloud-api/logstream"
 	"github.com/earthly/earthly/cloud"
 	"github.com/earthly/earthly/logbus"
+
+	"github.com/earthly/cloud-api/logstream"
+
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"

--- a/logbus/run.go
+++ b/logbus/run.go
@@ -5,8 +5,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/earthly/cloud-api/logstream"
 	"github.com/earthly/earthly/ast/spec"
+
+	"github.com/earthly/cloud-api/logstream"
 )
 
 // Run is a run logstream delta generator for a run.

--- a/logbus/setup/setup.go
+++ b/logbus/setup/setup.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/earthly/cloud-api/logstream"
 	"github.com/earthly/earthly/cloud"
 	"github.com/earthly/earthly/logbus"
 	"github.com/earthly/earthly/logbus/formatter"
@@ -13,6 +12,9 @@ import (
 	"github.com/earthly/earthly/logbus/solvermon"
 	"github.com/earthly/earthly/logbus/writersub"
 	"github.com/earthly/earthly/util/deltautil"
+
+	"github.com/earthly/cloud-api/logstream"
+
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/encoding/protojson"

--- a/logbus/solvermon/solvermon.go
+++ b/logbus/solvermon/solvermon.go
@@ -6,10 +6,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/earthly/cloud-api/logstream"
 	"github.com/earthly/earthly/logbus"
 	"github.com/earthly/earthly/util/vertexmeta"
 	"github.com/earthly/earthly/util/xcontext"
+
+	"github.com/earthly/cloud-api/logstream"
+
 	"github.com/moby/buildkit/client"
 	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"

--- a/logbus/solvermon/vertexmon.go
+++ b/logbus/solvermon/vertexmon.go
@@ -8,9 +8,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/earthly/cloud-api/logstream"
 	"github.com/earthly/earthly/logbus"
 	"github.com/earthly/earthly/util/vertexmeta"
+
+	"github.com/earthly/cloud-api/logstream"
+
 	"github.com/moby/buildkit/client"
 	"github.com/pkg/errors"
 )

--- a/logbus/writersub/raw.go
+++ b/logbus/writersub/raw.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/earthly/cloud-api/logstream"
+
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 )

--- a/outmon/solvermon.go
+++ b/outmon/solvermon.go
@@ -8,10 +8,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/dustin/go-humanize"
 	"github.com/earthly/earthly/conslogging"
 	"github.com/earthly/earthly/util/buildkitutil"
 	"github.com/earthly/earthly/util/vertexmeta"
+
+	"github.com/dustin/go-humanize"
 	"github.com/moby/buildkit/client"
 	"github.com/opencontainers/go-digest"
 )

--- a/outmon/vertexmon.go
+++ b/outmon/vertexmon.go
@@ -10,10 +10,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/armon/circbuf"
 	"github.com/earthly/earthly/conslogging"
 	"github.com/earthly/earthly/util/progressbar"
 	"github.com/earthly/earthly/util/vertexmeta"
+
+	"github.com/armon/circbuf"
 	"github.com/mattn/go-isatty"
 	"github.com/moby/buildkit/client"
 	"github.com/pkg/errors"

--- a/states/builderfun.go
+++ b/states/builderfun.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/earthly/earthly/util/platutil"
+
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 

--- a/states/image/image.go
+++ b/states/image/image.go
@@ -2,6 +2,7 @@ package image
 
 import (
 	"github.com/earthly/earthly/util/llbutil"
+
 	"github.com/moby/buildkit/exporter/containerimage/image"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 )

--- a/states/solvecache.go
+++ b/states/solvecache.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/earthly/earthly/util/llbutil/pllb"
 	"github.com/earthly/earthly/util/syncutil/synccache"
+
 	"github.com/pkg/errors"
 )
 

--- a/states/states.go
+++ b/states/states.go
@@ -10,6 +10,7 @@ import (
 	"github.com/earthly/earthly/util/llbutil/pllb"
 	"github.com/earthly/earthly/util/platutil"
 	"github.com/earthly/earthly/variables"
+
 	"github.com/google/uuid"
 )
 

--- a/states/visited.go
+++ b/states/visited.go
@@ -8,6 +8,7 @@ import (
 	"github.com/earthly/earthly/states/dedup"
 	"github.com/earthly/earthly/util/platutil"
 	"github.com/earthly/earthly/variables"
+
 	"github.com/pkg/errors"
 )
 

--- a/util/cliutil/earthlydir.go
+++ b/util/cliutil/earthlydir.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/earthly/earthly/util/fileutil"
+
 	"github.com/pkg/errors"
 )
 

--- a/util/containerutil/frontend.go
+++ b/util/containerutil/frontend.go
@@ -6,10 +6,10 @@ import (
 	"io"
 	"runtime"
 
+	"github.com/earthly/earthly/conslogging"
+
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
-
-	"github.com/earthly/earthly/conslogging"
 )
 
 // ContainerFrontend is an interface specifying all the container options Earthly needs to do.

--- a/util/containerutil/settings_test.go
+++ b/util/containerutil/settings_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/earthly/earthly/config"
 	"github.com/earthly/earthly/conslogging"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/util/containerutil/shell_shared.go
+++ b/util/containerutil/shell_shared.go
@@ -11,8 +11,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/containerd/containerd/platforms"
 	"github.com/earthly/earthly/conslogging"
+
+	"github.com/containerd/containerd/platforms"
 	"github.com/hashicorp/go-multierror"
 	_ "github.com/moby/buildkit/client/connhelper/dockercontainer" // Load "docker-container://" helper.
 	"github.com/pkg/errors"

--- a/util/deltautil/apply.go
+++ b/util/deltautil/apply.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	pb "github.com/earthly/cloud-api/logstream"
+
 	"google.golang.org/protobuf/proto"
 )
 

--- a/util/dockerutil/docker.go
+++ b/util/dockerutil/docker.go
@@ -9,9 +9,9 @@ import (
 	"github.com/earthly/earthly/conslogging"
 	"github.com/earthly/earthly/util/containerutil"
 	"github.com/earthly/earthly/util/platutil"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
 )
 
 // Manifest contains docker manifest data

--- a/util/flagutil/parse.go
+++ b/util/flagutil/parse.go
@@ -4,9 +4,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/pkg/errors"
-
 	flags "github.com/jessevdk/go-flags"
+	"github.com/pkg/errors"
 )
 
 // ArgumentModFunc accepts a flagName which corresponds to the long flag name, and a pointer

--- a/util/fsutilprogress/progress.go
+++ b/util/fsutilprogress/progress.go
@@ -6,8 +6,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/dustin/go-humanize"
 	"github.com/earthly/earthly/conslogging"
+
+	"github.com/dustin/go-humanize"
 	"github.com/tonistiigi/fsutil"
 )
 

--- a/util/gitutil/detectgit.go
+++ b/util/gitutil/detectgit.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/earthly/earthly/domain"
+
 	"github.com/pkg/errors"
 )
 

--- a/util/llbutil/copyop.go
+++ b/util/llbutil/copyop.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/earthly/earthly/util/llbutil/pllb"
 	"github.com/earthly/earthly/util/platutil"
+
 	"github.com/moby/buildkit/client/llb"
 	"github.com/pkg/errors"
 )

--- a/util/llbutil/fakedep.go
+++ b/util/llbutil/fakedep.go
@@ -4,6 +4,7 @@ import (
 	"github.com/earthly/earthly/util/llbutil/pllb"
 	"github.com/earthly/earthly/util/platutil"
 	"github.com/earthly/earthly/util/vertexmeta"
+
 	"github.com/moby/buildkit/client/llb"
 )
 

--- a/util/llbutil/platform_name.go
+++ b/util/llbutil/platform_name.go
@@ -3,8 +3,9 @@ package llbutil
 import (
 	"fmt"
 
-	"github.com/docker/distribution/reference"
 	"github.com/earthly/earthly/util/platutil"
+
+	"github.com/docker/distribution/reference"
 	"github.com/pkg/errors"
 )
 

--- a/util/llbutil/secretprovider/cloud.go
+++ b/util/llbutil/secretprovider/cloud.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/earthly/earthly/cloud"
+
 	"github.com/moby/buildkit/session/secrets"
 )
 

--- a/util/llbutil/statetoref.go
+++ b/util/llbutil/statetoref.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/earthly/earthly/util/llbutil/pllb"
 	"github.com/earthly/earthly/util/platutil"
+
 	"github.com/moby/buildkit/client/llb"
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/pkg/errors"

--- a/util/platutil/resolver.go
+++ b/util/platutil/resolver.go
@@ -1,8 +1,9 @@
 package platutil
 
 import (
-	"github.com/containerd/containerd/platforms"
 	"github.com/earthly/earthly/util/llbutil/pllb"
+
+	"github.com/containerd/containerd/platforms"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 

--- a/util/stringutil/random.go
+++ b/util/stringutil/random.go
@@ -8,7 +8,7 @@ import (
 
 var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
 
-//RandomAlphanumeric returns a random alphanumeric string of length n
+// RandomAlphanumeric returns a random alphanumeric string of length n
 func RandomAlphanumeric(n int) string {
 	var seed int64
 	err := binary.Read(crand.Reader, binary.BigEndian, &seed)

--- a/util/syncutil/synccache/synccache.go
+++ b/util/syncutil/synccache/synccache.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/earthly/earthly/util/syncutil/metacontext"
+
 	"github.com/pkg/errors"
 )
 

--- a/variables/builtin.go
+++ b/variables/builtin.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/containerd/containerd/platforms"
-
 	"github.com/earthly/earthly/domain"
 	"github.com/earthly/earthly/features"
 	"github.com/earthly/earthly/util/gitutil"
@@ -13,6 +11,8 @@ import (
 	"github.com/earthly/earthly/util/platutil"
 	"github.com/earthly/earthly/util/stringutil"
 	arg "github.com/earthly/earthly/variables/reserved"
+
+	"github.com/containerd/containerd/platforms"
 )
 
 // DefaultArgs contains additional builtin ARG values which need

--- a/variables/util.go
+++ b/variables/util.go
@@ -10,12 +10,12 @@ import (
 // once an unescaped '=' is found, all remaining chars will be used as-is without the need to be escaped.
 // the key and value are returned, along with a bool that is true if a value was defined (i.e. an equal was found)
 //
-// e.g. ParseKeyValue("foo")       -> `foo`,  ``,       false
-//      ParseKeyValue("foo=")      -> `foo`,  ``,       true
-//      ParseKeyValue("foo=bar")   -> `foo`,  `bar`,    true
-//      ParseKeyValue(`f\=oo=bar`) -> `f=oo`, `bar`,    true
-//      ParseKeyValue(`foo=bar=`)  -> `foo",  `bar=`,   true
-//      ParseKeyValue(`foo=bar\=`) -> `foo",  `bar\=`,  true
+// e.g. ParseKeyValue("foo")       -> "foo",  "",       false
+// e.g. ParseKeyValue("foo=")      -> "foo",  "",       true
+// e.g. ParseKeyValue("foo=bar")   -> "foo",  "bar",    true
+// e.g. ParseKeyValue("f\=oo=bar") -> "f=oo", "bar",    true
+// e.g. ParseKeyValue("foo=bar=")  -> "foo",  "bar=",   true
+// e.g. ParseKeyValue("foo=bar\=") -> "foo",  "bar\=",  true
 func ParseKeyValue(s string) (string, string, bool) {
 	key := []string{}
 	var escaped bool


### PR DESCRIPTION
This enables the gci linter which enforces imports are grouped consistently; it is currently set to be:

    standard

    github.com/earthly/earthly

    github.com/earthly/cloud-api

    3rd party imports

The imports can be automatically re-written with

    gci write --skip-generated --custom-order -s 'standard,prefix(github.com/earthly/earthly),prefix(github.com/earthly/cloud-api),default' .

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>