### PR TITLE
automatic shell-out for $HOME expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 
 - new ARG `EARTHLY_GIT_COMMIT_AUTHOR_TIMESTAMP` will contain the author timestamp of the current git commit, this ARG must be enabled with the `VERSION --git-commit-author-timestamp` feature flag. [#2462](https://github.com/earthly/earthly/pull/2462)
 
+### Changed
+
+- earthly will automatically shellout to determine the `$HOME` value when referenced; this requires the `--shell-out-anywhere` feature flag. [#2469](https://github.com/earthly/earthly/issues/2469)
+
 ### Fixed
 
 - Support for saving files larger than 64kB on failure within a `TRY/FINALLY` block. [#2452](https://github.com/earthly/earthly/issues/2452)

--- a/earthfile2llb/interpreter.go
+++ b/earthfile2llb/interpreter.go
@@ -2150,7 +2150,7 @@ func requiresShellOutOrCmdInvalid(s string) bool {
 		required = true
 		return "", nil
 	}
-	_, err := shlex.ProcessWordWithMap(s, map[string]string{})
+	_, err := shlex.ProcessWordWithMap(s, map[string]string{}, variables.ShellOutEnvs)
 	return required || err != nil
 }
 

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -150,6 +150,7 @@ ga-no-qemu:
     BUILD +chown-test
     BUILD +dotenv-test
     BUILD +env-test
+    BUILD +env-home-test
     BUILD +stack-failure-test
     BUILD +multi-stack-failure-test
     BUILD +no-cache-local-artifact-test
@@ -625,6 +626,9 @@ multi-stack-failure-test:
 
 env-test:
     DO +RUN_EARTHLY --earthfile=env.earth --extra_args="--no-output" --target=+test
+
+env-home-test:
+    DO +RUN_EARTHLY --earthfile=env-home.earth --extra_args="--secret sshkey=not-actually-a-ssh-key --no-output" --target=+test
 
 no-cache-local-artifact-test:
     DO +RUN_EARTHLY --earthfile=no-cache-local-artifact.earth --use_tmpfs=false --extra_args="--no-cache" --target=+test

--- a/tests/env-home.earth
+++ b/tests/env-home.earth
@@ -1,0 +1,4 @@
+VERSION --shell-out-anywhere 0.6
+FROM alpine:3.15
+test:
+    RUN --mount=type=secret,target=$HOME/.ssh/id_rsa,id=+secrets/sshkey test -f $HOME/.ssh/id_rsa && test "$(cat ~/.ssh/id_rsa)" = "not-actually-a-ssh-key"

--- a/util/shell/lex_test.go
+++ b/util/shell/lex_test.go
@@ -22,28 +22,28 @@ func TestShellParserMandatoryEnvVars(t *testing.T) {
 	noUnset := "${VAR?message here$ARG}"
 
 	// disallow empty
-	newWord, err = shlex.ProcessWord(noEmpty, setEnvs)
+	newWord, err = shlex.ProcessWord(noEmpty, setEnvs, nil)
 	require.NoError(t, err)
 	require.Equal(t, "plain", newWord)
 
-	_, err = shlex.ProcessWord(noEmpty, emptyEnvs)
+	_, err = shlex.ProcessWord(noEmpty, emptyEnvs, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "message herex")
 
-	_, err = shlex.ProcessWord(noEmpty, unsetEnvs)
+	_, err = shlex.ProcessWord(noEmpty, unsetEnvs, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "message herex")
 
 	// disallow unset
-	newWord, err = shlex.ProcessWord(noUnset, setEnvs)
+	newWord, err = shlex.ProcessWord(noUnset, setEnvs, nil)
 	require.NoError(t, err)
 	require.Equal(t, "plain", newWord)
 
-	newWord, err = shlex.ProcessWord(noUnset, emptyEnvs)
+	newWord, err = shlex.ProcessWord(noUnset, emptyEnvs, nil)
 	require.NoError(t, err)
 	require.Equal(t, "", newWord)
 
-	_, err = shlex.ProcessWord(noUnset, unsetEnvs)
+	_, err = shlex.ProcessWord(noUnset, unsetEnvs, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "message herex")
 }
@@ -87,7 +87,7 @@ func TestShellParser4EnvVars(t *testing.T) {
 
 		if ((platform == "W" || platform == "A") && runtime.GOOS == "windows") ||
 			((platform == "U" || platform == "A") && runtime.GOOS != "windows") {
-			newWord, err := shlex.ProcessWord(source, envs)
+			newWord, err := shlex.ProcessWord(source, envs, nil)
 			if expected == "error" {
 				require.Errorf(t, err, "input: %q, result: %q", source, newWord)
 			} else {
@@ -95,7 +95,7 @@ func TestShellParser4EnvVars(t *testing.T) {
 				require.Equal(t, expected, newWord, "at line %d of %s", lineCount, fn)
 			}
 
-			newWord, err = shlex.ProcessWordWithMap(source, envsMap)
+			newWord, err = shlex.ProcessWordWithMap(source, envsMap, nil)
 			if expected == "error" {
 				require.Errorf(t, err, "input: %q, result: %q", source, newWord)
 			} else {
@@ -150,7 +150,7 @@ func TestShellParser4Words(t *testing.T) {
 			expected := strings.Split(strings.TrimLeft(words[1], " "), ",")
 
 			// test for ProcessWords
-			result, err := shlex.ProcessWords(test, envs)
+			result, err := shlex.ProcessWords(test, envs, nil)
 
 			if err != nil {
 				result = []string{"error"}
@@ -166,7 +166,7 @@ func TestShellParser4Words(t *testing.T) {
 			}
 
 			// test for ProcessWordsWithMap
-			result, err = shlex.ProcessWordsWithMap(test, BuildEnvs(envs))
+			result, err = shlex.ProcessWordsWithMap(test, BuildEnvs(envs), nil)
 
 			if err != nil {
 				result = []string{"error"}

--- a/variables/collection.go
+++ b/variables/collection.go
@@ -15,6 +15,10 @@ import (
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
+var ShellOutEnvs = map[string]struct{}{
+	"HOME": struct{}{},
+}
+
 type stackFrame struct {
 	frameName string
 	// absRef is the ref any other ref in this frame would be relative to.
@@ -183,7 +187,7 @@ func (c *Collection) Expand(word string, shellOut shell.EvalShellOutFn) (string,
 	shlex := shell.NewLex('\\')
 	shlex.ShellOut = shellOut
 	varMap := c.effective().ActiveValueMap()
-	return shlex.ProcessWordWithMap(word, varMap)
+	return shlex.ProcessWordWithMap(word, varMap, ShellOutEnvs)
 }
 
 // DeclareArg declares an arg. The effective value may be


### PR DESCRIPTION
The HOME env is set by the shell and not in the docker image; if a user references $HOME we will automatically shellout to determine the value.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>