### PR TITLE
feat: allow to set gitImage via config file #2027

### DIFF
--- a/buildcontext/git.go
+++ b/buildcontext/git.go
@@ -34,6 +34,7 @@ const (
 type gitResolver struct {
 	cleanCollection *cleanup.Collection
 
+	gitImage       string
 	projectCache   *synccache.SyncCache // "gitURL#gitRef" -> *resolvedGitProject
 	buildFileCache *synccache.SyncCache // project ref -> local path
 	gitLookup      *GitLookup
@@ -193,8 +194,12 @@ func (gr *gitResolver) resolveGitProject(ctx context.Context, gwClient gwclient.
 		}
 
 		gitState := llb.Git(gitURL, gitRef, gitOpts...)
+		gitImage := gr.gitImage
+		if gitImage == "" {
+			gitImage = defaultGitImage
+		}
 		opImg := pllb.Image(
-			defaultGitImage, llb.MarkImageInternal, llb.ResolveModePreferLocal,
+			gitImage, llb.MarkImageInternal, llb.ResolveModePreferLocal,
 			llb.Platform(platr.LLBNative()))
 
 		// Get git hash.

--- a/buildcontext/resolver.go
+++ b/buildcontext/resolver.go
@@ -59,8 +59,14 @@ type Resolver struct {
 
 // NewResolver returns a new NewResolver.
 func NewResolver(cleanCollection *cleanup.Collection, gitLookup *GitLookup, console conslogging.ConsoleLogger, featureFlagOverrides string) *Resolver {
+	return NewResolverCustomGit(cleanCollection, gitLookup, console, featureFlagOverrides, "")
+}
+
+// NewResolverCustomGit returns a new Resolver instance with a custom gitImage.
+func NewResolverCustomGit(cleanCollection *cleanup.Collection, gitLookup *GitLookup, console conslogging.ConsoleLogger, featureFlagOverrides string, gitImage string) *Resolver {
 	return &Resolver{
 		gr: &gitResolver{
+			gitImage:        gitImage,
 			cleanCollection: cleanCollection,
 			projectCache:    synccache.New(),
 			buildFileCache:  synccache.New(),

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -81,6 +81,7 @@ type Opt struct {
 	InternalSecretStore                   *secretprovider.MutableMapStore
 	InteractiveDebugging                  bool
 	InteractiveDebuggingDebugLevelLogging bool
+	GitImage                              string
 }
 
 // BuildOpt is a collection of build options.
@@ -132,7 +133,7 @@ func NewBuilder(ctx context.Context, opt Opt) (*Builder, error) {
 		opt:      opt,
 		resolver: nil, // initialized below
 	}
-	b.resolver = buildcontext.NewResolver(opt.CleanCollection, opt.GitLookup, opt.Console, opt.FeatureFlagOverrides)
+	b.resolver = buildcontext.NewResolverCustomGit(opt.CleanCollection, opt.GitLookup, opt.Console, opt.FeatureFlagOverrides, opt.GitImage)
 	return b, nil
 }
 

--- a/cmd/earthly/build_cmd.go
+++ b/cmd/earthly/build_cmd.go
@@ -471,6 +471,7 @@ func (app *earthlyApp) actionBuildImp(cliCtx *cli.Context, flagArgs, nonFlagArgs
 		InternalSecretStore:                   internalSecretStore,
 		InteractiveDebugging:                  app.interactiveDebugging,
 		InteractiveDebuggingDebugLevelLogging: app.debug,
+		GitImage:							   app.cfg.Global.GitImage,
 	}
 	b, err := builder.NewBuilder(cliCtx.Context, builderOpts)
 	if err != nil {

--- a/cmd/earthly/build_cmd.go
+++ b/cmd/earthly/build_cmd.go
@@ -471,7 +471,7 @@ func (app *earthlyApp) actionBuildImp(cliCtx *cli.Context, flagArgs, nonFlagArgs
 		InternalSecretStore:                   internalSecretStore,
 		InteractiveDebugging:                  app.interactiveDebugging,
 		InteractiveDebuggingDebugLevelLogging: app.debug,
-		GitImage:							   app.cfg.Global.GitImage,
+		GitImage:                              app.cfg.Global.GitImage,
 	}
 	b, err := builder.NewBuilder(cliCtx.Context, builderOpts)
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -77,6 +77,7 @@ type GlobalConfig struct {
 	IPTables                 string   `yaml:"ip_tables"                  help:"Which iptables binary to use. Valid values are iptables-legacy or iptables-nft. Bypasses any autodetection."`
 	DisableLogSharing        bool     `yaml:"disable_log_sharing"        help:"Disable cloud log sharing when logged in with an Earthly account, see https://ci.earthly.dev for details."`
 	SecretProvider           string   `yaml:"secret_provider"            help:"Command to execute to retrieve secret."`
+	GitImage                 string   `yaml:"git_image"                  help:"Image used to resolve git repositories"`
 
 	// Obsolete.
 	CachePath      string `yaml:"cache_path"         help:" *Deprecated* The path to keep Earthly's cache."`

--- a/docs/earthly-config/earthly-config.md
+++ b/docs/earthly-config/earthly-config.md
@@ -163,10 +163,6 @@ Allows overriding Earthly's automatic MTU detection. This is used when configuri
 
 Allows overriding Earthly's automatic `ip_tables` module detection. Valid choices are `iptables-legacy` or `iptables-nft`.
 
-### git_image
-
-Allows to override the image used to run internal `git` commands (e.g. during `GIT CLONE` or `IMPORT`). This defaults to `alpine/git:v2.30.1`.
-
 ### no_loop_device (obsolete)
 
 This option is obsolete and it is ignored. Earthly no longer uses a loop device for its cache.

--- a/docs/earthly-config/earthly-config.md
+++ b/docs/earthly-config/earthly-config.md
@@ -163,6 +163,10 @@ Allows overriding Earthly's automatic MTU detection. This is used when configuri
 
 Allows overriding Earthly's automatic `ip_tables` module detection. Valid choices are `iptables-legacy` or `iptables-nft`.
 
+### git_image
+
+Allows to override the image used to run internal `git` commands (e.g. during `GIT CLONE` or `IMPORT`). This defaults to `alpine/git:v2.30.1`.
+
 ### no_loop_device (obsolete)
 
 This option is obsolete and it is ignored. Earthly no longer uses a loop device for its cache.


### PR DESCRIPTION
This adds support to set the `gitImage` via an entry in the config file:

```yaml
global:
   git_image: my/gitimage:v1.2.3
```