### PR TITLE
docs: clarify references to other builds in FROM

### DIFF
--- a/docs/basics/part-5-importing.md
+++ b/docs/basics/part-5-importing.md
@@ -43,7 +43,7 @@ But `FROM` also has the ability to import targets from Earthfiles in different d
 └── Earthfile
 
 ```
-We can use a target in the Earthfile in `/services/service-one` from inside the Earthfile in the root of our directory.
+We can use a target in the Earthfile in `/services/service-one` from inside the Earthfile in the root of our directory. NOTE: relative paths must use `./` or `../`.
 
 `./services/service-one/Earthfile`
 
@@ -72,7 +72,7 @@ build:
 ```
 This code tells `FROM` that there is another Earthfile in  the `services/service-one` directory and that the Earthfile  contains a target called `+deps`. In this case, if we were to run `+build` Earthly is smart enough to go into the subdirectory, run the  `+deps` target in that Earthfile, and then use it as the base image for `+build`.
 
-We can also reference an Earthfile in another repo, which works in a similar way.
+We can also reference an Earthfile in another repo, which works in a similar way. If the reference does not begin with one of `/`, `./`, or `../`, then earthly treats it as a repository.  See [the reference](../earthfile#from) for details.
 
 ```Dockerfile
 build:

--- a/docs/earthfile/earthfile.md
+++ b/docs/earthfile/earthfile.md
@@ -54,7 +54,8 @@ Examples:
 
 * Classical reference: `FROM alpine:latest`
 * Local reference: `FROM +another-target`
-* Relative reference: `FROM ./subdirectory+some-target`
+* Relative reference: `FROM ./subdirectory+some-target` or `FROM ../otherdirectory+some-target`
+* Absolute reference: `FROM /absolute/path+some-target`
 * Remote reference from a public or [private](https://docs.earthly.dev/docs/guides/auth) git repository: `FROM github.com/example/project+remote-target`
 
 The `FROM` command does not mark any saved images or artifacts of the referenced target for output, nor does it mark any push commands of the referenced target for pushing. For that, please use [`BUILD`](#build).


### PR DESCRIPTION
basics:
- clarify that relative paths require './' or ../'
- clarify how earthly recognizes a repository path in FROM

earthfile:
- add notes about '../' and '/' in FROM