### PR TITLE
Don't pass --platform to docker/podman

### DIFF
--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -61,7 +61,7 @@ jobs:
         if: inputs.BINARY == 'docker'
       - name: remove Docker
         run: ${{inputs.SUDO}} apt-get purge docker-engine docker docker.io docker-ce docker-ce-cli ; ${{inputs.SUDO}} rm -rf /usr/bin/docker
-        if: inputs.binary == 'podman'
+        if: inputs.binary != 'docker'
       - name: Install Podman (with apt-get)
         run: ${{inputs.SUDO}} apt-get update && ${{inputs.SUDO}} apt-get install -y podman
         if: inputs.binary == 'podman'

--- a/ast/tests/privileged.ast.json
+++ b/ast/tests/privileged.ast.json
@@ -7,6 +7,16 @@
         ],
         "name": "FROM"
       }
+    },
+    {
+      "command": {
+        "args": [
+          "apk",
+          "add",
+          "libcap"
+        ],
+        "name": "RUN"
+      }
     }
   ],
   "targets": [
@@ -32,14 +42,8 @@
           "command": {
             "args": [
               "--privileged",
-              "cat",
-              "/proc/self/status",
-              "|",
-              "grep",
-              "CapEff",
-              "|",
-              "grep",
-              "0000003fffffffff"
+              "capsh",
+              "--has-p=cap_sys_admin"
             ],
             "name": "RUN"
           }

--- a/tests/allow-privileged-import.earth
+++ b/tests/allow-privileged-import.earth
@@ -1,16 +1,17 @@
 VERSION 0.6
 FROM alpine:3.15
+RUN apk add libcap # for capsh
 
 IMPORT --allow-privileged github.com/earthly/test-remote/privileged:main
 IMPORT ./a/really/deep/subdir
 
 test-remote-import:
     COPY privileged+privileged/proc-status .
-    RUN cat proc-status | grep CapEff | grep 0000003fffffffff
+    RUN capsh --decode="$(cat proc-status | grep CapEff | awk '{print $2}')" | grep cap_sys_admin
 
 test-relative-import:
     COPY subdir+subdirprivileged/proc-status .
-    RUN cat proc-status | grep CapEff | grep 0000003fffffffff
+    RUN capsh --decode="$(cat proc-status | grep CapEff | awk '{print $2}')" | grep cap_sys_admin
 
 test-remote-cmd:
     DO privileged+PRIV

--- a/tests/allow-privileged.earth
+++ b/tests/allow-privileged.earth
@@ -1,5 +1,6 @@
 VERSION 0.6
 FROM alpine:3.15
+RUN apk add libcap # for capsh
 
 reject-privileged-in-remote-repo-triggered-by-from-locally:
     FROM github.com/earthly/test-remote/privileged:main+locally
@@ -55,7 +56,8 @@ allow-privileged-in-remote-repo-triggered-by-from-privileged:
 
 allow-privileged-in-remote-repo-triggered-by-copy-privileged:
     COPY --allow-privileged github.com/earthly/test-remote/privileged:main+privileged/proc-status .
-    RUN cat proc-status | grep CapEff | grep 0000003fffffffff
+    # checking for 0000003fffffffff might fail when running under podman, check the cap_sys_admin bit is set instead
+    RUN capsh --decode="$(cat proc-status | grep CapEff | awk '{print $2}')" | grep cap_sys_admin
 
 allow-privileged-in-remote-repo-triggered-by-build-privileged:
     BUILD --allow-privileged github.com/earthly/test-remote/privileged:main+privileged

--- a/tests/privileged.earth
+++ b/tests/privileged.earth
@@ -1,5 +1,10 @@
 VERSION 0.6
 FROM alpine:3.15
+RUN apk add libcap # for capsh
+
 test:
     RUN cat /proc/self/status | grep CapEff | grep 00000000a80425fb
-    RUN --privileged cat /proc/self/status | grep CapEff | grep 0000003fffffffff
+
+    # when running under podman CapEff is not always 0000003fffffffff; but might instead be 000001ffffffffff
+    # use the capsh tool (which reads from /proc/self/status) to check if the sys_admin capability is permitted
+    RUN --privileged capsh --has-p=cap_sys_admin

--- a/tests/true-false-flag.earth
+++ b/tests/true-false-flag.earth
@@ -1,8 +1,9 @@
 VERSION 0.6
 hello:
     FROM alpine:3.15
+    RUN apk add libcap # for capsh
     ARG PRIVILEGED=false
-    RUN --no-cache --privileged=$PRIVILEGED if cat /proc/self/status | grep CapEff | grep 0000003fffffffff >/dev/null; then echo "I have the power"; else echo "fight the power"; fi
+    RUN --no-cache --privileged=$PRIVILEGED if capsh --has-p=cap_sys_admin >/dev/null; then echo "I have the power"; else echo "fight the power"; fi
 
 all:
     BUILD +hello --PRIVILEGED=false

--- a/util/containerutil/docker.go
+++ b/util/containerutil/docker.go
@@ -32,8 +32,6 @@ func NewDockerShellFrontend(ctx context.Context, cfg *FrontendConfig) (Container
 			Console:                 cfg.Console,
 		},
 	}
-	// TODO: Find a cleaner way to pass down information to the shellFrontend
-	fe.FrontendInformation = fe.Information
 
 	// running `docker info --format={{.SecurityOptions}}` results in a panic() when docker is not running.
 	// To workaround this issue, first we run `docker info` to test docker is running, then again with the

--- a/util/containerutil/frontend.go
+++ b/util/containerutil/frontend.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"runtime"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
@@ -100,12 +99,4 @@ func frontendIfAvailable(ctx context.Context, feType string, cfg *FrontendConfig
 	}
 
 	return fe, nil
-}
-
-func getPlatform() string {
-	arch := runtime.GOARCH
-	if runtime.GOARCH == "arm" {
-		arch = "arm/v7"
-	}
-	return fmt.Sprintf("linux/%s", arch)
 }

--- a/util/containerutil/podman.go
+++ b/util/containerutil/podman.go
@@ -30,8 +30,6 @@ func NewPodmanShellFrontend(ctx context.Context, cfg *FrontendConfig) (Container
 			Console:                 cfg.Console,
 		},
 	}
-	// TODO: Find a cleaner way to pass down information to the shellFrontend
-	fe.FrontendInformation = fe.Information
 
 	output, err := fe.commandContextOutput(ctx, "info", "--format={{.Host.Security.Rootless}}")
 	if err != nil {

--- a/util/containerutil/shell_shared.go
+++ b/util/containerutil/shell_shared.go
@@ -24,9 +24,8 @@ type shellFrontend struct {
 	globalCompatibilityArgs []string
 	likelyPodman            bool
 
-	FrontendInformation func(ctx context.Context) (*FrontendInfo, error)
-	urls                *FrontendURLs
-	Console             conslogging.ConsoleLogger
+	urls    *FrontendURLs
+	Console conslogging.ConsoleLogger
 }
 
 func (sf *shellFrontend) IsAvailable(ctx context.Context) bool {

--- a/util/containerutil/shell_shared.go
+++ b/util/containerutil/shell_shared.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/containerd/containerd/platforms"
 	"github.com/earthly/earthly/conslogging"
 	"github.com/hashicorp/go-multierror"
 	_ "github.com/moby/buildkit/client/connhelper/dockercontainer" // Load "docker-container://" helper.
@@ -191,16 +190,8 @@ func (sf *shellFrontend) ContainerRun(ctx context.Context, containers ...Contain
 			args = append(args, "--publish", port)
 		}
 
-		platform := getPlatform()
-		supportsPlatform, platformCheckErr := sf.supportsPlatform(ctx, platform)
-		if platformCheckErr != nil {
-			err = multierror.Append(err, platformCheckErr)
-		}
-		if supportsPlatform {
-			args = append(args, "--platform", platform)
-		}
-
 		args = append(args, "-d") // Run detached, this feels implied by the API
+		args = append(args, "--pull", "missing")
 		args = append(args, "--name", container.NameOrID)
 		args = append(args, container.AdditionalArgs...)
 		args = append(args, sf.runCompatibilityArgs...)
@@ -300,35 +291,6 @@ func (sf *shellFrontend) commandContextOutput(ctx context.Context, args ...strin
 		return output, errors.Wrapf(err, "command failed: %s %s: %s: %s", sf.binaryName, strings.Join(args, " "), err.Error(), output.string())
 	}
 	return output, nil
-}
-
-func normalizePlatform(platform string) (string, error) {
-	parsedPlatform, err := platforms.Parse(platform)
-	if err != nil {
-		return "", errors.Wrapf(err, "failed to parse platform %s", platform)
-	}
-	platformSpec := platforms.Normalize(parsedPlatform)
-	return platforms.Format(platformSpec), nil
-}
-
-func (sf *shellFrontend) supportsPlatform(ctx context.Context, platform string) (bool, error) {
-	normalizedPlatform, err := normalizePlatform(platform)
-	if err != nil {
-		// Failing to normalize the platform means it may not be valid, so return false
-		sf.Console.VerbosePrintf("failed to normalize platform %s", platform)
-		return false, nil
-	}
-	frontendInfo, err := sf.FrontendInformation(ctx)
-	if err != nil {
-		return false, errors.Wrapf(err, "failed to get platform information")
-	}
-	normalizedServerPlatform, err := normalizePlatform(frontendInfo.ServerPlatform)
-	if err != nil {
-		// Failing to normalize the platform could mean its invalid, so return false
-		sf.Console.VerbosePrintf("failed to normalize server platform %s", frontendInfo.ServerPlatform)
-		return false, nil
-	}
-	return normalizedServerPlatform == normalizedPlatform, nil
 }
 
 func (sf *shellFrontend) setupAndValidateAddresses(feType string, cfg *FrontendConfig) (*FrontendURLs, error) {

--- a/util/containerutil/stub.go
+++ b/util/containerutil/stub.go
@@ -21,7 +21,6 @@ func NewStubFrontend(ctx context.Context, cfg *FrontendConfig) (ContainerFronten
 	fe := &stubFrontend{
 		shellFrontend: &shellFrontend{Console: cfg.Console},
 	}
-	fe.shellFrontend.FrontendInformation = fe.Information
 
 	var err error
 	fe.urls, err = fe.setupAndValidateAddresses(FrontendStub, cfg)


### PR DESCRIPTION
The `--platform` flag is only ever passed to docker/podman when both the
user and server platform values are equal. When they mismatch, the
`--platform` flag is ommitted, and the server's native platform is used.

Since the `--platform` value is only ever passed when the user and
server platforms are equal, it shouldn't matter; however in practice
there is a podman bug, which causes a pull to occur whenver the
`--platform` flag is specified: https://github.com/containers/podman/issues/15711

This bug will cause podman to always pull the earthly/buildkitd image from
docker hub, which will either 1) overwrite the local image if the image exists in docker hub,
and ultimately will cause our tests to run against an incorrect image
version, or 2) result in the following 404-error if the tag does not
exist:

    exit status 125: Trying to pull docker.io/earthly/buildkitd:dev-HEAD...
    Error: initializing source docker://earthly/buildkitd:dev-HEAD: reading manifest dev-HEAD in docker.io/earthly/buildkitd: manifest unknown: manifest unknown: exit status 125

This commit additionally updates the podman tests to use capsh rather
than grep for the `RUN --privileged` tests, as the Effective capabilities (CapEff)
bits are not always the same between docker and podman

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>