### PR TITLE
Add support for opt-in parallelism for LOCALLY commands

### DIFF
--- a/earthfile2llb/flags.go
+++ b/earthfile2llb/flags.go
@@ -125,3 +125,7 @@ type pipelineOpts struct {
 type cacheOpts struct {
 	Sharing string `long:"sharing" description:"The cache sharing mode: locked (default), shared, private"`
 }
+
+type locallyOpts struct {
+	Parallel bool `long:"allow-parallel" description:"Allow this locally command to run in parallel with other commands"`
+}

--- a/tests/local/Earthfile
+++ b/tests/local/Earthfile
@@ -32,6 +32,30 @@ test-local:
         fi
 
 
+##################################################
+# tests for running locally with --allow-parallel
+
+test-parallel:
+    BUILD +test-parallel-1
+    BUILD +test-parallel-2
+
+    COPY +test-parallel-1/data data1.txt
+    RUN diff data1.txt <(echo "hello1")
+
+    COPY +test-parallel-2/data data2.txt
+    RUN diff data2.txt <(echo "hello2")
+
+test-parallel-1:
+    LOCALLY --allow-parallel
+    RUN echo hello1 > /tmp/earthly-test-10878452-ff7a-4067-a75d-6239a2579590
+    SAVE ARTIFACT /tmp/earthly-test-10878452-ff7a-4067-a75d-6239a2579590 data
+
+test-parallel-2:
+    LOCALLY --allow-parallel
+    RUN echo hello2 > /tmp/earthly-test-61266c0a-e57c-4e96-9901-8c9201072174
+    SAVE ARTIFACT /tmp/earthly-test-61266c0a-e57c-4e96-9901-8c9201072174 data
+
+
 #################################################################################################################
 # tests for testing locally produced artifacts can be referenced by containerized targets
 


### PR DESCRIPTION
This is intended to resolve: [!1954](https://github.com/earthly/earthly/issues/1954)

The default behaviour for LOCALLY is to execute each step in serial, as its not possible to infer from context if the task is parallel safe, this commit adds a flag which allows you to mark your LOCALLY block as safe for parallel execution and speeds up the relevant tasks.