### PR TITLE
Allow toggling TLS and setting CA from CLI/environment

### DIFF
--- a/cmd/earthly/buildkit.go
+++ b/cmd/earthly/buildkit.go
@@ -72,7 +72,7 @@ func (app *earthlyApp) initFrontend(cliCtx *cli.Context) error {
 	app.buildkitdSettings.BuildkitAddress = app.buildkitHost
 	app.buildkitdSettings.LocalRegistryAddress = app.localRegistryHost
 	app.buildkitdSettings.UseTCP = bkURL.Scheme == "tcp"
-	app.buildkitdSettings.UseTLS = app.cfg.Global.TLSEnabled
+	app.buildkitdSettings.UseTLS = app.tlsEnabled || app.cfg.Global.TLSEnabled
 	app.buildkitdSettings.MaxParallelism = app.cfg.Global.BuildkitMaxParallelism
 	app.buildkitdSettings.CacheSizeMb = app.cfg.Global.BuildkitCacheSizeMb
 	app.buildkitdSettings.CacheSizePct = app.cfg.Global.BuildkitCacheSizePct
@@ -111,11 +111,9 @@ func (app *earthlyApp) getBuildkitClient(cliCtx *cli.Context, cloudClient cloud.
 }
 
 func (app *earthlyApp) handleTLSCertificateSettings(context *cli.Context) {
-	if !app.cfg.Global.TLSEnabled {
+	if !(app.cfg.Global.TLSEnabled || app.tlsEnabled) {
 		return
 	}
-
-	app.buildkitdSettings.TLSCA = app.cfg.Global.TLSCA
 
 	if !context.IsSet("tlscert") && app.cfg.Global.ClientTLSCert != "" {
 		app.certPath = app.cfg.Global.ClientTLSCert
@@ -125,8 +123,13 @@ func (app *earthlyApp) handleTLSCertificateSettings(context *cli.Context) {
 		app.keyPath = app.cfg.Global.ClientTLSKey
 	}
 
+	if !context.IsSet("tlsca") && app.cfg.Global.TLSCA != "" {
+		app.caPath = app.cfg.Global.TLSCA
+	}
+
 	app.buildkitdSettings.ClientTLSCert = app.certPath
 	app.buildkitdSettings.ClientTLSKey = app.keyPath
+	app.buildkitdSettings.TLSCA = app.caPath
 
 	app.buildkitdSettings.ServerTLSCert = app.cfg.Global.ServerTLSCert
 	app.buildkitdSettings.ServerTLSKey = app.cfg.Global.ServerTLSKey

--- a/cmd/earthly/flags.go
+++ b/cmd/earthly/flags.go
@@ -296,6 +296,7 @@ func (app *earthlyApp) buildFlags() []cli.Flag {
 		},
 		&cli.StringFlag{
 			Name:        "tlscert",
+			Aliases:     []string{"tls-cert"},
 			Value:       "./certs/earthly_cert.pem",
 			EnvVars:     []string{"EARTHLY_TLS_CERT"},
 			Usage:       wrap("The path to the client TLS cert", "If relative, will be interpreted as relative to the ~/.earthly folder."),
@@ -304,10 +305,27 @@ func (app *earthlyApp) buildFlags() []cli.Flag {
 		},
 		&cli.StringFlag{
 			Name:        "tlskey",
+			Aliases:     []string{"tls-key"},
 			Value:       "./certs/earthly_key.pem",
 			EnvVars:     []string{"EARTHLY_TLS_KEY"},
 			Usage:       wrap("The path to the client TLS key.", "If relative, will be interpreted as relative to the ~/.earthly folder."),
 			Destination: &app.keyPath,
+			Hidden:      true,
+		},
+		&cli.StringFlag{
+			Name:        "tlsca",
+			Aliases:     []string{"tls-ca"},
+			Value:       "./certs/earthly_ca.pem",
+			EnvVars:     []string{"EARTHLY_TLS_CA"},
+			Usage:       wrap("The path to the client CA cert.", "If relative, will be interpreted as relative to the ~/.earthly folder."),
+			Destination: &app.caPath,
+			Hidden:      true,
+		},
+		&cli.BoolFlag{
+			Name:        "tls-enabled",
+			EnvVars:     []string{"EARTHLY_TLS_ENABLED"},
+			Usage:       "If TLS should be used to communicate with Buildkit",
+			Destination: &app.tlsEnabled,
 			Hidden:      true,
 		},
 		&cli.StringFlag{

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -129,6 +129,8 @@ type cliFlags struct {
 	conversionParallelism      int
 	certPath                   string
 	keyPath                    string
+	caPath                     string
+	tlsEnabled                 bool
 	disableAnalytics           bool
 	featureFlagOverrides       string
 	localRegistryHost          string


### PR DESCRIPTION
This also adds aliases to other existing TLS-related flags to more closely match existing conventions around 'translating' between a CLI flag, environment variable, and config entry.

When I started this, it was 'obviously' a bug, but was only 95% certain towards the end.  It was easier to continue rather than abort and move to a question/request.

Originally I was trying to configure a local earthly client to execute against a remote buildkit setup using an `.env` file.  Needless to say, it was not possible.  No matter what I did, the only result I could achieve was a timeout.  After many hours, I tried specifying the equivalent CLI flags, and upon getting an error for `--tlsca` (but not `--tlskey` or `--tlscert`), the actual issue starting became clearer.

If this (perceived) limitation was actually intentional, let me know and I'll revise (or scrap) as necessary.

If you guys object to the aliases, I can remove them (but would in turn propose adding docs to call out the discrepancy).

There are currently no tests for this; I was only 95% sure this might be accepted, and there is no prior art in terms of testing this mechanism.  I saw there's a github action that tests the "local-remote", but that's the closest I could find.  If you're good with my change but feel tests are needed, I can see what I can do.