### PR TITLE
Note location of new post- v0.6.30 config file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ The token should be the same token you use to login with Docker Hub. Other repos
 ./build/*/*/earthly -P ./tests+env-test --DOCKERHUB_AUTH=false
 ```
 
-If you don't want to specify these directly on the CLI, or don't want to type these each time, its possible [to use an .env file instead](https://docs.earthly.dev/docs/earthly-command#environment-variables-and-.env-file). Here is a template to get you started:
+If you don't want to specify these directly on the CLI, or don't want to type these each time, it's possible [to use an .env file instead](https://docs.earthly.dev/docs/earthly-command#environment-variables-and-.env-file). Here is a template to get you started:
 
 ```shell
 DOCKERHUB_USER=<my-docker-username>
@@ -90,7 +90,7 @@ DOCKERHUB_TOKEN=<my-docker-token>
 The [Insecure Docker Hub Cache Example](https://docs.earthly.dev/ci-integration/pull-through-cache#insecure-docker-hub-cache-example), provides a guide on both
 running an insecure docker hub pull through cache as well as configuring Earthly to use that cache.
 
-Since Earthly uses itself for running the tests (Earthly-in-Earthly), simply configuring `~/.earthly/config.yml` is insufficient -- one must also configure the
+Since Earthly uses itself for running the tests (Earthly-in-Earthly), simply configuring `~/.earthly/config.yml`[^dir] is insufficient -- one must also configure the
 embedded version of Earthly to use the cache via build-args:
 
 ```bash
@@ -112,7 +112,7 @@ Updates to fsutil must first be vendored into buildkit, then updated under `go.m
 
 ## Running buildkit under debug mode
 
-Buildkit's scheduler has a debug mode, which can be enabled with the following `~/.earthly/config.yml` config:
+Buildkit's scheduler has a debug mode, which can be enabled with the following `~/.earthly/config.yml`[^dir] config:
 
 ```yml
 global:
@@ -142,6 +142,12 @@ Changes to the contents of `docs/` will be automatically updated to [docs.earthl
 
 When a new version of earthly is [released](release/README.md), the `next` branch gets merged into the `main` branch, which then propigates to the published documentation.
 
+### Config
+
+Starting with [v0.6.30](CHANGELOG.md#v0630---2022-11-22), the default location of the built binary's config file has
+changed to `~/.earthly-dev/config.yml`.  The standard location is not used as a fallback, so ensure you maintain your
+own symlink or copy (if needed).
+
 ## CLA
 
 ### Individual
@@ -151,3 +157,5 @@ All contributions must indicate agreement to the [Earthly Contributor License Ag
 ### Entity
 
 If you are an entity, please use the [Earthly Contributor License Agreement form](https://earthly.dev/cla-form) in addition to requiring your individual contributors to sign all contributions.
+
+[^dir]: Depending on the point in time earthly is being built the actual location [may be different](#config)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,8 +145,7 @@ When a new version of earthly is [released](release/README.md), the `next` branc
 ### Config
 
 Starting with [v0.6.30](CHANGELOG.md#v0630---2022-11-22), the default location of the built binary's config file has
-changed to `~/.earthly-dev/config.yml`.  The standard location is not used as a fallback, so ensure you maintain your
-own symlink or copy (if needed).
+changed to `~/.earthly-dev/config.yml`. The standard location is not used as a fallback; it is possible to `export EARTHLY_CONFIG=~/.earthly/config.yml`, or create a symlink if required.
 
 ## CLA
 


### PR DESCRIPTION
This bit me hard; it took me quite a while to figure out why the test suite was failing so horribly for me.  I'm not sure if it's because there are tests that don't respect `DOCKERHUB_MIRROR` or because I was using the binary to verify it solved my problem (#2516), but one or both resulted in me hitting hub's rate limit due to my config file not being used.

I'm happy to rephrase/reformat however you want; I just thought it was important to get documented.