### PR TITLE
docs: fix incorrect links in "Learn the basics Part 3: More Examples"

### DIFF
--- a/docs/basics/part-3-adding-dependencies-with-caching.md
+++ b/docs/basics/part-3-adding-dependencies-with-caching.md
@@ -123,10 +123,10 @@ docker:
 <details open>
 <summary>JavaScript</summary>
 
-To copy the files for [this example ( Part 4 )](https://github.com/earthly/earthly/tree/main/examples/tutorial/js/part4) run
+To copy the files for [this example ( Part 3 )](https://github.com/earthly/earthly/tree/main/examples/tutorial/js/part3) run
 
 ```bash
-earthly --artifact github.com/earthly/earthly/examples/tutorial/js:main+part4/part4 ./part4
+earthly --artifact github.com/earthly/earthly/examples/tutorial/js:main+part3/part3 ./part3
 ```
 
 Note that in our case, only the JavaScript version has an example where `FROM +deps` is used in more than one place: both in `build` and in `docker`. Nevertheless, all versions show how dependencies may be separated.
@@ -167,10 +167,10 @@ docker:
 <details open>
 <summary>Java</summary>
 
-To copy the files for [this example ( Part 4 )](https://github.com/earthly/earthly/tree/main/examples/tutorial/java/part4) run
+To copy the files for [this example ( Part 3 )](https://github.com/earthly/earthly/tree/main/examples/tutorial/java/part3) run
 
 ```bash
-earthly --artifact github.com/earthly/earthly/examples/tutorial/java:main+part4/part4 ./part4
+earthly --artifact github.com/earthly/earthly/examples/tutorial/java:main+part3/part3 ./part3
 ```
 
 `./Earthfile`
@@ -206,10 +206,10 @@ docker:
 <details open>
 <summary>Python</summary>
 
-To copy the files for [this example ( Part 4 )](https://github.com/earthly/earthly/tree/main/examples/tutorial/python/part4) run
+To copy the files for [this example ( Part 3 )](https://github.com/earthly/earthly/tree/main/examples/tutorial/python/part3) run
 
 ```bash
-earthly --artifact github.com/earthly/earthly/examples/tutorial/python:main+part4/part4 ./part4
+earthly --artifact github.com/earthly/earthly/examples/tutorial/python:main+part3/part3 ./part3
 ```
 
 `./Earthfile`


### PR DESCRIPTION
The links for "More examples" in "Learn the basics Part 3" were referencing Part 4 instead.
The code taken from the Earthfiles and shown in the docs seems correct.