### PR TITLE
explicitly check docker login vars are set

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -345,6 +345,8 @@ earthly-integration-test-base:
         IF [ "$DOCKERHUB_AUTH" = "true" ]
             RUN --secret USERNAME=$DOCKERHUB_USER_SECRET \
                 --secret TOKEN=$DOCKERHUB_TOKEN_SECRET \
+                (test -n "$USERNAME" || (echo "ERROR: USERNAME not set"; exit 1)) && \
+                (test -n "$TOKEN" || (echo "ERROR: TOKEN not set"; exit 1)) && \
                 docker login --username="$USERNAME" --password="$TOKEN"
         END
     ELSE
@@ -368,7 +370,10 @@ $(echo "$EARTHLY_ADDITIONAL_BUILDKIT_CONFIG" | sed "s/^/  /g")
         IF [ "$DOCKERHUB_AUTH" = "true" ]
             RUN --secret USERNAME=$DOCKERHUB_USER_SECRET \
                 --secret TOKEN=$DOCKERHUB_TOKEN_SECRET \
-                docker login $DOCKERHUB_MIRROR --username="$USERNAME" --password="$TOKEN"
+                (test -n "$DOCKERHUB_MIRROR" || (echo "ERROR: DOCKERHUB_MIRROR not set"; exit 1)) && \
+                (test -n "$USERNAME" || (echo "ERROR: USERNAME not set"; exit 1)) && \
+                (test -n "$TOKEN" || (echo "ERROR: TOKEN not set"; exit 1)) && \
+                docker login "$DOCKERHUB_MIRROR" --username="$USERNAME" --password="$TOKEN"
         END
     END
 


### PR DESCRIPTION
This is to help with sanity checking docker login is passed variables correctly.

For example, I had some tests that were failing on:

    WARN Earthfile line 369:12: The command 'RUN docker login $DOCKERHUB_MIRROR --username="$USERNAME" --***' failed: unauthorized

which were due to upstream server issues, but I wanted to eliminate the possibility that secrets were not correctly passed.