### PR TITLE
Decouple the `ast` submodule from the `util` package

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -188,10 +188,15 @@ unit-test:
     FROM +code
     COPY podman-setup.sh .
     ARG testname # when specified, only run specific unit-test, otherwise run all.
+
+    # pkgname determines the package name (or names) that will be tested. The go
+    # submodules must be specified explicitly or they will not be run, as
+    # "./..." does not match submodules.
+    ARG pkgname = ./... github.com/earthly/earthly/ast/... github.com/earthly/earthly/util/deltautil/...
     WITH DOCKER
         RUN ./podman-setup.sh && \
             if [ -n "$testname" ]; then testarg="-run $testname"; fi && \
-            go test -timeout 20m $testarg ./...
+            go test -timeout 20m $testarg $pkgname
     END
 
 changelog:

--- a/ast/env_var.go
+++ b/ast/env_var.go
@@ -1,0 +1,10 @@
+package ast
+
+import "regexp"
+
+var envVarNameRegexp = regexp.MustCompile(`^[a-zA-Z_]+[a-zA-Z0-9_]*$`)
+
+// IsValidEnvVarName returns true if env name is valid
+func IsValidEnvVarName(name string) bool {
+	return envVarNameRegexp.MatchString(name)
+}

--- a/ast/listener.go
+++ b/ast/listener.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/earthly/earthly/ast/parser"
 	"github.com/earthly/earthly/ast/spec"
-	"github.com/earthly/earthly/util/shell"
 	"github.com/pkg/errors"
 )
 
@@ -627,7 +626,7 @@ func (l *listener) EnterStmtWord(c *parser.StmtWordContext) {
 // ----------------------------------------------------------------------------
 
 func checkEnvVarName(str string) error {
-	if !shell.IsValidEnvVarName(str) {
+	if !IsValidEnvVarName(str) {
 		return errors.Errorf("invalid env key definition %s", str)
 	}
 	return nil

--- a/util/shell/env_var_name.go
+++ b/util/shell/env_var_name.go
@@ -1,10 +1,8 @@
 package shell
 
-import "regexp"
-
-var envVarNameRegexp = regexp.MustCompile(`^[a-zA-Z_]+[a-zA-Z0-9_]*$`)
+import "github.com/earthly/earthly/ast"
 
 // IsValidEnvVarName returns true if env name is valid
 func IsValidEnvVarName(name string) bool {
-	return envVarNameRegexp.MatchString(name)
+	return ast.IsValidEnvVarName(name)
 }


### PR DESCRIPTION
The `ast` submodule was a little broken because it was importing `github.com/earthly/earthly/util/shell` but did not have `github.com/earthly/earthly/util/shell` in its `go.mod`.  Running `go mod tidy` fixed that; but the whole point of having the `ast` package as a separate submodule was to allow other packages to import `ast` without downloading the whole `earthly` project.

The quick and dirty solution is to reverse the imports so that the `util/shell` package is importing `ast`, not the other way around.

This PR also fixes our `+unit-test` target to run tests against our current go submodules, since `./...` ignores submodules.