### PR TITLE
dont attempt secrets lookup when org or project not set

### DIFF
--- a/util/llbutil/secretprovider/cloud.go
+++ b/util/llbutil/secretprovider/cloud.go
@@ -26,7 +26,6 @@ func NewCloudStore(client cloud.Client) secrets.SecretStore {
 // secrets are referenced via +secret/name or +secret/org/name (or +secret/org/subdir1/.../name)
 // however by the time GetSecret is called, the "+secret" prefix is removed.
 func (cs *cloudStore) GetSecret(ctx context.Context, id string) ([]byte, error) {
-
 	q, err := url.ParseQuery(id)
 	if err != nil {
 		return nil, errors.New("failed to parse secret ID")
@@ -61,6 +60,12 @@ func (cs *cloudStore) GetSecret(ctx context.Context, id string) ([]byte, error) 
 		}
 
 	case "1": // Project-based secret style includes the org and project name
+		org := q.Get("org")
+		project := q.Get("project")
+		if org == "" || project == "" {
+			return nil, secrets.ErrNotFound
+		}
+
 		if !strings.HasPrefix(name, "user/") {
 			name = path.Join(q.Get("org"), q.Get("project"), name)
 		}


### PR DESCRIPTION
This fixes a bug where using `VERSION --use-project-secrets 0.6` causes secrets to be lookedup in the cloud with an empty org or project, which returns an unauthorized error rather than the expected `unable to lookup secret SECRET3: not found` error message (which causes the `+secrets-test` test to fail).

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>