### PR TITLE
buildkit http and insecure options are mutually exclusive

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -376,7 +376,6 @@ earthly-integration-test-base:
         IF [ "$DOCKERHUB_MIRROR_INSECURE" = "true" ]
             ENV EARTHLY_ADDITIONAL_BUILDKIT_CONFIG="$EARTHLY_ADDITIONAL_BUILDKIT_CONFIG
 [registry.\"$DOCKERHUB_MIRROR\"]
-  http = true
   insecure = true"
         END
 

--- a/docs/ci-integration/pull-through-cache.md
+++ b/docs/ci-integration/pull-through-cache.md
@@ -60,7 +60,6 @@ global:
       mirrors = ["<mirror>"]
 
     [registry."<mirror>"]
-      http = true
       insecure = true
 ```
 
@@ -176,7 +175,6 @@ global:
     [registry."docker.io"]
       mirrors = ["192.168.0.80:5000"]
     [registry."192.168.0.80:5000"]
-      http = true
       insecure = true
 ```
 

--- a/docs/guides/registries/self-signed.md
+++ b/docs/guides/registries/self-signed.md
@@ -41,7 +41,6 @@ To configure Earthly to use an insecure registry, use the following [Earthly con
 global:
   buildkit_additional_config: |
     [registry."<registry-hostname>"]
-      http = true
       insecure = true
 ```
 
@@ -55,6 +54,15 @@ build:
     ENTRYPOINT cat motd
     SAVE IMAGE --push --insecure <registry-hostname>/hello-earthly:with-love
 ```
+
+{% hint style='danger' %}
+##### Note
+
+The `http` and `insecure` settings are mutually exclusive. Setting `insecure=true` should only be used when the registry is https and is configured with an insecure certificate.
+Setting `http=true` is only for the case where a standard http-based registry is used (i.e. no SSL encryption). If both are set buildkit will attempt to connect to the registry using either http (port 80), or https (port 443).
+
+{% endhint %}
+
 
 ## Other BuildKit options
 

--- a/tests/registry-certs/Earthfile
+++ b/tests/registry-certs/Earthfile
@@ -10,7 +10,6 @@ ARG --global REGISTRY_IP
 ARG --global EARTHLY_BUILD_ARGS="REGISTRY"
 ARG --global REGISTRY_CONFIG="
 [registry.\"$REGISTRY\"]
-  http = true
   insecure = true
 "
 

--- a/tests/remote-cache/Earthfile
+++ b/tests/remote-cache/Earthfile
@@ -36,15 +36,14 @@ ARG --global EARTHLY_BUILD_ARGS="REGISTRY"
 ARG --global REGISTRY_CONFIG="
 [registry.\"$REGISTRY\"]
   http = true
-  insecure = true
 "
 
 COPY test.earth ./Earthfile
 
 all:
     BUILD +test1
-    #BUILD +test2
-    #BUILD +test3
+    BUILD +test2
+    BUILD +test3
 
 test1:
     RUN echo "content" >./input


### PR DESCRIPTION
If both http=true and insecure=true are set, buildkit will create two registry entries, one on port 80, and the other on port 443 and will attempt to connect to either server.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>