### PR TITLE
git-metadata-test: set author via env variable

### DIFF
--- a/tests/git-metadata/Earthfile
+++ b/tests/git-metadata/Earthfile
@@ -37,6 +37,11 @@ ssh git@git.example.com | grep \"Hi git! You've successfully authenticated, but 
 git config --global user.email \"onlyspammersemailthis@earthly.dev\"
 git config --global user.name \"test name\"
 
+# Also set git author details via env variable
+# just in case this prevents the flaky git commit bug we have been seeing in GHA
+export GIT_AUTHOR_NAME=\"test name\"
+export GIT_AUTHOR_EMAIL=\"onlyspammersemailthis@earthly.dev\"
+
 # test this worked (seems to be flaky in some tests)
 cat \$HOME/.gitconfig
 git config --global user.name


### PR DESCRIPTION
git will make use of GIT_AUTHOR_NAME and GIT_AUTHOR_EMAIL while detecting the author identity (see ident.c under git source).

We will attempt to explicitly set the env variables, in case that prevents the following error we periodically see in GHA:

    *** Please tell me who you are.

    Run

      git config --global user.email "you@example.com"
      git config --global user.name "Your Name"

    to set your account's default identity.
    Omit --global to set the identity only in this repository.

    fatal: unable to auto-detect email address (got 'root@buildkitsandbox.(none)')

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>