### PR TITLE
move tests that need earthly-technologies access

### DIFF
--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -113,6 +113,15 @@ jobs:
             --build-arg DOCKERHUB_AUTH=false \
           +test-no-qemu
         if: github.event_name != 'push' && github.event.pull_request.head.repo.full_name != github.repository
+      - name: Execute tests-that-require-earthly-technologies-account-access
+        run: |-
+          ${{inputs.SUDO}} ${{ inputs.BUILT_EARTHLY_PATH }} --ci -P \
+            --build-arg DOCKERHUB_AUTH=true \
+            --build-arg DOCKERHUB_USER_SECRET=+secrets/earthly-technologies/dockerhub-mirror/user \
+            --build-arg DOCKERHUB_TOKEN_SECRET=+secrets/earthly-technologies/dockerhub-mirror/pass \
+            --build-arg DOCKERHUB_MIRROR=registry-1.docker.io.mirror.corp.earthly.dev \
+          ./tests+tests-that-require-earthly-technologies-account-access
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
       - name: Install QEMU for Podman multi-arch building
         # qemu-user-static needed for cross-compilation (--platform) targets
         run: ${{inputs.SUDO}} apt-get update && ${{inputs.SUDO}} apt-get install -y qemu-user-static

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -135,13 +135,6 @@ ga-no-qemu:
         --DOCKERHUB_MIRROR=$DOCKERHUB_MIRROR \
         --DOCKERHUB_MIRROR_INSECURE=$DOCKERHUB_MIRROR_INSECURE \
         --DOCKERHUB_MIRROR_HTTP=$DOCKERHUB_MIRROR_HTTP
-    BUILD ./web+test \
-        --DOCKERHUB_AUTH=$DOCKERHUB_AUTH \
-        --DOCKERHUB_USER_SECRET=$DOCKERHUB_USER_SECRET \
-        --DOCKERHUB_TOKEN_SECRET=$DOCKERHUB_TOKEN_SECRET \
-        --DOCKERHUB_MIRROR=$DOCKERHUB_MIRROR \
-        --DOCKERHUB_MIRROR_INSECURE=$DOCKERHUB_MIRROR_INSECURE \
-        --DOCKERHUB_MIRROR_HTTP=$DOCKERHUB_MIRROR_HTTP
     BUILD +excludes-test
     BUILD +secrets-test
     BUILD +secrets-optional-prefix-test
@@ -244,6 +237,14 @@ ga-no-qemu:
         BUILD +save-artifact-after-push
         BUILD ./with-docker-via-command+test
     END
+
+tests-that-require-earthly-technologies-account-access:
+    BUILD ./web+test \
+        --DOCKERHUB_AUTH=$DOCKERHUB_AUTH \
+        --DOCKERHUB_USER_SECRET=$DOCKERHUB_USER_SECRET \
+        --DOCKERHUB_TOKEN_SECRET=$DOCKERHUB_TOKEN_SECRET \
+        --DOCKERHUB_MIRROR=$DOCKERHUB_MIRROR \
+        --DOCKERHUB_MIRROR_INSECURE=$DOCKERHUB_MIRROR_INSECURE
 
 # tests that only run on linux amd64
 # Note: this target is used to validate the USERPLATFORM user arg,


### PR DESCRIPTION
The tests/web test requires access to the earthly-technologies cloud-secrets account, which causes community contributors from running the high-level +test target.

This moves them to a separate target, which is triggered directly from GHA.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>