### PR TITLE
Documentation: add link to woodpecker-ci in SUMMARY.md

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -65,6 +65,7 @@
     * [Kubernetes](ci-integration/guides/kubernetes.md)
     * [Google Cloud Build](ci-integration/guides/google-cloud-build.md)
     * [GitLab CI/CD](ci-integration/guides/gitlab-integration.md)
+    * [Woodpecker CI](ci-integration/guides/woodpecker-integration.md)
 
 ## ☁️ Earthly Cloud
 


### PR DESCRIPTION
Follow up for previous Pull request: [2361](https://github.com/earthly/earthly/pull/2361) that added a little documentation on how to use earthly with woodpecker-ci. 

It was not showing up in the documentation yet and it seems that the missing occurrence in the summary might be the cause.