### PR TITLE
move staging builds to separate docker image

### DIFF
--- a/.github/workflows/ci-staging-deploy.yml
+++ b/.github/workflows/ci-staging-deploy.yml
@@ -20,6 +20,8 @@ jobs:
       EARTHLY_REPO: "earthly-staging"
       BREW_REPO: "homebrew-earthly-staging"
       DOCKERHUB_USER: "earthly"
+      DOCKERHUB_IMG: "earthly-staging"
+      DOCKERHUB_BUILDKIT_IMG: "buildkitd-staging"
       # Used in our github action as the token - TODO: look to change it into an input
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/Earthfile
+++ b/Earthfile
@@ -342,7 +342,9 @@ earthly-docker:
     ARG EARTHLY_TARGET_TAG_DOCKER
     ARG TAG="dev-$EARTHLY_TARGET_TAG_DOCKER"
     COPY (+earthly/earthly --VERSION=$TAG --DEFAULT_INSTALLATION_NAME="earthly") /usr/bin/earthly
-    SAVE IMAGE --push --cache-from=earthly/earthly:main earthly/earthly:$TAG
+    ARG DOCKERHUB_USER="earthly"
+    ARG DOCKERHUB_IMG="earthly"
+    SAVE IMAGE --push --cache-from=earthly/earthly:main $DOCKERHUB_USER/$DOCKERHUB_IMG:$TAG
 
 earthly-integration-test-base:
     FROM +earthly-docker

--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -62,12 +62,13 @@ buildkitd:
     ENV EARTHLY_CACHE_VERSION="2" # whenever this value changes, a forced cache reset is performed
     VOLUME /tmp/earthly
     ENTRYPOINT ["/usr/bin/entrypoint.sh", "buildkitd", "--config=/etc/buildkitd.toml"]
-    ARG REGISTRY_USER="earthly"
+    ARG DOCKERHUB_USER="earthly"
+    ARG DOCKERHUB_BUILDKIT_IMG="buildkitd"
     ARG IMAGE_REGISTRY="docker.io"
 
     # Ensure that the image we save is a fully qualified name. Podman defaults to "localhost", while Docker defaults to
     # "docker.io". This keeps it consistent across both frontends.
-    SAVE IMAGE --push --cache-from=$IMAGE_REGISTRY/earthly/buildkitd:main $IMAGE_REGISTRY/$REGISTRY_USER/buildkitd:$TAG
+    SAVE IMAGE --push --cache-from=$IMAGE_REGISTRY/earthly/buildkitd:main $IMAGE_REGISTRY/$DOCKERHUB_USER/$DOCKERHUB_BUILDKIT_IMG:$TAG
 
 buildkit-sha:
     RUN apk add git

--- a/release/Earthfile
+++ b/release/Earthfile
@@ -34,30 +34,37 @@ release-dind:
 release-dockerhub:
     ARG --required RELEASE_TAG
     ARG DOCKERHUB_USER="earthly"
+    ARG DOCKERHUB_IMG="earthly"
+    ARG DOCKERHUB_BUILDKIT_IMG="buildkitd"
     ARG PUSH_LATEST_TAG="false"
     ARG PUSH_PRERELEASE_TAG="false"
-    BUILD +perform-release-dockerhub --RELEASE_TAG="$RELEASE_TAG" --DOCKERHUB_USER="$DOCKERHUB_USER"
+    BUILD +perform-release-dockerhub --RELEASE_TAG="$RELEASE_TAG" --DOCKERHUB_USER="$DOCKERHUB_USER" --DOCKERHUB_IMG="$DOCKERHUB_IMG" --DOCKERHUB_BUILDKIT_IMG="$DOCKERHUB_BUILDKIT_IMG"
     IF [ "$PUSH_LATEST_TAG" = "true" ]
-      BUILD +perform-release-dockerhub --RELEASE_TAG="latest" --DOCKERHUB_USER="$DOCKERHUB_USER"
+      BUILD +perform-release-dockerhub --RELEASE_TAG="latest" --DOCKERHUB_USER="$DOCKERHUB_USER" --DOCKERHUB_IMG="$DOCKERHUB_IMG" --DOCKERHUB_BUILDKIT_IMG="$DOCKERHUB_BUILDKIT_IMG"
     END
     IF [ "$PUSH_PRERELEASE_TAG" = "true" ]
-      BUILD +perform-release-dockerhub --RELEASE_TAG="prerelease" --DOCKERHUB_USER="$DOCKERHUB_USER"
+      BUILD +perform-release-dockerhub --RELEASE_TAG="prerelease" --DOCKERHUB_USER="$DOCKERHUB_USER" --DOCKERHUB_IMG="$DOCKERHUB_IMG" --DOCKERHUB_BUILDKIT_IMG="$DOCKERHUB_BUILDKIT_IMG"
     END
 
 perform-release-dockerhub:
     ARG --required RELEASE_TAG
     ARG DOCKERHUB_USER="earthly"
+    ARG DOCKERHUB_IMG="earthly"
+    ARG DOCKERHUB_BUILDKIT_IMG="buildkitd"
     BUILD \
         --platform=linux/amd64 \
         --platform=linux/arm64 \
         ../+earthly-docker \
-        --TAG="$RELEASE_TAG"
+        --TAG="$RELEASE_TAG" \
+        --DOCKERHUB_USER="$DOCKERHUB_USER" \
+        --DOCKERHUB_IMG="$DOCKERHUB_IMG"
     BUILD \
         --platform=linux/amd64 \
         --platform=linux/arm64 \
         ../buildkitd+buildkitd \
         --TAG="$RELEASE_TAG" \
-        --DOCKERHUB_USER="$DOCKERHUB_USER"
+        --DOCKERHUB_USER="$DOCKERHUB_USER" \
+        --DOCKERHUB_BUILDKIT_IMG="$DOCKERHUB_BUILDKIT_IMG"
 
 release-notes:
     FROM python:3
@@ -82,13 +89,14 @@ release-github:
     ARG GITHUB_USER="earthly"
     ARG EARTHLY_REPO="earthly"
     ARG DOCKERHUB_USER="earthly"
+    ARG DOCKERHUB_BUILDKIT_IMG="buildkitd"
     ARG PRERELEASE="false"
     ARG EARTHLY_GIT_HASH
     RUN test -n "$EARTHLY_GIT_HASH"
     COPY +release-notes/notes.txt release-notes.txt
     COPY (../+earthly-all/* \
          --VERSION=$RELEASE_TAG \
-         --DEFAULT_BUILDKITD_IMAGE="$DOCKERHUB_USER/buildkitd:$RELEASE_TAG" \
+         --DEFAULT_BUILDKITD_IMAGE="$DOCKERHUB_USER/$DOCKERHUB_BUILDKIT_IMG:$RELEASE_TAG" \
          --DEFAULT_INSTALLATION_NAME="earthly" \
          ) ./release/
     RUN ls ./release


### PR DESCRIPTION
push staging builds to a separate earthly/earthly-staging and earthly/buildkitd-staging docker images, to make it easier for users to differentiate between version tags when viewing docker hub.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>