### PR TITLE
Revert example VERSION changes

### DIFF
--- a/examples/bazel/Earthfile
+++ b/examples/bazel/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION --use-cache-command 0.6
 
 FROM ubuntu:22.04
 WORKDIR /workspace

--- a/examples/c/Earthfile
+++ b/examples/c/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 FROM alpine
 WORKDIR /c-example
 

--- a/examples/cache-command/mvn/Earthfile
+++ b/examples/cache-command/mvn/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION --use-cache-command 0.6
 
 FROM maven:3.8.4-openjdk-17
 WORKDIR /app

--- a/examples/cache-command/npm/Earthfile
+++ b/examples/cache-command/npm/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION --use-cache-command 0.6
 
 FROM node:17-alpine3.14
 WORKDIR /app

--- a/examples/cobol/Earthfile
+++ b/examples/cobol/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 FROM ubuntu:20.04
 
 ## for apt to be noninteractive

--- a/examples/cpp/Earthfile
+++ b/examples/cpp/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 FROM ubuntu:20.04
 
 ## for apt to be noninteractive

--- a/examples/cutoff-optimization/Earthfile
+++ b/examples/cutoff-optimization/Earthfile
@@ -4,7 +4,7 @@
 # 3) ReRun `earthly +run`
 # Result: `build` will rerun, but `link` and `run` will be served from the cache as main.o is unchanged
 
-VERSION 0.7
+VERSION 0.6
 FROM alpine
 WORKDIR /code
 RUN apk add --update --no-cache build-base

--- a/examples/dotnet/Earthfile
+++ b/examples/dotnet/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1.302-alpine3.12
 WORKDIR /dotnet-example
 

--- a/examples/elixir/Earthfile
+++ b/examples/elixir/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 
 deps:
     FROM elixir:1.10-alpine

--- a/examples/go-monorepo/Earthfile
+++ b/examples/go-monorepo/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 
 all-unit-test:
     BUILD ./libs/hello+unit-test

--- a/examples/go-monorepo/libs/hello/Earthfile
+++ b/examples/go-monorepo/libs/hello/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 
 deps:
     FROM golang:1.17-alpine

--- a/examples/go-monorepo/services/one/Earthfile
+++ b/examples/go-monorepo/services/one/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 
 deps:
     FROM golang:1.17-alpine

--- a/examples/go-monorepo/services/two/Earthfile
+++ b/examples/go-monorepo/services/two/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 
 deps:
     FROM golang:1.17-alpine

--- a/examples/go/Earthfile
+++ b/examples/go/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 FROM golang:1.15-alpine3.13
 WORKDIR /go-example
 

--- a/examples/grpc/Earthfile
+++ b/examples/grpc/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 FROM node:13.10.1-alpine3.11
 
 WORKDIR /example-grpc

--- a/examples/import/Earthfile
+++ b/examples/import/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 IMPORT ./some/local/path AS lib
 IMPORT github.com/earthly/hello-world:main  # if alias is not provided, defaults to last element in path (in this case, hello-world)
 

--- a/examples/import/some/local/path/Earthfile
+++ b/examples/import/some/local/path/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 
 base-image:
     FROM busybox:1.32.0

--- a/examples/integration-test/Earthfile
+++ b/examples/integration-test/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 FROM earthly/dind:alpine
 WORKDIR /scala-example
 RUN apk add openjdk11 bash wget postgresql-client

--- a/examples/java/Earthfile
+++ b/examples/java/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 FROM openjdk:8-jdk-alpine
 RUN apk add --update --no-cache gradle
 WORKDIR /java-example

--- a/examples/js/Earthfile
+++ b/examples/js/Earthfile
@@ -1,5 +1,5 @@
 
-VERSION 0.7
+VERSION 0.6
 FROM node:15.12.0-alpine3.13
 WORKDIR /js-example
 

--- a/examples/monorepo/Earthfile
+++ b/examples/monorepo/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 
 all:
     BUILD ./frontend+docker

--- a/examples/monorepo/frontend/Earthfile
+++ b/examples/monorepo/frontend/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 FROM node:13.10.1-alpine3.11
 
 WORKDIR /example-multirepo

--- a/examples/monorepo/html/Earthfile
+++ b/examples/monorepo/html/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 FROM alpine:3.11
 
 WORKDIR /example-static

--- a/examples/monorepo/js/Earthfile
+++ b/examples/monorepo/js/Earthfile
@@ -1,5 +1,5 @@
 
-VERSION 0.7
+VERSION 0.6
 FROM node:13.10.1-alpine3.11
 
 WORKDIR /example-js

--- a/examples/multiplatform-cross-compile/Earthfile
+++ b/examples/multiplatform-cross-compile/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 
 # An example where multi-platform images are possible without the need of any emulation.
 # The build takes place on linux/amd64, however multiple image variants are produced in the end.

--- a/examples/multiplatform/Earthfile
+++ b/examples/multiplatform/Earthfile
@@ -1,5 +1,5 @@
 
-VERSION 0.7
+VERSION 0.6
 
 all:
     BUILD \

--- a/examples/multirepo/Earthfile
+++ b/examples/multirepo/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 FROM node:13.10.1-alpine3.11
 
 WORKDIR /example-multirepo

--- a/examples/next-js-netlify/Earthfile
+++ b/examples/next-js-netlify/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 FROM --platform=linux/amd64 node:latest
 WORKDIR /app
 

--- a/examples/python/Earthfile
+++ b/examples/python/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 FROM python:3
 WORKDIR /code
 

--- a/examples/react/Earthfile
+++ b/examples/react/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 
 build: 
   FROM node:16.10.0-alpine

--- a/examples/readme/go1/Earthfile
+++ b/examples/readme/go1/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 FROM golang:1.19-alpine3.15
 RUN apk --update --no-cache add git curl
 WORKDIR /go-example

--- a/examples/readme/go2/Earthfile
+++ b/examples/readme/go2/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 FROM golang:1.15-alpine3.13
 RUN apk --update --no-cache add git g++ make curl wget ca-certificates
 RUN echo "Some time-consuming operation" && sleep 10 && echo "...done"

--- a/examples/readme/proto/Earthfile
+++ b/examples/readme/proto/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 FROM golang:1.15-alpine3.13
 WORKDIR /proto-example
 

--- a/examples/ruby-on-rails/Earthfile
+++ b/examples/ruby-on-rails/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 FROM ruby:2.6.5
 WORKDIR /ruby-on-rails-example
 ENV BUNDLER_VERSION=2.1.4

--- a/examples/ruby/Earthfile
+++ b/examples/ruby/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 FROM ruby:2.7.1
 WORKDIR /ruby-example
 

--- a/examples/rust/Earthfile
+++ b/examples/rust/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 FROM rust:1.59
 WORKDIR /rustexample
 

--- a/examples/scala/Earthfile
+++ b/examples/scala/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 FROM hseeberger/scala-sbt:11.0.7_1.3.13_2.11.12
 WORKDIR /scala-example
 

--- a/examples/terraform/Earthfile
+++ b/examples/terraform/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 
 prep: 
     FROM hashicorp/terraform:light

--- a/examples/tutorial/Earthfile
+++ b/examples/tutorial/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 FROM alpine:3.15
 WORKDIR /tutorial
 

--- a/examples/tutorial/go/Earthfile
+++ b/examples/tutorial/go/Earthfile
@@ -1,5 +1,5 @@
 
-VERSION 0.7
+VERSION 0.6
 FROM alpine:3.15
 WORKDIR /tutorial
 

--- a/examples/tutorial/go/part1/Earthfile
+++ b/examples/tutorial/go/part1/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 FROM golang:1.15-alpine3.13
 WORKDIR /go-workdir
 

--- a/examples/tutorial/go/part2/Earthfile
+++ b/examples/tutorial/go/part2/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 FROM golang:1.15-alpine3.13
 WORKDIR /go-workdir
 

--- a/examples/tutorial/go/part3/Earthfile
+++ b/examples/tutorial/go/part3/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 FROM golang:1.15-alpine3.13
 WORKDIR /go-workdir
 

--- a/examples/tutorial/go/part4/Earthfile
+++ b/examples/tutorial/go/part4/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 FROM golang:1.15-alpine3.13
 WORKDIR /go-workdir
 

--- a/examples/tutorial/go/part5/Earthfile
+++ b/examples/tutorial/go/part5/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 FROM golang:1.15-alpine3.13
 WORKDIR /go-workdir
 

--- a/examples/tutorial/go/part5/services/service-one/Earthfile
+++ b/examples/tutorial/go/part5/services/service-one/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 FROM golang:1.15-alpine3.13
 WORKDIR /go-workdir
 

--- a/examples/tutorial/go/part6/Earthfile
+++ b/examples/tutorial/go/part6/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 FROM golang:1.15-alpine3.13
 WORKDIR /go-workdir
 

--- a/examples/tutorial/java/Earthfile
+++ b/examples/tutorial/java/Earthfile
@@ -1,5 +1,5 @@
 
-VERSION 0.7
+VERSION 0.6
 FROM alpine:3.15
 WORKDIR /tutorial
 

--- a/examples/tutorial/java/part1/Earthfile
+++ b/examples/tutorial/java/part1/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 FROM openjdk:8-jdk-alpine
 RUN apk add --update --no-cache gradle
 WORKDIR /java-example

--- a/examples/tutorial/java/part2/Earthfile
+++ b/examples/tutorial/java/part2/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 FROM openjdk:8-jdk-alpine
 RUN apk add --update --no-cache gradle
 WORKDIR /java-example

--- a/examples/tutorial/java/part3/Earthfile
+++ b/examples/tutorial/java/part3/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 FROM openjdk:8-jdk-alpine
 RUN apk add --update --no-cache gradle
 WORKDIR /java-example

--- a/examples/tutorial/java/part4/Earthfile
+++ b/examples/tutorial/java/part4/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 FROM openjdk:8-jdk-alpine
 RUN apk add --update --no-cache gradle
 WORKDIR /java-example

--- a/examples/tutorial/java/part5/Earthfile
+++ b/examples/tutorial/java/part5/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 FROM openjdk:8-jdk-alpine
 RUN apk add --update --no-cache gradle
 WORKDIR /java-example

--- a/examples/tutorial/java/part5/services/service-one/Earthfile
+++ b/examples/tutorial/java/part5/services/service-one/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 FROM openjdk:8-jdk-alpine
 RUN apk add --update --no-cache gradle
 WORKDIR /java-example

--- a/examples/tutorial/java/part6/Earthfile
+++ b/examples/tutorial/java/part6/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 FROM openjdk:8-jdk-alpine
 RUN apk add --update --no-cache gradle
 WORKDIR /java-example

--- a/examples/tutorial/js/Earthfile
+++ b/examples/tutorial/js/Earthfile
@@ -1,5 +1,5 @@
 
-VERSION 0.7
+VERSION 0.6
 FROM alpine:3.15
 WORKDIR /tutorial
 

--- a/examples/tutorial/js/part1/Earthfile
+++ b/examples/tutorial/js/part1/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 FROM node:13.10.1-alpine3.11
 WORKDIR /js-example
 

--- a/examples/tutorial/js/part2/Earthfile
+++ b/examples/tutorial/js/part2/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 FROM node:13.10.1-alpine3.11
 WORKDIR /js-example
 

--- a/examples/tutorial/js/part3/Earthfile
+++ b/examples/tutorial/js/part3/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 FROM node:13.10.1-alpine3.11
 WORKDIR /js-example
 

--- a/examples/tutorial/js/part4/Earthfile
+++ b/examples/tutorial/js/part4/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 FROM node:13.10.1-alpine3.11
 WORKDIR /js-example
 

--- a/examples/tutorial/js/part5/Earthfile
+++ b/examples/tutorial/js/part5/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 FROM node:13.10.1-alpine3.11
 WORKDIR /js-example
 

--- a/examples/tutorial/js/part5/services/service-one/Earthfile
+++ b/examples/tutorial/js/part5/services/service-one/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 FROM node:13.10.1-alpine3.11
 WORKDIR /js-example
 

--- a/examples/tutorial/js/part6/Earthfile
+++ b/examples/tutorial/js/part6/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 FROM node:13.10.1-alpine3.11
 WORKDIR /js-example
 

--- a/examples/tutorial/python/Earthfile
+++ b/examples/tutorial/python/Earthfile
@@ -1,5 +1,5 @@
 
-VERSION 0.7
+VERSION 0.6
 FROM alpine:3.15
 WORKDIR /tutorial
 

--- a/examples/tutorial/python/part1/Earthfile
+++ b/examples/tutorial/python/part1/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 FROM python:3
 WORKDIR /code
 

--- a/examples/tutorial/python/part2/Earthfile
+++ b/examples/tutorial/python/part2/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 FROM python:3
 WORKDIR /code
 

--- a/examples/tutorial/python/part3/Earthfile
+++ b/examples/tutorial/python/part3/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 FROM python:3
 WORKDIR /code
 

--- a/examples/tutorial/python/part4/Earthfile
+++ b/examples/tutorial/python/part4/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 FROM python:3
 WORKDIR /code
 

--- a/examples/tutorial/python/part5/Earthfile
+++ b/examples/tutorial/python/part5/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 FROM python:3
 WORKDIR /code
 

--- a/examples/tutorial/python/part5/services/service-one/Earthfile
+++ b/examples/tutorial/python/part5/services/service-one/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 FROM python:3
 WORKDIR /code
 

--- a/examples/tutorial/python/part6/Earthfile
+++ b/examples/tutorial/python/part6/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 FROM python:3
 WORKDIR /code
 

--- a/examples/typescript-node/Earthfile
+++ b/examples/typescript-node/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.6
 FROM node:latest
 
 WORKDIR typescript-node-example


### PR DESCRIPTION
This reverts all example changes from commit de73e7d2052e01dffda48c92e62adabbff7f4747.

Our documentation points to `main` under github, and some users may be confused by the examples being set to `VERSION 0.7`, which will fail when run against earthly v0.6.X