### PR TITLE
fix release.sh not passing prerelease arg

### DIFF
--- a/release/README.md
+++ b/release/README.md
@@ -13,6 +13,10 @@
   ```bash
   export RELEASE_TAG="v..."
   ```
+* Is it a pre-release?
+  ```bash
+  export PRERELEASE="true-or-false"
+  ```
 * Make sure you are on main
   ```bash
   git checkout main && git pull
@@ -28,7 +32,7 @@
   | Windows (WSL) | [![Build status](https://badge.buildkite.com/19d9cf7fcfb3e0ee45adcb29abb5ef3cfcd994fba2d6dc148c.svg)](https://buildkite.com/earthly-technologies/earthly-windows-scheduled)
 * Run
   ```bash
-  env -i HOME="$HOME" PATH="$PATH" SSH_AUTH_SOCK="$SSH_AUTH_SOCK" RELEASE_TAG="$RELEASE_TAG" USER="$USER" ./release.sh
+  env -i HOME="$HOME" PATH="$PATH" SSH_AUTH_SOCK="$SSH_AUTH_SOCK" RELEASE_TAG="$RELEASE_TAG" USER="$USER" PRERELEASE="$PRERELEASE" ./release.sh
   ```
 * Merge branch `main` into `next`, then merge branch `next` into `main`.
 * Update the version for the installation command in the following places:


### PR DESCRIPTION
The prerelease value was not correctly passed to the +release-github target, which caused the RC to show up as latest.

This additionally re-orders the earthly version detection logic to handle the case where the earthly command override is missing.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>