### PR TITLE
Fix logic for custom BUILDKIT_PROJECT

### DIFF
--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -5,7 +5,7 @@ FROM alpine:3.15
 buildkitd:
     ARG BUILDKIT_PROJECT
     IF [ "$BUILDKIT_PROJECT" != "" ]
-        IF case "$BUILDKIT_PROJECT" in "../*") true;; "*") false;; esac
+        IF case "$BUILDKIT_PROJECT" in "../*") true;; *) false;; esac
             # Assuming this is coming from the main Earthly Earthfile.
             ARG BUILDKIT_BASE_IMAGE=../$BUILDKIT_PROJECT+build
         ELSE


### PR DESCRIPTION
The default wasn't working as intended, which resulted in every `BUILDKIT_PROJECT` value being treated as a local target (even when clearly a remote).

Example: 
```
$ earthly ./buildkitd+buildkitd --BUILDKIT_PROJECT=github.com/earthly/buildkit:earthly-main
 <snip>
./buildkitd+buildkitd | BUILDKIT_PROJECT=github.com/earthly/buildkit:earthly-main
./buildkitd+buildkitd | *cached* --> IF [ "$BUILDKIT_PROJECT" != "" ]
./buildkitd+buildkitd | BUILDKIT_PROJECT=github.com/earthly/buildkit:earthly-main
./buildkitd+buildkitd | *cached* --> IF case "$BUILDKIT_PROJECT" in "../*") true;; "*") false;; esac
Error: build target: build main: failed to solve: buildkitd/Earthfile line 20:4 apply FROM ../github.com/earthly/buildkit:earthly-main+build: apply build ../github.com/earthly/buildkit:earthly-main+build: earthfile2llb for ../github.com/earthly/buildkit:earthly-main+build: resolve build context for target ./github.com/earthly/buildkit:earthly-main+build: No Earthfile nor build.earth file found for target ./github.com/earthly/buildkit:earthly-main+build
in		github.com/rrjjvv/earthly/buildkitd:custom-bk-project-fix+buildkitd --BUILDKIT_BASE_IMAGE= --BUILDKIT_PROJECT=github.com/earthly/buildkit:earthly-main --EARTHLY_TARGET_TAG_DOCKER= --TAG=
```
Illustration of the difference:
```
$ docker run --rm -it alpine:3.15 /bin/sh
/ # case matchme in "nope") false;; "*") echo "no sir"; false;; esac; echo $?
0
/ # case matchme in "nope") false;; *) echo "no sir"; false;; esac; echo $?
no sir
1
```
The quoted asterisk is a literal match for an asterisk, so there is no actual default match, and when there's no match, the case returns zero (thus transformed into a local relative target).