### PR TITLE
Fix description for `--use-chmod` feature

### DIFF
--- a/features/features.go
+++ b/features/features.go
@@ -42,7 +42,7 @@ type Features struct {
 	NoTarBuildOutput         bool `long:"no-tar-build-output" description:"do not print output when creating a tarball to load into WITH DOCKER"`
 	ShellOutAnywhere         bool `long:"shell-out-anywhere" description:"allow shelling-out in the middle of ARGs, or any other command"`
 	UseCacheCommand          bool `long:"use-cache-command" description:"allow use of CACHE command in Earthfiles"`
-	UseChmod                 bool `long:"use-chmod" description:"enable the SAVE IMAGE --no-manifest-list option"`
+	UseChmod                 bool `long:"use-chmod" description:"enable the COPY --chmod option"`
 	UseCopyLink              bool `long:"use-copy-link" description:"use the equivalent of COPY --link for all copy-like operations"`
 	UseHostCommand           bool `long:"use-host-command" description:"allow use of HOST command in Earthfiles"`
 	UseNoManifestList        bool `long:"use-no-manifest-list" description:"enable the SAVE IMAGE --no-manifest-list option"`


### PR DESCRIPTION
This is something I had noticed a long time ago, but minor enough that it wasn't worth a dedicated PR, and then forgot by the time I had a real PR where I could shoehorn it in.

When @vladaionescu pointed me to https://github.com/earthly/earthly/blob/next/docs/earthfile/features.md and I saw the bad description, I immediately recognized it and became 99% sure that doc was auto-generated from code.  So this is more about fixing the docs, and assuming this is first step.  And since this is truly "code", I assume it should be merged to 'main' (and you'll do something after to get it and/or the generated content to 'next').