### PR TITLE
ast: recover from popping too many modes

### DIFF
--- a/ast/lexer.go
+++ b/ast/lexer.go
@@ -47,6 +47,12 @@ func (l *lexer) getMode() int {
 // popRecipeMode removes the recipe mode stack frame and then places back anything that existed
 // on top of it.
 func (l *lexer) popRecipeMode() {
+	defer func() {
+		// Recovering here prevents a panic due to erroneous indentation. The
+		// tokens will still fail to match our parser grammar, so we have no
+		// need to add an error of our own.
+		_ = recover()
+	}()
 	m := l.getMode()
 	if m == parser.EarthLexerRECIPE {
 		// Special case: nothing above.

--- a/tests/invalid/Earthfile
+++ b/tests/invalid/Earthfile
@@ -20,18 +20,24 @@ WORKDIR /test
 test-trailing-backslash:
     DO +RUN_EARTHLY_ARGS --earthfile=trailing-backslash.earth --should_fail=true --target=+base
 
+test-leading-whitespace:
+    DO +RUN_EARTHLY_ARGS --earthfile=leading-whitespace.earth --should_fail=true --target=+base --output_contains="syntax error"
+
 test-all:
     BUILD +test-trailing-backslash
+    BUILD +test-leading-whitespace
 
 RUN_EARTHLY_ARGS:
     COMMAND
     ARG earthfile
     ARG target
     ARG should_fail=false
+    ARG output_contains
     DO tests+RUN_EARTHLY \
         --earthfile=$earthfile \
         --target=$target \
         --should_fail=$should_fail \
+        --output_contains=$output_contains \
         --DOCKERHUB_AUTH=$DOCKERHUB_AUTH \
         --DOCKERHUB_USER_SECRET=$DOCKERHUB_USER_SECRET \
         --DOCKERHUB_TOKEN_SECRET=$DOCKERHUB_TOKEN_SECRET \

--- a/tests/invalid/leading-whitespace.earth
+++ b/tests/invalid/leading-whitespace.earth
@@ -1,0 +1,9 @@
+VERSION 0.7
+FROM alpine:3.15
+
+ ARG foo
+# ^^ leading whitespace at the top level causes INDENT/DEDENT confusion in the
+# parser. This error should be caught and output, but should not cause earthly
+# to panic.
+
+RUN true


### PR DESCRIPTION
In certain edge cases, erroneous indentation was causing us to call popRecipeMode too many times. Simply adding a 'recover' changes our panic into a syntax error.

Resolves #2603 