### PR TITLE
rename output phases to summary

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -41,13 +41,13 @@ import (
 
 const (
 	// PhaseInit is the phase text for the init phase.
-	PhaseInit = "1. Init 🚀"
+	PhaseInit = "Init 🚀"
 	// PhaseBuild is the phase text for the build phase.
-	PhaseBuild = "2. Build 🔧"
+	PhaseBuild = "Build 🔧"
 	// PhasePush is the phase text for the push phase.
-	PhasePush = "3. Push ⏫"
+	PhasePush = "Push Summary ⏫"
 	// PhaseOutput is the phase text for the output phase.
-	PhaseOutput = "4. Local Output 🎁"
+	PhaseOutput = "Local Output Summary 🎁"
 )
 
 // Opt represent builder options.


### PR DESCRIPTION
WAIT/END makes it possible to perform a push or local output during the build phase, since these operations may have occurred prior to the push and local output phases, these phases will be renamed to be a summary to make it more clear they don't imply the order.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>