### PR TITLE
commands for cloud-stored registry auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ Earthfiles to use 0.7 (or 0.6), you can declare `VERSION 0.5` to continue to use
 **Pushing no longer requires everything else to succeed**
 
 The behavior of the `--push` mode has changed in a backwards incompatible manner. Previously, `--push` commands would only execute if all other commands had succeeded. This precondition is no longer enforced, to allow for more flexible push ordering via the new `WAIT` clause. To achieve the behavior of the previous `--push` mode, you need to wrap any pre-required commands in a `WAIT` clause. For example, to push an image only if tests have passed, you would do the following:
-  
+
 ```Earthfile
 test-and-push:
   WAIT
@@ -125,6 +125,7 @@ For more information on the individual Earthfile feature flags see the [Earthfil
 - The new ARG `EARTHLY_LOCALLY` indicates whether the current target is executed in a `LOCALLY` context. Previously under `VERSION --earthly-locally-arg 0.6`.
 - The new ARGs `EARTHLY_GIT_AUTHOR` and `EARTHLY_GIT_CO_AUTHORS` contain the author and co-authors of the current git commit, respectively. Previously under `VERSION --earthly-git-author-args 0.6`.
 - `earthly doc [projectRef[+targetRef]]` is a new subcommand in *beta* status.  It will parse and output documentation comments on targets.
+- Ability to store docker registry credentials in cloud secrets and corresponding `earthly registry login|list|logout` commands; credentials can be associated with either your user or project.
 
 ### Fixed
 

--- a/cloud/secret_new.go
+++ b/cloud/secret_new.go
@@ -130,7 +130,12 @@ func (c *client) RemoveSecret(ctx context.Context, path string) error {
 		return err
 	}
 
-	if status != http.StatusOK {
+	switch status {
+	case http.StatusOK:
+		break
+	case http.StatusNotFound:
+		return secrets.ErrNotFound
+	default:
 		return errors.Errorf("failed to delete secret: %s", body)
 	}
 

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -160,6 +160,9 @@ type cliFlags struct {
 	requestID                  string
 	buildID                    string
 	loginProvider              string
+	registryUsername           string
+	registryPassword           string
+	registryPasswordStdin      bool
 }
 
 type analyticsMetadata struct {

--- a/cmd/earthly/registry_cmds.go
+++ b/cmd/earthly/registry_cmds.go
@@ -25,14 +25,12 @@ func (app *earthlyApp) registryCmds() []*cli.Command {
 			Flags: []cli.Flag{
 				&cli.StringFlag{
 					Name:        "org",
-					EnvVars:     []string{"EARTHLY_ORG"},
 					Usage:       "The organization to which the project belongs.",
 					Required:    false,
 					Destination: &app.orgName,
 				},
 				&cli.StringFlag{
 					Name:        "project",
-					EnvVars:     []string{"EARTHLY_PROJECT"},
 					Usage:       "The organization project in which to store registry credentials, if empty credentials will be stored under the user's secret storage.",
 					Required:    false,
 					Destination: &app.projectName,
@@ -69,14 +67,12 @@ func (app *earthlyApp) registryCmds() []*cli.Command {
 			Flags: []cli.Flag{
 				&cli.StringFlag{
 					Name:        "org",
-					EnvVars:     []string{"EARTHLY_ORG"},
 					Usage:       "The organization to which the project belongs.",
 					Required:    false,
 					Destination: &app.orgName,
 				},
 				&cli.StringFlag{
 					Name:        "project",
-					EnvVars:     []string{"EARTHLY_PROJECT"},
 					Usage:       "The organization project in which to store registry credentials, if empty credentials will be stored under the user's secret storage.",
 					Required:    false,
 					Destination: &app.projectName,
@@ -92,14 +88,12 @@ func (app *earthlyApp) registryCmds() []*cli.Command {
 			Flags: []cli.Flag{
 				&cli.StringFlag{
 					Name:        "org",
-					EnvVars:     []string{"EARTHLY_ORG"},
 					Usage:       "The organization to which the project belongs.",
 					Required:    false,
 					Destination: &app.orgName,
 				},
 				&cli.StringFlag{
 					Name:        "project",
-					EnvVars:     []string{"EARTHLY_PROJECT"},
 					Usage:       "The organization project in which to store registry credentials, if empty credentials will be stored under the user's secret storage.",
 					Required:    false,
 					Destination: &app.projectName,

--- a/cmd/earthly/registry_cmds.go
+++ b/cmd/earthly/registry_cmds.go
@@ -47,14 +47,14 @@ func (app *earthlyApp) registryCmds() []*cli.Command {
 				&cli.StringFlag{
 					Name:        "password",
 					EnvVars:     []string{"EARTHLY_REGISTRY_PASSWORD"},
-					Usage:       "The password to use when logging into the registry.",
+					Usage:       "The password to use when logging into the registry (use --password-stdin to prevent leaking your password via your shell history).",
 					Required:    false,
 					Destination: &app.registryPassword,
 				},
 				&cli.BoolFlag{
 					Name:        "password-stdin",
 					EnvVars:     []string{"EARTHLY_REGISTRY_PASSWORD_STDIN"},
-					Usage:       "Read the password from stdin.",
+					Usage:       "Read the password from stdin (recommended).",
 					Required:    false,
 					Destination: &app.registryPasswordStdin,
 				},

--- a/cmd/earthly/registry_cmds.go
+++ b/cmd/earthly/registry_cmds.go
@@ -1,0 +1,273 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/earthly/earthly/cloud"
+	"github.com/moby/buildkit/session/secrets"
+	"github.com/pkg/errors"
+	"github.com/urfave/cli/v2"
+)
+
+func (app *earthlyApp) registryCmds() []*cli.Command {
+	return []*cli.Command{
+		{
+			Name:        "login",
+			Usage:       "Login and store credentials in earthly-cloud",
+			Description: "Login and store credentials in earthly-cloud",
+			UsageText: "earthly registry login --username <username> --password <password> [<host>]\n" +
+				"	earthly registry login --org <org> --project <project> --username <username> --password <password> [<host>]\n",
+			Action: app.actionRegistryLogin,
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:        "org",
+					EnvVars:     []string{"EARTHLY_ORG"},
+					Usage:       "The organization to which the project belongs.",
+					Required:    false,
+					Destination: &app.orgName,
+				},
+				&cli.StringFlag{
+					Name:        "project",
+					EnvVars:     []string{"EARTHLY_PROJECT"},
+					Usage:       "The organization project in which to store registry credentials, if empty credentials will be stored under the user's secret storage.",
+					Required:    false,
+					Destination: &app.projectName,
+				},
+				&cli.StringFlag{
+					Name:        "username",
+					EnvVars:     []string{"EARTHLY_REGISTRY_USERNAME"},
+					Usage:       "The username to use when logging into the registry.",
+					Required:    true,
+					Destination: &app.registryUsername,
+				},
+				&cli.StringFlag{
+					Name:        "password",
+					EnvVars:     []string{"EARTHLY_REGISTRY_PASSWORD"},
+					Usage:       "The password to use when logging into the registry.",
+					Required:    false,
+					Destination: &app.registryPassword,
+				},
+				&cli.BoolFlag{
+					Name:        "password-stdin",
+					EnvVars:     []string{"EARTHLY_REGISTRY_PASSWORD_STDIN"},
+					Usage:       "Read the password from stdin.",
+					Required:    false,
+					Destination: &app.registryPasswordStdin,
+				},
+			},
+		},
+		{
+			Name:  "list",
+			Usage: "List configured registries",
+			UsageText: "earthly registry list\n" +
+				"	earthly registry list --org <org> --project <project>\n",
+			Action: app.actionRegistryList,
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:        "org",
+					EnvVars:     []string{"EARTHLY_ORG"},
+					Usage:       "The organization to which the project belongs.",
+					Required:    false,
+					Destination: &app.orgName,
+				},
+				&cli.StringFlag{
+					Name:        "project",
+					EnvVars:     []string{"EARTHLY_PROJECT"},
+					Usage:       "The organization project in which to store registry credentials, if empty credentials will be stored under the user's secret storage.",
+					Required:    false,
+					Destination: &app.projectName,
+				},
+			},
+		},
+		{
+			Name:  "logout",
+			Usage: "Logout of a registry (that has credentials stored in earthly-cloud)",
+			UsageText: "earthly registry logout [<host>]\n" +
+				"	earthly registry login --org <org> --project <project> [<host>]\n",
+			Action: app.actionRegistryLogout,
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:        "org",
+					EnvVars:     []string{"EARTHLY_ORG"},
+					Usage:       "The organization to which the project belongs.",
+					Required:    false,
+					Destination: &app.orgName,
+				},
+				&cli.StringFlag{
+					Name:        "project",
+					EnvVars:     []string{"EARTHLY_PROJECT"},
+					Usage:       "The organization project in which to store registry credentials, if empty credentials will be stored under the user's secret storage.",
+					Required:    false,
+					Destination: &app.projectName,
+				},
+			},
+		},
+	}
+}
+
+func (app *earthlyApp) isUserRegistryLocation() (bool, error) {
+	if app.orgName == "" && app.projectName == "" {
+		return true, nil
+	}
+	if app.orgName == "" {
+		return false, fmt.Errorf("--project was specified without an --org value")
+	}
+	if app.projectName == "" {
+		return false, fmt.Errorf("--org was specified without a --project value")
+	}
+	return false, nil
+}
+
+func (app *earthlyApp) getRegistriesPath() (string, error) {
+	user, err := app.isUserRegistryLocation()
+	if err != nil {
+		return "", err
+	}
+	if user {
+		return "/user/std/registry/", nil
+	}
+	return fmt.Sprintf("/%s/%s/std/registry/", app.orgName, app.projectName), nil
+}
+
+func (app *earthlyApp) actionRegistryLogin(cliCtx *cli.Context) error {
+	app.commandName = "registryLogin"
+
+	path, err := app.getRegistriesPath()
+	if err != nil {
+		return err
+	}
+
+	cloudClient, err := app.newCloudClient()
+	if err != nil {
+		return err
+	}
+
+	if cliCtx.NArg() > 1 {
+		return fmt.Errorf("only a single host can be given")
+	}
+
+	host := cliCtx.Args().Get(0)
+	if host == "" {
+		host = "registry-1.docker.io"
+	}
+
+	if strings.Contains(host, "/") {
+		return fmt.Errorf("hosts is malformed")
+	}
+
+	var password []byte
+	if app.registryPasswordStdin {
+		if app.registryPassword != "" {
+			return fmt.Errorf("only one of  --password or --password-stdin")
+		}
+		password, err = io.ReadAll(os.Stdin)
+		if err != nil {
+			return errors.Wrap(err, "failed to read from stdin")
+		}
+	} else {
+		password = []byte(app.registryPassword)
+	}
+	if len(password) == 0 {
+		return fmt.Errorf("password can not be empty")
+	}
+
+	err = cloudClient.SetSecret(cliCtx.Context, path+host+"/username", []byte(app.registryUsername))
+	if err != nil {
+		return err
+	}
+	err = cloudClient.SetSecret(cliCtx.Context, path+host+"/password", password)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type registryCredentials struct {
+	host     string
+	username string
+}
+
+func secretsToRegistryLogins(pathPrefix string, secrets []*cloud.Secret) []*registryCredentials {
+	logins := []*registryCredentials{}
+	for _, secret := range secrets {
+		parts := strings.Split(strings.TrimPrefix(secret.Path, pathPrefix), "/")
+		if len(parts) != 2 {
+			continue
+		}
+		host := parts[0]
+		key := parts[1]
+
+		if key == "username" {
+			logins = append(logins, &registryCredentials{
+				host:     host,
+				username: secret.Value,
+			})
+		}
+	}
+	return logins
+}
+
+func (app *earthlyApp) actionRegistryList(cliCtx *cli.Context) error {
+	app.commandName = "registryList"
+
+	path, err := app.getRegistriesPath()
+	if err != nil {
+		return err
+	}
+
+	cloudClient, err := app.newCloudClient()
+	if err != nil {
+		return err
+	}
+
+	secrets, err := cloudClient.ListSecrets(cliCtx.Context, path)
+	if err != nil {
+		return err
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintf(w, "%s\t%s\n", "Registry", "username")
+	for _, registry := range secretsToRegistryLogins(path, secrets) {
+		fmt.Fprintf(w, "%s\t%s\n", registry.host, registry.username)
+	}
+	w.Flush()
+
+	return nil
+}
+
+func (app *earthlyApp) actionRegistryLogout(cliCtx *cli.Context) error {
+	app.commandName = "registryRemove"
+	path, err := app.getRegistriesPath()
+	if err != nil {
+		return err
+	}
+
+	cloudClient, err := app.newCloudClient()
+	if err != nil {
+		return err
+	}
+
+	host := cliCtx.Args().Get(0)
+	if host == "" {
+		host = "registry-1.docker.io"
+	}
+
+	if cliCtx.NArg() > 1 {
+		return fmt.Errorf("only a single registry host can be given")
+	}
+
+	fmt.Printf("Removing login credentials for %s\n", host)
+	for _, secretName := range []string{"username", "password"} {
+		err = cloudClient.RemoveSecret(cliCtx.Context, path+host+"/"+secretName)
+		if err != nil && !errors.Is(err, secrets.ErrNotFound) {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/cmd/earthly/root_cmds.go
+++ b/cmd/earthly/root_cmds.go
@@ -290,8 +290,8 @@ Set up a whole custom git repository for a server called example.com, using a si
 		{
 			Name:        "registry",
 			Aliases:     []string{"registries"},
-			Description: "Manage registry access *experimental*",
-			Usage:       "Manage registry access *experimental*",
+			Description: "Manage registry access *beta*",
+			Usage:       "Manage registry access *beta*",
 			Subcommands: app.registryCmds(),
 		},
 		{

--- a/cmd/earthly/root_cmds.go
+++ b/cmd/earthly/root_cmds.go
@@ -288,6 +288,13 @@ Set up a whole custom git repository for a server called example.com, using a si
 			Subcommands: app.secretCmds(),
 		},
 		{
+			Name:        "registry",
+			Aliases:     []string{"registries"},
+			Description: "Manage registry access *experimental*",
+			Usage:       "Manage registry access *experimental*",
+			Subcommands: app.registryCmds(),
+		},
+		{
 			Name:        "web",
 			Description: "Access the web UI",
 			Usage:       "Access the web UI via your default browser and print the url",

--- a/cmd/earthly/root_cmds.go
+++ b/cmd/earthly/root_cmds.go
@@ -290,8 +290,8 @@ Set up a whole custom git repository for a server called example.com, using a si
 		{
 			Name:        "registry",
 			Aliases:     []string{"registries"},
-			Description: "Manage registry access *beta*",
-			Usage:       "Manage registry access *beta*",
+			Description: "Manage registry access",
+			Usage:       "Manage registry access",
 			Subcommands: app.registryCmds(),
 		},
 		{

--- a/cmd/earthly/secret_cmds.go
+++ b/cmd/earthly/secret_cmds.go
@@ -19,7 +19,9 @@ func (app *earthlyApp) secretCmds() []*cli.Command {
 			Usage: "Stores a secret in the secrets store",
 			UsageText: "earthly [options] secret set <path> <value>\n" +
 				"   earthly [options] secret set --file <local-path> <path>\n" +
-				"   earthly [options] secret set --stdin <path>",
+				"   earthly [options] secret set --stdin <path>\n" +
+				"\n" +
+				"Security Recommendation: use --file or --stdin to avoid accidentally storing secrets in your shell's history",
 			Action: app.actionSecretsSetV2,
 			Flags: []cli.Flag{
 				&cli.StringFlag{

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -246,6 +246,12 @@ tests-that-require-earthly-technologies-account-access:
         --DOCKERHUB_TOKEN_SECRET=$DOCKERHUB_TOKEN_SECRET \
         --DOCKERHUB_MIRROR=$DOCKERHUB_MIRROR \
         --DOCKERHUB_MIRROR_INSECURE=$DOCKERHUB_MIRROR_INSECURE
+    BUILD ./registry-command+test \
+        --DOCKERHUB_AUTH=$DOCKERHUB_AUTH \
+        --DOCKERHUB_USER_SECRET=$DOCKERHUB_USER_SECRET \
+        --DOCKERHUB_TOKEN_SECRET=$DOCKERHUB_TOKEN_SECRET \
+        --DOCKERHUB_MIRROR=$DOCKERHUB_MIRROR \
+        --DOCKERHUB_MIRROR_INSECURE=$DOCKERHUB_MIRROR_INSECURE
 
 # tests that only run on linux amd64
 # Note: this target is used to validate the USERPLATFORM user arg,

--- a/tests/autocompletion/Earthfile
+++ b/tests/autocompletion/Earthfile
@@ -24,6 +24,7 @@ ls
 org 
 project 
 prune 
+registry 
 satellite 
 secret " > expected
     RUN COMP_LINE="earthly " COMP_POINT=8 earthly > actual
@@ -43,6 +44,7 @@ ls
 org 
 project 
 prune 
+registry 
 satellite 
 secret 
 web " > expected

--- a/tests/registry-command/Earthfile
+++ b/tests/registry-command/Earthfile
@@ -1,0 +1,25 @@
+VERSION 0.7
+PROJECT earthly-technologies/core
+
+ARG DOCKERHUB_USER_SECRET=+secrets/DOCKERHUB_USER
+ARG DOCKERHUB_TOKEN_SECRET=+secrets/DOCKERHUB_TOKEN
+ARG DOCKERHUB_MIRROR
+ARG DOCKERHUB_MIRROR_INSECURE=false
+ARG DOCKERHUB_MIRROR_HTTP=false
+ARG DOCKERHUB_AUTH=true
+FROM ../..+earthly-integration-test-base \
+    --DOCKERHUB_AUTH=$DOCKERHUB_AUTH \
+    --DOCKERHUB_USER_SECRET=$DOCKERHUB_USER_SECRET \
+    --DOCKERHUB_TOKEN_SECRET=$DOCKERHUB_TOKEN_SECRET \
+    --DOCKERHUB_MIRROR=$DOCKERHUB_MIRROR \
+    --DOCKERHUB_MIRROR_INSECURE=$DOCKERHUB_MIRROR_INSECURE \
+    --DOCKERHUB_MIRROR_HTTP=$DOCKERHUB_MIRROR_HTTP
+
+IMPORT .. AS tests
+
+WORKDIR /test
+
+test:
+    COPY test-project.sh test-user.sh lock.sh unlock.sh .
+    RUN --no-cache --secret EARTHLY_TOKEN=fake-user-write-token \
+        ./lock.sh && ( ./test-user.sh && ./test-project.sh) || ( ./unlock.sh && echo "test failed"; exit 1) && ./unlock.sh

--- a/tests/registry-command/lock.sh
+++ b/tests/registry-command/lock.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+set -ex
+
+ORG="ryan-test"
+PROJECT="registry-command-test-project"
+
+lock="$(earthly secrets --org "$ORG" --project "$PROJECT" get lock || true)"
+if [ -n "$lock" ]; then
+    # TODO implement a secrets ls --long, which would show a "date created/modified" column
+    # then if the lock is older than 1 minute, we would consider it abandoned, delete it, and create
+    # a new lock. For now, we will simply sleep for 30 seconds (which should be enough time for the test to pass)
+    echo "lock exists; sleeping for 30 seconds"
+    sleep 30
+fi
+
+echo "no lock exists; proceeding to lock it"
+
+id="$(uuidgen)"
+test -n "$id"
+
+earthly secrets --org "$ORG" --project "$PROJECT" set lock "$id"
+
+sleep 1
+
+lock="$(earthly secrets --org "$ORG" --project "$PROJECT" get lock)"
+if [ "$lock" != "$id" ]; then
+  echo "failed to lock"
+  exec ./lock.sh # try again
+fi
+
+echo "$id" > /tmp/registry-command-lock
+echo locked

--- a/tests/registry-command/test-project.sh
+++ b/tests/registry-command/test-project.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+set -ex
+
+# WARNING -- RACE-CONDITION: this test is not thread-safe (since it makes use of a shared project's secrets)
+# the lock.sh and unlock.sh scripts must first be run
+
+ORG="ryan-test"
+PROJECT="registry-command-test-project"
+
+clearprojectsecrets() {
+    earthly secrets --org "$ORG" --project "$PROJECT" ls /user/std/registry | xargs -r -n 1 earthly secrets --org "$ORG" --project "$PROJECT" rm
+}
+
+# clear out secrets from previous test
+clearprojectsecrets
+
+# test dockerhub credentials do not exist
+earthly registry list --org "$ORG" --project "$PROJECT" | grep -v registry-1.docker.io
+
+# set dockerhub credentials
+earthly registry login --org "$ORG" --project "$PROJECT" --username myprojecttest --password keepitsecret
+
+# test dockerhub credentials exist
+earthly registry list --org "$ORG" --project "$PROJECT" | grep registry-1.docker.io
+
+# test username and password were correctly stored in underlying std secret
+test "$(earthly secrets --org "$ORG" --project "$PROJECT" get std/registry/registry-1.docker.io/username)" = "myprojecttest"
+test "$(earthly secrets --org "$ORG" --project "$PROJECT" get std/registry/registry-1.docker.io/password)" = "keepitsecret"
+
+# test a different host
+echo -n keepitsecret2  | earthly registry login --org "$ORG" --project "$PROJECT" --username myprojecttest2 --password-stdin corp-registry.earthly.dev
+
+# both dockerhub and corp-registry should exist
+earthly registry list --org "$ORG" --project "$PROJECT" | grep registry-1.docker.io
+earthly registry list --org "$ORG" --project "$PROJECT" | grep corp-registry.earthly.dev
+
+# test username and password were correctly stored in underlying std secret
+test "$(earthly secrets --org "$ORG" --project "$PROJECT" get std/registry/registry-1.docker.io/username)" = "myprojecttest"
+test "$(earthly secrets --org "$ORG" --project "$PROJECT" get std/registry/registry-1.docker.io/password)" = "keepitsecret"
+test "$(earthly secrets --org "$ORG" --project "$PROJECT" get std/registry/corp-registry.earthly.dev/username)" = "myprojecttest2"
+test "$(earthly secrets --org "$ORG" --project "$PROJECT" get std/registry/corp-registry.earthly.dev/password)" = "keepitsecret2"
+
+clearprojectsecrets

--- a/tests/registry-command/test-user.sh
+++ b/tests/registry-command/test-user.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+set -ex
+
+# WARNING -- RACE-CONDITION: this test is not thread-safe (since it makes use of a shared user's secrets)
+# the lock.sh and unlock.sh scripts must first be run
+
+clearusersecrets() {
+    earthly secrets ls /user/std/ | xargs -r -n 1 earthly secrets rm
+}
+
+# clear out secrets from previous test
+clearusersecrets
+
+# test dockerhub credentials do not exist
+earthly registry list | grep -v registry-1.docker.io
+
+# set dockerhub credentials
+earthly registry login --username mytest --password keepitsafe
+
+# test dockerhub credentials exist
+earthly registry list | grep registry-1.docker.io
+
+# test username and password were correctly stored in underlying std secret
+test "$(earthly secrets get /user/std/registry/registry-1.docker.io/username)" = "mytest"
+test "$(earthly secrets get /user/std/registry/registry-1.docker.io/password)" = "keepitsafe"
+
+# clear out secrets (just in case project-based registry accidentally uses user-based)
+clearusersecrets

--- a/tests/registry-command/unlock.sh
+++ b/tests/registry-command/unlock.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+ORG="ryan-test"
+PROJECT="registry-command-test-project"
+
+id="$(cat /tmp/registry-command-lock)"
+
+lock="$(earthly secrets --org "$ORG" --project "$PROJECT" get lock || true)"
+if [ "$lock" = "$id" ]; then
+  earthly secrets --org "$ORG" --project "$PROJECT" rm lock
+else
+  echo "unlock failed: unexpected lock contents (expected $id; got $lock)"
+fi

--- a/tests/web/Earthfile
+++ b/tests/web/Earthfile
@@ -1,4 +1,5 @@
-VERSION 0.6 # this requires old secrets
+VERSION 0.7
+PROJECT earthly-technologies/core
 
 ARG DOCKERHUB_USER_SECRET=+secrets/DOCKERHUB_USER
 ARG DOCKERHUB_TOKEN_SECRET=+secrets/DOCKERHUB_TOKEN
@@ -25,8 +26,8 @@ test:
         && rm output-file \
         && if [[ "$output" != *"provider=github"* ]]; then echo "failed to find provider=github in output" && exit 1; fi
 
-    RUN --secret EARTHLY_TOKEN=+secrets/earthly-technologies/earthly/fake-user/token earthly web 2>&1 | grep -qE "https://ci(-beta)?.earthly.dev/login\?token=.+"
-    RUN --secret EARTHLY_TOKEN=+secrets/earthly-technologies/earthly/fake-user/token earthly web --provider github 2>output-file \
+    RUN --secret EARTHLY_TOKEN=fake-user-write-token earthly web 2>&1 | grep -qE "https://ci(-beta)?.earthly.dev/login\?token=.+"
+    RUN --secret EARTHLY_TOKEN=fake-user-write-token earthly web --provider github 2>output-file \
         && output=$(cat output-file) \
         && rm output-file \
         && if [[ "$output" != *"provider=github"* ]]; then echo "failed to find provider=github in output" && exit 1; fi \


### PR DESCRIPTION
Adds `earthly registry login/list/logout` commands which are used to manage cloud-stored registry credentials.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>