### PR TITLE
cmd/earthly: fix deferred error check

### DIFF
--- a/cmd/earthly/build_cmd.go
+++ b/cmd/earthly/build_cmd.go
@@ -573,7 +573,7 @@ func receiveFileVersion1(ctx context.Context, conn io.ReadWriteCloser, localArti
 	return f.Close()
 }
 
-func receiveFileVersion2(ctx context.Context, conn io.ReadWriteCloser, localArtifactWhiteList *gatewaycrafter.LocalArtifactWhiteList) error {
+func receiveFileVersion2(ctx context.Context, conn io.ReadWriteCloser, localArtifactWhiteList *gatewaycrafter.LocalArtifactWhiteList) (retErr error) {
 	// dst path
 	dst, err := debuggercommon.ReadUint16PrefixedData(conn)
 	if err != nil {
@@ -590,7 +590,7 @@ func receiveFileVersion2(ctx context.Context, conn io.ReadWriteCloser, localArti
 	}
 
 	defer func() {
-		if err != nil {
+		if retErr != nil {
 			// don't output incomplete data
 			_ = f.Close()
 			_ = os.Remove(string(dst))

--- a/debugger/common/common.go
+++ b/debugger/common/common.go
@@ -45,6 +45,9 @@ const (
 	WinSizeData = 0x04
 )
 
+// End of network protocol magic numbers
+//******************************************************************************************
+
 var (
 	// ErrDataOverflow occurs when too much data is sent
 	ErrDataOverflow = errors.New("Data overflow")
@@ -52,9 +55,6 @@ var (
 	// ErrDataUnderflow occurs when too little data is received
 	ErrDataUnderflow = errors.New("Data underflow")
 )
-
-// End of network protocol magic numbers
-//******************************************************************************************
 
 // ReadUint16PrefixedData first reads a uint16 then reads that many bytes of data
 func ReadUint16PrefixedData(r io.Reader) ([]byte, error) {


### PR DESCRIPTION
In receiveFileVersion2, a deferred error check was checking the wrong error variable. This meant that we never entered the if block.