### PR TITLE
[logstream]: Logstream enabled by default

### DIFF
--- a/cmd/earthly/flags.go
+++ b/cmd/earthly/flags.go
@@ -152,6 +152,7 @@ func (app *earthlyApp) rootFlags() []cli.Flag {
 			Usage:       "Enable log streaming only locally",
 			Destination: &app.logstream,
 			Hidden:      true, // Internal.
+			Value:       true,
 		},
 		&cli.BoolFlag{
 			Name:        "logstream-upload",
@@ -159,6 +160,7 @@ func (app *earthlyApp) rootFlags() []cli.Flag {
 			Usage:       "Enable log stream uploading",
 			Destination: &app.logstreamUpload,
 			Hidden:      true, // Internal.
+			Value:       true,
 		},
 		&cli.StringFlag{
 			Name:        "logstream-debug-file",


### PR DESCRIPTION
Enable logstream as the default log location for version 0.7.
