### PR TITLE
fix: raise error when setting feature flag values

### DIFF
--- a/features/features.go
+++ b/features/features.go
@@ -171,7 +171,7 @@ func GetFeatures(version *spec.Version) (*Features, bool, error) {
 		return nil, false, errUnexpectedArgs
 	}
 
-	parsedArgs, err := flagutil.ParseArgsWithValueModifierAndOptions("VERSION", &ftrs, version.Args, instrumentVersion, goflags.PassDoubleDash|goflags.PassAfterNonOption|goflags.AllowBoolValues)
+	parsedArgs, err := flagutil.ParseArgsWithValueModifierAndOptions("VERSION", &ftrs, version.Args, instrumentVersion, goflags.PassDoubleDash|goflags.PassAfterNonOption)
 	if err != nil {
 		return nil, false, err
 	}

--- a/tests/version/Earthfile
+++ b/tests/version/Earthfile
@@ -51,6 +51,9 @@ test-multi-line-with-args2:
 test-multi-line-with-newline:
     DO +RUN_EARTHLY_ARGS --earthfile=multi-line-with-empty-newline.earth --target=+test
 
+test-no-feature-flag-overrides:
+    DO +RUN_EARTHLY_ARGS --should_fail=true --earthfile=invalid-feature-flag-override.earth --target=+test --output_contains="bool flag .--referenced-save-only. cannot have an argument"
+
 test-version-only-import:
     RUN mkdir subdir
     RUN echo "VERSION 0.5" > subdir/Earthfile
@@ -89,6 +92,7 @@ test-all:
     BUILD +test-whitespace-then-version
     BUILD +test-version-only-import
     BUILD +test-invalid-versions
+    BUILD +test-no-feature-flag-overrides
 
 RUN_EARTHLY_ARGS:
     COMMAND

--- a/tests/version/invalid-feature-flag-override.earth
+++ b/tests/version/invalid-feature-flag-override.earth
@@ -1,0 +1,1 @@
+VERSION --referenced-save-only=false 0.6


### PR DESCRIPTION
Boolean overrides for feature flags should not be possible; this change
will now raise an error instead of silently ignoring them.

While it is technically possible to implement disabling feature flags,
we chose to raise an error instead to encourage users to fully adopt
a new VERSION.

This is because feature flags are for experimental features, once they
are promoted they become part of the forward-direction of earthly;
allowing users to adopt the latest version while individually flipping a
feature off may lead to buggy experiences.

If a user really wants to disable a feature, then they will have to
remain at a previous VERSION, and instead select the (experimental) features
they wish to enable (with caution).

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>