### PR TITLE
work-around for implicit WAIT/END inline cache bug

### DIFF
--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -1079,7 +1079,12 @@ func (c *Converter) SaveImage(ctx context.Context, imageNames []string, pushImag
 					c.opt.ExportCoordinator.AddPushedImageSummary(c.target.StringCanonical(), si.DockerTag, c.mts.Final.ID, c.opt.DoPushes)
 				}
 
-				si.SkipBuilder = true
+				// TODO this is here as a work-around for https://github.com/earthly/earthly/issues/2178
+				// ideally we should always set SkipBuilder = true even when we are under the first implicit wait block
+				// however we don't want to break inline caching for users who are using VERSION 0.7 without any explicit WAIT blocks
+				if !c.opt.UseInlineCache || len(c.waitBlockStack) > 1 {
+					si.SkipBuilder = true
+				}
 			}
 			c.mts.Final.SaveImages = append(c.mts.Final.SaveImages, si)
 		}

--- a/tests/remote-cache/Earthfile
+++ b/tests/remote-cache/Earthfile
@@ -1,23 +1,5 @@
-VERSION                             \
---check-duplicate-images            \
---ci-arg                            \
---earthly-git-author-args           \
---earthly-locally-arg               \
---earthly-version-arg               \
---explicit-global                   \
---git-commit-author-timestamp       \
---new-platform                      \
---no-tar-build-output               \
---shell-out-anywhere                \
---use-cache-command                 \
---use-chmod                         \
---use-copy-link                     \
---use-host-command                  \
---use-no-manifest-list              \
---use-pipelines                     \
---use-project-secrets               \
-#--wait-block                        \
-0.6
+VERSION 0.7
+
 ARG --global DOCKERHUB_USER_SECRET=+secrets/DOCKERHUB_USER
 ARG --global DOCKERHUB_TOKEN_SECRET=+secrets/DOCKERHUB_TOKEN
 ARG --global DOCKERHUB_MIRROR

--- a/tests/remote-cache/test.earth
+++ b/tests/remote-cache/test.earth
@@ -1,23 +1,4 @@
-VERSION                             \
---check-duplicate-images            \
---ci-arg                            \
---earthly-git-author-args           \
---earthly-locally-arg               \
---earthly-version-arg               \
---explicit-global                   \
---git-commit-author-timestamp       \
---new-platform                      \
---no-tar-build-output               \
---shell-out-anywhere                \
---use-cache-command                 \
---use-chmod                         \
---use-copy-link                     \
---use-host-command                  \
---use-no-manifest-list              \
---use-pipelines                     \
---use-project-secrets               \
-#--wait-block                        \
-0.6
+VERSION 0.7
 
 
 ARG --global REGISTRY


### PR DESCRIPTION
If a user is using VERSION 0.7 without any explicit WAIT block, we will use the build function to perform the export due to a bug that exists in the earthly-specific Export buildkit grpc call, which skips the inline cache.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>