### PR TITLE
If PATH is missing, shell out to determine it

### DIFF
--- a/variables/collection.go
+++ b/variables/collection.go
@@ -17,6 +17,7 @@ import (
 
 var ShellOutEnvs = map[string]struct{}{
 	"HOME": struct{}{},
+	"PATH": struct{}{},
 }
 
 type stackFrame struct {


### PR DESCRIPTION
Some docker images (e.g. opensuse/tumbleweed) don't define the `PATH` environment (but rather defines it inside the image container layers).

This fixes https://github.com/earthly/earthly/issues/290#issuecomment-1410735538

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>