### PR TITLE
always apply SAVE ARTIFACT --keep-own flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,21 +76,22 @@ Declaring `VERSION 0.7` is equivalent to
 
 ```
 VERSION \
-  --explicit-global \
   --check-duplicate-images \
+  --earthly-git-author-args \
+  --earthly-locally-arg \
   --earthly-version-arg \
-  --use-cache-command \
-  --use-host-command \
-  --use-copy-link \
+  --explicit-global \
   --new-platform \
   --no-tar-build-output \
-  --use-no-manifest-list \
-  --use-chmod \
+  --save-artifact-keep-own \
   --shell-out-anywhere \
-  --earthly-locally-arg \
-  --use-project-secrets \
+  --use-cache-command \
+  --use-chmod \
+  --use-copy-link \
+  --use-host-command \
+  --use-no-manifest-list \
   --use-pipelines \
-  --earthly-git-author-args \
+  --use-project-secrets \
   --wait-block \
   0.6
 ```
@@ -110,6 +111,7 @@ For more information on the individual Earthfile feature flags see the [Earthfil
 - `earthly ls` has been promoted from *experimental* to *beta* status.
 - Setting a `VERSION` feature flag boolean to false (or any other value) will now raise an error; previously it was syntactically valid but had no effect.
 - `SAVE ARTIFACT <path> AS LOCAL ...` when used under a `TRY` / `FINALLY` can fail to be fully transferred to the host when the `TRY` command fails (resulting in an partially transferred file); an underflow can still occur, and is now detected and will not export the partial file. [2452](https://github.com/earthly/earthly/issues/2452)
+- The `--keep-own` flag for `SAVE ARTIFACT` is now applied by default; note that `COPY --keep-own` must still be used in order to keep ownership
 
 ### Added
 

--- a/earthfile2llb/interpreter.go
+++ b/earthfile2llb/interpreter.go
@@ -1048,6 +1048,13 @@ func (i *Interpreter) handleSaveArtifact(ctx context.Context, cmd spec.Command) 
 		return nil
 	}
 
+	if i.converter.ftrs.SaveArtifactKeepOwn {
+		if opts.KeepOwn {
+			fmt.Fprintf(os.Stderr, "Deprecation: SAVE ARTIFACT --keep-own is now applied by default, setting it no longer has any effect\n")
+		}
+		opts.KeepOwn = true
+	}
+
 	err = i.converter.SaveArtifact(ctx, saveFrom, expandedSaveTo, expandedSaveAsLocalTo, opts.KeepTs, opts.KeepOwn, opts.IfExists, opts.SymlinkNoFollow, opts.Force, i.pushOnlyAllowed)
 	if err != nil {
 		return i.wrapError(err, cmd.SourceLocation, "apply SAVE ARTIFACT")

--- a/features/features.go
+++ b/features/features.go
@@ -40,6 +40,7 @@ type Features struct {
 	GitCommitAuthorTimestamp bool `long:"git-commit-author-timestamp" description:"include EARTHLY_GIT_COMMIT_AUTHOR_TIMESTAMP arg"`
 	NewPlatform              bool `long:"new-platform" description:"enable new platform behavior"`
 	NoTarBuildOutput         bool `long:"no-tar-build-output" description:"do not print output when creating a tarball to load into WITH DOCKER"`
+	SaveArtifactKeepOwn      bool `long:"save-artifact-keep-own" description:"always apply the --keep-own flag with SAVE ARTIFACT"`
 	ShellOutAnywhere         bool `long:"shell-out-anywhere" description:"allow shelling-out in the middle of ARGs, or any other command"`
 	UseCacheCommand          bool `long:"use-cache-command" description:"allow use of CACHE command in Earthfiles"`
 	UseChmod                 bool `long:"use-chmod" description:"enable the COPY --chmod option"`
@@ -223,6 +224,7 @@ func GetFeatures(version *spec.Version) (*Features, bool, error) {
 		ftrs.GitCommitAuthorTimestamp = true
 		ftrs.NewPlatform = true
 		ftrs.NoTarBuildOutput = true
+		ftrs.SaveArtifactKeepOwn = true
 		ftrs.ShellOutAnywhere = true
 		ftrs.UseCacheCommand = true
 		ftrs.UseChmod = true

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -77,6 +77,7 @@ ga-no-qemu:
     BUILD +privileged-test
     BUILD +copy-test
     BUILD +copy-test-verbose-output
+    BUILD +copy-keep-own-test
     BUILD +cache-test
     BUILD +git-clone-test
     # this has been moved to a seperate target until we get the flakey "tell me who you are" bug
@@ -311,6 +312,10 @@ earthly --config \$earthly_config --verbose +copy 2>&1 | tee output2.txt;
     # test SAVE ARTIFACT AS LOCAL texts is output
     DO +RUN_EARTHLY --earthfile=copy-verbose.earth --extra_args="--verbose" --target=+save --output_contains="received data for important-data .12 B."
     RUN ls -la important-data
+
+copy-keep-own-test:
+    DO +RUN_EARTHLY --target=+test-known-user --earthfile=copy-keep-own.earth
+    DO +RUN_EARTHLY --target=+test-unknown-user --earthfile=copy-keep-own.earth
 
 cache-test:
     # Test that a file can be passed between runs through the mounted cache.

--- a/tests/copy-keep-own.earth
+++ b/tests/copy-keep-own.earth
@@ -1,0 +1,34 @@
+VERSION 0.7
+
+withtestuser:
+  FROM alpine:3.15
+  RUN adduser -D testuser
+  WORKDIR /test
+
+producer:
+  FROM +withtestuser
+  RUN touch testperms
+  RUN chown testuser:testuser testperms
+  SAVE ARTIFACT testperms
+
+test-known-user:
+  FROM +withtestuser
+  WORKDIR /test
+  COPY --keep-own +producer/testperms .
+  RUN test "$(stat -c '%u' testperms)" = "1000"
+  RUN test "$(stat -c '%U' testperms)" = "testuser"
+  RUN test "$(stat -c '%g' testperms)" = "1000"
+  RUN test "$(stat -c '%G' testperms)" = "testuser"
+
+test-unknown-user:
+  FROM alpine:3.15
+  WORKDIR /test
+  COPY --keep-own +producer/testperms .
+  RUN test "$(stat -c '%u' testperms)" = "1000"
+  RUN test "$(stat -c '%U' testperms)" = "UNKNOWN"
+  RUN test "$(stat -c '%g' testperms)" = "1000"
+  RUN test "$(stat -c '%G' testperms)" = "UNKNOWN"
+
+test:
+  BUILD +test-known-user
+  BUILD +test-unknown-user


### PR DESCRIPTION
In order to copy a file from one target to another with the same ownership information requires the `--keep-own` flag be applied to both `SAVE ARTIFACT` and `COPY`.

The final `COPY`'s `--keep-own` flag should be sufficient for determining if the original file's permissions are to be copied over or not.

This fixes #2640

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>