### PR TITLE
satellite test needs docker hub access

### DIFF
--- a/.github/workflows/reusable-misc-tests.yml
+++ b/.github/workflows/reusable-misc-tests.yml
@@ -61,6 +61,10 @@ jobs:
           earthly config global.buildkit_additional_config "'[registry.\"docker.io\"]
           mirrors = [\"registry-1.docker.io.mirror.corp.earthly.dev\"]'"
         if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+      - name: Login to docker hub -- for satellite based tests that are not configured to use our mirror (Earthly Only)
+        run: |-
+          docker login --username "${{ secrets.DOCKERHUB_USERNAME }}" --password "${{ secrets.DOCKERHUB_TOKEN }}"
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
       - name: Link Earthly dir to Earthly dev dir
         run: mkdir -p ~/.earthly && ln -s ~/.earthly ~/.earthly-dev
       - name: Build latest earthly using released earthly

--- a/scripts/tests/earthly-image.sh
+++ b/scripts/tests/earthly-image.sh
@@ -88,7 +88,7 @@ if [ "$FRONTEND" = "docker" ]; then
 fi
 
 echo "Test satellite (not privileged, no buildkit)."
-"$FRONTEND" run --rm -e EARTHLY_ADDITIONAL_BUILDKIT_CONFIG -v "$dockerconfig:/root/.docker/config.json" -e EARTHLY_TOKEN="${EARTHLY_TOKEN}" -e NO_BUILDKIT=1 "${EARTHLY_IMAGE}" --org earthly-technologies --sat core-test --no-cache github.com/earthly/hello-world+hello 2>&1 | tee output.txt
+"$FRONTEND" run --rm -e EARTHLY_TOKEN="${EARTHLY_TOKEN}" -e NO_BUILDKIT=1 "${EARTHLY_IMAGE}" --org earthly-technologies --sat core-test --no-cache github.com/earthly/hello-world+hello 2>&1 | tee output.txt
 grep "Hello World" output.txt
 grep "Earthly installation is working correctly" output.txt
 


### PR DESCRIPTION
The satellite test needs a valid docker hub credential, or it will be rate-limited.

Perhaps one day we will be able to configure a mirror; however, that option doesn't exist currently for satellites.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>