### PR TITLE
Medium is Default Size for Satellites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 
 ## Unreleased
 
+The default size when launching a new satellite is now medium instead of large.
+
 ## v0.7.0-rc2 - 2023-02-01
 
 The documentation for this version is available at the [Earthly 0.7 documentation page](https://docs.earthly.dev/v/earthly-0.7/).

--- a/cloud/satellite.go
+++ b/cloud/satellite.go
@@ -43,6 +43,11 @@ const (
 	SatelliteSizeXLarge = "xlarge"
 )
 
+const (
+	SatellitePlatformAMD64 = "linux/amd64"
+	SatellitePlatformARM64 = "linux/arm64"
+)
+
 const DefaultSatelliteSize = SatelliteSizeMedium
 
 // SatelliteInstance contains details about a remote Buildkit instance.
@@ -319,4 +324,13 @@ var validSizes = map[string]bool{
 
 func ValidSatelliteSize(size string) bool {
 	return validSizes[size]
+}
+
+var validPlatforms = map[string]bool{
+	SatellitePlatformAMD64: true,
+	SatellitePlatformARM64: true,
+}
+
+func ValidSatellitePlatform(size string) bool {
+	return validPlatforms[size]
 }

--- a/cloud/satellite.go
+++ b/cloud/satellite.go
@@ -35,6 +35,15 @@ const (
 	SatelliteStatusUnknown = "Unknown"
 )
 
+const (
+	SatelliteSizeSmall  = "small"
+	SatelliteSizeMedium = "medium"
+	SatelliteSizeLarge  = "large"
+	SatelliteSizeXLarge = "xlarge"
+)
+
+const DefaultSatelliteSize = SatelliteSizeMedium
+
 // SatelliteInstance contains details about a remote Buildkit instance.
 type SatelliteInstance struct {
 	Name                   string
@@ -297,4 +306,15 @@ func satelliteStatus(status pb.SatelliteStatus) string {
 	default:
 		return SatelliteStatusUnknown
 	}
+}
+
+var validSizes = map[string]bool{
+	SatelliteSizeSmall:  true,
+	SatelliteSizeMedium: true,
+	SatelliteSizeLarge:  true,
+	SatelliteSizeXLarge: true,
+}
+
+func ValidSatelliteSize(size string) bool {
+	return validSizes[size]
 }

--- a/cloud/satellite.go
+++ b/cloud/satellite.go
@@ -36,6 +36,7 @@ const (
 )
 
 const (
+	SatelliteSizeXSmall = "xsmall"
 	SatelliteSizeSmall  = "small"
 	SatelliteSizeMedium = "medium"
 	SatelliteSizeLarge  = "large"
@@ -309,6 +310,8 @@ func satelliteStatus(status pb.SatelliteStatus) string {
 }
 
 var validSizes = map[string]bool{
+	"":                  true,
+	SatelliteSizeXSmall: true,
 	SatelliteSizeSmall:  true,
 	SatelliteSizeMedium: true,
 	SatelliteSizeLarge:  true,

--- a/cloud/satellite.go
+++ b/cloud/satellite.go
@@ -310,7 +310,6 @@ func satelliteStatus(status pb.SatelliteStatus) string {
 }
 
 var validSizes = map[string]bool{
-	"":                  true,
 	SatelliteSizeXSmall: true,
 	SatelliteSizeSmall:  true,
 	SatelliteSizeMedium: true,

--- a/cmd/earthly/satellite_cmds.go
+++ b/cmd/earthly/satellite_cmds.go
@@ -20,6 +20,8 @@ import (
 	"github.com/earthly/earthly/util/containerutil"
 )
 
+const satelliteSizeFlag = "size"
+
 func (app *earthlyApp) satelliteCmds() []*cli.Command {
 	return []*cli.Command{
 		{
@@ -37,7 +39,7 @@ func (app *earthlyApp) satelliteCmds() []*cli.Command {
 					Destination: &app.satellitePlatform,
 				},
 				&cli.StringFlag{
-					Name:        "size",
+					Name:        satelliteSizeFlag,
 					Usage:       "The size of the satellite. See https://earthly.dev/pricing#compute for details on each size. Supported values: small, medium, large.",
 					Required:    false,
 					Destination: &app.satelliteSize,
@@ -310,8 +312,10 @@ func (app *earthlyApp) actionSatelliteLaunch(cliCtx *cli.Context) error {
 		return err
 	}
 
-	if cliCtx.IsSet(size) && !cloud.ValidSatelliteSize(size) {
-		return errors.Errorf("not a valid size: %s", size)
+	if cliCtx.IsSet(satelliteSizeFlag) {
+		if !cloud.ValidSatelliteSize(size) {
+			return errors.Errorf("not a valid size: %s", size)
+		}
 	} else {
 		size = cloud.DefaultSatelliteSize
 	}

--- a/cmd/earthly/satellite_cmds.go
+++ b/cmd/earthly/satellite_cmds.go
@@ -310,11 +310,10 @@ func (app *earthlyApp) actionSatelliteLaunch(cliCtx *cli.Context) error {
 		return err
 	}
 
-	if size == "" {
-		size = cloud.DefaultSatelliteSize
-	}
-	if !cloud.ValidSatelliteSize(size) {
+	if cliCtx.IsSet(size) && !cloud.ValidSatelliteSize(size) {
 		return errors.Errorf("not a valid size: %s", size)
+	} else {
+		size = cloud.DefaultSatelliteSize
 	}
 
 	if window == "" {

--- a/cmd/earthly/satellite_cmds.go
+++ b/cmd/earthly/satellite_cmds.go
@@ -310,6 +310,13 @@ func (app *earthlyApp) actionSatelliteLaunch(cliCtx *cli.Context) error {
 		return err
 	}
 
+	if size == "" {
+		size = cloud.SatelliteSizeMedium
+	}
+	if !cloud.ValidSatelliteSize(size) {
+		return errors.Errorf("not a valid size: %s", size)
+	}
+
 	if window == "" {
 		window = "02:00"
 	}

--- a/cmd/earthly/satellite_cmds.go
+++ b/cmd/earthly/satellite_cmds.go
@@ -311,7 +311,7 @@ func (app *earthlyApp) actionSatelliteLaunch(cliCtx *cli.Context) error {
 	}
 
 	if size == "" {
-		size = cloud.SatelliteSizeMedium
+		size = cloud.DefaultSatelliteSize
 	}
 	if !cloud.ValidSatelliteSize(size) {
 		return errors.Errorf("not a valid size: %s", size)

--- a/cmd/earthly/satellite_cmds.go
+++ b/cmd/earthly/satellite_cmds.go
@@ -20,8 +20,6 @@ import (
 	"github.com/earthly/earthly/util/containerutil"
 )
 
-const satelliteSizeFlag = "size"
-
 func (app *earthlyApp) satelliteCmds() []*cli.Command {
 	return []*cli.Command{
 		{
@@ -36,12 +34,14 @@ func (app *earthlyApp) satelliteCmds() []*cli.Command {
 					Name:        "platform",
 					Usage:       "The platform to use when launching a new satellite. Supported values: linux/amd64, linux/arm64.",
 					Required:    false,
+					Value:       cloud.SatellitePlatformAMD64,
 					Destination: &app.satellitePlatform,
 				},
 				&cli.StringFlag{
-					Name:        satelliteSizeFlag,
+					Name:        "size",
 					Usage:       "The size of the satellite. See https://earthly.dev/pricing#compute for details on each size. Supported values: small, medium, large.",
 					Required:    false,
+					Value:       cloud.SatelliteSizeMedium,
 					Destination: &app.satelliteSize,
 				},
 				&cli.StringSliceFlag{
@@ -312,12 +312,11 @@ func (app *earthlyApp) actionSatelliteLaunch(cliCtx *cli.Context) error {
 		return err
 	}
 
-	if cliCtx.IsSet(satelliteSizeFlag) {
-		if !cloud.ValidSatelliteSize(size) {
-			return errors.Errorf("not a valid size: %s", size)
-		}
-	} else {
-		size = cloud.DefaultSatelliteSize
+	if !cloud.ValidSatellitePlatform(platform) {
+		return errors.Errorf("not a valid platform: '%s'", platform)
+	}
+	if !cloud.ValidSatelliteSize(size) {
+		return errors.Errorf("not a valid size: '%s'", size)
 	}
 
 	if window == "" {


### PR DESCRIPTION
Newly launched satellites will now be in the medium size instead of large (which is the server default).