### PR TITLE
ast/antlrhandler: add hints to syntax errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,7 @@ For more information on the individual Earthfile feature flags see the [Earthfil
 - `SAVE ARTIFACT <path> AS LOCAL ...` when used under a `TRY` / `FINALLY` can fail to be fully transferred to the host when the `TRY` command fails (resulting in an partially transferred file); an underflow can still occur, and is now detected and will not export the partial file. [2452](https://github.com/earthly/earthly/issues/2452)
 - The `--keep-own` flag for `SAVE ARTIFACT` is now applied by default; note that `COPY --keep-own` must still be used in order to keep ownership
 - Values from the `.env` file will no longer be propigated to Earthfile `ARG`s or `RUN --secret=...` commands; instead values must be placed in `.arg` or `.secret` files respectively. Note that this is a backwards incompatible change and will apply to all Earthfiles (regardless of the defined `VERSION` value). [#1736](https://github.com/earthly/earthly/issues/1736)
+- Some particularly obtuse syntax errors now have hints added to help clarify what the expected syntax might be. [#2656](https://github.com/earthly/earthly/issues/2656)
 
 
 ### Added

--- a/ast/alias_test.go
+++ b/ast/alias_test.go
@@ -12,6 +12,7 @@ var (
 	equal            = matchers.Equal
 	beNil            = matchers.BeNil
 	containSubstring = matchers.ContainSubstring
+	endWith          = matchers.EndWith
 
 	haveMethodExecuted = pers.HaveMethodExecuted
 	returning          = pers.Returning

--- a/ast/antlrhandler/error_listener.go
+++ b/ast/antlrhandler/error_listener.go
@@ -1,9 +1,26 @@
 package antlrhandler
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/antlr/antlr4/runtime/Go/antlr"
+	"github.com/earthly/earthly/ast/parser"
 	"github.com/pkg/errors"
 )
+
+// humanName makes an attempt to translate the name of a symbol into something
+// humans can read clearly.
+func humanName(symbol string) string {
+	switch symbol {
+	case "NL":
+		return `\n`
+	case "EQUALS":
+		return "="
+	default:
+		return symbol
+	}
+}
 
 // ReturnErrorListener allows for the errors to be collected and returned after parsing.
 type ReturnErrorListener struct {
@@ -13,10 +30,87 @@ type ReturnErrorListener struct {
 
 // NewReturnErrorListener returns a new ReturnErrorListener.
 func NewReturnErrorListener() *ReturnErrorListener {
-	return new(ReturnErrorListener)
+	return &ReturnErrorListener{}
 }
 
 // SyntaxError implements ErrorListener SyntaxError.
 func (rel *ReturnErrorListener) SyntaxError(recognizer antlr.Recognizer, offendingSymbol interface{}, line, column int, msg string, e antlr.RecognitionException) {
-	rel.Errs = append(rel.Errs, errors.Errorf("syntax error: line %d:%d %s", line, column, msg))
+	p, ok := recognizer.(*antlr.BaseParser)
+	if !ok {
+		rel.Errs = append(rel.Errs, errors.Errorf("syntax error: line %d:%d: %v", line, column, msg))
+		return
+	}
+
+	// The line/column arguments seem to be passed in as the start of the
+	// statement that failed to parse. But it seems like we get closer to the
+	// real problem using GetCurrentToken() and its location.
+	currTok := p.GetCurrentToken()
+	tokLine := currTok.GetLine()
+	tokCol := currTok.GetColumn()
+	currLit := currTok.GetText()
+
+	hintErr := hintError{
+		err: errors.Errorf("syntax error: line %d:%d: unexpected '%v': %s", tokLine, tokCol, humanName(currLit), msg),
+	}
+
+	expected := p.GetExpectedTokens().StringVerbose(p.LiteralNames, p.SymbolicNames, false)
+	hintErr.hints = []string{fmt.Sprintf("I got lost looking for '%v'", humanName(expected))}
+
+	stream := p.GetInputStream()
+	currIdx := stream.Index()
+	switch e.(type) {
+	case *antlr.NoViableAltException:
+		// TODO: this error doesn't give us much option to give good hints.
+		// Usually, when there's "no viable alternative", antlr rolls back to a
+		// previous token, so the offendingSymbol is misleading.
+		//
+		// What has been tried:
+		//
+		// - walk forward using stream.Seek(idx) until p.GetCurrentToken() does
+		//   not match p.GetExpectedTokens(). Ideally, this gives us the first
+		//   token that doesn't match the expected token set. Unfortunately,
+		//   p.GetExpectedTokens() returns a *antlr.IntervalSet which ... has
+		//   zero useful exported methods or fields.
+
+		// Until we can figure that out, the "I got lost looking for..." message
+		// is pretty likely to be misleading.
+		hintErr.hints[0] = "I couldn't find a pattern that completes the current statement - check your quote pairs, paren pairs, and newlines"
+	default:
+	}
+
+	// Just to prevent duplicates, since we seem to run into them sometimes
+	hintSet := map[string]struct{}{
+		hintErr.hints[0]: {},
+	}
+
+	for idx := currIdx; idx >= 0; idx-- {
+		stream.Seek(idx)
+		tok := p.GetCurrentToken()
+		if tok.GetTokenType() != parser.EarthLexerAtom {
+			// The Atom type is our catch-all, and is the most likely candidate
+			// for consuming something the user intended as a keyword. Other
+			// tokens would probably provide misleading hints.
+			continue
+		}
+		if currLine, currCol := tok.GetLine(), tok.GetColumn(); currLine < line || (currLine == line && currCol < column) {
+			break
+		}
+		tokLit := tok.GetText()
+		for _, lit := range p.LiteralNames {
+			lit = strings.Trim(lit, "'")
+			if lit == "" {
+				continue
+			}
+			if tokLit == lit {
+				msg := fmt.Sprintf("I parsed '%v' as a word, but it looks like it should be a keyword - is it on the wrong line?", lit)
+				if _, ok := hintSet[msg]; ok {
+					break
+				}
+				hintSet[msg] = struct{}{}
+				hintErr.hints = append(hintErr.hints, msg)
+				break
+			}
+		}
+	}
+	rel.Errs = append(rel.Errs, hintErr)
 }

--- a/ast/antlrhandler/hint_error.go
+++ b/ast/antlrhandler/hint_error.go
@@ -1,0 +1,32 @@
+package antlrhandler
+
+import (
+	"fmt"
+	"strings"
+)
+
+type hintError struct {
+	err   error
+	hints []string
+}
+
+func WithHints(err error, hints ...string) error {
+	if err == nil {
+		return nil
+	}
+	return hintError{err: err, hints: hints}
+}
+
+func (e hintError) Error() string {
+	if len(e.hints) == 0 {
+		return e.err.Error()
+	}
+	return fmt.Sprintf(`%v
+
+Hints:
+  - %v`, e.err, strings.Join(e.hints, "\n  - "))
+}
+
+func (e hintError) Unwrap() error {
+	return e.err
+}

--- a/ast/ast_test.go
+++ b/ast/ast_test.go
@@ -11,14 +11,14 @@ import (
 	"github.com/poy/onpar/v2/expect"
 )
 
-func TestParse(t *testing.T) {
+func TestParse(topT *testing.T) {
 	type testCtx struct {
 		t      *testing.T
 		expect expect.Expectation
 		reader *mockNamedReader
 	}
 
-	o := onpar.BeforeEach(onpar.New(t), func(t *testing.T) testCtx {
+	o := onpar.BeforeEach(onpar.New(topT), func(t *testing.T) testCtx {
 		return testCtx{
 			t:      t,
 			expect: expect.New(t),

--- a/ast/parse_errors_test.go
+++ b/ast/parse_errors_test.go
@@ -1,0 +1,81 @@
+package ast_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/earthly/earthly/ast"
+	"github.com/poy/onpar/v2"
+	"github.com/poy/onpar/v2/expect"
+)
+
+type namedReader struct {
+	*bytes.Reader
+
+	name string
+}
+
+func (b namedReader) Name() string {
+	return b.name
+}
+
+func TestParserErrors(topT *testing.T) {
+	type testCtx struct {
+		t      *testing.T
+		expect expect.Expectation
+	}
+
+	o := onpar.BeforeEach(onpar.New(topT), func(t *testing.T) testCtx {
+		return testCtx{
+			t:      t,
+			expect: expect.New(t),
+		}
+	})
+
+	for _, tt := range []struct {
+		name         string
+		body         string
+		expectedHint string
+	}{
+		{
+			name: "missing newline token",
+			body: `
+VERSION 0.7
+
+test:
+    FROM alpine
+    IF $foo END
+`,
+			expectedHint: `
+Hints:
+  - I couldn't find a pattern that completes the current statement - check your quote pairs, paren pairs, and newlines
+  - I parsed 'END' as a word, but it looks like it should be a keyword - is it on the wrong line?`,
+		},
+		{
+			name: "key-value with missing EQUALS",
+			body: `
+VERSION 0.7
+
+test:
+    FROM alpine
+    LABEL a
+`,
+			expectedHint: `
+Hints:
+  - I got lost looking for '=' - did you define a key/value pair without a value?`,
+		},
+	} {
+		tt := tt
+		o.Spec(tt.name, func(tc testCtx) {
+			b := namedReader{
+				Reader: bytes.NewReader([]byte(tt.body)),
+				name:   strings.Replace(tt.name, " ", "_", -1) + ".earth",
+			}
+			_, err := ast.ParseOpts(context.Background(), ast.FromReader(b))
+			tc.expect(err).To(haveOccurred())
+			tc.expect(err.Error()).To(endWith(tt.expectedHint))
+		})
+	}
+}

--- a/ast/parser/export.go
+++ b/ast/parser/export.go
@@ -9,3 +9,8 @@ func GetLexerModeNames() []string {
 func GetLexerSymbolicNames() []string {
 	return lexerSymbolicNames
 }
+
+// GetLexerLiteralNames returns the generated literal names.
+func GetLexerLiteralNames() []string {
+	return lexerLiteralNames
+}


### PR DESCRIPTION
Our parser/lexer syntax errors are extremely hard to comprehend and have been causing confusion. This updates our ErrorListener and ErrorStrategy with a few niceties, attempting to add extra context about the incorrect syntax.

These cases are pretty minimal, but they're a start.

---

For issue #2656 in particular, here's the updated error message:

```
Error: build target: build main: failed to solve: resolve build context for target +foo: Earthfile line 5:45 '
': invalid syntax

Hints:
  - I got lost looking for '=' - did you define a key/value pair without a value?
```