### PR TITLE
import testify functions explicitly

### DIFF
--- a/analytics/analytics_test.go
+++ b/analytics/analytics_test.go
@@ -5,8 +5,6 @@ package analytics
 
 import (
 	"testing"
-
-	. "github.com/stretchr/testify/assert"
 )
 
 // TestGetRepoHash tests the git repo hashing never changes

--- a/analytics/imports_test.go
+++ b/analytics/imports_test.go
@@ -1,0 +1,14 @@
+package analytics
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	NoError = assert.NoError
+	Equal   = assert.Equal
+	Nil     = assert.Nil
+	True    = assert.True
+	False   = assert.False
+	Error   = assert.Error
+)

--- a/autocomplete/complete_test.go
+++ b/autocomplete/complete_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/earthly/earthly/buildcontext"
 	"github.com/earthly/earthly/conslogging"
 
-	. "github.com/stretchr/testify/assert"
 	"github.com/urfave/cli/v2"
 )
 

--- a/autocomplete/imports_test.go
+++ b/autocomplete/imports_test.go
@@ -1,0 +1,14 @@
+package autocomplete
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	NoError = assert.NoError
+	Equal   = assert.Equal
+	Nil     = assert.Nil
+	True    = assert.True
+	False   = assert.False
+	Error   = assert.Error
+)

--- a/buildcontext/gitlookup_test.go
+++ b/buildcontext/gitlookup_test.go
@@ -3,8 +3,6 @@ package buildcontext
 import (
 	"fmt"
 	"testing"
-
-	. "github.com/stretchr/testify/assert"
 )
 
 func Test_parseKeyScanIfHostMatches(t *testing.T) {

--- a/buildcontext/imports_test.go
+++ b/buildcontext/imports_test.go
@@ -1,0 +1,14 @@
+package buildcontext
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	NoError = assert.NoError
+	Equal   = assert.Equal
+	Nil     = assert.Nil
+	True    = assert.True
+	False   = assert.False
+	Error   = assert.Error
+)

--- a/domain/domain_test.go
+++ b/domain/domain_test.go
@@ -5,8 +5,6 @@ package domain
 
 import (
 	"testing"
-
-	. "github.com/stretchr/testify/assert"
 )
 
 var targetTests = []struct {

--- a/domain/domain_windows_test.go
+++ b/domain/domain_windows_test.go
@@ -5,8 +5,6 @@ package domain
 
 import (
 	"testing"
-
-	. "github.com/stretchr/testify/assert"
 )
 
 var targetTests = []struct {

--- a/domain/imports_test.go
+++ b/domain/imports_test.go
@@ -1,0 +1,14 @@
+package domain
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	NoError = assert.NoError
+	Equal   = assert.Equal
+	Nil     = assert.Nil
+	True    = assert.True
+	False   = assert.False
+	Error   = assert.Error
+)

--- a/features/features_test.go
+++ b/features/features_test.go
@@ -3,8 +3,6 @@ package features
 import (
 	"fmt"
 	"testing"
-
-	. "github.com/stretchr/testify/assert"
 )
 
 func TestFeaturesStringEnabled(t *testing.T) {

--- a/features/imports_test.go
+++ b/features/imports_test.go
@@ -1,0 +1,14 @@
+package features
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	NoError = assert.NoError
+	Equal   = assert.Equal
+	Nil     = assert.Nil
+	True    = assert.True
+	False   = assert.False
+	Error   = assert.Error
+)

--- a/util/gitutil/detectgit_test.go
+++ b/util/gitutil/detectgit_test.go
@@ -2,8 +2,6 @@ package gitutil
 
 import (
 	"testing"
-
-	. "github.com/stretchr/testify/assert"
 )
 
 func TestParseGitRemoteURL(t *testing.T) {

--- a/util/gitutil/imports_test.go
+++ b/util/gitutil/imports_test.go
@@ -1,0 +1,14 @@
+package gitutil
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	NoError = assert.NoError
+	Equal   = assert.Equal
+	Nil     = assert.Nil
+	True    = assert.True
+	False   = assert.False
+	Error   = assert.Error
+)

--- a/util/stringutil/imports_test.go
+++ b/util/stringutil/imports_test.go
@@ -1,0 +1,14 @@
+package stringutil
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	NoError = assert.NoError
+	Equal   = assert.Equal
+	Nil     = assert.Nil
+	True    = assert.True
+	False   = assert.False
+	Error   = assert.Error
+)

--- a/util/stringutil/scrub_test.go
+++ b/util/stringutil/scrub_test.go
@@ -2,8 +2,6 @@ package stringutil
 
 import (
 	"testing"
-
-	. "github.com/stretchr/testify/assert"
 )
 
 func TestScrub(t *testing.T) {

--- a/variables/builtin_test.go
+++ b/variables/builtin_test.go
@@ -2,8 +2,6 @@ package variables
 
 import (
 	"testing"
-
-	. "github.com/stretchr/testify/assert"
 )
 
 func TestGetProjectName(t *testing.T) {

--- a/variables/imports_test.go
+++ b/variables/imports_test.go
@@ -1,0 +1,14 @@
+package variables
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	NoError = assert.NoError
+	Equal   = assert.Equal
+	Nil     = assert.Nil
+	True    = assert.True
+	False   = assert.False
+	Error   = assert.Error
+)

--- a/variables/parsenew_test.go
+++ b/variables/parsenew_test.go
@@ -2,8 +2,6 @@ package variables
 
 import (
 	"testing"
-
-	. "github.com/stretchr/testify/assert"
 )
 
 func TestParseFlagArgs(t *testing.T) {

--- a/variables/reserved/imports_test.go
+++ b/variables/reserved/imports_test.go
@@ -1,0 +1,14 @@
+package reserved
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	NoError = assert.NoError
+	Equal   = assert.Equal
+	Nil     = assert.Nil
+	True    = assert.True
+	False   = assert.False
+	Error   = assert.Error
+)

--- a/variables/reserved/names_test.go
+++ b/variables/reserved/names_test.go
@@ -10,8 +10,6 @@ import (
 	"runtime"
 	"strings"
 	"testing"
-
-	. "github.com/stretchr/testify/assert"
 )
 
 // getConsts parses names.go and returns all constants.

--- a/variables/util_test.go
+++ b/variables/util_test.go
@@ -2,8 +2,6 @@ package variables
 
 import (
 	"testing"
-
-	. "github.com/stretchr/testify/assert"
 )
 
 func TestParseEscapedKeyValue(t *testing.T) {


### PR DESCRIPTION
Rather than do a dot import, i.e.

    . "github.com/stretchr/testify/assert"

testify assertion functions will be defined in a corresponding `imports_test.go` file, to make it more obvious where these functions are coming from. This makes it easier when grepping.

Furthermore, an upcoming linter change started complaining about these imports.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>