### PR TITLE
cloud.Client should just be a struct

### DIFF
--- a/analytics/analytics.go
+++ b/analytics/analytics.go
@@ -190,7 +190,7 @@ type Meta struct {
 }
 
 // CollectAnalytics sends analytics to api.earthly.dev
-func CollectAnalytics(ctx context.Context, cloudClient cloud.Client, displayErrors bool, meta Meta, installationName string) {
+func CollectAnalytics(ctx context.Context, cloudClient *cloud.Client, displayErrors bool, meta Meta, installationName string) {
 	var err error
 	ciName, ci := DetectCI()
 	repoHash := getRepoHash()

--- a/cloud/account.go
+++ b/cloud/account.go
@@ -23,7 +23,7 @@ type TokenDetail struct {
 	Expiry time.Time
 }
 
-func (c *client) ListPublicKeys(ctx context.Context) ([]string, error) {
+func (c *Client) ListPublicKeys(ctx context.Context) ([]string, error) {
 	status, body, err := c.doCall(ctx, "GET", "/api/v0/account/keys", withAuth())
 	if err != nil {
 		return nil, err
@@ -45,7 +45,7 @@ func (c *client) ListPublicKeys(ctx context.Context) ([]string, error) {
 	return keys, nil
 }
 
-func (c *client) AddPublicKey(ctx context.Context, key string) error {
+func (c *Client) AddPublicKey(ctx context.Context, key string) error {
 	key = strings.TrimSpace(key) + "\n"
 	status, body, err := c.doCall(ctx, "PUT", "/api/v0/account/keys", withAuth(), withBody([]byte(key)))
 	if err != nil {
@@ -61,7 +61,7 @@ func (c *client) AddPublicKey(ctx context.Context, key string) error {
 	return nil
 }
 
-func (c *client) RemovePublicKey(ctx context.Context, key string) error {
+func (c *Client) RemovePublicKey(ctx context.Context, key string) error {
 	key = strings.TrimSpace(key) + "\n"
 	status, body, err := c.doCall(ctx, "DELETE", "/api/v0/account/keys", withAuth(), withBody([]byte(key)))
 	if err != nil {
@@ -77,7 +77,7 @@ func (c *client) RemovePublicKey(ctx context.Context, key string) error {
 	return nil
 }
 
-func (c *client) CreateToken(ctx context.Context, name string, write bool, expiry *time.Time) (string, error) {
+func (c *Client) CreateToken(ctx context.Context, name string, write bool, expiry *time.Time) (string, error) {
 	name = url.QueryEscape(name)
 	expiryPB := timestamppb.New(expiry.UTC())
 	authToken := secretsapi.AuthToken{
@@ -98,7 +98,7 @@ func (c *client) CreateToken(ctx context.Context, name string, write bool, expir
 	return string(body), nil
 }
 
-func (c *client) ListTokens(ctx context.Context) ([]*TokenDetail, error) {
+func (c *Client) ListTokens(ctx context.Context) ([]*TokenDetail, error) {
 	status, body, err := c.doCall(ctx, "GET", "/api/v0/account/tokens", withAuth())
 	if err != nil {
 		return nil, err
@@ -128,7 +128,7 @@ func (c *client) ListTokens(ctx context.Context) ([]*TokenDetail, error) {
 	return tokenDetails, nil
 }
 
-func (c *client) RemoveToken(ctx context.Context, name string) error {
+func (c *Client) RemoveToken(ctx context.Context, name string) error {
 	name = url.QueryEscape(name)
 	status, body, err := c.doCall(ctx, "DELETE", "/api/v0/account/token/"+name, withAuth())
 	if err != nil {
@@ -144,7 +144,7 @@ func (c *client) RemoveToken(ctx context.Context, name string) error {
 	return nil
 }
 
-func (c *client) WhoAmI(ctx context.Context) (string, string, bool, error) {
+func (c *Client) WhoAmI(ctx context.Context) (string, string, bool, error) {
 	email, writeAccess, err := c.ping(ctx)
 	if err != nil {
 		return "", "", false, err
@@ -160,7 +160,7 @@ func (c *client) WhoAmI(ctx context.Context) (string, string, bool, error) {
 	return email, authType, writeAccess, nil
 }
 
-func (c *client) GetPublicKeys(ctx context.Context) ([]*agent.Key, error) {
+func (c *Client) GetPublicKeys(ctx context.Context) ([]*agent.Key, error) {
 	keys, err := c.sshAgent.List()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to list ssh keys")
@@ -181,7 +181,7 @@ func (c *client) GetPublicKeys(ctx context.Context) ([]*agent.Key, error) {
 	return keys, nil
 }
 
-func (c *client) RegisterEmail(ctx context.Context, email string) error {
+func (c *Client) RegisterEmail(ctx context.Context, email string) error {
 	status, body, err := c.doCall(ctx, "PUT", fmt.Sprintf("/api/v0/account/create/%s", url.QueryEscape(email)))
 	if err != nil {
 		return err
@@ -196,7 +196,7 @@ func (c *client) RegisterEmail(ctx context.Context, email string) error {
 	return nil
 }
 
-func (c *client) CreateAccount(ctx context.Context, email, verificationToken, password, publicKey string, termsConditionsPrivacy bool) error {
+func (c *Client) CreateAccount(ctx context.Context, email, verificationToken, password, publicKey string, termsConditionsPrivacy bool) error {
 	if !IsValidEmail(ctx, email) {
 		return errors.Errorf("invalid email: %q", email)
 	}
@@ -245,7 +245,7 @@ func (c *client) CreateAccount(ctx context.Context, email, verificationToken, pa
 
 // ping calls the ping endpoint on the server,
 // which is used to both test an auth token and retrieve the associated email address.
-func (c *client) ping(ctx context.Context) (email string, writeAccess bool, err error) {
+func (c *Client) ping(ctx context.Context) (email string, writeAccess bool, err error) {
 	status, body, err := c.doCall(ctx, "GET", "/api/v0/account/ping", withAuth())
 	if err != nil {
 		return "", false, errors.Wrap(err, "failed executing ping request")
@@ -264,7 +264,7 @@ func (c *client) ping(ctx context.Context) (email string, writeAccess bool, err 
 	return resp.Email, resp.WriteAccess, nil
 }
 
-func (c *client) AccountResetRequestToken(ctx context.Context, email string) error {
+func (c *Client) AccountResetRequestToken(ctx context.Context, email string) error {
 	email = url.QueryEscape(email)
 	status, _, err := c.doCall(ctx, "PUT", "/api/v0/account/reset/"+email)
 	if err != nil {
@@ -276,7 +276,7 @@ func (c *client) AccountResetRequestToken(ctx context.Context, email string) err
 	return nil
 }
 
-func (c *client) AccountReset(ctx context.Context, email, token, password string) error {
+func (c *Client) AccountReset(ctx context.Context, email, token, password string) error {
 	createAccountRequest := secretsapi.ResetPasswordRequest{
 		Email:             email,
 		VerificationToken: token,

--- a/cloud/analytics.go
+++ b/cloud/analytics.go
@@ -31,7 +31,7 @@ type EarthlyAnalytics struct {
 }
 
 // SendAnalytics send an analytics event to the Cloud server.
-func (c *client) SendAnalytics(ctx context.Context, data *EarthlyAnalytics) error {
+func (c *Client) SendAnalytics(ctx context.Context, data *EarthlyAnalytics) error {
 	payload, err := json.Marshal(data)
 	if err != nil {
 		return errors.Wrap(err, "failed to marshal data")

--- a/cloud/auth.go
+++ b/cloud/auth.go
@@ -23,7 +23,7 @@ import (
 // Credentials may be either email/password, ssh-based, or a custom token.
 // Upon successful authenticate, the JWT provided by the server is stored in
 // ~/.earthly/auth.jwt, and can be refreshed any time via another call to Authenticate().
-func (c *client) Authenticate(ctx context.Context) error {
+func (c *Client) Authenticate(ctx context.Context) error {
 	var err error
 	switch {
 	case c.email != "" && c.password != "":
@@ -42,11 +42,11 @@ func (c *client) Authenticate(ctx context.Context) error {
 	return c.saveToken()
 }
 
-func (c *client) IsLoggedIn(ctx context.Context) bool {
+func (c *Client) IsLoggedIn(ctx context.Context) bool {
 	return c.authToken != "" || c.authCredToken != ""
 }
 
-func (c *client) FindSSHCredentials(ctx context.Context, emailToFind string) error {
+func (c *Client) FindSSHCredentials(ctx context.Context, emailToFind string) error {
 	keys, err := c.GetPublicKeys(ctx)
 	if err != nil {
 		return err
@@ -80,7 +80,7 @@ func (c *client) FindSSHCredentials(ctx context.Context, emailToFind string) err
 	return ErrNoAuthorizedPublicKeys
 }
 
-func (c *client) GetAuthToken(ctx context.Context) (string, error) {
+func (c *Client) GetAuthToken(ctx context.Context) (string, error) {
 	err := c.Authenticate(ctx) // Ensure the current token is valid
 	if err != nil {
 		return "", errors.Wrap(err, "could not authenticate")
@@ -88,7 +88,7 @@ func (c *client) GetAuthToken(ctx context.Context) (string, error) {
 	return c.authToken, nil
 }
 
-func (c *client) SetSSHCredentials(ctx context.Context, email, sshKey string) error {
+func (c *Client) SetSSHCredentials(ctx context.Context, email, sshKey string) error {
 	sshKeyType, sshKeyBlob, _, err := parseSSHKey(sshKey)
 	if err != nil {
 		return err
@@ -113,7 +113,7 @@ func (c *client) SetSSHCredentials(ctx context.Context, email, sshKey string) er
 	return c.saveCredentials(ctx, email, sshKeyType, sshKeyBlob)
 }
 
-func (c *client) DeleteCachedToken(ctx context.Context) error {
+func (c *Client) DeleteCachedToken(ctx context.Context) error {
 	var zero time.Time
 	c.authToken = ""
 	c.authTokenExpiry = zero
@@ -130,7 +130,7 @@ func (c *client) DeleteCachedToken(ctx context.Context) error {
 	return nil
 }
 
-func (c *client) DeleteAuthCache(ctx context.Context) error {
+func (c *Client) DeleteAuthCache(ctx context.Context) error {
 	err := c.DeleteCachedToken(ctx)
 	if err != nil {
 		return err
@@ -142,7 +142,7 @@ func (c *client) DeleteAuthCache(ctx context.Context) error {
 	return nil
 }
 
-func (c *client) SetTokenCredentials(ctx context.Context, token string) (string, error) {
+func (c *Client) SetTokenCredentials(ctx context.Context, token string) (string, error) {
 	c.email = ""
 	c.password = ""
 	c.authCredToken = token
@@ -157,15 +157,15 @@ func (c *client) SetTokenCredentials(ctx context.Context, token string) (string,
 	return email, nil
 }
 
-func (c *client) DisableSSHKeyGuessing(ctx context.Context) {
+func (c *Client) DisableSSHKeyGuessing(ctx context.Context) {
 	c.disableSSHKeyGuessing = true
 }
 
-func (c *client) SetAuthTokenDir(ctx context.Context, path string) {
+func (c *Client) SetAuthTokenDir(ctx context.Context, path string) {
 	c.authDir = path
 }
 
-func (c *client) SetPasswordCredentials(ctx context.Context, email, password string) error {
+func (c *Client) SetPasswordCredentials(ctx context.Context, email, password string) error {
 	c.authCredToken = ""
 	c.email = email
 	c.password = password
@@ -185,7 +185,7 @@ func IsValidEmail(ctx context.Context, email string) bool {
 	return len(parts) == 2
 }
 
-func (c *client) loadCredentials() error {
+func (c *Client) loadCredentials() error {
 	credPath, err := c.getCredentialsPath(false)
 	if err != nil {
 		return err
@@ -223,7 +223,7 @@ func (c *client) loadCredentials() error {
 	return nil
 }
 
-func (c *client) loadToken() error {
+func (c *Client) loadToken() error {
 	tokenPath, err := c.getTokenPath(false)
 	if err != nil {
 		return err
@@ -252,7 +252,7 @@ func (c *client) loadToken() error {
 	return nil
 }
 
-func (c *client) getCredentialsPath(create bool) (string, error) {
+func (c *Client) getCredentialsPath(create bool) (string, error) {
 	confDirPath := c.authDir
 	if confDirPath == "" {
 		if create {
@@ -269,7 +269,7 @@ func (c *client) getCredentialsPath(create bool) (string, error) {
 	return credPath, nil
 }
 
-func (c *client) migrateOldToken() error {
+func (c *Client) migrateOldToken() error {
 	confDirPath := c.authDir
 	if confDirPath == "" {
 		confDirPath = cliutil.GetEarthlyDir(c.installationName)
@@ -284,7 +284,7 @@ func (c *client) migrateOldToken() error {
 	return nil
 }
 
-func (c *client) getTokenPath(create bool) (string, error) {
+func (c *Client) getTokenPath(create bool) (string, error) {
 	confDirPath := c.authDir
 	if confDirPath == "" {
 		if create {
@@ -301,7 +301,7 @@ func (c *client) getTokenPath(create bool) (string, error) {
 	return tokenPath, nil
 }
 
-func (c *client) saveCredentials(ctx context.Context, email, tokenType, tokenValue string) error {
+func (c *Client) saveCredentials(ctx context.Context, email, tokenType, tokenValue string) error {
 	tokenPath, err := c.getCredentialsPath(true)
 	if err != nil {
 		return err
@@ -325,7 +325,7 @@ func (c *client) saveCredentials(ctx context.Context, email, tokenType, tokenVal
 	return nil
 }
 
-func (c *client) saveSSHCredentials(ctx context.Context, email, sshKey string) error {
+func (c *Client) saveSSHCredentials(ctx context.Context, email, sshKey string) error {
 	sshKeyType, sshKeyBlob, _, err := parseSSHKey(sshKey)
 	if err != nil {
 		return err
@@ -333,12 +333,12 @@ func (c *client) saveSSHCredentials(ctx context.Context, email, sshKey string) e
 	return c.saveCredentials(ctx, email, sshKeyType, sshKeyBlob)
 }
 
-func (c *client) savePasswordCredentials(ctx context.Context, email, password string) error {
+func (c *Client) savePasswordCredentials(ctx context.Context, email, password string) error {
 	password64 := base64.StdEncoding.EncodeToString([]byte(password))
 	return c.saveCredentials(ctx, email, "password", password64)
 }
 
-func (c *client) deleteCachedCredentials() error {
+func (c *Client) deleteCachedCredentials() error {
 	c.email = ""
 	c.password = ""
 	c.authCredToken = ""
@@ -360,7 +360,7 @@ func (c *client) deleteCachedCredentials() error {
 //   - ~/.earthly/auth.jwt
 //
 // If a an old-style auth.token file exists, it is automatically migrated and removed.
-func (c *client) loadAuthStorage() error {
+func (c *Client) loadAuthStorage() error {
 	if err := c.migrateOldToken(); err != nil {
 		return err
 	}
@@ -373,7 +373,7 @@ func (c *client) loadAuthStorage() error {
 	return nil
 }
 
-func (c *client) saveToken() error {
+func (c *Client) saveToken() error {
 	path, err := c.getTokenPath(true)
 	if err != nil {
 		return err
@@ -388,20 +388,20 @@ func (c *client) saveToken() error {
 	return nil
 }
 
-func (c *client) loginWithPassword(ctx context.Context) error {
+func (c *Client) loginWithPassword(ctx context.Context) error {
 	var err error
 	c.authCredToken = getPasswordAuthToken(c.email, c.password)
 	c.authToken, c.authTokenExpiry, err = c.login(ctx, c.authCredToken)
 	return err
 }
 
-func (c *client) loginWithToken(ctx context.Context) error {
+func (c *Client) loginWithToken(ctx context.Context) error {
 	var err error
 	c.authToken, c.authTokenExpiry, err = c.login(ctx, "token "+c.authCredToken)
 	return err
 }
 
-func (c *client) loginWithSSH(ctx context.Context) error {
+func (c *Client) loginWithSSH(ctx context.Context) error {
 	if c.disableSSHKeyGuessing {
 		return ErrNoAuthorizedPublicKeys
 	}
@@ -436,7 +436,7 @@ func (c *client) loginWithSSH(ctx context.Context) error {
 // login calls the login endpoint on the cloud server, passing the provided credentials.
 // If auth succeeds, a new jwt token is returned with it's expiry date.
 // ErrUnauthorized is returned if the credentials are not valid.
-func (c *client) login(ctx context.Context, credentials string) (token string, expiry time.Time, err error) {
+func (c *Client) login(ctx context.Context, credentials string) (token string, expiry time.Time, err error) {
 	var zero time.Time
 	status, body, err := c.doCall(ctx, "POST", "/api/v0/account/login",
 		withHeader("Authorization", credentials))
@@ -457,7 +457,7 @@ func (c *client) login(ctx context.Context, credentials string) (token string, e
 	return resp.Token, resp.Expiry.AsTime().UTC(), nil
 }
 
-func (c *client) getChallenge(ctx context.Context) (string, error) {
+func (c *Client) getChallenge(ctx context.Context) (string, error) {
 	status, body, err := c.doCall(ctx, "GET", "/api/v0/account/auth-challenge")
 	if err != nil {
 		return "", err
@@ -479,7 +479,7 @@ func (c *client) getChallenge(ctx context.Context) (string, error) {
 	return challengeResponse.Challenge, nil
 }
 
-func (c *client) signChallenge(challenge string, key *agent.Key) (string, string, error) {
+func (c *Client) signChallenge(challenge string, key *agent.Key) (string, string, error) {
 	sig, err := c.sshAgent.SignWithFlags(key, []byte(challenge), agent.SignatureFlagRsaSha512)
 	if err != nil {
 		return "", "", err
@@ -488,7 +488,7 @@ func (c *client) signChallenge(challenge string, key *agent.Key) (string, string
 	return sig.Format, s, nil
 }
 
-func (c *client) getSSHCredentials(challenge string, key *agent.Key) (credentials string, err error) {
+func (c *Client) getSSHCredentials(challenge string, key *agent.Key) (credentials string, err error) {
 	sigFormat, sig, err := c.signChallenge(challenge, key)
 	if err != nil {
 		return credentials, err

--- a/cloud/auth_test.go
+++ b/cloud/auth_test.go
@@ -23,7 +23,7 @@ var testTokenExp = time.Now().Add(24 * time.Hour).UTC()
 
 func TestClient_Authenticate(t *testing.T) {
 	srv := mockServer(t)
-	cc := &client{
+	cc := &Client{
 		httpAddr: srv.URL,
 		email:    testEmail,
 		password: testPass,
@@ -45,7 +45,7 @@ func TestClient_Authenticate(t *testing.T) {
 }
 
 func TestClient_loadAuthStorage(t *testing.T) {
-	cc := &client{
+	cc := &Client{
 		authToken:       testToken,
 		authTokenExpiry: testTokenExp,
 		email:           testEmail,

--- a/cloud/client.go
+++ b/cloud/client.go
@@ -34,78 +34,7 @@ const (
 	requestID            = "request-id"
 )
 
-// Client contains gRPC and REST endpoints to the Earthly Cloud backend.
-type Client interface {
-	RegisterEmail(ctx context.Context, email string) error
-	CreateAccount(ctx context.Context, email, verificationToken, password, publicKey string, termsConditionsPrivacy bool) error
-	Authenticate(ctx context.Context) error
-	Get(ctx context.Context, path string) ([]byte, error)
-	Remove(ctx context.Context, path string) error
-	Set(ctx context.Context, path string, data []byte) error
-	List(ctx context.Context, path string) ([]string, error)
-	GetPublicKeys(ctx context.Context) ([]*agent.Key, error)
-	CreateOrg(ctx context.Context, org string) error
-	Invite(ctx context.Context, org, user string, write bool) error
-	InviteToOrg(ctx context.Context, invite *OrgInvitation) (string, error)
-	AcceptInvite(ctx context.Context, inviteCode string) error
-	ListInvites(ctx context.Context, org string) ([]*OrgInvitation, error)
-	ListOrgs(ctx context.Context) ([]*OrgDetail, error)
-	ListOrgPermissions(ctx context.Context, path string) ([]*OrgPermissions, error)
-	ListOrgMembers(ctx context.Context, orgName string) ([]*OrgMember, error)
-	UpdateOrgMember(ctx context.Context, orgName, userEmail, permission string) error
-	RemoveOrgMember(ctx context.Context, orgName, userEmail string) error
-	RevokePermission(ctx context.Context, path, user string) error
-	ListPublicKeys(ctx context.Context) ([]string, error)
-	AddPublicKey(ctx context.Context, key string) error
-	RemovePublicKey(ctx context.Context, key string) error
-	CreateToken(context.Context, string, bool, *time.Time) (string, error)
-	ListTokens(ctx context.Context) ([]*TokenDetail, error)
-	RemoveToken(ctx context.Context, token string) error
-	WhoAmI(ctx context.Context) (string, string, bool, error)
-	UploadLog(ctx context.Context, pathOnDisk string) (string, error)
-	SetPasswordCredentials(context.Context, string, string) error
-	SetTokenCredentials(ctx context.Context, token string) (string, error)
-	SetSSHCredentials(ctx context.Context, email, sshKey string) error
-	FindSSHCredentials(ctx context.Context, emailToFind string) error
-	DeleteAuthCache(ctx context.Context) error
-	DeleteCachedToken(ctx context.Context) error
-	DisableSSHKeyGuessing(ctx context.Context)
-	SetAuthTokenDir(ctx context.Context, path string)
-	SendAnalytics(ctx context.Context, data *EarthlyAnalytics) error
-	IsLoggedIn(ctx context.Context) bool
-	GetAuthToken(ctx context.Context) (string, error)
-	LaunchSatellite(ctx context.Context, name, orgID, platform, size, version, maintenanceWindow string, features []string) error
-	GetOrgID(ctx context.Context, name string) (string, error)
-	ListSatellites(ctx context.Context, orgID string) ([]SatelliteInstance, error)
-	GetSatellite(ctx context.Context, name, orgID string) (*SatelliteInstance, error)
-	DeleteSatellite(ctx context.Context, name, orgID string) error
-	ReserveSatellite(ctx context.Context, name, orgID, gitAuthor, gitConfigEmail string, isCI bool) chan SatelliteStatusUpdate
-	WakeSatellite(ctx context.Context, name, orgID string) chan SatelliteStatusUpdate
-	SleepSatellite(ctx context.Context, name, orgID string) chan SatelliteStatusUpdate
-	UpdateSatellite(ctx context.Context, name, orgID, version, maintenanceWindow string, dropCache bool, featureFlags []string) error
-	CreateProject(ctx context.Context, name, orgName string) (*Project, error)
-	ListProjects(ctx context.Context, orgName string) ([]*Project, error)
-	GetProject(ctx context.Context, orgName, name string) (*Project, error)
-	DeleteProject(ctx context.Context, orgName, name string) error
-	AddProjectMember(ctx context.Context, orgName, name, userEmail, permission string) error
-	UpdateProjectMember(ctx context.Context, orgName, name, userEmail, permission string) error
-	ListProjectMembers(ctx context.Context, orgName, name string) ([]*ProjectMember, error)
-	RemoveProjectMember(ctx context.Context, orgName, name, userEmail string) error
-	ListSecrets(ctx context.Context, path string) ([]*Secret, error)
-	GetProjectSecret(ctx context.Context, org, project, secretName string) (*Secret, error)
-	GetUserSecret(ctx context.Context, secretName string) (*Secret, error)
-	GetUserOrProjectSecret(ctx context.Context, secretName string) (*Secret, error)
-	SetSecret(ctx context.Context, path string, secret []byte) error
-	RemoveSecret(ctx context.Context, path string) error
-	ListSecretPermissions(ctx context.Context, path string) ([]*SecretPermission, error)
-	SetSecretPermission(ctx context.Context, path, userEmail, permission string) error
-	RemoveSecretPermission(ctx context.Context, path, userEmail string) error
-	AccountResetRequestToken(ctx context.Context, userEmail string) error
-	AccountReset(ctx context.Context, userEmail, token, password string) error
-	StreamLogs(ctx context.Context, buildID string, deltas chan []*logstream.Delta) error
-}
-
-type client struct {
+type Client struct {
 	httpAddr              string
 	sshKeyBlob            []byte // sshKey to use
 	forceSSHKey           bool   // if true only use the above ssh key, don't attempt to guess others
@@ -126,11 +55,9 @@ type client struct {
 	installationName      string
 }
 
-var _ Client = &client{}
-
 // NewClient provides a new Earthly Cloud client
-func NewClient(httpAddr, grpcAddr string, useInsecure bool, agentSockPath, authCredsOverride, authJWTOverride, installationName, requestID string, warnFunc func(string, ...interface{})) (Client, error) {
-	c := &client{
+func NewClient(httpAddr, grpcAddr string, useInsecure bool, agentSockPath, authCredsOverride, authJWTOverride, installationName, requestID string, warnFunc func(string, ...interface{})) (*Client, error) {
+	c := &Client{
 		httpAddr: httpAddr,
 		sshAgent: &lazySSHAgent{
 			sockPath: agentSockPath,
@@ -176,7 +103,7 @@ func NewClient(httpAddr, grpcAddr string, useInsecure bool, agentSockPath, authC
 	return c, nil
 }
 
-func (c *client) getRequestID() string {
+func (c *Client) getRequestID() string {
 	if c.requestID != "" {
 		return c.requestID
 	}

--- a/cloud/http.go
+++ b/cloud/http.go
@@ -82,7 +82,7 @@ func withBody(body []byte) requestOpt {
 	}
 }
 
-func (c *client) doCall(ctx context.Context, method, url string, opts ...requestOpt) (int, []byte, error) {
+func (c *Client) doCall(ctx context.Context, method, url string, opts ...requestOpt) (int, []byte, error) {
 	const maxAttempt = 10
 	const maxSleepBeforeRetry = time.Second * 3
 
@@ -174,7 +174,7 @@ func shouldRetry(status int, body []byte, callErr error, warnFunc func(string, .
 	}
 }
 
-func (c *client) doCallImp(ctx context.Context, r request, method, url, reqID string, opts ...requestOpt) (int, []byte, error) {
+func (c *Client) doCallImp(ctx context.Context, r request, method, url, reqID string, opts ...requestOpt) (int, []byte, error) {
 	var bodyReader io.Reader
 	var bodyLen int64
 	if r.hasBody {

--- a/cloud/log.go
+++ b/cloud/log.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (c *client) UploadLog(ctx context.Context, pathOnDisk string) (string, error) {
+func (c *Client) UploadLog(ctx context.Context, pathOnDisk string) (string, error) {
 	status, body, err := c.doCall(ctx, http.MethodPost, "/api/v0/logs", withAuth(), withFileBody(pathOnDisk), withHeader("Content-Type", "application/gzip"))
 	if err != nil {
 		return "", err

--- a/cloud/logstream.go
+++ b/cloud/logstream.go
@@ -10,7 +10,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-func (c *client) StreamLogs(ctx context.Context, buildID string, deltasCh chan []*logstream.Delta) error {
+func (c *Client) StreamLogs(ctx context.Context, buildID string, deltasCh chan []*logstream.Delta) error {
 	streamClient, err := c.logstream.StreamLogs(c.withAuth(ctx), grpc_retry.Disable())
 	if err != nil {
 		return errors.Wrap(err, "failed to create log stream client")

--- a/cloud/org.go
+++ b/cloud/org.go
@@ -34,7 +34,7 @@ type OrgMember struct {
 }
 
 // ListOrgs lists all orgs a user has permission to view.
-func (c *client) ListOrgs(ctx context.Context) ([]*OrgDetail, error) {
+func (c *Client) ListOrgs(ctx context.Context) ([]*OrgDetail, error) {
 	status, body, err := c.doCall(ctx, "GET", "/api/v0/admin/organizations", withAuth())
 	if err != nil {
 		return nil, err
@@ -66,7 +66,7 @@ func (c *client) ListOrgs(ctx context.Context) ([]*OrgDetail, error) {
 }
 
 // Invite a user to an org.
-func (c *client) Invite(ctx context.Context, path, user string, write bool) error {
+func (c *Client) Invite(ctx context.Context, path, user string, write bool) error {
 	orgName, ok := getOrgFromPath(path)
 	if !ok {
 		return errors.Errorf("invalid path")
@@ -95,7 +95,7 @@ func (c *client) Invite(ctx context.Context, path, user string, write bool) erro
 }
 
 // RevokePermission removes the org permission from the user.
-func (c *client) RevokePermission(ctx context.Context, path, user string) error {
+func (c *Client) RevokePermission(ctx context.Context, path, user string) error {
 	orgName, ok := getOrgFromPath(path)
 	if !ok {
 		return errors.Errorf("invalid path")
@@ -121,7 +121,7 @@ func (c *client) RevokePermission(ctx context.Context, path, user string) error 
 }
 
 // ListOrgPermissions returns all configured permissions for the org.
-func (c *client) ListOrgPermissions(ctx context.Context, path string) ([]*OrgPermissions, error) {
+func (c *Client) ListOrgPermissions(ctx context.Context, path string) ([]*OrgPermissions, error) {
 	orgName, ok := getOrgFromPath(path)
 	if !ok {
 		return nil, errors.Errorf("invalid path")
@@ -160,7 +160,7 @@ func (c *client) ListOrgPermissions(ctx context.Context, path string) ([]*OrgPer
 }
 
 // CreateOrg creates a new org by name.
-func (c *client) CreateOrg(ctx context.Context, org string) error {
+func (c *Client) CreateOrg(ctx context.Context, org string) error {
 	status, body, err := c.doCall(ctx, "PUT", fmt.Sprintf("/api/v0/admin/organizations/%s", url.QueryEscape(org)), withAuth())
 	if err != nil {
 		return err
@@ -176,7 +176,7 @@ func (c *client) CreateOrg(ctx context.Context, org string) error {
 }
 
 // GetOrgID retrieves the org ID for a named org.
-func (c *client) GetOrgID(ctx context.Context, orgName string) (string, error) {
+func (c *Client) GetOrgID(ctx context.Context, orgName string) (string, error) {
 	orgs, err := c.ListOrgs(ctx)
 	if err != nil {
 		return "", err

--- a/cloud/org_new.go
+++ b/cloud/org_new.go
@@ -22,7 +22,7 @@ type OrgInvitation struct {
 }
 
 // InviteToOrg sends an email invitation to a user and asks for them to join an org.
-func (c *client) InviteToOrg(ctx context.Context, invite *OrgInvitation) (string, error) {
+func (c *Client) InviteToOrg(ctx context.Context, invite *OrgInvitation) (string, error) {
 	u := "/api/v0/invitations"
 
 	req := &secretsapi.CreateInvitationRequest{
@@ -51,7 +51,7 @@ func (c *client) InviteToOrg(ctx context.Context, invite *OrgInvitation) (string
 }
 
 // ListOrgMembers returns a collection of org members.
-func (c *client) ListOrgMembers(ctx context.Context, orgName string) ([]*OrgMember, error) {
+func (c *Client) ListOrgMembers(ctx context.Context, orgName string) ([]*OrgMember, error) {
 	u := fmt.Sprintf("/api/v1/organizations/%s/members", orgName)
 
 	status, body, err := c.doCall(ctx, http.MethodGet, u, withAuth())
@@ -84,7 +84,7 @@ func (c *client) ListOrgMembers(ctx context.Context, orgName string) ([]*OrgMemb
 }
 
 // UpdateOrgMember updates a member's permission in an org.
-func (c *client) UpdateOrgMember(ctx context.Context, orgName, userEmail, permission string) error {
+func (c *Client) UpdateOrgMember(ctx context.Context, orgName, userEmail, permission string) error {
 	u := fmt.Sprintf("/api/v1/organizations/%s/members/%s", orgName, userEmail)
 
 	req := &secretsapi.UpdateOrgMemberRequest{
@@ -108,7 +108,7 @@ func (c *client) UpdateOrgMember(ctx context.Context, orgName, userEmail, permis
 }
 
 // RemoveOrgMember removes a member from the org.
-func (c *client) RemoveOrgMember(ctx context.Context, orgName, userEmail string) error {
+func (c *Client) RemoveOrgMember(ctx context.Context, orgName, userEmail string) error {
 	u := fmt.Sprintf("/api/v1/organizations/%s/members/%s", orgName, userEmail)
 
 	status, body, err := c.doCall(ctx, http.MethodDelete, u, withAuth())
@@ -124,7 +124,7 @@ func (c *client) RemoveOrgMember(ctx context.Context, orgName, userEmail string)
 }
 
 // AcceptInvite accepts the org invitation and adds the user to the org.
-func (c *client) AcceptInvite(ctx context.Context, inviteCode string) error {
+func (c *Client) AcceptInvite(ctx context.Context, inviteCode string) error {
 	u := "/api/v0/invitations/" + inviteCode
 
 	status, body, err := c.doCall(ctx, http.MethodPost, u, withAuth())
@@ -140,7 +140,7 @@ func (c *client) AcceptInvite(ctx context.Context, inviteCode string) error {
 }
 
 // ListInvites returns a collection of organization invites and their status.
-func (c *client) ListInvites(ctx context.Context, org string) ([]*OrgInvitation, error) {
+func (c *Client) ListInvites(ctx context.Context, org string) ([]*OrgInvitation, error) {
 	u := "/api/v0/invitations?org=" + org
 
 	status, body, err := c.doCall(ctx, http.MethodGet, u, withAuth())

--- a/cloud/project.go
+++ b/cloud/project.go
@@ -30,7 +30,7 @@ type ProjectMember struct {
 }
 
 // CreateProject creates a new project within the specified organization.
-func (c *client) CreateProject(ctx context.Context, name, orgName string) (*Project, error) {
+func (c *Client) CreateProject(ctx context.Context, name, orgName string) (*Project, error) {
 	u := "/api/v0/projects"
 
 	req := &secretsapi.CreateProjectRequest{
@@ -66,7 +66,7 @@ func (c *client) CreateProject(ctx context.Context, name, orgName string) (*Proj
 
 // ListProjects returns all projects in the organization that are visible to the
 // logged-in user.
-func (c *client) ListProjects(ctx context.Context, orgName string) ([]*Project, error) {
+func (c *Client) ListProjects(ctx context.Context, orgName string) ([]*Project, error) {
 	u := fmt.Sprintf("/api/v0/projects/%s", orgName)
 
 	status, body, err := c.doCall(ctx, http.MethodGet, u, withAuth())
@@ -100,7 +100,7 @@ func (c *client) ListProjects(ctx context.Context, orgName string) ([]*Project, 
 }
 
 // GetProject loads a single project from the projects endpoint.
-func (c *client) GetProject(ctx context.Context, orgName, name string) (*Project, error) {
+func (c *Client) GetProject(ctx context.Context, orgName, name string) (*Project, error) {
 	u := fmt.Sprintf("/api/v0/projects/%s/%s", orgName, name)
 
 	status, body, err := c.doCall(ctx, http.MethodGet, u, withAuth())
@@ -128,7 +128,7 @@ func (c *client) GetProject(ctx context.Context, orgName, name string) (*Project
 }
 
 // DeleteProject deletes a given project by name.
-func (c *client) DeleteProject(ctx context.Context, orgName, name string) error {
+func (c *Client) DeleteProject(ctx context.Context, orgName, name string) error {
 	u := fmt.Sprintf("/api/v0/projects/%s/%s", orgName, name)
 
 	status, body, err := c.doCall(ctx, http.MethodDelete, u, withAuth())
@@ -144,7 +144,7 @@ func (c *client) DeleteProject(ctx context.Context, orgName, name string) error 
 }
 
 // AddProjectMember adds a new member to the project by email or user ID.
-func (c *client) AddProjectMember(ctx context.Context, orgName, name, userEmail, permission string) error {
+func (c *Client) AddProjectMember(ctx context.Context, orgName, name, userEmail, permission string) error {
 	u := fmt.Sprintf("/api/v0/projects/%s/%s/members", orgName, name)
 
 	req := &secretsapi.AddProjectMemberRequest{
@@ -165,7 +165,7 @@ func (c *client) AddProjectMember(ctx context.Context, orgName, name, userEmail,
 }
 
 // UpdateProjectMember updates an existing member with the new permission
-func (c *client) UpdateProjectMember(ctx context.Context, orgName, name, userEmail, permission string) error {
+func (c *Client) UpdateProjectMember(ctx context.Context, orgName, name, userEmail, permission string) error {
 	u := fmt.Sprintf("/api/v0/projects/%s/%s/members/%s", orgName, name, userEmail)
 
 	req := &secretsapi.AddProjectMemberRequest{
@@ -186,7 +186,7 @@ func (c *client) UpdateProjectMember(ctx context.Context, orgName, name, userEma
 }
 
 // ListProjectMembers will return all project members if the user has permission to do so.
-func (c *client) ListProjectMembers(ctx context.Context, orgName, name string) ([]*ProjectMember, error) {
+func (c *Client) ListProjectMembers(ctx context.Context, orgName, name string) ([]*ProjectMember, error) {
 	u := fmt.Sprintf("/api/v0/projects/%s/%s/members", orgName, name)
 
 	status, body, err := c.doCall(ctx, http.MethodGet, u, withAuth())
@@ -221,7 +221,7 @@ func (c *client) ListProjectMembers(ctx context.Context, orgName, name string) (
 }
 
 // RemoveProjectMember will remove a member from a project.
-func (c *client) RemoveProjectMember(ctx context.Context, orgName, name, userEmail string) error {
+func (c *Client) RemoveProjectMember(ctx context.Context, orgName, name, userEmail string) error {
 	u := fmt.Sprintf("/api/v0/projects/%s/%s/members/%s", orgName, name, userEmail)
 
 	status, body, err := c.doCall(ctx, http.MethodDelete, u, withAuth())

--- a/cloud/satellite.go
+++ b/cloud/satellite.go
@@ -65,7 +65,7 @@ type SatelliteInstance struct {
 	RevisionID             int32
 }
 
-func (c *client) ListSatellites(ctx context.Context, orgID string) ([]SatelliteInstance, error) {
+func (c *Client) ListSatellites(ctx context.Context, orgID string) ([]SatelliteInstance, error) {
 	resp, err := c.compute.ListSatellites(c.withAuth(ctx), &pb.ListSatellitesRequest{
 		OrgId: orgID,
 	})
@@ -86,7 +86,7 @@ func (c *client) ListSatellites(ctx context.Context, orgID string) ([]SatelliteI
 	return instances, nil
 }
 
-func (c *client) GetSatellite(ctx context.Context, name, orgID string) (*SatelliteInstance, error) {
+func (c *Client) GetSatellite(ctx context.Context, name, orgID string) (*SatelliteInstance, error) {
 	resp, err := c.compute.GetSatellite(c.withAuth(ctx), &pb.GetSatelliteRequest{
 		OrgId: orgID,
 		Name:  name,
@@ -109,7 +109,7 @@ func (c *client) GetSatellite(ctx context.Context, name, orgID string) (*Satelli
 	}, nil
 }
 
-func (c *client) DeleteSatellite(ctx context.Context, name, orgID string) error {
+func (c *Client) DeleteSatellite(ctx context.Context, name, orgID string) error {
 	_, err := c.compute.DeleteSatellite(c.withAuth(ctx), &pb.DeleteSatelliteRequest{
 		OrgId: orgID,
 		Name:  name,
@@ -120,7 +120,7 @@ func (c *client) DeleteSatellite(ctx context.Context, name, orgID string) error 
 	return nil
 }
 
-func (c *client) LaunchSatellite(ctx context.Context, name, orgID, platform, size, version, maintenanceWindow string, features []string) error {
+func (c *Client) LaunchSatellite(ctx context.Context, name, orgID, platform, size, version, maintenanceWindow string, features []string) error {
 	req := &pb.LaunchSatelliteRequest{
 		OrgId:                  orgID,
 		Name:                   name,
@@ -142,7 +142,7 @@ type SatelliteStatusUpdate struct {
 	Err   error
 }
 
-func (c *client) ReserveSatellite(ctx context.Context, name, orgID, gitAuthor, gitConfigEmail string, isCI bool) (out chan SatelliteStatusUpdate) {
+func (c *Client) ReserveSatellite(ctx context.Context, name, orgID, gitAuthor, gitConfigEmail string, isCI bool) (out chan SatelliteStatusUpdate) {
 	out = make(chan SatelliteStatusUpdate)
 	go func() {
 		// Some notes on the 10-minute timeout here:
@@ -184,7 +184,7 @@ func (c *client) ReserveSatellite(ctx context.Context, name, orgID, gitAuthor, g
 	return out
 }
 
-func (c *client) WakeSatellite(ctx context.Context, name, orgID string) (out chan SatelliteStatusUpdate) {
+func (c *Client) WakeSatellite(ctx context.Context, name, orgID string) (out chan SatelliteStatusUpdate) {
 	out = make(chan SatelliteStatusUpdate)
 	go func() {
 		ctxTimeout, cancel := context.WithTimeout(ctx, 5*time.Minute)
@@ -218,7 +218,7 @@ func (c *client) WakeSatellite(ctx context.Context, name, orgID string) (out cha
 	return out
 }
 
-func (c *client) SleepSatellite(ctx context.Context, name, orgID string) (out chan SatelliteStatusUpdate) {
+func (c *Client) SleepSatellite(ctx context.Context, name, orgID string) (out chan SatelliteStatusUpdate) {
 	out = make(chan SatelliteStatusUpdate)
 	go func() {
 		ctxTimeout, cancel := context.WithTimeout(ctx, 5*time.Minute)
@@ -253,7 +253,7 @@ func (c *client) SleepSatellite(ctx context.Context, name, orgID string) (out ch
 	return out
 }
 
-func (c *client) UpdateSatellite(ctx context.Context, name, orgID, version, maintenanceWindow string, dropCache bool, featureFlags []string) error {
+func (c *Client) UpdateSatellite(ctx context.Context, name, orgID, version, maintenanceWindow string, dropCache bool, featureFlags []string) error {
 	req := &pb.UpdateSatelliteRequest{
 		OrgId:                  orgID,
 		Name:                   name,

--- a/cloud/secret.go
+++ b/cloud/secret.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (c *client) Remove(ctx context.Context, path string) error {
+func (c *Client) Remove(ctx context.Context, path string) error {
 	if path == "" || path[0] != '/' {
 		return errors.Errorf("invalid path")
 	}
@@ -28,7 +28,7 @@ func (c *client) Remove(ctx context.Context, path string) error {
 	return nil
 }
 
-func (c *client) List(ctx context.Context, path string) ([]string, error) {
+func (c *Client) List(ctx context.Context, path string) ([]string, error) {
 	if path != "" && !strings.HasSuffix(path, "/") {
 		return nil, errors.Errorf("invalid path")
 	}
@@ -49,7 +49,7 @@ func (c *client) List(ctx context.Context, path string) ([]string, error) {
 	return strings.Split(string(body), "\n"), nil
 }
 
-func (c *client) Get(ctx context.Context, path string) ([]byte, error) {
+func (c *Client) Get(ctx context.Context, path string) ([]byte, error) {
 	if path == "" || path[0] != '/' || strings.HasSuffix(path, "/") {
 		return nil, errors.Errorf("invalid path")
 	}
@@ -67,7 +67,7 @@ func (c *client) Get(ctx context.Context, path string) ([]byte, error) {
 	return body, nil
 }
 
-func (c *client) Set(ctx context.Context, path string, data []byte) error {
+func (c *Client) Set(ctx context.Context, path string, data []byte) error {
 	if path == "" || path[0] != '/' {
 		return errors.Errorf("invalid path")
 	}

--- a/cloud/secret_new.go
+++ b/cloud/secret_new.go
@@ -30,7 +30,7 @@ type SecretPermission struct {
 }
 
 // ListSecrets returns a list of secrets base on the given path.
-func (c *client) ListSecrets(ctx context.Context, path string) ([]*Secret, error) {
+func (c *Client) ListSecrets(ctx context.Context, path string) ([]*Secret, error) {
 	if !strings.HasPrefix(path, "/") {
 		path = "/" + path
 	}
@@ -66,7 +66,7 @@ func (c *client) ListSecrets(ctx context.Context, path string) ([]*Secret, error
 }
 
 // GetProjectSecret gets a secret from a project secret store
-func (c *client) GetProjectSecret(ctx context.Context, org, project, secretName string) (*Secret, error) {
+func (c *Client) GetProjectSecret(ctx context.Context, org, project, secretName string) (*Secret, error) {
 	if org == "" {
 		return nil, fmt.Errorf("GetProjectSecret called with empty org")
 	}
@@ -80,7 +80,7 @@ func (c *client) GetProjectSecret(ctx context.Context, org, project, secretName 
 }
 
 // GetUserSecret gets a secret from the current user's personal secret store
-func (c *client) GetUserSecret(ctx context.Context, secretName string) (*Secret, error) {
+func (c *Client) GetUserSecret(ctx context.Context, secretName string) (*Secret, error) {
 	if secretName == "" {
 		return nil, fmt.Errorf("GetUserSecret called with empty secretName")
 	}
@@ -89,7 +89,7 @@ func (c *client) GetUserSecret(ctx context.Context, secretName string) (*Secret,
 
 // GetUserOrProjectSecret gets a secret from a project or the current user's personal secret store,
 // depending on the path being structured as /org/project/... or /user/... respectively.
-func (c *client) GetUserOrProjectSecret(ctx context.Context, path string) (*Secret, error) {
+func (c *Client) GetUserOrProjectSecret(ctx context.Context, path string) (*Secret, error) {
 	if !strings.HasPrefix(path, "/") {
 		return nil, ErrMalformedSecretPath
 	}
@@ -100,7 +100,7 @@ func (c *client) GetUserOrProjectSecret(ctx context.Context, path string) (*Secr
 	return c.getSecretV2(ctx, path)
 }
 
-func (c *client) getSecretV2(ctx context.Context, path string) (*Secret, error) {
+func (c *Client) getSecretV2(ctx context.Context, path string) (*Secret, error) {
 	res, err := c.ListSecrets(ctx, path)
 	if err != nil {
 		return nil, err
@@ -114,7 +114,7 @@ func (c *client) getSecretV2(ctx context.Context, path string) (*Secret, error) 
 }
 
 // SetSecret adds or updates the given path and secret combination.
-func (c *client) SetSecret(ctx context.Context, path string, secret []byte) error {
+func (c *Client) SetSecret(ctx context.Context, path string, secret []byte) error {
 	if !strings.HasPrefix(path, "/") {
 		path = "/" + path
 	}
@@ -133,7 +133,7 @@ func (c *client) SetSecret(ctx context.Context, path string, secret []byte) erro
 }
 
 // RemoveSecret deletes a secret by path name.
-func (c *client) RemoveSecret(ctx context.Context, path string) error {
+func (c *Client) RemoveSecret(ctx context.Context, path string) error {
 	if !strings.HasPrefix(path, "/") {
 		path = "/" + path
 	}
@@ -157,7 +157,7 @@ func (c *client) RemoveSecret(ctx context.Context, path string) error {
 }
 
 // ListSecretPermissions returns a set of user permissions for project secrets.
-func (c *client) ListSecretPermissions(ctx context.Context, path string) ([]*SecretPermission, error) {
+func (c *Client) ListSecretPermissions(ctx context.Context, path string) ([]*SecretPermission, error) {
 	if !strings.HasPrefix(path, "/") {
 		path = "/" + path
 	}
@@ -194,7 +194,7 @@ func (c *client) ListSecretPermissions(ctx context.Context, path string) ([]*Sec
 }
 
 // SetSecretPermission is used to set a user permission on a given secret path.
-func (c *client) SetSecretPermission(ctx context.Context, path, userEmail, permission string) error {
+func (c *Client) SetSecretPermission(ctx context.Context, path, userEmail, permission string) error {
 	if !strings.HasPrefix(path, "/") {
 		path = "/" + path
 	}
@@ -218,7 +218,7 @@ func (c *client) SetSecretPermission(ctx context.Context, path, userEmail, permi
 }
 
 // RemoveSecretPermission removes a secret permission for the user and path.
-func (c *client) RemoveSecretPermission(ctx context.Context, path, userEmail string) error {
+func (c *Client) RemoveSecretPermission(ctx context.Context, path, userEmail string) error {
 	if !strings.HasPrefix(path, "/") {
 		path = "/" + path
 	}

--- a/cmd/earthly/account_cmds.go
+++ b/cmd/earthly/account_cmds.go
@@ -666,7 +666,7 @@ func (app *earthlyApp) printLogSharingMessage() {
 		"\tearthly config global.disable_log_sharing true")
 }
 
-func (app *earthlyApp) loginAndSavePasswordCredentials(ctx context.Context, cloudClient cloud.Client, email, password string) error {
+func (app *earthlyApp) loginAndSavePasswordCredentials(ctx context.Context, cloudClient *cloud.Client, email, password string) error {
 	err := cloudClient.SetPasswordCredentials(ctx, email, password)
 	if err != nil {
 		return err

--- a/cmd/earthly/buildkit.go
+++ b/cmd/earthly/buildkit.go
@@ -97,7 +97,7 @@ func (app *earthlyApp) initFrontend(cliCtx *cli.Context) error {
 	return nil
 }
 
-func (app *earthlyApp) getBuildkitClient(cliCtx *cli.Context, cloudClient cloud.Client) (*client.Client, error) {
+func (app *earthlyApp) getBuildkitClient(cliCtx *cli.Context, cloudClient *cloud.Client) (*client.Client, error) {
 	err := app.initFrontend(cliCtx)
 	if err != nil {
 		return nil, err
@@ -132,7 +132,7 @@ func (app *earthlyApp) handleTLSCertificateSettings(context *cli.Context) {
 	app.buildkitdSettings.ServerTLSKey = app.cfg.Global.ServerTLSKey
 }
 
-func (app *earthlyApp) configureSatellite(cliCtx *cli.Context, cloudClient cloud.Client, gitAuthor, gitConfigEmail string) error {
+func (app *earthlyApp) configureSatellite(cliCtx *cli.Context, cloudClient *cloud.Client, gitAuthor, gitConfigEmail string) error {
 	if cliCtx.IsSet("buildkit-host") && cliCtx.IsSet("satellite") {
 		return errors.New("cannot specify both buildkit-host and satellite")
 	}
@@ -204,7 +204,7 @@ func (app *earthlyApp) isUsingSatellite(cliCtx *cli.Context) bool {
 	return app.cfg.Satellite.Name != "" || app.satelliteName != ""
 }
 
-func (app *earthlyApp) reserveSatellite(ctx context.Context, cloudClient cloud.Client, name, orgID, gitAuthor, gitConfigEmail string) error {
+func (app *earthlyApp) reserveSatellite(ctx context.Context, cloudClient *cloud.Client, name, orgID, gitAuthor, gitConfigEmail string) error {
 	console := app.console.WithPrefix("satellite")
 	_, isCI := analytics.DetectCI()
 	out := cloudClient.ReserveSatellite(ctx, name, orgID, gitAuthor, gitConfigEmail, isCI)

--- a/cmd/earthly/common.go
+++ b/cmd/earthly/common.go
@@ -17,7 +17,7 @@ import (
 	"github.com/earthly/earthly/util/fileutil"
 )
 
-func (app *earthlyApp) newCloudClient() (cloud.Client, error) {
+func (app *earthlyApp) newCloudClient() (*cloud.Client, error) {
 	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock,
 		app.authToken, app.authJWT, app.installationName, app.requestID, app.console.Warnf)
 	if err != nil {

--- a/cmd/earthly/project_cmds.go
+++ b/cmd/earthly/project_cmds.go
@@ -322,7 +322,7 @@ func (app *earthlyApp) actionProjectMemberUpdate(cliCtx *cli.Context) error {
 }
 
 // projectOrgName returns the specified org or retrieves the default org from the API.
-func (app *earthlyApp) projectOrgName(ctx context.Context, cloudClient cloud.Client) (string, error) {
+func (app *earthlyApp) projectOrgName(ctx context.Context, cloudClient *cloud.Client) (string, error) {
 
 	if app.orgName != "" {
 		return app.orgName, nil

--- a/cmd/earthly/satellite_cmds.go
+++ b/cmd/earthly/satellite_cmds.go
@@ -252,7 +252,7 @@ func (app *earthlyApp) printSatellitesJSON(satellites []cloud.SatelliteInstance,
 	fmt.Println(string(b))
 }
 
-func (app *earthlyApp) getSatelliteOrgID(ctx context.Context, cloudClient cloud.Client) (string, error) {
+func (app *earthlyApp) getSatelliteOrgID(ctx context.Context, cloudClient *cloud.Client) (string, error) {
 	// We are cheating here and forcing a re-auth before running any satellite commands.
 	// This is because there is an issue on the backend where the token might be outdated
 	// if a user was invited to an org recently after already logging-in.

--- a/logbus/logstreamer/logstreamer.go
+++ b/logbus/logstreamer/logstreamer.go
@@ -21,7 +21,7 @@ import (
 // log deltas to the cloud. It retries on transient errors.
 type LogStreamer struct {
 	bus             *logbus.Bus
-	c               cloud.Client
+	c               *cloud.Client
 	buildID         string
 	initialManifest *logstream.RunManifest
 	doneCh          chan struct{}
@@ -33,7 +33,7 @@ type LogStreamer struct {
 }
 
 // New creates a new LogStreamer.
-func New(ctx context.Context, bus *logbus.Bus, c cloud.Client, initialManifest *logstream.RunManifest) *LogStreamer {
+func New(ctx context.Context, bus *logbus.Bus, c *cloud.Client, initialManifest *logstream.RunManifest) *LogStreamer {
 	ls := &LogStreamer{
 		bus:             bus,
 		c:               c,

--- a/logbus/setup/setup.go
+++ b/logbus/setup/setup.go
@@ -72,7 +72,7 @@ func (bs *BusSetup) SetOrgAndProject(orgName, projectName string) {
 
 // StartLogStreamer starts a LogStreamer for the given build. The
 // LogStreamer streams logs to the cloud.
-func (bs *BusSetup) StartLogStreamer(ctx context.Context, c cloud.Client) {
+func (bs *BusSetup) StartLogStreamer(ctx context.Context, c *cloud.Client) {
 	bs.LogStreamer = logstreamer.New(ctx, bs.Bus, c, bs.InitialManifest)
 }
 

--- a/util/llbutil/authprovider/cloudauth/authprovider.go
+++ b/util/llbutil/authprovider/cloudauth/authprovider.go
@@ -45,7 +45,7 @@ type ProjectBasedAuthProvider interface {
 	AddProject(org, project string)
 }
 
-func NewProvider(cfg *configfile.ConfigFile, cloudClient cloud.Client, console conslogging.ConsoleLogger) session.Attachable {
+func NewProvider(cfg *configfile.ConfigFile, cloudClient *cloud.Client, console conslogging.ConsoleLogger) session.Attachable {
 	return &authProvider{
 		authConfigCache: map[string]*authConfig{},
 		config:          cfg,
@@ -77,7 +77,7 @@ type authProvider struct {
 	// earthly-add on
 	orgProjects     []orgProject
 	seenOrgProjects map[string]struct{}
-	cloudClient     cloud.Client
+	cloudClient     *cloud.Client
 	console         conslogging.ConsoleLogger
 
 	// The need for this mutex is not well understood.

--- a/util/llbutil/secretprovider/cloud.go
+++ b/util/llbutil/secretprovider/cloud.go
@@ -11,11 +11,11 @@ import (
 )
 
 type cloudStore struct {
-	client cloud.Client
+	client *cloud.Client
 }
 
 // NewCloudStore returns a new cloud secret store
-func NewCloudStore(client cloud.Client) secrets.SecretStore {
+func NewCloudStore(client *cloud.Client) secrets.SecretStore {
 	return &cloudStore{
 		client: client,
 	}


### PR DESCRIPTION
As per https://github.com/golang/go/wiki/CodeReviewComments#interfaces an interface should be defined wherever it is used, and not in the cloud package.

If an interface is needed by a specific caller of the client, then it's best to create a much smaller interface tied to the use of the client, which will make it more clear which methods must bet implemented for that specific portion of the code.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>