### PR TITLE
logbus/logstreamer: fix drain blocking on read from nil channel

### DIFF
--- a/logbus/logstreamer/import_test.go
+++ b/logbus/logstreamer/import_test.go
@@ -1,0 +1,15 @@
+package logstreamer_test
+
+import (
+	"git.sr.ht/~nelsam/hel/v4/pkg/pers"
+	"github.com/poy/onpar/matchers"
+)
+
+var (
+	not          = matchers.Not
+	haveOccurred = matchers.HaveOccurred
+
+	haveMethodExecuted = pers.HaveMethodExecuted
+	within             = pers.Within
+	storeArgs          = pers.StoreArgs
+)

--- a/logbus/logstreamer/logstreamer_chaos_test.go
+++ b/logbus/logstreamer/logstreamer_chaos_test.go
@@ -21,7 +21,7 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-const testTimeout = 10 * time.Second
+const chaosTestTimeout = 10 * time.Second
 
 func newTestLogStreamer(ctx context.Context, client *mockCloudClient, initMani *logstream.RunManifest, opts ...logstreamer.Opt) (*logstreamer.LogStreamer, func(*testing.T)) {
 	str := logstreamer.New(ctx, logbus.New(), client, initMani, opts...)
@@ -47,8 +47,8 @@ func TestDataRace_InitManifest(t *testing.T) {
 }
 
 func exerciseInitManifest(t *testing.T) {
-	client := newMockCloudClient(t, testTimeout)
-	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	client := newMockCloudClient(t, chaosTestTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), chaosTestTimeout)
 	defer cancel()
 
 	initManifest := &logstream.RunManifest{
@@ -97,7 +97,7 @@ func exerciseInitManifest(t *testing.T) {
 	expect.Expect(t, client).To(
 		pers.HaveMethodExecuted(
 			"StreamLogs",
-			pers.Within(testTimeout),
+			pers.Within(chaosTestTimeout),
 			pers.StoreArgs(&streamCtx, &buildID, &deltas),
 		),
 	)
@@ -150,8 +150,8 @@ func exerciseDeadlock(t *testing.T) {
 	runtime.GOMAXPROCS(2)
 	const chSize = 10
 
-	client := newMockCloudClient(t, testTimeout)
-	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	client := newMockCloudClient(t, chaosTestTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), chaosTestTimeout)
 	defer cancel()
 
 	// We need a heavily congested log streamer, with a full channel.
@@ -164,7 +164,7 @@ func exerciseDeadlock(t *testing.T) {
 	expect.Expect(t, client).To(
 		pers.HaveMethodExecuted(
 			"StreamLogs",
-			pers.Within(testTimeout),
+			pers.Within(chaosTestTimeout),
 			pers.WithArgs(pers.Any, "foo", pers.Any),
 		),
 	)
@@ -219,7 +219,7 @@ func exerciseDeadlock(t *testing.T) {
 	// to `WriteAsync` should eventually unblock, so all done channels should
 	// close.
 
-	timeout := time.After(testTimeout)
+	timeout := time.After(chaosTestTimeout)
 
 	for i, ch := range append(unblocked, extrasUnblocked...) {
 		select {

--- a/logbus/logstreamer/logstreamer_test.go
+++ b/logbus/logstreamer/logstreamer_test.go
@@ -1,0 +1,129 @@
+package logstreamer_test
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"git.sr.ht/~nelsam/hel/v4/pkg/pers"
+	"github.com/earthly/cloud-api/logstream"
+	"github.com/earthly/earthly/cloud"
+	"github.com/earthly/earthly/logbus/logstreamer"
+	"github.com/pkg/errors"
+	"github.com/poy/onpar/expect"
+	"github.com/poy/onpar/v2"
+)
+
+const testTimeout = time.Second
+
+func TestLogstreamer(topT *testing.T) {
+	type testCtx struct {
+		t      *testing.T
+		expect expect.Expectation
+		ctx    context.Context
+
+		mockClient *mockCloudClient
+		mockBus    *mockLogBus
+
+		streamer *logstreamer.LogStreamer
+	}
+
+	o := onpar.BeforeEach(onpar.New(topT), func(t *testing.T) testCtx {
+		expect := expect.New(t)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+		t.Cleanup(cancel)
+
+		bus := newMockLogBus(t, testTimeout)
+		client := newMockCloudClient(t, testTimeout)
+
+		initManifest := &logstream.RunManifest{
+			BuildId: "foo",
+			Version: 1,
+		}
+
+		streamer := logstreamer.New(ctx, bus, client, initManifest)
+		return testCtx{
+			t:          t,
+			expect:     expect,
+			ctx:        ctx,
+			mockClient: client,
+			mockBus:    bus,
+			streamer:   streamer,
+		}
+	})
+
+	o.Spec("after close, the deltas continually return EOF", func(tt testCtx) {
+		var (
+			ctx     context.Context
+			buildID string
+			deltas  cloud.Deltas
+		)
+		tt.expect(tt.mockClient).To(haveMethodExecuted(
+			"StreamLogs",
+			within(testTimeout),
+			storeArgs(&ctx, &buildID, &deltas),
+		))
+		_, _ = deltas.Next(tt.ctx) // ignore the initial manifest
+
+		go tt.streamer.Close()
+
+		_, err := deltas.Next(tt.ctx)
+		tt.expect(err).To(beErr(io.EOF))
+
+		// If the code doesn't check for a nil channel and tries to read off of
+		// it, then it will block until the context is cancelled instead of
+		// returning EOF.
+		_, err = deltas.Next(tt.ctx)
+		tt.expect(err).To(beErr(io.EOF))
+
+		pers.Return(tt.mockClient.StreamLogsOutput, nil)
+	})
+
+	o.Spec("Close can finish even when it is being flooded with Write calls", func(tt testCtx) {
+		tt.expect(tt.mockClient).To(haveMethodExecuted(
+			"StreamLogs",
+			within(testTimeout),
+		))
+
+		go func() {
+			for {
+				select {
+				case <-tt.ctx.Done():
+					return
+				default:
+					tt.streamer.Write(&logstream.Delta{})
+				}
+			}
+		}()
+
+		// At the time of this writing, returning nil here just closes the
+		// retryLoop. Since we're exercising the `deltas` closing, not the
+		// retryLoop, returning here should do what we want.
+		//
+		// If returning here automatically closes the streamer so that it
+		// ignores calls to Write, then this test will no longer be valid.
+		pers.Return(tt.mockClient.StreamLogsOutput, nil)
+
+		tt.expect(tt.streamer.Close()).To(not(haveOccurred()))
+	})
+}
+
+type beErrMatcher struct {
+	err error
+}
+
+func beErr(err error) beErrMatcher {
+	return beErrMatcher{err: err}
+}
+
+func (m beErrMatcher) Match(actual any) (any, error) {
+	err, ok := actual.(error)
+	if !ok {
+		return nil, errors.Errorf("expected type %T to implement error", actual)
+	}
+	if !errors.Is(err, m.err) {
+		return nil, errors.Errorf("expected errors.Is([%v], [%v]) to be true", err, m.err)
+	}
+	return actual, nil
+}


### PR DESCRIPTION
I also added a test for `Close()` draining when it's being flooded with messages, because I think it would have issues with that without the mutex lock (and since it's a channel, I wouldn't be surprised if the mutex lock is removed some day). However, due to the mutex lock, it's actually not a current problem. But having a test there for if/when the mutex lock is removed is nice.