### PR TITLE
ast: handle unindented comments in recipe bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 
 - The `unexpected env` warning can now be silenced by creating a `.arg` or `.secret` file. [#2696](https://github.com/earthly/earthly/issues/2696).
 
+### Fixed
+
+- Unindented comments in the middle of recipe blocks no longer cause parser errors. [#2697](https://github.com/earthly/earthly/issues/2697)
+
 ## v0.7.0 - 2023-02-21
 
 The documentation for this version is available at the [Earthly 0.7 documentation page](https://docs.earthly.dev/v/earthly-0.7/).

--- a/ast/ast_test.go
+++ b/ast/ast_test.go
@@ -326,6 +326,26 @@ bar:
 			tt.expect(tgt.Name).To(equal("bar"))
 			tt.expect(tgt.Docs).To(equal("bar is a documented target\n"))
 		})
+
+		o.Spec("it does not treat comments in otherwise-empty targets as documentation for the next target", func(tt testCtx) {
+			mockEarthfile(tt.t, tt.reader, []byte(`
+VERSION 0.7
+
+
+foo:
+    # bar is not a documentation line
+
+bar:
+    RUN echo bar
+`))
+			f, err := ast.ParseOpts(context.Background(), ast.FromReader(tt.reader))
+			tt.expect(err).To(not(haveOccurred()))
+
+			tt.expect(f.Targets).To(haveLen(2))
+			tgt := f.Targets[1]
+			tt.expect(tgt.Name).To(equal("bar"))
+			tt.expect(tgt.Docs).To(equal(""))
+		})
 	})
 }
 


### PR DESCRIPTION
This solves an issue where unindented comments in recipe bodies would trigger a DEDENT token, causing parser errors when the comments really should just be ignored.

This also incidentally allows documentation to be on a line immediately following a comment if that comment is in an indented block (e.g. if the previous target ended with a comment).

Resolves #2697 