### PR TITLE
silence unexpected env warning when .arg exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 
 ## Unreleased
 
+### Changed
+
+- The `unexpected env` warning can now be silenced by creating a `.arg` or `.secret` file. [#2696](https://github.com/earthly/earthly/issues/2696).
+
 ## v0.7.0 - 2023-02-21
 
 The documentation for this version is available at the [Earthly 0.7 documentation page](https://docs.earthly.dev/v/earthly-0.7/).

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -620,10 +620,15 @@ chown-test:
 
 dotenv-test:
     RUN echo "TEST_IN_DOTENV=this-should-not-appear-as-a-build-arg" >.env
+    DO +RUN_EARTHLY --earthfile=dotenv.earth --extra_args="--no-output" --target=+test-no-dotenv --output_contain="unexpected env .TEST_IN_DOTENV.: as of v0.7.0, --build-arg values must be defined in .arg"
+
+    RUN touch .arg
+    DO +RUN_EARTHLY --earthfile=dotenv.earth --extra_args="--no-output" --target=+test-no-dotenv --output_does_not_contain="unexpected env .TEST_IN_DOTENV.: as of v0.7.0, --build-arg values must be defined in .arg"
+
     RUN echo "TEST_ARG_1=abracadabra" >.arg
     RUN echo "TEST_SEC_2=foo" >.secret
     RUN echo "TEST_ARG_3=bar" >>.arg
-    DO +RUN_EARTHLY --earthfile=dotenv.earth --extra_args="--no-output" --target=+test --output_contains="unexpected env .TEST_IN_DOTENV.: as of v0.7.0, --build-arg values must be defined in .arg"
+    DO +RUN_EARTHLY --earthfile=dotenv.earth --extra_args="--no-output" --target=+test
 
     # test non-standard .arg paths can be used
     RUN mv .arg .some-other-arg
@@ -1272,6 +1277,7 @@ RUN_EARTHLY:
     ARG use_tmpfs=true
     ARG exec_cmd=
     ARG output_contains=
+    ARG output_does_not_contain=
     ARG grep_flags=
     ARG verbose=1
     IF [ ! -z "$earthfile" ]
@@ -1329,7 +1335,13 @@ RUN_EARTHLY:
         fi
         if [ -n \"$output_contains\" ]; then
             if ! grep $grep_flags \"$output_contains\" earthly.output >/dev/null; then
-                echo ERROR: earthly output did not contain \\\"$output_contains\\\"
+                echo \"ERROR: earthly output did not contain \\\"$output_contains\\\"\"
+                exit 1
+            fi
+        fi
+        if [ -n \"$output_does_not_contain\" ]; then
+            if grep $grep_flags \"$output_does_not_contain\" earthly.output >/dev/null; then
+                echo \"ERROR: earthly output contains \\\"$output_does_not_contain\\\" (which is unexpected)\"
                 exit 1
             fi
         fi


### PR DESCRIPTION
The `unexpected env ... --build-arg values must be defined in .arg` warning can now be silenced by creating a .arg or .secret file.