### PR TITLE
display --ssh in RUN command

### DIFF
--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -1817,10 +1817,11 @@ func (c *Converter) internalRun(ctx context.Context, opts ConvertRunOpts) (pllb.
 
 	runOpts = append(runOpts, mountRunOpts...)
 	commandStr := fmt.Sprintf(
-		"%s %s%s%s%s%s%s",
+		"%s %s%s%s%s%s%s%s",
 		opts.CommandName, // e.g. "RUN", "IF", "FOR", "ARG"
 		strIf(opts.Privileged, "--privileged "),
 		strIf(opts.Push, "--push "),
+		strIf(opts.WithSSH, "--ssh "),
 		strIf(opts.NoCache, "--no-cache "),
 		strIf(opts.Interactive, "--interactive "),
 		strIf(opts.InteractiveKeep, "--interactive-keep "),


### PR DESCRIPTION
running `RUN --push --ssh ...` didn't correctly display the --ssh flag in the output logs:

Before:

    --> RUN --push stat $SSH_AUTH_SOCK

After:

    --> RUN --push --ssh stat $SSH_AUTH_SOCK