### PR TITLE
Allow toggling TLS and setting CA from CLI/environment

### DIFF
--- a/cmd/earthly/buildkit.go
+++ b/cmd/earthly/buildkit.go
@@ -72,7 +72,7 @@ func (app *earthlyApp) initFrontend(cliCtx *cli.Context) error {
 	app.buildkitdSettings.BuildkitAddress = app.buildkitHost
 	app.buildkitdSettings.LocalRegistryAddress = app.localRegistryHost
 	app.buildkitdSettings.UseTCP = bkURL.Scheme == "tcp"
-	app.buildkitdSettings.UseTLS = app.cfg.Global.TLSEnabled
+	app.buildkitdSettings.UseTLS = app.tlsEnabled || app.cfg.Global.TLSEnabled
 	app.buildkitdSettings.MaxParallelism = app.cfg.Global.BuildkitMaxParallelism
 	app.buildkitdSettings.CacheSizeMb = app.cfg.Global.BuildkitCacheSizeMb
 	app.buildkitdSettings.CacheSizePct = app.cfg.Global.BuildkitCacheSizePct
@@ -111,11 +111,9 @@ func (app *earthlyApp) getBuildkitClient(cliCtx *cli.Context, cloudClient *cloud
 }
 
 func (app *earthlyApp) handleTLSCertificateSettings(context *cli.Context) {
-	if !app.cfg.Global.TLSEnabled {
+	if !(app.cfg.Global.TLSEnabled || app.tlsEnabled) {
 		return
 	}
-
-	app.buildkitdSettings.TLSCA = app.cfg.Global.TLSCA
 
 	if !context.IsSet("tlscert") && app.cfg.Global.ClientTLSCert != "" {
 		app.certPath = app.cfg.Global.ClientTLSCert
@@ -125,8 +123,13 @@ func (app *earthlyApp) handleTLSCertificateSettings(context *cli.Context) {
 		app.keyPath = app.cfg.Global.ClientTLSKey
 	}
 
+	if !context.IsSet("tlsca") && app.cfg.Global.TLSCA != "" {
+		app.caPath = app.cfg.Global.TLSCA
+	}
+
 	app.buildkitdSettings.ClientTLSCert = app.certPath
 	app.buildkitdSettings.ClientTLSKey = app.keyPath
+	app.buildkitdSettings.TLSCA = app.caPath
 
 	app.buildkitdSettings.ServerTLSCert = app.cfg.Global.ServerTLSCert
 	app.buildkitdSettings.ServerTLSKey = app.cfg.Global.ServerTLSKey

--- a/cmd/earthly/flags.go
+++ b/cmd/earthly/flags.go
@@ -317,6 +317,7 @@ func (app *earthlyApp) buildFlags() []cli.Flag {
 		},
 		&cli.StringFlag{
 			Name:        "tlscert",
+			Aliases:     []string{"tls-cert"},
 			Value:       "./certs/earthly_cert.pem",
 			EnvVars:     []string{"EARTHLY_TLS_CERT"},
 			Usage:       wrap("The path to the client TLS cert", "If relative, will be interpreted as relative to the ~/.earthly folder."),
@@ -325,10 +326,27 @@ func (app *earthlyApp) buildFlags() []cli.Flag {
 		},
 		&cli.StringFlag{
 			Name:        "tlskey",
+			Aliases:     []string{"tls-key"},
 			Value:       "./certs/earthly_key.pem",
 			EnvVars:     []string{"EARTHLY_TLS_KEY"},
 			Usage:       wrap("The path to the client TLS key.", "If relative, will be interpreted as relative to the ~/.earthly folder."),
 			Destination: &app.keyPath,
+			Hidden:      true,
+		},
+		&cli.StringFlag{
+			Name:        "tlsca",
+			Aliases:     []string{"tls-ca"},
+			Value:       "./certs/earthly_ca.pem",
+			EnvVars:     []string{"EARTHLY_TLS_CA"},
+			Usage:       wrap("The path to the client CA cert.", "If relative, will be interpreted as relative to the ~/.earthly folder."),
+			Destination: &app.caPath,
+			Hidden:      true,
+		},
+		&cli.BoolFlag{
+			Name:        "tls-enabled",
+			EnvVars:     []string{"EARTHLY_TLS_ENABLED"},
+			Usage:       "If TLS should be used to communicate with Buildkit",
+			Destination: &app.tlsEnabled,
 			Hidden:      true,
 		},
 		&cli.StringFlag{

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -135,6 +135,8 @@ type cliFlags struct {
 	conversionParallelism           int
 	certPath                        string
 	keyPath                         string
+	caPath                          string
+	tlsEnabled                      bool
 	disableAnalytics                bool
 	featureFlagOverrides            string
 	localRegistryHost               string


### PR DESCRIPTION
This also adds aliases to other existing TLS-related flags to more closely match existing conventions around 'translating' between a CLI flag, environment variable, and config entry.