### PR TITLE
Update base image for scala example

### DIFF
--- a/examples/scala/Earthfile
+++ b/examples/scala/Earthfile
@@ -1,5 +1,5 @@
 VERSION 0.7
-FROM hseeberger/scala-sbt:11.0.7_1.3.13_2.11.12
+FROM sbtscala/scala-sbt:eclipse-temurin-jammy-17.0.5_8_1.8.2_2.13.10
 WORKDIR /scala-example
 
 deps:


### PR DESCRIPTION
The scala example did not work on my MacBook Pro M2 Max running colima. The process was stalled indefinitely (or at least over 1 hour).  Memory was not the issue, but the base image.
Just running a compilation with `docker run -it --rm -v $PWD:/work -w /work hseeberger/scala-sbt:11.0.7_1.3.13_2.11.12 sbt package` also did not compleet. 
Using the `scala-sbt` as base image did work.