### PR TITLE
option for skipping cgroup setup

### DIFF
--- a/buildkitd/entrypoint.sh
+++ b/buildkitd/entrypoint.sh
@@ -44,6 +44,8 @@ fi
 if [ -f "/sys/fs/cgroup/cgroup.controllers" ]; then
     echo "detected cgroups v2; buildkit/entrypoint.sh running under pid=$$"
 
+    cat /sys/fs/cgroup/cgroup.procs > /dev/null || (echo "failed to cat cgroup.procs, unable to proceed." && exit 1)
+
     mkdir -p /sys/fs/cgroup/earthly
     mkdir -p /sys/fs/cgroup/buildkit
     echo "$$" > /sys/fs/cgroup/earthly/cgroup.procs

--- a/buildkitd/entrypoint.sh
+++ b/buildkitd/entrypoint.sh
@@ -41,7 +41,9 @@ if [ -z "$EARTHLY_CACHE_VERSION" ]; then
     exit 1
 fi
 
-if [ -f "/sys/fs/cgroup/cgroup.controllers" ]; then
+if [ "$EARTHLY_SKIP_CGROUP_SETUP" = "true" ]; then
+    echo "cgroup setup skipped; buildkit/entrypoint.sh running under pid=$$"
+elif [ -f "/sys/fs/cgroup/cgroup.controllers" ]; then
     echo "detected cgroups v2; buildkit/entrypoint.sh running under pid=$$"
 
     cat /sys/fs/cgroup/cgroup.procs > /dev/null || (echo "failed to cat cgroup.procs, unable to proceed." && exit 1)


### PR DESCRIPTION
skip cgroup setup when `EARTHLY_SKIP_CGROUP_SETUP = true`

This can also be set via `~/.earthly/config.yml`:

```
global:
    buildkit_additional_args: [ "-e", "EARTHLY_SKIP_CGROUP_SETUP=true" ]
```

When not skipped, fail fast if cgroup access is denied.