### PR TITLE
ARG: add an --explicit-env feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 ### Added
 
 - Support for `RUN --network=none`, which prevents programs from using any network resources. [#834](https://github.com/earthly/earthly/issues/834)
+- Added an experimental feature that prevents `ARG` and `FOR ... IN ...` from impacting the environment of commands unless `--env` is used explicitly. [#1575](https://github.com/earthly/earthly/issues/1575)
+  To enable this feature use `VERSION --arg-explicit-env 0.7`.
 
 ### Changed
 

--- a/cmd/earthly/build_cmd.go
+++ b/cmd/earthly/build_cmd.go
@@ -95,7 +95,7 @@ func (app *earthlyApp) warnIfArgContainsBuildArg(flagArgs []string) {
 func (app *earthlyApp) combineVariables(dotEnvMap map[string]string, flagArgs []string) (*variables.Scope, error) {
 	dotEnvVars := variables.NewScope()
 	for k, v := range dotEnvMap {
-		dotEnvVars.AddInactive(k, v)
+		dotEnvVars.Add(k, v)
 	}
 	buildArgs := append([]string{}, app.buildArgs.Value()...)
 	buildArgs = append(buildArgs, flagArgs...)

--- a/earthfile2llb/earthfile2llb.go
+++ b/earthfile2llb/earthfile2llb.go
@@ -331,7 +331,7 @@ func GetTargetArgs(ctx context.Context, resolver *buildcontext.Resolver, gwClien
 	for _, stmt := range t.Recipe {
 		if stmt.Command != nil && stmt.Command.Name == "ARG" {
 			isBase := t.Name == "base"
-			// since Arg opts are ignored (and feature flags are not available) we set explicitGlobalArgFlag as false
+			// since Arg opts are ignored (and feature flags are not available) we set feature flags to false
 			explicitGlobal := false
 			_, argName, _, err := parseArgArgs(ctx, *stmt.Command, isBase, explicitGlobal)
 			if err != nil {
@@ -341,5 +341,4 @@ func GetTargetArgs(ctx context.Context, resolver *buildcontext.Resolver, gwClien
 		}
 	}
 	return args, nil
-
 }

--- a/earthfile2llb/earthfile2llb.go
+++ b/earthfile2llb/earthfile2llb.go
@@ -333,7 +333,8 @@ func GetTargetArgs(ctx context.Context, resolver *buildcontext.Resolver, gwClien
 			isBase := t.Name == "base"
 			// since Arg opts are ignored (and feature flags are not available) we set feature flags to false
 			explicitGlobal := false
-			_, argName, _, err := parseArgArgs(ctx, *stmt.Command, isBase, explicitGlobal)
+			explicitEnv := false
+			_, argName, _, err := parseArgArgs(ctx, *stmt.Command, isBase, explicitGlobal, explicitEnv)
 			if err != nil {
 				return nil, errors.Wrapf(err, "failed to parse ARG arguments %v", stmt.Command.Args)
 			}

--- a/earthfile2llb/flags.go
+++ b/earthfile2llb/flags.go
@@ -19,6 +19,7 @@ type forOpts struct {
 	Secrets    []string `long:"secret" description:"Make available a secret"`
 	Mounts     []string `long:"mount" description:"Mount a file or directory"`
 	Separators string   `long:"sep" description:"The separators to use for tokenizing the output of the IN expression. Defaults to '\n\t '"`
+	Env        bool     `long:"env" description:"Pass the FOR variable to the buildkit context as an environment variable"`
 }
 
 type runOpts struct {
@@ -117,6 +118,7 @@ type importOpts struct {
 type argOpts struct {
 	Required bool `long:"required" description:"Require argument to be non-empty"`
 	Global   bool `long:"global" description:"Global argument to make available to all other targets"`
+	Env      bool `long:"env" description:"Env argument to be passed through to the buildkit context"`
 }
 
 type pipelineOpts struct {

--- a/earthfile2llb/interpreter.go
+++ b/earthfile2llb/interpreter.go
@@ -171,19 +171,23 @@ func (i *Interpreter) handleStatement(ctx context.Context, stmt spec.Statement) 
 	ctx = ContextWithSourceLocation(ctx, stmt.SourceLocation)
 	if stmt.Command != nil {
 		return i.handleCommand(ctx, *stmt.Command)
-	} else if stmt.With != nil {
-		return i.handleWith(ctx, *stmt.With)
-	} else if stmt.If != nil {
-		return i.handleIf(ctx, *stmt.If)
-	} else if stmt.For != nil {
-		return i.handleFor(ctx, *stmt.For)
-	} else if stmt.Wait != nil {
-		return i.handleWait(ctx, *stmt.Wait)
-	} else if stmt.Try != nil {
-		return i.handleTry(ctx, *stmt.Try)
-	} else {
-		return i.errorf(stmt.SourceLocation, "unexpected statement type")
 	}
+	if stmt.With != nil {
+		return i.handleWith(ctx, *stmt.With)
+	}
+	if stmt.If != nil {
+		return i.handleIf(ctx, *stmt.If)
+	}
+	if stmt.For != nil {
+		return i.handleFor(ctx, *stmt.For)
+	}
+	if stmt.Wait != nil {
+		return i.handleWait(ctx, *stmt.Wait)
+	}
+	if stmt.Try != nil {
+		return i.handleTry(ctx, *stmt.Try)
+	}
+	return i.errorf(stmt.SourceLocation, "unexpected statement type")
 }
 
 func (i *Interpreter) handleCommand(ctx context.Context, cmd spec.Command) (err error) {

--- a/features/features.go
+++ b/features/features.go
@@ -55,6 +55,7 @@ type Features struct {
 	NoUseRegistryForWithDocker bool `long:"no-use-registry-for-with-docker" description:"disable use-registry-for-with-docker"`
 	TryFinally                 bool `long:"try" description:"allow the use of the TRY/FINALLY commands"`
 	NoNetwork                  bool `long:"no-network" description:"allow the use of RUN --network=none commands"`
+	ArgExplicitEnv             bool `long:"arg-explicit-env" description:"require args to have explicit settings to be used as environment variables"`
 
 	Major int
 	Minor int

--- a/features/features_test.go
+++ b/features/features_test.go
@@ -1,12 +1,14 @@
-package features
+package features_test
 
 import (
-	"fmt"
+	"reflect"
 	"testing"
+
+	"github.com/earthly/earthly/features"
 )
 
 func TestFeaturesStringEnabled(t *testing.T) {
-	fts := &Features{
+	fts := &features.Features{
 		Major:              0,
 		Minor:              5,
 		ReferencedSaveOnly: true,
@@ -16,7 +18,7 @@ func TestFeaturesStringEnabled(t *testing.T) {
 }
 
 func TestFeaturesStringDisabled(t *testing.T) {
-	fts := &Features{
+	fts := &features.Features{
 		Major:              1,
 		Minor:              1,
 		ReferencedSaveOnly: false,
@@ -26,8 +28,8 @@ func TestFeaturesStringDisabled(t *testing.T) {
 }
 
 func TestApplyFlagOverrides(t *testing.T) {
-	fts := &Features{}
-	err := ApplyFlagOverrides(fts, "referenced-save-only")
+	fts := &features.Features{}
+	err := features.ApplyFlagOverrides(fts, "referenced-save-only")
 	Nil(t, err)
 	Equal(t, true, fts.ReferencedSaveOnly)
 	Equal(t, false, fts.UseCopyIncludePatterns)
@@ -37,8 +39,8 @@ func TestApplyFlagOverrides(t *testing.T) {
 }
 
 func TestApplyFlagOverridesWithDashDashPrefix(t *testing.T) {
-	fts := &Features{}
-	err := ApplyFlagOverrides(fts, "--referenced-save-only")
+	fts := &features.Features{}
+	err := features.ApplyFlagOverrides(fts, "--referenced-save-only")
 	Nil(t, err)
 	Equal(t, true, fts.ReferencedSaveOnly)
 	Equal(t, false, fts.UseCopyIncludePatterns)
@@ -48,8 +50,8 @@ func TestApplyFlagOverridesWithDashDashPrefix(t *testing.T) {
 }
 
 func TestApplyFlagOverridesMultipleFlags(t *testing.T) {
-	fts := &Features{}
-	err := ApplyFlagOverrides(fts, "referenced-save-only,use-copy-include-patterns,no-implicit-ignore")
+	fts := &features.Features{}
+	err := features.ApplyFlagOverrides(fts, "referenced-save-only,use-copy-include-patterns,no-implicit-ignore")
 	Nil(t, err)
 	Equal(t, true, fts.ReferencedSaveOnly)
 	Equal(t, true, fts.UseCopyIncludePatterns)
@@ -59,8 +61,8 @@ func TestApplyFlagOverridesMultipleFlags(t *testing.T) {
 }
 
 func TestApplyFlagOverridesEmptyString(t *testing.T) {
-	fts := &Features{}
-	err := ApplyFlagOverrides(fts, "")
+	fts := &features.Features{}
+	err := features.ApplyFlagOverrides(fts, "")
 	Nil(t, err)
 	Equal(t, false, fts.ReferencedSaveOnly)
 	Equal(t, false, fts.UseCopyIncludePatterns)
@@ -69,44 +71,64 @@ func TestApplyFlagOverridesEmptyString(t *testing.T) {
 	Equal(t, false, fts.NoImplicitIgnore)
 }
 
-func TestVersionAtLeast(t *testing.T) {
-	tests := []struct {
-		earthlyVer Features
-		major      int
-		minor      int
-		expected   bool
+func TestAvailableFlags(t *testing.T) {
+	// This test feels like it may be overkill, but it's nice to know that if we
+	// introduce a typo we have to introduce it twice for our tests to still
+	// pass.
+	for _, tt := range []struct {
+		flag  string
+		field string
 	}{
-		{
-			earthlyVer: Features{Major: 0, Minor: 6},
-			major:      0,
-			minor:      5,
-			expected:   true,
-		},
-		{
-			earthlyVer: Features{Major: 0, Minor: 6},
-			major:      0,
-			minor:      7,
-			expected:   false,
-		},
-		{
-			earthlyVer: Features{Major: 0, Minor: 6},
-			major:      1,
-			minor:      2,
-			expected:   false,
-		},
-		{
-			earthlyVer: Features{Major: 1, Minor: 2},
-			major:      1,
-			minor:      2,
-			expected:   true,
-		},
-	}
-	for _, test := range tests {
-		title := fmt.Sprintf("earthly version %d.%d is at least %d.%d",
-			test.earthlyVer.Major, test.earthlyVer.Minor, test.major, test.minor)
-		t.Run(title, func(t *testing.T) {
-			actual := versionAtLeast(test.earthlyVer, test.major, test.minor)
-			Equal(t, test.expected, actual)
+		// 0.5
+		{"exec-after-parallel", "ExecAfterParallel"},
+		{"parallel-load", "ParallelLoad"},
+		{"use-registry-for-with-docker", "UseRegistryForWithDocker"},
+
+		// 0.6
+		{"for-in", "ForIn"},
+		{"no-implicit-ignore", "NoImplicitIgnore"},
+		{"referenced-save-only", "ReferencedSaveOnly"},
+		{"require-force-for-unsafe-saves", "RequireForceForUnsafeSaves"},
+		{"use-copy-include-patterns", "UseCopyIncludePatterns"},
+
+		// 0.7
+		{"check-duplicate-images", "CheckDuplicateImages"},
+		{"ci-arg", "EarthlyCIArg"},
+		{"earthly-git-author-args", "EarthlyGitAuthorArgs"},
+		{"earthly-locally-arg", "EarthlyLocallyArg"},
+		{"earthly-version-arg", "EarthlyVersionArg"},
+		{"explicit-global", "ExplicitGlobal"},
+		{"git-commit-author-timestamp", "GitCommitAuthorTimestamp"},
+		{"new-platform", "NewPlatform"},
+		{"no-tar-build-output", "NoTarBuildOutput"},
+		{"save-artifact-keep-own", "SaveArtifactKeepOwn"},
+		{"shell-out-anywhere", "ShellOutAnywhere"},
+		{"use-cache-command", "UseCacheCommand"},
+		{"use-chmod", "UseChmod"},
+		{"use-copy-link", "UseCopyLink"},
+		{"use-host-command", "UseHostCommand"},
+		{"use-no-manifest-list", "UseNoManifestList"},
+		{"use-pipelines", "UsePipelines"},
+		{"use-project-secrets", "UseProjectSecrets"},
+		{"wait-block", "WaitBlock"},
+
+		// unreleased
+		{"no-use-registry-for-with-docker", "NoUseRegistryForWithDocker"},
+		{"try", "TryFinally"},
+		{"no-network", "NoNetwork"},
+	} {
+		tt := tt
+		t.Run(tt.flag, func(t *testing.T) {
+			t.Parallel()
+
+			var fts features.Features
+			err := features.ApplyFlagOverrides(&fts, tt.flag)
+			Nil(t, err)
+			field := reflect.ValueOf(fts).FieldByName(tt.field)
+			True(t, field.IsValid(), "field %v does not exist on %T", tt.field, fts)
+			val, ok := field.Interface().(bool)
+			True(t, ok, "field %v was not a boolean", tt.field)
+			True(t, val, "expected field %v to be set to true by flag %v", tt.field, tt.flag)
 		})
 	}
 }

--- a/features/features_test.go
+++ b/features/features_test.go
@@ -116,6 +116,7 @@ func TestAvailableFlags(t *testing.T) {
 		{"no-use-registry-for-with-docker", "NoUseRegistryForWithDocker"},
 		{"try", "TryFinally"},
 		{"no-network", "NoNetwork"},
+		{"arg-explicit-env", "ArgExplicitEnv"},
 	} {
 		tt := tt
 		t.Run(tt.flag, func(t *testing.T) {

--- a/features/features_unexported_test.go
+++ b/features/features_unexported_test.go
@@ -1,0 +1,57 @@
+package features
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Equal aliases require.Equal. NOTE: if we have significantly more tests
+// testing unexported code, these should move to a separate
+// imports_unexported_test.go file.
+var Equal = require.Equal
+
+func TestVersionAtLeast(t *testing.T) {
+	tests := []struct {
+		earthlyVer Features
+		major      int
+		minor      int
+		expected   bool
+	}{
+		{
+			earthlyVer: Features{Major: 0, Minor: 6},
+			major:      0,
+			minor:      5,
+			expected:   true,
+		},
+		{
+			earthlyVer: Features{Major: 0, Minor: 6},
+			major:      0,
+			minor:      7,
+			expected:   false,
+		},
+		{
+			earthlyVer: Features{Major: 0, Minor: 6},
+			major:      1,
+			minor:      2,
+			expected:   false,
+		},
+		{
+			earthlyVer: Features{Major: 1, Minor: 2},
+			major:      1,
+			minor:      2,
+			expected:   true,
+		},
+	}
+	for _, test := range tests {
+		test := test
+		title := fmt.Sprintf("earthly version %d.%d is at least %d.%d",
+			test.earthlyVer.Major, test.earthlyVer.Minor, test.major, test.minor)
+		t.Run(title, func(t *testing.T) {
+			t.Parallel()
+			actual := versionAtLeast(test.earthlyVer, test.major, test.minor)
+			Equal(t, test.expected, actual)
+		})
+	}
+}

--- a/features/imports_test.go
+++ b/features/imports_test.go
@@ -1,14 +1,14 @@
-package features
+package features_test
 
 import (
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
-	NoError = assert.NoError
-	Equal   = assert.Equal
-	Nil     = assert.Nil
-	True    = assert.True
-	False   = assert.False
-	Error   = assert.Error
+	NoError = require.NoError
+	Equal   = require.Equal
+	Nil     = require.Nil
+	True    = require.True
+	False   = require.False
+	Error   = require.Error
 )

--- a/states/states.go
+++ b/states/states.go
@@ -219,8 +219,8 @@ func (sts *SingleTarget) AddBuildArgInput(bai dedup.BuildArgInput) {
 func (sts *SingleTarget) AddOverridingVarsAsBuildArgInputs(overridingVars *variables.Scope) {
 	sts.tiMu.Lock()
 	defer sts.tiMu.Unlock()
-	for _, key := range overridingVars.SortedAny() {
-		ovVar, _ := overridingVars.GetAny(key)
+	for _, key := range overridingVars.Sorted() {
+		ovVar, _ := overridingVars.Get(key)
 		sts.targetInput = sts.targetInput.WithBuildArgInput(
 			dedup.BuildArgInput{ConstantValue: ovVar, Name: key})
 	}

--- a/states/visited.go
+++ b/states/visited.go
@@ -141,7 +141,7 @@ func CompareTargetInputs(target domain.Target, platr *platutil.Resolver, allowPr
 		return false, nil
 	}
 	for _, bai := range other.BuildArgs {
-		variable, found := overridingVars.GetAny(bai.Name)
+		variable, found := overridingVars.Get(bai.Name)
 		if found {
 			baiVariable := dedup.BuildArgInput{
 				Name:          bai.Name,

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -207,6 +207,7 @@ ga-no-qemu:
     BUILD +infinite-recursion
     BUILD +from-dockerfile-arg
     BUILD +cache-mount-arg
+    BUILD +non-env-arg-cached
     BUILD +true-false-flag
     BUILD +true-false-flag-invalid
     BUILD +dont-save-indirect-remote-artifact
@@ -330,6 +331,17 @@ cache-test:
         --post_command=">output.txt 2>&1" # check that all is still cached if re-running the prev version
     RUN cat output.txt
     RUN cat output.txt | grep '\*cached\* --> RUN echo hey'
+
+non-env-arg-cached:
+    DO +RUN_EARTHLY --earthfile=non-env-arg-cached.earth --target=+test --use_tmpfs=false
+    DO +RUN_EARTHLY --earthfile=non-env-arg-cached.earth --target="+test --foo=baz" --use_tmpfs=false --output_contains="\*cached\* --> RUN echo bar"
+    DO +RUN_EARTHLY --earthfile=non-env-arg-cached.earth --target="+test --foo=bacon" --use_tmpfs=false --output_contains="| bacon"
+    DO +RUN_EARTHLY --earthfile=non-env-arg-cached.earth --target="+test --foo=eggs" --use_tmpfs=false --output_not_contains="\*cached\* --> RUN echo baz"
+
+    DO +RUN_EARTHLY --earthfile=non-env-arg-cached.earth --target=+test-for --use_tmpfs=false
+    DO +RUN_EARTHLY --earthfile=non-env-arg-cached.earth --target="+test-for --foo=baz" --use_tmpfs=false --output_contains="\*cached\* --> RUN echo bacon"
+    DO +RUN_EARTHLY --earthfile=non-env-arg-cached.earth --target="+test-for --foo=bacon" --use_tmpfs=false --output_contains="| bacon"
+    DO +RUN_EARTHLY --earthfile=non-env-arg-cached.earth --target="+test-for --foo=eggs" --use_tmpfs=false --output_not_contains="\*cached\* --> RUN echo eggs"
 
 git-clone-test:
     DO +RUN_EARTHLY --earthfile=git-clone.earth --target=+test

--- a/tests/non-env-arg-cached.earth
+++ b/tests/non-env-arg-cached.earth
@@ -1,0 +1,23 @@
+VERSION --arg-explicit-env 0.7
+test:
+    FROM alpine:3.15
+    ARG foo = bar
+    RUN echo bar
+    RUN echo $foo
+
+    # --env should force the next RUN command to cache-bust on variable change.
+    ARG --env bar = foo
+    RUN echo baz
+
+test-for:
+    FROM alpine:3.15
+    ARG foo = bar
+    FOR f IN $foo
+        RUN echo bacon
+        RUN echo $foo
+    END
+
+    # --env should force the cache bust even though ARG foo does not have --env.
+    FOR --env f IN $foo
+        RUN echo eggs
+    END

--- a/variables/builtin.go
+++ b/variables/builtin.go
@@ -25,30 +25,30 @@ type DefaultArgs struct {
 // BuiltinArgs returns a scope containing the builtin args.
 func BuiltinArgs(target domain.Target, platr *platutil.Resolver, gitMeta *gitutil.GitMetadata, defaultArgs DefaultArgs, ftrs *features.Features, push bool, ci bool) *Scope {
 	ret := NewScope()
-	ret.AddInactive(arg.EarthlyTarget, target.StringCanonical())
-	ret.AddInactive(arg.EarthlyTargetProject, target.ProjectCanonical())
+	ret.Add(arg.EarthlyTarget, target.StringCanonical())
+	ret.Add(arg.EarthlyTargetProject, target.ProjectCanonical())
 	targetNoTag := target
 	targetNoTag.Tag = ""
-	ret.AddInactive(arg.EarthlyTargetProjectNoTag, targetNoTag.ProjectCanonical())
-	ret.AddInactive(arg.EarthlyTargetName, target.Target)
-	ret.AddInactive(arg.EarthlyTargetTag, target.Tag)
-	ret.AddInactive(arg.EarthlyTargetTagDocker, llbutil.DockerTagSafe(target.Tag))
+	ret.Add(arg.EarthlyTargetProjectNoTag, targetNoTag.ProjectCanonical())
+	ret.Add(arg.EarthlyTargetName, target.Target)
+	ret.Add(arg.EarthlyTargetTag, target.Tag)
+	ret.Add(arg.EarthlyTargetTagDocker, llbutil.DockerTagSafe(target.Tag))
 	SetPlatformArgs(ret, platr)
 	setUserPlatformArgs(ret, platr)
 	if ftrs.NewPlatform {
 		setNativePlatformArgs(ret, platr)
 	}
 	if ftrs.WaitBlock {
-		ret.AddInactive(arg.EarthlyPush, fmt.Sprintf("%t", push))
+		ret.Add(arg.EarthlyPush, fmt.Sprintf("%t", push))
 	}
 
 	if ftrs.EarthlyVersionArg {
-		ret.AddInactive(arg.EarthlyVersion, defaultArgs.EarthlyVersion)
-		ret.AddInactive(arg.EarthlyBuildSha, defaultArgs.EarthlyBuildSha)
+		ret.Add(arg.EarthlyVersion, defaultArgs.EarthlyVersion)
+		ret.Add(arg.EarthlyBuildSha, defaultArgs.EarthlyBuildSha)
 	}
 
 	if ftrs.EarthlyCIArg {
-		ret.AddInactive(arg.EarthlyCI, fmt.Sprintf("%t", ci))
+		ret.Add(arg.EarthlyCI, fmt.Sprintf("%t", ci))
 	}
 
 	if ftrs.EarthlyLocallyArg {
@@ -56,38 +56,38 @@ func BuiltinArgs(target domain.Target, platr *platutil.Resolver, gitMeta *gituti
 	}
 
 	if gitMeta != nil {
-		ret.AddInactive(arg.EarthlyGitHash, gitMeta.Hash)
-		ret.AddInactive(arg.EarthlyGitShortHash, gitMeta.ShortHash)
+		ret.Add(arg.EarthlyGitHash, gitMeta.Hash)
+		ret.Add(arg.EarthlyGitShortHash, gitMeta.ShortHash)
 		branch := ""
 		if len(gitMeta.Branch) > 0 {
 			branch = gitMeta.Branch[0]
 		}
-		ret.AddInactive(arg.EarthlyGitBranch, branch)
+		ret.Add(arg.EarthlyGitBranch, branch)
 		tag := ""
 		if len(gitMeta.Tags) > 0 {
 			tag = gitMeta.Tags[0]
 		}
-		ret.AddInactive(arg.EarthlyGitTag, tag)
-		ret.AddInactive(arg.EarthlyGitOriginURL, gitMeta.RemoteURL)
-		ret.AddInactive(arg.EarthlyGitOriginURLScrubbed, stringutil.ScrubCredentials(gitMeta.RemoteURL))
-		ret.AddInactive(arg.EarthlyGitProjectName, getProjectName(gitMeta.RemoteURL))
-		ret.AddInactive(arg.EarthlyGitCommitTimestamp, gitMeta.CommitterTimestamp)
+		ret.Add(arg.EarthlyGitTag, tag)
+		ret.Add(arg.EarthlyGitOriginURL, gitMeta.RemoteURL)
+		ret.Add(arg.EarthlyGitOriginURLScrubbed, stringutil.ScrubCredentials(gitMeta.RemoteURL))
+		ret.Add(arg.EarthlyGitProjectName, getProjectName(gitMeta.RemoteURL))
+		ret.Add(arg.EarthlyGitCommitTimestamp, gitMeta.CommitterTimestamp)
 
 		if ftrs.GitCommitAuthorTimestamp {
-			ret.AddInactive(arg.EarthlyGitCommitAuthorTimestamp, gitMeta.AuthorTimestamp)
+			ret.Add(arg.EarthlyGitCommitAuthorTimestamp, gitMeta.AuthorTimestamp)
 		}
 		if gitMeta.CommitterTimestamp == "" {
-			ret.AddInactive(arg.EarthlySourceDateEpoch, "0")
+			ret.Add(arg.EarthlySourceDateEpoch, "0")
 		} else {
-			ret.AddInactive(arg.EarthlySourceDateEpoch, gitMeta.CommitterTimestamp)
+			ret.Add(arg.EarthlySourceDateEpoch, gitMeta.CommitterTimestamp)
 		}
 		if ftrs.EarthlyGitAuthorArgs {
-			ret.AddInactive(arg.EarthlyGitAuthor, gitMeta.Author)
-			ret.AddInactive(arg.EarthlyGitCoAuthors, strings.Join(gitMeta.CoAuthors, " "))
+			ret.Add(arg.EarthlyGitAuthor, gitMeta.Author)
+			ret.Add(arg.EarthlyGitCoAuthors, strings.Join(gitMeta.CoAuthors, " "))
 		}
 	} else {
 		// Ensure SOURCE_DATE_EPOCH is always available
-		ret.AddInactive(arg.EarthlySourceDateEpoch, "0")
+		ret.Add(arg.EarthlySourceDateEpoch, "0")
 	}
 	return ret
 }
@@ -96,31 +96,31 @@ func BuiltinArgs(target domain.Target, platr *platutil.Resolver, gitMeta *gituti
 func SetPlatformArgs(s *Scope, platr *platutil.Resolver) {
 	platform := platr.Materialize(platr.Current())
 	llbPlatform := platr.ToLLBPlatform(platform)
-	s.AddInactive(arg.TargetPlatform, platform.String())
-	s.AddInactive(arg.TargetOS, llbPlatform.OS)
-	s.AddInactive(arg.TargetArch, llbPlatform.Architecture)
-	s.AddInactive(arg.TargetVariant, llbPlatform.Variant)
+	s.Add(arg.TargetPlatform, platform.String())
+	s.Add(arg.TargetOS, llbPlatform.OS)
+	s.Add(arg.TargetArch, llbPlatform.Architecture)
+	s.Add(arg.TargetVariant, llbPlatform.Variant)
 }
 
 func setUserPlatformArgs(s *Scope, platr *platutil.Resolver) {
 	platform := platr.LLBUser()
-	s.AddInactive(arg.UserPlatform, platforms.Format(platform))
-	s.AddInactive(arg.UserOS, platform.OS)
-	s.AddInactive(arg.UserArch, platform.Architecture)
-	s.AddInactive(arg.UserVariant, platform.Variant)
+	s.Add(arg.UserPlatform, platforms.Format(platform))
+	s.Add(arg.UserOS, platform.OS)
+	s.Add(arg.UserArch, platform.Architecture)
+	s.Add(arg.UserVariant, platform.Variant)
 }
 
 func setNativePlatformArgs(s *Scope, platr *platutil.Resolver) {
 	platform := platr.LLBNative()
-	s.AddInactive(arg.NativePlatform, platforms.Format(platform))
-	s.AddInactive(arg.NativeOS, platform.OS)
-	s.AddInactive(arg.NativeArch, platform.Architecture)
-	s.AddInactive(arg.NativeVariant, platform.Variant)
+	s.Add(arg.NativePlatform, platforms.Format(platform))
+	s.Add(arg.NativeOS, platform.OS)
+	s.Add(arg.NativeArch, platform.Architecture)
+	s.Add(arg.NativeVariant, platform.Variant)
 }
 
 // SetLocally sets the locally built-in arg value
 func SetLocally(s *Scope, locally bool) {
-	s.AddInactive(arg.EarthlyLocally, fmt.Sprintf("%v", locally))
+	s.Add(arg.EarthlyLocally, fmt.Sprintf("%v", locally))
 }
 
 // getProjectName returns the deprecated PROJECT_NAME value

--- a/variables/imports_test.go
+++ b/variables/imports_test.go
@@ -1,14 +1,9 @@
-package variables
+package variables_test
 
-import (
-	"github.com/stretchr/testify/assert"
-)
+import "github.com/poy/onpar/matchers"
 
 var (
-	NoError = assert.NoError
-	Equal   = assert.Equal
-	Nil     = assert.Nil
-	True    = assert.True
-	False   = assert.False
-	Error   = assert.Error
+	beTrue  = matchers.BeTrue
+	beFalse = matchers.BeFalse
+	equal   = matchers.Equal
 )

--- a/variables/imports_unexported_test.go
+++ b/variables/imports_unexported_test.go
@@ -1,0 +1,14 @@
+package variables
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	NoError = assert.NoError
+	Equal   = assert.Equal
+	Nil     = assert.Nil
+	True    = assert.True
+	False   = assert.False
+	Error   = assert.Error
+)

--- a/variables/parse.go
+++ b/variables/parse.go
@@ -39,7 +39,7 @@ func ParseCommandLineArgs(args []string) (*Scope, error) {
 				return nil, errors.Errorf("env var %s not set", key)
 			}
 		}
-		ret.AddInactive(key, value)
+		ret.Add(key, value)
 	}
 	return ret, nil
 }
@@ -52,7 +52,7 @@ func ParseArgs(args []string, pncvf ProcessNonConstantVariableFunc, current *Col
 		if err != nil {
 			return nil, errors.Wrapf(err, "parse build arg %s", arg)
 		}
-		ret.AddInactive(name, variable)
+		ret.Add(name, variable)
 	}
 	return ret, nil
 }
@@ -80,7 +80,7 @@ func parseArg(arg string, pncvf ProcessNonConstantVariableFunc, current *Collect
 		}
 		return name, v, nil
 	}
-	v, ok := current.GetActive(name)
+	v, ok := current.Get(name, WithActive())
 	if !ok {
 		return "", "", errors.Errorf("value not specified for build arg %s and no value can be inferred", name)
 	}
@@ -107,7 +107,7 @@ func ParseEnvVars(envVars []string) *Scope {
 	ret := NewScope()
 	for _, envVar := range envVars {
 		k, v, _ := ParseKeyValue(envVar)
-		ret.AddActive(k, v)
+		ret.Add(k, v, WithActive())
 	}
 	return ret
 }

--- a/variables/parse.go
+++ b/variables/parse.go
@@ -107,7 +107,7 @@ func ParseEnvVars(envVars []string) *Scope {
 	ret := NewScope()
 	for _, envVar := range envVars {
 		k, v, _ := ParseKeyValue(envVar)
-		ret.Add(k, v, WithActive())
+		ret.Add(k, v, WithActive(), WithEnv())
 	}
 	return ret
 }

--- a/variables/scope.go
+++ b/variables/scope.go
@@ -32,34 +32,32 @@ func (s *Scope) Clone() *Scope {
 	return ret
 }
 
-// GetAny returns a variable by name, even if it is not active.
-func (s *Scope) GetAny(name string) (string, bool) {
-	variable, found := s.variables[name]
-	return variable, found
-}
-
-// GetActive returns an active variable by name.
-func (s *Scope) GetActive(name string) (string, bool) {
-	variable, found := s.variables[name]
-	active := false
-	if found {
-		active = s.activeVariables[name]
+// Get gets a variable by name.
+func (s *Scope) Get(name string, opts ...ScopeOpt) (string, bool) {
+	opt := applyOpts(opts...)
+	v, ok := s.variables[name]
+	if !ok {
+		return "", false
 	}
-	if !active {
-		variable = ""
+	if opt.active && !s.activeVariables[name] {
+		return "", false
 	}
-	return variable, active
+	return v, true
 }
 
-// AddInactive adds an inactive variable in the collection.
-func (s *Scope) AddInactive(name string, variable string) {
-	s.variables[name] = variable
-}
-
-// AddActive adds and activates a variable in the collection.
-func (s *Scope) AddActive(name string, variable string) {
-	s.activeVariables[name] = true
-	s.variables[name] = variable
+// Add sets a variable to a value within this scope. It returns true if the
+// value was set.
+func (s *Scope) Add(name, value string, opts ...ScopeOpt) bool {
+	opt := applyOpts(opts...)
+	_, existed := s.variables[name]
+	if opt.noOverride && existed {
+		return false
+	}
+	s.variables[name] = value
+	if opt.active {
+		s.activeVariables[name] = true
+	}
+	return true
 }
 
 // Remove removes a variable from the scope.
@@ -68,82 +66,92 @@ func (s *Scope) Remove(name string) {
 	delete(s.activeVariables, name)
 }
 
-// ActiveValueMap returns a map of the values of the active variables.
-func (s *Scope) ActiveValueMap() map[string]string {
-	ret := make(map[string]string)
-	for name := range s.activeVariables {
-		ret[name] = s.variables[name]
+// Map returns a name->value variable map of variables in this scope.
+func (s *Scope) Map(opts ...ScopeOpt) map[string]string {
+	opt := applyOpts(opts...)
+	m := make(map[string]string)
+	for k, v := range s.variables {
+		if opt.active && !s.activeVariables[k] {
+			continue
+		}
+		m[k] = v
 	}
-	return ret
+	return m
 }
 
-// AllValueMap returns a map of the values of all the variables.
-func (s *Scope) AllValueMap() map[string]string {
-	ret := make(map[string]string)
-	for name, value := range s.variables {
-		ret[name] = value
+// Keys returns a sorted list of variable names in this Scope.
+func (s *Scope) Sorted(opts ...ScopeOpt) []string {
+	opt := applyOpts(opts...)
+	var sorted []string
+	for k := range s.variables {
+		if opt.active && !s.activeVariables[k] {
+			continue
+		}
+		sorted = append(sorted, k)
 	}
-	return ret
+	sort.Strings(sorted)
+	return sorted
 }
 
-// SortedActive returns the active variable names in a sorted slice.
-func (s *Scope) SortedActive() []string {
-	varNames := make([]string, 0, len(s.activeVariables))
-	for varName := range s.activeVariables {
-		varNames = append(varNames, varName)
-	}
-	sort.Strings(varNames)
-	return varNames
-}
-
-// SortedAny returns the variable names in a sorted slice.
-func (s *Scope) SortedAny() []string {
-	varNames := make([]string, 0, len(s.variables))
-	for varName := range s.variables {
-		varNames = append(varNames, varName)
-	}
-	sort.Strings(varNames)
-	return varNames
-}
-
-// CombineScopes combines all the variables across all scopes, with
-// left precedence.
+// CombineScopes combines all the variables across all scopes, with the
+// following precedence:
+//
+// 1. Active variables
+// 2. Inactive variables
+// 3. All other things equal, left-most scopes have precedence
 func CombineScopes(scopes ...*Scope) *Scope {
-	allActive := make(map[string]bool)
-	for _, scope := range scopes {
-		for name := range scope.activeVariables {
-			allActive[name] = true
-		}
-	}
-	allInactive := make(map[string]bool)
-	for _, scope := range scopes {
-		for name := range scope.variables {
-			if !allActive[name] {
-				allInactive[name] = true
-			}
-		}
-	}
-
 	s := NewScope()
-AllActiveLoop:
-	for name := range allActive {
-		for _, scope := range scopes {
-			variable, active := scope.GetActive(name)
-			if active {
-				s.AddActive(name, variable)
-				continue AllActiveLoop
-			}
-		}
+	precedence := [][]ScopeOpt{
+		{WithActive()},
+		nil,
 	}
-AllInactiveLoop:
-	for name := range allInactive {
+	for _, opts := range precedence {
+		addOpts := append(opts, NoOverride())
 		for _, scope := range scopes {
-			variable, found := scope.GetAny(name)
-			if found {
-				s.AddInactive(name, variable)
-				continue AllInactiveLoop
+			for k, v := range scope.Map(opts...) {
+				s.Add(k, v, addOpts...)
 			}
 		}
 	}
 	return s
+}
+
+type scopeOpts struct {
+	active     bool
+	noOverride bool
+}
+
+func applyOpts(opts ...ScopeOpt) scopeOpts {
+	var opt scopeOpts
+	for _, o := range opts {
+		opt = o(opt)
+	}
+	return opt
+}
+
+// ScopeOpt is an option function for setting flags when adding to or getting
+// from a Scope.
+type ScopeOpt func(scopeOpts) scopeOpts
+
+// WithActive is a ScopeOpt for active variables. When passed to Add, it sets
+// the variable to active; when passed to Get or Map, it causes them to only
+// return active variables.
+func WithActive() ScopeOpt {
+	return func(o scopeOpts) scopeOpts {
+		o.active = true
+		return o
+	}
+}
+
+// NoOverride only applies to Add. When passed to Add, NoOverride will prevent
+// Add from overriding an existing value.
+//
+// This will also prevent Add from applying other opts to the existing variable,
+// so if the caller wishes to set options on the existing value, they should
+// update the value on a false return from Add.
+func NoOverride() ScopeOpt {
+	return func(o scopeOpts) scopeOpts {
+		o.noOverride = true
+		return o
+	}
 }

--- a/variables/scope_test.go
+++ b/variables/scope_test.go
@@ -1,0 +1,165 @@
+package variables_test
+
+import (
+	"testing"
+
+	"github.com/earthly/earthly/variables"
+	"github.com/poy/onpar/expect"
+	"github.com/poy/onpar/v2"
+)
+
+func TestScope(topT *testing.T) {
+	type testCtx struct {
+		t      *testing.T
+		expect expect.Expectation
+		scope  *variables.Scope
+	}
+
+	o := onpar.BeforeEach(onpar.New(topT), func(t *testing.T) testCtx {
+		return testCtx{
+			t:      t,
+			expect: expect.New(t),
+			scope:  variables.NewScope(),
+		}
+	})
+
+	o.Spec("it returns false for unset variables", func(tc testCtx) {
+		_, ok := tc.scope.Get("foo")
+		tc.expect(ok).To(beFalse())
+	})
+
+	o.Spec("NoOverride prevents Add from overriding an existing value", func(tc testCtx) {
+		tc.scope.Add("foo", "bar")
+		tc.scope.Add("foo", "baz", variables.WithActive(), variables.NoOverride())
+
+		v, ok := tc.scope.Get("foo")
+		tc.expect(ok).To(beTrue())
+		tc.expect(v).To(equal("bar"))
+
+		_, ok = tc.scope.Get("foo", variables.WithActive())
+		tc.expect(ok).To(beFalse())
+	})
+
+	o.Spec("it returns a sorted list of names", func(tc testCtx) {
+		tc.scope.Add("a", "", variables.WithActive())
+		tc.scope.Add("z", "", variables.WithActive())
+		tc.scope.Add("e", "")
+		tc.scope.Add("b", "", variables.WithActive())
+
+		inactive := tc.scope.Sorted()
+		tc.expect(inactive).To(equal([]string{"a", "b", "e", "z"}))
+		active := tc.scope.Sorted(variables.WithActive())
+		tc.expect(active).To(equal([]string{"a", "b", "z"}))
+	})
+
+	for _, tt := range []struct {
+		testName    string
+		useOpts     []variables.ScopeOpt
+		failGetOpts []variables.ScopeOpt
+		name        string
+		value       string
+	}{
+		{
+			testName: "it stores inactive values",
+			failGetOpts: []variables.ScopeOpt{
+				variables.WithActive(),
+			},
+			name:  "foo",
+			value: "bar",
+		},
+		{
+			testName: "it stores active values",
+			useOpts:  []variables.ScopeOpt{variables.WithActive()},
+			name:     "bar",
+			value:    "baz",
+		},
+		{
+			testName: "it stores active env variables",
+			useOpts: []variables.ScopeOpt{
+				variables.WithActive(),
+			},
+			name:  "bacon",
+			value: "eggs",
+		},
+	} {
+		tt := tt
+		o.Spec(tt.testName, func(tc testCtx) {
+			ok := tc.scope.Add(tt.name, tt.value)
+			tc.expect(ok).To(beTrue())
+			for _, opt := range tt.useOpts {
+				_, ok := tc.scope.Get(tt.name, opt)
+				tc.expect(ok).To(beFalse())
+				ok = tc.scope.Add(tt.name, tt.value, opt, variables.NoOverride())
+				tc.expect(ok).To(beFalse())
+				ok = tc.scope.Add(tt.name, tt.value, opt)
+				tc.expect(ok).To(beTrue())
+			}
+
+			value, ok := tc.scope.Get(tt.name)
+			tc.expect(ok).To(beTrue())
+			tc.expect(value).To(equal(tt.value))
+			for _, opt := range tt.useOpts {
+				value, ok := tc.scope.Get(tt.name, opt)
+				tc.expect(ok).To(beTrue())
+				tc.expect(value).To(equal(tt.value))
+
+				m := tc.scope.Map(opt)
+				value, ok = m[tt.name]
+				tc.expect(ok).To(beTrue())
+				tc.expect(value).To(equal(tt.value))
+			}
+
+			for _, opt := range tt.failGetOpts {
+				_, ok := tc.scope.Get(tt.name, opt)
+				tc.expect(ok).To(beFalse())
+
+				m := tc.scope.Map(opt)
+				_, ok = m[tt.name]
+				tc.expect(ok).To(beFalse())
+			}
+
+			clone := tc.scope.Clone()
+			value, ok = clone.Get(tt.name)
+			tc.expect(ok).To(beTrue())
+			tc.expect(value).To(equal(tt.value))
+			for _, opt := range tt.useOpts {
+				value, ok = clone.Get(tt.name, opt)
+				tc.expect(ok).To(beTrue())
+				tc.expect(value).To(equal(tt.value))
+			}
+
+			tc.scope.Remove(tt.name)
+			tc.scope.Add(tt.name, tt.value)
+			for _, opt := range tt.useOpts {
+				_, ok := tc.scope.Get(tt.name, opt)
+				tc.expect(ok).To(beFalse())
+			}
+		})
+	}
+
+	o.Group("CombineScopes", func() {
+		o.Spec("it prefers left values", func(tc testCtx) {
+			tc.scope.Add("a", "b")
+
+			other := variables.NewScope()
+			other.Add("a", "c")
+
+			c := variables.CombineScopes(tc.scope, other)
+			v, ok := c.Get("a")
+			tc.expect(ok).To(beTrue())
+			tc.expect(v).To(equal("b"))
+		})
+
+		o.Spec("it prefers active to inactive values", func(tc testCtx) {
+			tc.scope.Add("active", "b")
+
+			other := variables.NewScope()
+			other.Add("active", "d", variables.WithActive())
+
+			c := variables.CombineScopes(tc.scope, other)
+			env, ok := c.Get("active")
+			tc.expect(ok).To(beTrue())
+			tc.expect(env).To(equal("d"))
+		})
+	})
+}


### PR DESCRIPTION
When --arg-explicit-env is set in the feature flags, commands will only be cache-busted when 'ARG --env' is used or the ARG in question is explicitly used by the command.