### PR TITLE
make RUN ... errors easier to read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 
 ## Unreleased
 
+### Changed
+
+- Simplified error message when a RUN command fails with an exit code. [#2742](https://github.com/earthly/earthly/issues/2742)
+
 ## v0.7.1 - 2023-03-01
 
 ### Added

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -61,6 +61,8 @@ const (
 	secretFileFlag    = "secret-file-path"
 )
 
+var runExitCodeRegexp = regexp.MustCompile(`did not complete successfully: exit code: [^0][0-9]*$`)
+
 type earthlyApp struct {
 	cliApp      *cli.App
 	console     conslogging.ConsoleLogger
@@ -647,6 +649,9 @@ func (app *earthlyApp) run(ctx context.Context, args []string) int {
 		}
 
 		switch {
+		case runExitCodeRegexp.MatchString(err.Error()):
+			// error has already been displayed in console, don't display it again
+			return 1
 		case strings.Contains(err.Error(), "security.insecure is not allowed"):
 			app.logbus.Run().SetFatalError(time.Now(), "", "", logstream.FailureType_FAILURE_TYPE_NEEDS_PRIVILEGED, err.Error())
 			app.console.Warnf("Error: earthly --allow-privileged (earthly -P) flag is required\n")

--- a/scripts/tests/interactive-debugger/interactive-run/test-interactive-run.py
+++ b/scripts/tests/interactive-debugger/interactive-run/test-interactive-run.py
@@ -30,7 +30,7 @@ def test_with_exit_code(earthly_path, timeout, exit_code_to_send):
             c.sendline(str(exit_code_to_send))
 
             if exit_code_to_send:
-                expected_text = f'did not complete successfully: exit code: {exit_code_to_send}'
+                expected_text = f'did not complete successfully. Exit code {exit_code_to_send}'
                 try:
                     c.expect(expected_text, timeout=10)
                 except Exception as e:


### PR DESCRIPTION
This detects and silences failures of the form

    Error: build target: build main: failed to solve: unlazy force execution: process "/bin/sh -c GLIBC_VER=2.31-r0 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin /usr/bin/earth_debugger /bin/sh -c '... did not complete successfully: exit code: 1

As they are displayed in a clearer format higher up in the output.