### PR TITLE
Remove warning logs about feature flags used on satellites

### DIFF
--- a/cmd/earthly/buildkit.go
+++ b/cmd/earthly/buildkit.go
@@ -169,11 +169,6 @@ func (app *earthlyApp) configureSatellite(cliCtx *cli.Context, cloudClient *clou
 	app.analyticsMetadata.isSatellite = true
 	app.analyticsMetadata.satelliteCurrentVersion = "" // TODO
 
-	app.console.Printf("") // newline
-	app.console.Printf("The following feature flag is recommended for use with Satellites and will be auto-enabled:")
-	app.console.Printf("  --new-platform")
-	app.console.Printf("") // newline
-
 	if app.featureFlagOverrides != "" {
 		app.featureFlagOverrides += ","
 	}


### PR DESCRIPTION
These are enabled by default now in 0.7 anyways

![Screenshot 2023-03-07 155405](https://user-images.githubusercontent.com/3247216/223550152-2c39f010-46cb-41f8-9eb7-65bfd49b64f4.png)
