### PR TITLE
add test for silent analytics failure

### DIFF
--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -227,6 +227,7 @@ ga-no-qemu:
     BUILD +pipelines
     BUILD +doc
     BUILD +no-network
+    BUILD +test-works-without-earthly-server
 
     # Forcing the implicit global wait/end block, causes some tests, which rely
     # on the ability to have two different targets issue the same SAVE IMAGE tag name
@@ -1269,6 +1270,25 @@ pipelines:
         --should_fail=true \
         --output_contains="valid triggers include"
 
+test-works-without-earthly-server:
+    # first warm-up the cache
+    DO +RUN_EARTHLY --verbose=false --earthfile=true.earth --target=+true
+
+    RUN echo "#!/bin/sh
+    set -e
+    unset EARTHLY_DISABLE_ANALYTICS
+    for host in ci.earthly.dev api.earthly.dev; do
+      echo \"blocking \$host\"
+      for ip in \$(getent hosts \$host | awk '{ print \$1 }'); do
+        iptables -A OUTPUT -d \$ip -j DROP
+      done
+    done
+    date +%s > start-time
+    " > /tmp/precommand && chmod +x /tmp/precommand
+    DO +RUN_EARTHLY --verbose=false --pre_command=/tmp/precommand --post_command=" && date +%s > end-time" --earthfile=true.earth --target=+true
+    RUN if grep "failed sending analytics" earthly.output; then echo "analytics should have failed silently, but didnt" && exit 1; fi
+    RUN export duration=$(echo "$(cat end-time) - $(cat start-time)" | bc) && test "$duration" -lt 45 || (echo "it took $duration seconds to run +true, which is too long" && exit 1)
+
 RUN_EARTHLY:
     COMMAND
     ARG earthfile=
@@ -1288,7 +1308,7 @@ RUN_EARTHLY:
         COPY "$earthfile" "$earthfile_dest"
     END
     RUN echo "
-        set -x
+        set -ex
         export EARTHLY_VERBOSE=$verbose
         if $use_tmpfs; then
             export EARTHLY_TMP_DIR=/tmp/earthly-tmpfs
@@ -1307,10 +1327,14 @@ RUN_EARTHLY:
             fi
             export EARTHLY_EXEC_CMD=\"$exec_cmd\"
             echo running earthly with EARTHLY_EXEC_CMD=\$EARTHLY_EXEC_CMD
+            set +e
             (/bin/sh /usr/bin/earthly-entrypoint.sh; echo exit_code=\$?) 2>&1 | tee earthly.output
+            set -e
         else
             echo running earthly with $target
+            set +e
             (eval \"/usr/bin/earthly-entrypoint.sh $extra_args $target $post_command\"; echo exit_code=\$?) 2>&1 | tee earthly.output
+            set -e
         fi
 
         if ! tail -n 1 earthly.output | grep 'exit_code=[0-9]\+'; then

--- a/tests/true.earth
+++ b/tests/true.earth
@@ -1,0 +1,5 @@
+VERSION 0.7
+
+true:
+  FROM alpine:3.17
+  RUN true


### PR DESCRIPTION
the "failed to send analytics" message should only ever appear under verbose logging.