### PR TITLE
propagate push to wait block items

### DIFF
--- a/earthfile2llb/earthfile2llb.go
+++ b/earthfile2llb/earthfile2llb.go
@@ -247,12 +247,19 @@ func Earthfile2LLB(ctx context.Context, target domain.Target, opt ConvertOpt, in
 		opt.MainTargetDetailsFuture = nil
 	}
 	if found {
+		// The found target may have initially been created by a FROM or a COPY;
+		// however, if it is referenced a second time by a BUILD, it may contain items that
+		// require a save (export to the local host) or a push
 		if opt.DoSaves {
-			// Set the do saves flag, in case it was not set before.
 			sts.SetDoSaves()
+		}
+		if opt.DoPushes {
+			sts.SetDoPushes()
+		}
+		if opt.DoSaves || opt.DoPushes {
 			err := sts.Wait(ctx)
 			if err != nil {
-				return nil, errors.Wrapf(err, "resolve build context for target %s", target.String())
+				return nil, errors.Wrapf(err, "wait failed on target %s", target.String())
 			}
 		}
 		sts.AttachTopLevelWaitItems(ctx, opt.waitBlock)

--- a/earthfile2llb/save_image_wait_item.go
+++ b/earthfile2llb/save_image_wait_item.go
@@ -29,11 +29,15 @@ func newSaveImage(si states.SaveImage, c *Converter, push, localExport bool) wai
 func (siwi *saveImageWaitItem) SetDoSave() {
 	siwi.mu.Lock()
 	defer siwi.mu.Unlock()
-	siwi.localExport = true
+	if siwi.si.DockerTag != "" {
+		siwi.localExport = true
+	}
 }
 
 func (siwi *saveImageWaitItem) SetDoPush() {
 	siwi.mu.Lock()
 	defer siwi.mu.Unlock()
-	siwi.push = true
+	if siwi.si.DockerTag != "" {
+		siwi.push = true
+	}
 }

--- a/states/states.go
+++ b/states/states.go
@@ -170,6 +170,12 @@ func (sts *SingleTarget) SetDoPushes() {
 	sts.doSavesMu.Lock()
 	defer sts.doSavesMu.Unlock()
 	sts.doPushes = true
+	for _, wi := range sts.WaitItems {
+		wi.SetDoPush()
+	}
+	for _, wb := range sts.WaitBlocks {
+		wb.SetDoPushes()
+	}
 }
 
 // AddWaitBlock adds a wait block to the state

--- a/tests/wait-block/common/test.sh
+++ b/tests/wait-block/common/test.sh
@@ -4,6 +4,8 @@
 set -uxe
 set -o pipefail
 
+CHECK_TAG_WAS_PUSHED=${CHECK_TAG_WAS_PUSHED:-false}
+
 initialwd="$(pwd)"
 cd "$(dirname "$0")"
 

--- a/tests/wait-block/common/test.sh
+++ b/tests/wait-block/common/test.sh
@@ -79,6 +79,15 @@ set +e
 exit_code="$?"
 set -e
 
+if [ "$CHECK_TAG_WAS_PUSHED" = "true" ]; then
+    manifest_output=$(mktemp /tmp/earthly-wait-block-test.XXXXX)
+    which jq || (echo "jq must be installed" && exit 1)
+    which curl || (echo "curl must be installed" && exit 1)
+    curl -k "https://$REGISTRY/v2/myuser/myimg/manifests/$tag" > $manifest_output
+    test "$(cat "$manifest_output" | jq -r .tag)" = "$tag"
+    rm $manifest_output
+fi
+
 # Cleanup.
 docker stop "$registry_name" || true
 

--- a/tests/wait-block/save-image-push-implicit-wait-block/Earthfile
+++ b/tests/wait-block/save-image-push-implicit-wait-block/Earthfile
@@ -1,0 +1,23 @@
+VERSION 0.7
+
+# dummy target to warm up the cache
+# but the test shouldn't use this since the pre-warming stage passes a --push
+deps:
+    FROM alpine:3.17
+
+common-base:
+    FROM alpine:3.17
+    ARG --required REGISTRY
+    ARG --required tag
+    SAVE IMAGE --push $REGISTRY/myuser/myimg:$tag
+
+use-common-base:
+    FROM +common-base
+    RUN echo "this won't trigger the SAVE IMAGE in common-base"
+
+test:
+    BUILD +use-common-base
+    FROM alpine:3.17
+    IF sleep 5
+      BUILD +common-base
+    END

--- a/tests/wait-block/save-image-push-implicit-wait-block/test.sh
+++ b/tests/wait-block/save-image-push-implicit-wait-block/test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+export CHECK_TAG_WAS_PUSHED=true
+
+cd "$(dirname "$0")"
+../common/test.sh --push


### PR DESCRIPTION
Fixes a race bug where the --push option was not correctly propagated to
targets that were first indirectly referenced by a `FROM` or `COPY`, but
then later referenced by an explicit `BUILD`.

This was missed in eee3db502797bfb74e91886db59e685434e15ccc
and fixes https://github.com/earthly/earthly/issues/2762.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>