### PR TITLE
use pre-build rot13 image in interactive-test

### DIFF
--- a/scripts/tests/interactive-debugger/docker-compose/Earthfile
+++ b/scripts/tests/interactive-debugger/docker-compose/Earthfile
@@ -4,7 +4,6 @@ FROM earthly/dind:alpine
 fail-with-docker-compose:
     WORKDIR /test
     RUN echo ZTg4Y2MyYjgtYzE3OS00ZWQ3LThlYWUtMjA3YTBlZjc1NDZj > /data.txt
-    COPY Dockerfile ./
     COPY docker-compose.yml ./
     WITH DOCKER --compose=docker-compose.yml
         RUN false

--- a/scripts/tests/interactive-debugger/docker-compose/docker-compose.yml
+++ b/scripts/tests/interactive-debugger/docker-compose/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   rot13:
-    build: .
+    image: earthly/rot13:latest
     ports:
       - 127.0.0.1:5432:5432
     environment:

--- a/scripts/tests/interactive-debugger/docker-compose/rot13/Dockerfile
+++ b/scripts/tests/interactive-debugger/docker-compose/rot13/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.17
 RUN apk add --no-cache nmap-ncat
 
 # rot13 echo server

--- a/scripts/tests/interactive-debugger/docker-compose/rot13/README
+++ b/scripts/tests/interactive-debugger/docker-compose/rot13/README
@@ -1,0 +1,7 @@
+This Dockerfile is used in the interactive compose test.
+It used to be referenced in the docker-compose file; however, it was
+prebuilt with:
+
+    docker buildx build --tag earthly/rot13:latest --push .
+
+to speed up the test.

--- a/scripts/tests/interactive-debugger/docker-compose/test-docker-compose.py
+++ b/scripts/tests/interactive-debugger/docker-compose/test-docker-compose.py
@@ -27,9 +27,9 @@ def test_interactive(earthly_path, timeout):
             time.sleep(5)
 
             # test we can obtain decoded text from the rot13 echo server that is created via docker-compose
-            c.sendline('docker exec test_rot13_1 sh -c \'(echo Nstunavfgna; sleep 1) | ncat localhost 5432\'')
+            c.sendline('docker exec test_rot13_1 sh -c \'(echo guvf vf zl Frpe3g Z3ff4tr; sleep 1) | ncat localhost 5432\'')
             try:
-                c.expect('Afghanistan', timeout=timeout)
+                c.expect('this is my Secr3t M3ss4ge', timeout=timeout)
             except Exception as e:
                 raise RuntimeError('failed to find Afghanistan in output (indicating we were unable to obtain decoded text from the rot13 echo server that was started via docker compose)')
 


### PR DESCRIPTION
Use a pre-built image to speed up the tests.