### PR TITLE
Misc. doc updates (0.7 specific)

### DIFF
--- a/docs/basics/part-1-a-simple-earthfile.md
+++ b/docs/basics/part-1-a-simple-earthfile.md
@@ -1,7 +1,7 @@
 Below you'll find a simple example of an Earthfile. All the magic of Earthly happens in the Earthfile, which you may notice is very similar to a Dockerfile. This is an intentional design decision. Existing Dockerfiles can easily be ported to Earthly by copying them to an Earthfile and tweaking them slightly.
 
 ```Dockerfile
-VERSION 0.6
+VERSION 0.7
 FROM golang:1.15-alpine3.13
 WORKDIR /go-workdir
 
@@ -34,7 +34,7 @@ We'll slowly build up to the Earthfile we have above. Let's start with these fir
 
 `./tutorial/Earthfile`
 ```Dockerfile
-VERSION 0.6
+VERSION 0.7
 FROM golang:1.15-alpine3.13
 WORKDIR /go-workdir
 ```
@@ -97,7 +97,7 @@ Lastly, we save the current state as a docker image, which will have the docker 
 Notice how we already had Go installed for both our `+build` and `+docker` targets. This is because  targets inherit from the base target which for us was the `FROM golang:1.15-alpine3.13` that we set up at the top of the file. But it's worth noting that targets can define their own environments. For example:
 
 ```Dockerfile
-VERSION 0.6
+VERSION 0.7
 FROM golang:1.15-alpine3.13
 WORKDIR /go-workdir
 
@@ -161,7 +161,7 @@ earthly --artifact github.com/earthly/earthly/examples/tutorial/js:main+part1/pa
 `./Earthfile`
 
 ```Dockerfile
-VERSION 0.6
+VERSION 0.7
 FROM node:13.10.1-alpine3.11
 WORKDIR /js-example
 
@@ -202,7 +202,7 @@ earthly --artifact github.com/earthly/earthly/examples/tutorial/java:main+part1/
 `./Earthfile`
 
 ```Dockerfile
-VERSION 0.6
+VERSION 0.7
 FROM openjdk:8-jdk-alpine
 RUN apk add --update --no-cache gradle
 WORKDIR /java-example
@@ -270,7 +270,7 @@ earthly --artifact github.com/earthly/earthly/examples/tutorial/python:main+part
 `./Earthfile`
 
 ```Dockerfile
-VERSION 0.6
+VERSION 0.7
 FROM python:3
 WORKDIR /code
 

--- a/docs/basics/part-2-outputs.md
+++ b/docs/basics/part-2-outputs.md
@@ -161,7 +161,7 @@ earthly --artifact github.com/earthly/earthly/examples/tutorial/js:main+part2/pa
 `./Earthfile`
 
 ```Dockerfile
-VERSION 0.6
+VERSION 0.7
 FROM node:13.10.1-alpine3.11
 WORKDIR /js-example
 
@@ -202,7 +202,7 @@ earthly --artifact github.com/earthly/earthly/examples/tutorial/java:main+part2/
 `./Earthfile`
 
 ```Dockerfile
-VERSION 0.6
+VERSION 0.7
 FROM openjdk:8-jdk-alpine
 RUN apk add --update --no-cache gradle
 WORKDIR /java-example
@@ -270,7 +270,7 @@ earthly --artifact github.com/earthly/earthly/examples/tutorial/python:main+part
 `./Earthfile`
 
 ```Dockerfile
-VERSION 0.6
+VERSION 0.7
 FROM python:3
 WORKDIR /code
 

--- a/docs/basics/part-3-adding-dependencies-with-caching.md
+++ b/docs/basics/part-3-adding-dependencies-with-caching.md
@@ -43,7 +43,7 @@ Now we can update our Earthfile to copy in the `go.mod` and `go.sum`.
 `./Earthfile`
 
 ```Dockerfile
-VERSION 0.6
+VERSION 0.7
 FROM golang:1.15-alpine3.13
 WORKDIR /go-workdir
 
@@ -67,7 +67,7 @@ If, however, we could first download the dependencies and only afterwards copy a
 `./Earthfile`
 
 ```Dockerfile
-VERSION 0.6
+VERSION 0.7
 FROM golang:1.15-alpine3.13
 WORKDIR /go-workdir
 
@@ -95,7 +95,7 @@ In some cases, the dependencies might be used in more than one build target. For
 `./Earthfile`
 
 ```Dockerfile
-VERSION 0.6
+VERSION 0.7
 FROM golang:1.15-alpine3.13
 WORKDIR /go-workdir
 
@@ -134,7 +134,7 @@ Note that in our case, only the JavaScript version has an example where `FROM +d
 `./Earthfile`
 
 ```Dockerfile
-VERSION 0.6
+VERSION 0.7
 FROM node:13.10.1-alpine3.11
 WORKDIR /js-example
 
@@ -176,7 +176,7 @@ earthly --artifact github.com/earthly/earthly/examples/tutorial/java:main+part3/
 `./Earthfile`
 
 ```Dockerfile
-VERSION 0.6
+VERSION 0.7
 FROM openjdk:8-jdk-alpine
 RUN apk add --update --no-cache gradle
 WORKDIR /java-example
@@ -215,7 +215,7 @@ earthly --artifact github.com/earthly/earthly/examples/tutorial/python:main+part
 `./Earthfile`
 
 ```Dockerfile
-VERSION 0.6
+VERSION 0.7
 FROM python:3
 WORKDIR /code
 

--- a/docs/basics/part-4-args.md
+++ b/docs/basics/part-4-args.md
@@ -90,7 +90,7 @@ earthly --artifact github.com/earthly/earthly/examples/tutorial/js:main+part4/pa
 `./Earthfile`
 
 ```Dockerfile
-VERSION 0.6
+VERSION 0.7
 FROM node:13.10.1-alpine3.11
 WORKDIR /js-example
 
@@ -133,7 +133,7 @@ earthly --artifact github.com/earthly/earthly/examples/tutorial/java:main+part4/
 `./Earthfile`
 
 ```Dockerfile
-VERSION 0.6
+VERSION 0.7
 FROM openjdk:8-jdk-alpine
 RUN apk add --update --no-cache gradle
 WORKDIR /java-example
@@ -173,7 +173,7 @@ earthly --artifact github.com/earthly/earthly/examples/tutorial/python:main+part
 `./Earthfile`
 
 ```Dockerfile
-VERSION 0.6
+VERSION 0.7
 FROM python:3
 WORKDIR /code
 

--- a/docs/basics/part-5-importing.md
+++ b/docs/basics/part-5-importing.md
@@ -11,7 +11,7 @@ Examples in [Python](#more-examples), [JavaScript](#more-examples) and [Java](#m
 So far we've seen how the `FROM` command in Earthly has the ability to reference another target's image as its base image, like in the case below where the `+build` target uses the image from the `+deps` target.
 
 ```Dockerfile
-VERSION 0.6
+VERSION 0.7
 FROM golang:1.15-alpine3.13
 WORKDIR /go-workdir
 
@@ -49,7 +49,7 @@ We can use a target in the Earthfile in `/services/service-one` from inside the 
 
 ```Dockerfile
 
-VERSION 0.6
+VERSION 0.7
 FROM golang:1.15-alpine3.13
 WORKDIR /go-workdir
 
@@ -86,7 +86,7 @@ build:
 In addition to importing single targets from other files, we can also import an entire Earthfile with the `IMPORT` command. This is helpful if there are several targets in a separate Earthfile that you want access to in your current file. It also allows you to create an alias.
 
 ```Dockerfile
-VERSION 0.6
+VERSION 0.7
 IMPORT ./services/service-one AS my_service
 FROM golang:1.15-alpine3.13
 WORKDIR /go-workdir
@@ -115,7 +115,7 @@ earthly --artifact github.com/earthly/earthly/examples/tutorial/js:main+part5/pa
 `./Earthfile`
 
 ```Dockerfile
-VERSION 0.6
+VERSION 0.7
 FROM node:13.10.1-alpine3.11
 WORKDIR /js-example
 
@@ -150,7 +150,7 @@ earthly --artifact github.com/earthly/earthly/examples/tutorial/java:main+part5/
 `./Earthfile`
 
 ```Dockerfile
-VERSION 0.6
+VERSION 0.7
 FROM openjdk:8-jdk-alpine
 RUN apk add --update --no-cache gradle
 WORKDIR /java-example
@@ -185,7 +185,7 @@ earthly --artifact github.com/earthly/earthly/examples/tutorial/python:main+part
 `./Earthfile`
 
 ```Dockerfile
-VERSION 0.6
+VERSION 0.7
 FROM python:3
 WORKDIR /code
 

--- a/docs/basics/part-6-using-docker-with-earthly.md
+++ b/docs/basics/part-6-using-docker-with-earthly.md
@@ -118,7 +118,7 @@ func TestIntegration(t *testing.T) {
 ```
 
 ```Dockerfile
-VERSION 0.6
+VERSION 0.7
 FROM golang:1.15-alpine3.13
 WORKDIR /go-workdir
 
@@ -133,7 +133,7 @@ test-setup:
     COPY main.go .
     COPY main_integration_test.go .
     ENV CGO_ENABLED=0
-    ENTRYPOINT [ "go", "test", "github.com/earthly/earthly/examples/go"]
+    ENTRYPOINT ["go", "test", "github.com/earthly/earthly/examples/go"]
     SAVE IMAGE test:latest
 
 integration-tests:
@@ -299,7 +299,7 @@ The `Earthfile` is at the root of the directory.
 `./Earthfile`
 
 ```Dockerfile
-VERSION 0.6
+VERSION 0.7
 FROM node:13.10.1-alpine3.11
 WORKDIR /js-example
 
@@ -376,7 +376,7 @@ earthly --artifact github.com/earthly/earthly/examples/tutorial/java:main+part6/
 `./Earthfile`
 
 ```Dockerfile
-VERSION 0.6
+VERSION 0.7
 FROM openjdk:8-jdk-alpine
 RUN apk add --update --no-cache gradle
 WORKDIR /java-example
@@ -402,13 +402,13 @@ docker:
 
 with-postgresql:
     FROM earthly/dind:alpine
-	  COPY ./docker-compose.yml .
-	  RUN apk update
-	  RUN apk add postgresql-client
-	  WITH DOCKER --compose docker-compose.yml --load app:latest=+docker
-		    RUN while ! pg_isready --host=localhost --port=5432; do sleep 1; done ;\
-			    docker run --network=default_java/part6_default app
-	  END
+    COPY ./docker-compose.yml .
+    RUN apk update
+    RUN apk add postgresql-client
+    WITH DOCKER --compose docker-compose.yml --load app:latest=+docker
+        RUN while ! pg_isready --host=localhost --port=5432; do sleep 1; done ;\
+            docker run --network=default_java/part6_default app
+    END
 
 ```
 
@@ -549,14 +549,14 @@ networks:
 `./Earthfile`
 
 ```Dockerfile
-VERSION 0.6
+VERSION 0.7
 FROM python:3
 WORKDIR /code
 
 build:
-  COPY ./requirements.txt .
-  RUN pip install -r requirements.txt
-  COPY . .
+    COPY ./requirements.txt .
+    RUN pip install -r requirements.txt
+    COPY . .
 
 run-tests:
     FROM earthly/dind:alpine

--- a/docs/best-practices/best-practices.md
+++ b/docs/best-practices/best-practices.md
@@ -126,7 +126,7 @@ Repo 2:
 
 ```Dockerfile
 # Bad
-VERSION 0.6
+VERSION 0.7
 FROM alpine:3.15
 WORKDIR /work
 print-file:
@@ -147,7 +147,7 @@ repo 1
 
 ```Dockerfile
 # Repo 1 Earthfile
-VERSION 0.6
+VERSION 0.7
 FROM alpine:3.15
 WORKDIR /work
 file:
@@ -159,7 +159,7 @@ Repo 2:
 
 ```Dockerfile
 # Repo 2 Earthfile
-VERSION 0.6
+VERSION 0.7
 IMPORT github.com/my-co/repo-1
 FROM alpine:3.15
 WORKDIR /work
@@ -866,7 +866,7 @@ In the above example, the file `some-file.txt` is copied from the sibling direct
 
 ```Dockerfile
 # ./dir1/Earthfile
-VERSION 0.6
+VERSION 0.7
 FROM alpine:3.15
 WORKDIR /work
 file:
@@ -949,7 +949,7 @@ If a target acts as a wrapper for another target and that other target produces 
 
 ```Dockerfile
 # No pass-through artifacts
-VERSION 0.6
+VERSION 0.7
 FROM alpine:3.15
 build:
     ARG some_arg=...
@@ -963,7 +963,7 @@ build-for-windows:
 
 ```Dockerfile
 # With pass-through artifacts
-VERSION 0.6
+VERSION 0.7
 FROM alpine:3.15
 build:
     ARG some_arg=...
@@ -982,7 +982,7 @@ Similarly, if a target emits an image, then that image can be also emitted by a 
 
 ```Dockerfile
 # No pass-through image
-VERSION 0.6
+VERSION 0.7
 FROM alpine:3.15
 build:
     ARG some_arg=...
@@ -995,7 +995,7 @@ build-wrapper:
 
 ```Dockerfile
 # With pass-through image
-VERSION 0.6
+VERSION 0.7
 FROM alpine:3.15
 build:
     ARG some_arg=...

--- a/docs/earthfile/earthfile.md
+++ b/docs/earthfile/earthfile.md
@@ -1114,8 +1114,6 @@ Same as [`RUN --secret <env-var>=<secret-id>`](#secret-less-than-env-var-greater
 
 ## FOR
 
-Enable via `VERSION 0.6`.
-
 #### Synopsis
 
 * ```

--- a/docs/earthfile/earthfile.md
+++ b/docs/earthfile/earthfile.md
@@ -1265,12 +1265,7 @@ example:
     END
 ```
 
-## CACHE (beta)
-
-{% hint style='info' %}
-##### Note
-The `CACHE` command is in beta and must be enabled via `VERSION --use-cache-command 0.6`.
-{% endhint %}
+## CACHE
 
 #### Synopsis
 

--- a/docs/earthly-command/earthly-command.md
+++ b/docs/earthly-command/earthly-command.md
@@ -76,11 +76,11 @@ The build arg overrides only apply to the target being called directly and any o
 
 For more information about build args see the [`ARG` Earthfile command](../earthfile/earthfile.md#arg).
 
-#### Environment Variables and .env File
+#### Environment Variables and .arg File
 
 As specified under the [options section](#options), all flag options have an environment variable equivalent, which can be used as an alternative.
 
-Furthermore, additional environment variables are also read from a file named `.env`, if one exists in the current directory. The syntax of the `.env` file is of the form
+Furthermore, additional environment variables are also read from a file named `.arg`, if one exists in the current directory. The syntax of the `.arg` file is of the form
 
 ```.env
 <NAME_OF_ENV_VAR>=<value>
@@ -92,27 +92,23 @@ as one variable per line, without any surrounding quotes. If quotes are included
 ```.env
 # Settings
 EARTHLY_ALLOW_PRIVILEGED=true
-MY_SETTING=a setting which contains spaces
 
-# Secrets
-MY_SECRET=MmQ1MjFlY2UtYzhlNi00YjJkLWI5YTMtNjIzNzJmYjcwOTJk
-ANOTHER_SECRET=MjA5YjU2ZTItYmIxOS00MDQ3LWFlNzYtNmQ5NGEyZDFlYTQx
+MY_SETTING=a setting which contains spaces
 ```
 
 {% hint style='info' %}
 ##### Note
-The directory used for loading the `.env` file is the directory where `earthly` is called from and not necessarily the directory where the Earthfile is located in.
+The directory used for loading the `.arg` file is the directory where `earthly` is called from and not necessarily the directory where the Earthfile is located in.
 {% endhint %}
 
-The additional environment variables specified in the `.env` file are loaded by `earthly` in three distinct ways:
+The additional environment variables specified in the `.arg` file are loaded by `earthly` in two distinct ways:
 
 * **Setting options for `earthly` itself** - the settings are loaded if they match the environment variable equivalent of an `earthly` option.
 * **Build args** - the settings are passed on to the build and are used to override any [`ARG`](../earthfile/earthfile.md#arg) declaration.
-* **Secrets** - the settings are passed on to the build to be referenced via the [`RUN --secret`](../earthfile/earthfile.md#secret-less-than-env-var-greater-than-less-than-secret-ref-greater-than) option.
 
 {% hint style='danger' %}
 ##### Important
-The `.env` file is meant for settings which are specific to the local environment the build executes in. These settings may cause inconsistencies in the way the build executes on different systems, leading to builds that are difficult to reproduce. Keep the contents of `.env` files to a minimum to avoid such issues.
+The `.arg` file is meant for settings which are specific to the local environment the build executes in. These settings may cause inconsistencies in the way the build executes on different systems, leading to builds that are difficult to reproduce. Keep the contents of `.arg` files to a minimum to avoid such issues.
 {% endhint %}
 
 #### Global Options

--- a/docs/earthly-config/earthly-config.md
+++ b/docs/earthly-config/earthly-config.md
@@ -67,7 +67,7 @@ When used in combination with `cache_size_mb`, the lesser of the two values will
 
 A custom user-supplied program to call which returns a secret for use by earthly. The secret identifier is passed as the first argument to the program.
 
-If no secret is found, the program can instruct earthly to continue searching for secrets under `.env`, by exiting with a status code of `2`, all other non-zero
+If no secret is found, the program can instruct earthly to continue searching for secrets under `.secret`, by exiting with a status code of `2`, all other non-zero
 status codes will cause earthly to exit.
 
 For example, if you have:

--- a/docs/guides/advanced-local-caching.md
+++ b/docs/guides/advanced-local-caching.md
@@ -7,7 +7,7 @@ We will discuss a specific example where dependencies are cached using multiple 
 ```Dockerfile
 # Earthfile
 
-VERSION 0.6
+VERSION 0.7
 FROM openjdk:8-jdk-alpine
 RUN apk add --update --no-cache gradle
 WORKDIR /java-example
@@ -30,7 +30,7 @@ One option is to use layer-based caching to first download all dependencies and 
 ```Dockerfile
 # Earthfile
 
-VERSION 0.6
+VERSION 0.7
 FROM openjdk:8-jdk-alpine
 RUN apk add --update --no-cache gradle
 WORKDIR /java-example
@@ -58,7 +58,7 @@ For these cases, the build could use a cache mount. A cache mount is a volume th
 ```Dockerfile
 # Earthfile
 
-VERSION 0.6
+VERSION 0.7
 FROM openjdk:8-jdk-alpine
 RUN apk add --update --no-cache gradle
 WORKDIR /java-example

--- a/docs/guides/build-args.md
+++ b/docs/guides/build-args.md
@@ -108,10 +108,10 @@ Argument values can be set multiple ways:
 
     This may be useful if you have a set of build args that you'd like to always use and would prefer not to have to specify them on the command line every time. The `EARTHLY_BUILD_ARGS` environment variable may also be stored in your `~/.bashrc` file, or some other shell-specific startup script.
 
-4. From a `.env` file
+4. From an `.arg` file
 
-   It is also possible to create an `.env` file to contain the build arguments to pass
-   to earthly. First create an `.env` file with:
+   It is also possible to create an `.arg` file to contain the build arguments to pass
+   to earthly. First create an `.arg` file with:
    
    ```
    name=eggplant
@@ -235,9 +235,9 @@ This is possible in a few ways:
 
    Multiple secrets can be specified by separating them with a comma.
 
-4. Via the `.env` file.
+4. Via the `.secret` file.
 
-   Create a `.env` file in the same directory where you plan to run `earthly` from. Its contents should be:
+   Create a `.secret` file in the same directory where you plan to run `earthly` from. Its contents should be:
    
    ```
    passwd=itsasecret

--- a/docs/guides/build-args.md
+++ b/docs/guides/build-args.md
@@ -19,7 +19,7 @@ Let's consider a "hello world" example that allows us to change who is being gre
 We will create a hello target that accepts the `name` argument:
 
 ```Dockerfile
-VERSION 0.6
+VERSION 0.7
 FROM alpine:latest
 
 hello:

--- a/docs/guides/debugging.md
+++ b/docs/guides/debugging.md
@@ -12,7 +12,7 @@ Let's consider a test example that prints out a randomly generated phrase:
 ```Dockerfile
 # Earthfile
 
-VERSION 0.6
+VERSION 0.7
 FROM python:3
 WORKDIR /code
 
@@ -98,7 +98,7 @@ Note that even though we fixed the problem during debugging, the image will not 
 ```Dockerfile
 # Earthfile
 
-VERSION 0.6
+VERSION 0.7
 FROM python:3
 WORKDIR /code
 
@@ -117,7 +117,7 @@ Let's consider a more complicated example where we are running integration tests
 ```Dockerfile
 # Earthfile
 
-VERSION 0.6
+VERSION 0.7
 
 server:
   COPY server.py .
@@ -191,7 +191,7 @@ Ah ha! The problem is our test is expecting a lowercase `h`, so we can fix our g
 ```Dockerfile
 # Earthfile
 
-VERSION 0.6
+VERSION 0.7
 
 server:
   COPY server.py .

--- a/docs/guides/integration.md
+++ b/docs/guides/integration.md
@@ -132,7 +132,7 @@ We start with a simple Earthfile that can build and create a docker image for ou
 
 We start from an appropriate docker image and set up a working directory. 
 ``` Dockerfile
-VERSION 0.6
+VERSION 0.7
 FROM earthly/dind:alpine
 WORKDIR /scala-example
 RUN apk add openjdk11 bash wget postgresql-client

--- a/docs/guides/udc.md
+++ b/docs/guides/udc.md
@@ -60,9 +60,9 @@ PRINT_VAR:
 Global imports and global args are inherited from the `base` target of the same Earthfile where the command is defined in (this may be distinct from the `base` target of the caller).
 
 ```Dockerfile
-VERSION 0.6
+VERSION 0.7
 
-ARG a_global_var=value-in-global
+ARG --global a_global_var=value-in-global
 
 build:
     # prints "value-in-global"


### PR DESCRIPTION
My original intent was only to update the `.env`/`.arg`/`.secret` changes, as that was very noticeable.  Then I started noticing other things on the way.

There are still a number of `0.6.x` references that I left untouched for various reasons.  The subset I changed were mostly around the 'language' (e.g., `VERSION 0.7`), which are very user-facing and 'static'.  The rest were largely around advanced deployment, esp. download links and docker tags, which are probably less visible and are moving targets.