### PR TITLE
verbose logging for git matchers

### DIFF
--- a/util/stringutil/scrub.go
+++ b/util/stringutil/scrub.go
@@ -2,7 +2,7 @@ package stringutil
 
 import "regexp"
 
-var scrubRegexp = regexp.MustCompile(`(//[^:]+):([^@]+)@`)
+var scrubRegexp = regexp.MustCompile(`^(([a-zA-Z]+://)?([^:]+)):([^@]+)@`)
 
 // ScrubCredentials removes credentials from a string
 func ScrubCredentials(s string) string {

--- a/util/stringutil/scrub_test.go
+++ b/util/stringutil/scrub_test.go
@@ -8,3 +8,8 @@ func TestScrub(t *testing.T) {
 	s := ScrubCredentials("https://user:password@github.com/org/repo.git")
 	Equal(t, "https://user:***@github.com/org/repo.git", s)
 }
+
+func TestScrubMissingProtocol(t *testing.T) {
+	s := ScrubCredentials("user:password@github.com/org/repo.git")
+	Equal(t, "user:***@github.com/org/repo.git", s)
+}


### PR DESCRIPTION
Adds additional verbose logging messages for when git substitution is used.