### PR TITLE
Allow saves to more destinations on `TRY` failures

### DIFF
--- a/cmd/earthly/build_cmd.go
+++ b/cmd/earthly/build_cmd.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/url"
 	"os"
+	"path"
 	"strings"
 	"time"
 
@@ -630,6 +631,10 @@ func receiveFileVersion2(ctx context.Context, conn io.ReadWriteCloser, localArti
 
 	if !localArtifactWhiteList.Exists(string(dst)) {
 		return fmt.Errorf("file %s does not appear in the white list", dst)
+	}
+	err = os.MkdirAll(path.Dir(string(dst)), 0755)
+	if err != nil {
+		return err
 	}
 
 	f, err := os.Create(string(dst))

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -1896,6 +1896,11 @@ func (c *Converter) internalRun(ctx context.Context, opts ConvertRunOpts) (pllb.
 			}
 			dst := path.Join(localPathAbs, interactiveSaveFile.Dst)
 			c.opt.LocalArtifactWhiteList.Add(dst)
+			// The receiveFile handler will only be given the relative, so needs to whitelisted as well.
+			// This is needed when e.g. the user specifies a destination of "out/", which is then rewritten
+			// to "out/file".  If the user specified a full file path, e.g. "out/file", then this is redundant
+			// since the waitBlock will add that same value.  This makes it explicit.
+			c.opt.LocalArtifactWhiteList.Add(interactiveSaveFile.Dst)
 
 			saveFiles = append(saveFiles, debuggercommon.SaveFilesSettings{
 				Src:      interactiveSaveFile.Src,

--- a/earthfile2llb/interpreter.go
+++ b/earthfile2llb/interpreter.go
@@ -522,6 +522,10 @@ func (i *Interpreter) handleTry(ctx context.Context, tryStmt spec.TryStatement) 
 			if strings.Contains(saveAsLocalTo, "$") {
 				return i.errorf(cmd.Command.SourceLocation, "TRY/CATCH/FINALLY does not (currently) support expanding args for SAVE ARTIFACT paths")
 			}
+			destIsDir := strings.HasSuffix(saveAsLocalTo, "/") || saveAsLocalTo == "."
+			if destIsDir {
+				saveAsLocalTo = path.Join(saveAsLocalTo, path.Base(saveFrom))
+			}
 			saveArtifacts = append(saveArtifacts, debuggercommon.SaveFilesSettings{
 				Src:      saveFrom,
 				Dst:      saveAsLocalTo,

--- a/tests/try-catch/try-finally-fail/.gitignore
+++ b/tests/try-catch/try-finally-fail/.gitignore
@@ -1,1 +1,3 @@
 .testdata
+data
+out/

--- a/tests/try-catch/try-finally-fail/Earthfile
+++ b/tests/try-catch/try-finally-fail/Earthfile
@@ -6,3 +6,27 @@ test:
     FINALLY
         SAVE ARTIFACT data AS LOCAL .testdata
     END
+
+test-save-to-curdir:
+    FROM alpine:3.15
+    TRY
+        RUN echo magic > data && false
+    FINALLY
+        SAVE ARTIFACT data AS LOCAL ./
+    END
+
+test-save-to-child-dir:
+    FROM alpine:3.15
+    TRY
+        RUN echo magic > data && false
+    FINALLY
+        SAVE ARTIFACT data AS LOCAL out/
+    END
+
+test-save-to-child-file:
+    FROM alpine:3.15
+    TRY
+        RUN echo magic > data && false
+    FINALLY
+        SAVE ARTIFACT data AS LOCAL out/.testdata
+    END

--- a/tests/try-catch/try-finally-fail/test.sh
+++ b/tests/try-catch/try-finally-fail/test.sh
@@ -8,14 +8,30 @@ cd "$(dirname "$0")"
 earthly=${earthly-"../../../build/linux/amd64/earthly"}
 echo "using earthly=$(realpath "$earthly")"
 
-rm .testdata || true # cleanup
+cleanup() {
+  rm -r .testdata data out/ || true
+}
 
-set +e
-"$earthly" $@ +test
-exit_code="$?"
-set -e
+execute() {
+  local target="$1"
+  local expected_path="$2"
+  shift 2
 
-test -f .testdata
-test "$(cat .testdata)" = "magic"
-test "$(md5sum .testdata | awk '{print $1}')" = "b6e7f4684fae52db1c9e33687b697d38"
-test "$exit_code" -ne "0"
+  cleanup
+
+  set +e
+  "$earthly" $@ "$target"
+  exit_code="$?"
+  set -e
+
+  test -f "$expected_path"
+  test "$(cat "$expected_path")" = "magic"
+  test "$(md5sum "$expected_path" | awk '{print $1}')" = "b6e7f4684fae52db1c9e33687b697d38"
+  test "$exit_code" -ne "0"
+}
+
+execute '+test' .testdata "$@"
+execute '+test-save-to-curdir' data "$@"
+execute '+test-save-to-child-dir' out/data "$@"
+execute '+test-save-to-child-file' out/.testdata "$@"
+cleanup


### PR DESCRIPTION
Fixes #2800 

This allows all three failures scenarios to work, namely:
1. Saving to the current directory (`AS LOCAL ./`)
2. Saving to a child directory (`AS LOCAL docs/`)
3. Saving to a named file in a child directory (`AS LOCAL docs/data.txt`)

I know this is experimental functionality, which is both a reason you may accept (not as worried about compatibility, etc.) or reject (wanting to address this in a different way in a future rewrite) the change.  Since I had already done the investigation, which was the hard part, I figured I'd take my chances.
