### PR TITLE
Fix usage of Hub mirrors for testing

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -432,14 +432,21 @@ earthly-integration-test-base:
         # Use a mirror, supports mirroring Docker Hub only.
         ENV EARTHLY_ADDITIONAL_BUILDKIT_CONFIG="[registry.\"docker.io\"]
   mirrors = [\"$DOCKERHUB_MIRROR\"]"
+        ENV MIRROR_CONFIG="[registry.\"$DOCKERHUB_MIRROR\"]"
         IF [ "$DOCKERHUB_MIRROR_INSECURE" = "true" ]
             ENV EARTHLY_ADDITIONAL_BUILDKIT_CONFIG="$EARTHLY_ADDITIONAL_BUILDKIT_CONFIG
+  insecure = true"
+            ENV MIRROR_CONFIG="$MIRROR_CONFIG
   insecure = true"
         END
         IF [ "$DOCKERHUB_MIRROR_HTTP" = "true" ]
             ENV EARTHLY_ADDITIONAL_BUILDKIT_CONFIG="$EARTHLY_ADDITIONAL_BUILDKIT_CONFIG
   http = true"
+            ENV MIRROR_CONFIG="$MIRROR_CONFIG
+  http = true"
         END
+        ENV EARTHLY_ADDITIONAL_BUILDKIT_CONFIG="$EARTHLY_ADDITIONAL_BUILDKIT_CONFIG
+$MIRROR_CONFIG"
 
         # NOTE: newlines+indentation is important here, see https://github.com/earthly/earthly/issues/1764 for potential pitfalls
         # yaml will convert newlines to spaces when using regular quoted-strings, therefore we will use the literal-style (denoted by `|`)


### PR DESCRIPTION
This stopped working (reason currently unknown), but probably something with the previous http/insecure changes, or the buildkit update.  This writes out an explicit stanza for the mirror registry.

Previously:
```
[registry."docker.io"]
  mirrors = ["mymirror"]
  http = true
```

After this change:
```
[registry."docker.io"]
  mirrors = ["mymirror"]
  http = true
[registry."mymirror"]
  http = true
```

The buildkit docs (https://github.com/moby/buildkit/blob/master/docs/buildkitd.toml.md?plain=1#L97-L101) show the current way being syntantically correct.  We probably assumed that `http = true` would apply to the list of mirrors, but doesn't.  At least anymore.  It probably applies to the registry itself.

Regardless of why/when it stopped working, this makes it work properly again.  The 'fixed' format matches the format of my personal `config.yml` file, and matches your docs too (https://github.com/earthly/earthly/blob/main/docs/ci-integration/pull-through-cache.md?plain=1#L58-L63)