### PR TITLE
earthly doc: output documentation for ARGs, ARTIFACTs, and IMAGEs

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -405,6 +405,7 @@ earthly-docker:
 
 earthly-integration-test-base:
     FROM +earthly-docker
+    RUN apk add pcre-tools
     ENV NO_DOCKER=1
     ENV NETWORK_MODE=host # Note that this breaks access to embedded registry in WITH DOCKER.
     ENV EARTHLY_VERSION_FLAG_OVERRIDES=no-use-registry-for-with-docker # Use tar-based due to above.

--- a/ast/ast_test.go
+++ b/ast/ast_test.go
@@ -346,6 +346,78 @@ bar:
 			tt.expect(tgt.Name).To(equal("bar"))
 			tt.expect(tgt.Docs).To(equal(""))
 		})
+
+		o.Spec("it parses documentation on ARGs", func(tt testCtx) {
+			// It felt cleaner to check the doc comment's first word against the
+			// target's name at a higher level where we can display hints to the
+			// user about why the comments are not considered documentation.
+			mockEarthfile(tt.t, tt.reader, []byte(`
+VERSION 0.6
+
+foo:
+    # foo is the argument that will be echoed
+    ARG foo = bar
+    RUN echo $foo
+`))
+			f, err := ast.ParseOpts(context.Background(), ast.FromReader(tt.reader))
+			tt.expect(err).To(not(haveOccurred()))
+
+			tt.expect(f.Targets).To(haveLen(1))
+			tgt := f.Targets[0]
+			tt.expect(tgt.Recipe).To(haveLen(2))
+			arg := tgt.Recipe[0]
+			tt.expect(arg.Command).To(not(beNil()))
+			tt.expect(arg.Command.Name).To(equal("ARG"))
+			tt.expect(arg.Command.Docs).To(equal("foo is the argument that will be echoed\n"))
+		})
+
+		o.Spec("it parses documentation on SAVE ARTIFACT", func(tt testCtx) {
+			// It felt cleaner to check the doc comment's first word against the
+			// target's name at a higher level where we can display hints to the
+			// user about why the comments are not considered documentation.
+			mockEarthfile(tt.t, tt.reader, []byte(`
+VERSION 0.6
+
+foo:
+    RUN echo foo > bar.txt
+    # bar.txt will contain the output of this target
+    SAVE ARTIFACT bar.txt
+`))
+			f, err := ast.ParseOpts(context.Background(), ast.FromReader(tt.reader))
+			tt.expect(err).To(not(haveOccurred()))
+
+			tt.expect(f.Targets).To(haveLen(1))
+			tgt := f.Targets[0]
+			tt.expect(tgt.Recipe).To(haveLen(2))
+			arg := tgt.Recipe[1]
+			tt.expect(arg.Command).To(not(beNil()))
+			tt.expect(arg.Command.Name).To(equal("SAVE ARTIFACT"))
+			tt.expect(arg.Command.Docs).To(equal("bar.txt will contain the output of this target\n"))
+		})
+
+		o.Spec("it parses documentation on SAVE IMAGE", func(tt testCtx) {
+			// It felt cleaner to check the doc comment's first word against the
+			// target's name at a higher level where we can display hints to the
+			// user about why the comments are not considered documentation.
+			mockEarthfile(tt.t, tt.reader, []byte(`
+VERSION 0.6
+
+foo:
+    RUN echo foo > bar.txt
+    # foo is an image that contains a bar.txt file
+    SAVE IMAGE foo
+`))
+			f, err := ast.ParseOpts(context.Background(), ast.FromReader(tt.reader))
+			tt.expect(err).To(not(haveOccurred()))
+
+			tt.expect(f.Targets).To(haveLen(1))
+			tgt := f.Targets[0]
+			tt.expect(tgt.Recipe).To(haveLen(2))
+			arg := tgt.Recipe[1]
+			tt.expect(arg.Command).To(not(beNil()))
+			tt.expect(arg.Command.Name).To(equal("SAVE IMAGE"))
+			tt.expect(arg.Command.Docs).To(equal("foo is an image that contains a bar.txt file\n"))
+		})
 	})
 }
 

--- a/ast/listener.go
+++ b/ast/listener.go
@@ -90,7 +90,9 @@ func (l *listener) docs(c antlr.ParserRuleContext) string {
 	comments := l.tokStream.GetHiddenTokensToLeft(c.GetStart().GetTokenIndex(), parser.EarthLexerCOMMENTS_CHANNEL)
 	var docs string
 	for _, c := range comments {
-		line := strings.TrimSpace(strings.TrimPrefix(c.GetText(), "#"))
+		line := strings.TrimSpace(c.GetText())
+		line = strings.TrimPrefix(line, "#")
+		line = strings.TrimSpace(line)
 		docs += line + "\n"
 	}
 	return docs
@@ -182,7 +184,9 @@ func (l *listener) ExitStmt(c *parser.StmtContext) {
 // Command --------------------------------------------------------------------
 
 func (l *listener) EnterCommandStmt(c *parser.CommandStmtContext) {
-	l.command = new(spec.Command)
+	l.command = &spec.Command{
+		Docs: l.docs(c),
+	}
 	if l.enableSourceMap {
 		l.command.SourceLocation = &spec.SourceLocation{
 			File:        l.filePath,

--- a/cmd/earthly/doc_cmds.go
+++ b/cmd/earthly/doc_cmds.go
@@ -1,0 +1,258 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/earthly/earthly/ast/spec"
+	"github.com/earthly/earthly/buildcontext"
+	"github.com/earthly/earthly/domain"
+	"github.com/earthly/earthly/earthfile2llb"
+	"github.com/earthly/earthly/util/platutil"
+	gwclient "github.com/moby/buildkit/frontend/gateway/client"
+	"github.com/pkg/errors"
+	"github.com/urfave/cli/v2"
+)
+
+func (app *earthlyApp) actionDocumentTarget(cliCtx *cli.Context) error {
+	app.commandName = "docTarget"
+
+	if cliCtx.NArg() > 1 {
+		return errors.New("invalid number of arguments provided")
+	}
+
+	var tgtPath string
+	if cliCtx.NArg() > 0 {
+		tgtPath = cliCtx.Args().Get(0)
+		switch tgtPath[0] {
+		case '.', '/', '+':
+		default:
+			return errors.New("remote-paths are not currently supported - documentation targets must start with one of ['.', '/', '+']")
+		}
+	}
+
+	singleTgt := true
+	if !strings.ContainsRune(tgtPath, '+') {
+		tgtPath += "+base"
+		singleTgt = false
+	}
+
+	target, err := domain.ParseTarget(tgtPath)
+	if err != nil {
+		return errors.Errorf("unable to parse target [%v]", tgtPath)
+	}
+
+	gitLookup := buildcontext.NewGitLookup(app.console, app.sshAuthSock)
+	resolver := buildcontext.NewResolver(nil, gitLookup, app.console, "")
+	platr := platutil.NewResolver(platutil.GetUserPlatform())
+	var gwClient gwclient.Client
+	bc, err := resolver.Resolve(cliCtx.Context, gwClient, platr, target)
+	if err != nil {
+		return errors.Wrap(err, "failed to resolve target")
+	}
+
+	const docsIndent = "  "
+
+	if singleTgt {
+		tgt, err := findTarget(bc.Earthfile, target.Target)
+		if err != nil {
+			return errors.Wrap(err, "failed to look up target")
+		}
+		return app.documentSingleTarget(cliCtx, "", docsIndent, tgt, true)
+	}
+
+	tgts := bc.Earthfile.Targets
+	fmt.Println("TARGETS:")
+	const tgtIndent = docsIndent
+	for _, tgt := range tgts {
+		_ = app.documentSingleTarget(cliCtx, tgtIndent, docsIndent, tgt, false)
+	}
+
+	return nil
+}
+
+func docString(body string, names ...string) (string, error) {
+	firstWordEnd := strings.IndexRune(body, ' ')
+	if firstWordEnd == -1 {
+		return "", errors.Errorf("failed to parse first word of documentation comments")
+	}
+	firstWord := body[:firstWordEnd]
+	for _, n := range names {
+		if firstWord == n {
+			return body, nil
+		}
+	}
+	return "", errors.Errorf("no doc comment found [hint: a comment was found but the first word was not one of (%s)]", strings.Join(names, ", "))
+}
+
+type docSection struct {
+	identifier string
+	body       string
+}
+
+func docSectionsOutput(currIndent, scopeIndent, title string, sections ...docSection) string {
+	if len(sections) == 0 {
+		return ""
+	}
+	out := indent(currIndent, title+":") + "\n"
+	currIndent += scopeIndent
+	for _, section := range sections {
+		out += indent(currIndent, section.identifier) + "\n"
+		if section.body == "" {
+			continue
+		}
+		indented := indent(currIndent+scopeIndent, section.body)
+		out += strings.Trim(indented, "\n") + "\n"
+	}
+	return out
+}
+
+type blockIO struct {
+	// TODO: globals
+	requiredArgs   []docSection
+	optionalArgs   []docSection
+	artifacts      []docSection
+	localArtifacts []docSection
+	images         []docSection
+}
+
+func (io blockIO) options() string {
+	var options []string
+	for _, arg := range io.requiredArgs {
+		options = append(options, arg.identifier)
+	}
+	for _, arg := range io.optionalArgs {
+		options = append(options, fmt.Sprintf("[%s]", arg.identifier))
+	}
+	return strings.Join(options, " ")
+}
+
+func (io blockIO) help(indent, scopeIndent string) string {
+	return docSectionsOutput(indent, scopeIndent, "REQUIRED ARGS", io.requiredArgs...) +
+		docSectionsOutput(indent, scopeIndent, "OPTIONAL ARGS", io.optionalArgs...) +
+		docSectionsOutput(indent, scopeIndent, "ARTIFACTS", io.artifacts...) +
+		docSectionsOutput(indent, scopeIndent, "LOCAL ARTIFACTS", io.localArtifacts...) +
+		docSectionsOutput(indent, scopeIndent, "IMAGES", io.images...)
+}
+
+func parseDocSections(cliCtx *cli.Context, cmds spec.Block) (*blockIO, error) {
+	var io blockIO
+	for _, rb := range cmds {
+		if rb.Command == nil {
+			continue
+		}
+		cmd := *rb.Command
+		identifiers, err := earthfile2llb.Name(cliCtx.Context, cmd)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to parse name(s) of command type %v", cmd.Name)
+		}
+		switch cmd.Name {
+		case "ARG":
+			var dflt string
+			if len(identifiers) == 2 {
+				dflt = identifiers[1]
+				identifiers = identifiers[:1]
+			}
+			if len(identifiers) != 1 {
+				return nil, errors.Errorf("ARG should have exactly 1 identifier after consuming the default; got %v", len(identifiers))
+			}
+			docs, _ := docString(cmd.Docs, identifiers...)
+			argDoc := docSection{
+				identifier: "--" + identifiers[0],
+				body:       docs,
+			}
+			if dflt != "" {
+				argDoc.identifier += "=" + dflt
+			}
+			if isRequired(cmd) {
+				io.requiredArgs = append(io.requiredArgs, argDoc)
+				continue
+			}
+			io.optionalArgs = append(io.optionalArgs, argDoc)
+		case "SAVE ARTIFACT":
+			docs, _ := docString(cmd.Docs, identifiers...)
+			artDoc := docSection{
+				body: docs,
+			}
+			if len(identifiers) == 1 {
+				artDoc.identifier = identifiers[0]
+				io.artifacts = append(io.artifacts, artDoc)
+				continue
+			}
+			artDoc.identifier = fmt.Sprintf("%s -> %s", identifiers[0], identifiers[1])
+			io.localArtifacts = append(io.localArtifacts, artDoc)
+		case "SAVE IMAGE":
+			if len(identifiers) == 0 {
+				continue
+			}
+			docs, _ := docString(cmd.Docs, identifiers...)
+			io.images = append(io.images, docSection{
+				identifier: strings.Join(identifiers, ", "),
+				body:       docs,
+			})
+		}
+	}
+	return &io, nil
+}
+
+func (app *earthlyApp) documentSingleTarget(cliCtx *cli.Context, currIndent, scopeIndent string, tgt spec.Target, includeBlockDocs bool) error {
+	if tgt.Docs == "" {
+		return errors.Errorf("no doc comment found [hint: add a comment starting with the word '%s' on the line immediately above this target]", tgt.Name)
+	}
+
+	docs, err := docString(tgt.Docs, tgt.Name)
+	if err != nil {
+		return err
+	}
+
+	blockIO, err := parseDocSections(cliCtx, tgt.Recipe)
+	if err != nil {
+		return errors.Wrapf(err, "failed to parse body of recipe '%v'", tgt.Name)
+	}
+
+	usage := indent(currIndent, "+"+tgt.Name)
+	options := blockIO.options()
+	if options != "" {
+		usage += " " + options
+	}
+	fmt.Println(usage)
+	docIndent := currIndent + scopeIndent + scopeIndent
+	indented := indent(docIndent, docs)
+	fmt.Println(strings.Trim(indented, "\n"))
+
+	if !includeBlockDocs {
+		return nil
+	}
+
+	fmt.Println(blockIO.help(currIndent+scopeIndent, scopeIndent))
+	return nil
+}
+
+func indent(indent, s string) string {
+	lines := strings.Split(s, "\n")
+	for i, l := range lines {
+		if l == "" {
+			continue
+		}
+		lines[i] = indent + l
+	}
+	return strings.Join(lines, "\n")
+}
+
+func isRequired(cmd spec.Command) bool {
+	for _, arg := range cmd.Args {
+		if arg == "--required" {
+			return true
+		}
+	}
+	return false
+}
+
+func findTarget(ef spec.Earthfile, name string) (spec.Target, error) {
+	for _, tgt := range ef.Targets {
+		if tgt.Name == name {
+			return tgt, nil
+		}
+	}
+	return spec.Target{}, errors.Errorf("could not find target named [%v]", name)
+}

--- a/cmd/earthly/root_cmds.go
+++ b/cmd/earthly/root_cmds.go
@@ -16,7 +16,6 @@ import (
 	"github.com/urfave/cli/v2"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/earthly/earthly/ast/spec"
 	"github.com/earthly/earthly/buildcontext"
 	"github.com/earthly/earthly/buildkitd"
 	"github.com/earthly/earthly/config"
@@ -25,7 +24,6 @@ import (
 	"github.com/earthly/earthly/earthfile2llb"
 	"github.com/earthly/earthly/util/cliutil"
 	"github.com/earthly/earthly/util/fileutil"
-	"github.com/earthly/earthly/util/platutil"
 	"github.com/earthly/earthly/util/termutil"
 )
 
@@ -593,87 +591,6 @@ func ifNilBoolDefault(ptr *bool, defaultValue bool) bool {
 	return *ptr
 }
 
-func (app *earthlyApp) actionDocumentTarget(cliCtx *cli.Context) error {
-	app.commandName = "docTarget"
-
-	if cliCtx.NArg() > 1 {
-		return errors.New("invalid number of arguments provided")
-	}
-
-	var tgtPath string
-	if cliCtx.NArg() > 0 {
-		tgtPath = cliCtx.Args().Get(0)
-		switch tgtPath[0] {
-		case '.', '/', '+':
-		default:
-			return errors.New("remote-paths are not currently supported - documentation targets must start with one of ['.', '/', '+']")
-		}
-	}
-
-	singleTgt := true
-	if !strings.ContainsRune(tgtPath, '+') {
-		tgtPath += "+base"
-		singleTgt = false
-	}
-
-	target, err := domain.ParseTarget(tgtPath)
-	if err != nil {
-		return errors.Errorf("unable to parse target [%v]", tgtPath)
-	}
-
-	gitLookup := buildcontext.NewGitLookup(app.console, app.sshAuthSock)
-	resolver := buildcontext.NewResolver(nil, gitLookup, app.console, "")
-	platr := platutil.NewResolver(platutil.GetUserPlatform())
-	var gwClient gwclient.Client
-	bc, err := resolver.Resolve(cliCtx.Context, gwClient, platr, target)
-	if err != nil {
-		return errors.Wrap(err, "failed to resolve target")
-	}
-
-	const docsIndent = "  "
-
-	if singleTgt {
-		tgt, err := findTarget(bc.Earthfile, target.Target)
-		if err != nil {
-			return errors.Wrap(err, "failed to look up target")
-		}
-		return app.documentSingleTarget("", docsIndent, tgt)
-		// TODO: print arg docs - probably a flag to documentSingleTarget.
-	}
-
-	tgts := bc.Earthfile.Targets
-	fmt.Println("TARGETS:")
-	const (
-		nameIndent = docsIndent
-		bodyIndent = docsIndent + docsIndent
-	)
-	for _, tgt := range tgts {
-		_ = app.documentSingleTarget(nameIndent, bodyIndent, tgt)
-	}
-
-	return nil
-}
-
-func (app *earthlyApp) documentSingleTarget(nameIndent, docIndent string, tgt spec.Target) error {
-	if tgt.Docs == "" {
-		return errors.Errorf("no doc comment found [hint: add a comment starting with the word '%s' on the line immediately above this target]", tgt.Name)
-	}
-
-	firstWordEnd := strings.IndexRune(tgt.Docs, ' ')
-	if firstWordEnd == -1 {
-		return errors.Errorf("failed to parse first word of documentation comments")
-	}
-	firstWord := tgt.Docs[:firstWordEnd]
-	if firstWord != tgt.Name {
-		return errors.Errorf("no doc comment found [hint: a comment was found but the first word was not '%s']", tgt.Name)
-	}
-
-	fmt.Println(indent(nameIndent, "+"+tgt.Name))
-	indented := indent(docIndent, tgt.Docs)
-	fmt.Println(strings.Trim(indented, "\n"))
-	return nil
-}
-
 func (app *earthlyApp) actionListTargets(cliCtx *cli.Context) error {
 	app.commandName = "listTargets"
 
@@ -810,24 +727,4 @@ func (app *earthlyApp) actionPrune(cliCtx *cli.Context) error {
 	}
 	app.console.Printf("Freed %s\n", humanize.Bytes(total))
 	return nil
-}
-
-func findTarget(ef spec.Earthfile, name string) (spec.Target, error) {
-	for _, tgt := range ef.Targets {
-		if tgt.Name == name {
-			return tgt, nil
-		}
-	}
-	return spec.Target{}, errors.Errorf("could not find target named [%v]", name)
-}
-
-func indent(indent, s string) string {
-	lines := strings.Split(s, "\n")
-	for i, l := range lines {
-		if l == "" {
-			continue
-		}
-		lines[i] = indent + l
-	}
-	return strings.Join(lines, "\n")
 }

--- a/earthfile2llb/interpreter.go
+++ b/earthfile2llb/interpreter.go
@@ -997,7 +997,7 @@ func (i *Interpreter) handleCopy(ctx context.Context, cmd spec.Command) error {
 	return nil
 }
 
-func parseSaveArtifactArgs(args []string) (string, string, string, bool) {
+func parseSaveArtifactArgs(args []string) (from, to, asLocal string, _ bool) {
 	saveAsLocalTo := ""
 	saveTo := "./"
 	if len(args) >= 4 {
@@ -1364,7 +1364,7 @@ var errGlobalArgNotInBase = errors.New("global ARG can only be set in the base t
 
 // parseArgArgs parses the ARG command's arguments
 // and returns the argOpts, key, value (or nil if missing), or error
-func parseArgArgs(ctx context.Context, cmd spec.Command, isBaseTarget bool, explicitGlobalFeature bool) (argOpts, string, *string, error) {
+func parseArgArgs(ctx context.Context, cmd spec.Command, isBaseTarget bool, explicitGlobalFeature bool) (_ argOpts, name string, dflt *string, _ error) {
 	opts := argOpts{}
 	args, err := parseArgs("ARG", &opts, getArgsCopy(cmd))
 	if err != nil {

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -226,6 +226,7 @@ ga-no-qemu:
     BUILD +build-after-from
     BUILD +pipelines
     BUILD +doc
+    BUILD +doc-recipe-block
     BUILD +no-network
     BUILD +test-works-without-earthly-server
 
@@ -622,7 +623,7 @@ chown-test:
 
 dotenv-test:
     RUN echo "TEST_IN_DOTENV=this-should-not-appear-as-a-build-arg" >.env
-    DO +RUN_EARTHLY --earthfile=dotenv.earth --extra_args="--no-output" --target=+test-no-dotenv --output_contain="unexpected env .TEST_IN_DOTENV.: as of v0.7.0, --build-arg values must be defined in .arg"
+    DO +RUN_EARTHLY --earthfile=dotenv.earth --extra_args="--no-output" --target=+test-no-dotenv --output_contains="unexpected env .TEST_IN_DOTENV.: as of v0.7.0, --build-arg values must be defined in .arg"
 
     RUN touch .arg
     DO +RUN_EARTHLY --earthfile=dotenv.earth --extra_args="--no-output" --target=+test-no-dotenv --output_does_not_contain="unexpected env .TEST_IN_DOTENV.: as of v0.7.0, --build-arg values must be defined in .arg"
@@ -1161,21 +1162,57 @@ help:
     RUN earthly --help | grep 'buildkit-volume-name'
 
 doc:
-    DO +RUN_EARTHLY --earthfile=target-docs.earth --extra_args="doc" --target="" --output_contains="TARGETS:
-  +documented-target
+    DO +RUN_EARTHLY --earthfile=target-docs.earth --extra_args="doc" --target="" --post_command=">output.txt"
+    RUN pcregrep --multiline "TARGETS:
+  \+documented-target
+      documented-target is a target with documentation
+      that spans multiple lines.
+
+      It also has a separator between paragraphs." output.txt
+    DO +RUN_EARTHLY --earthfile=target-docs.earth --extra_args="doc" --target="" --grep_flags="-v" --output_contains="undocumented-target"
+    DO +RUN_EARTHLY --earthfile=target-docs.earth --extra_args="doc" --target="" --grep_flags="-v" --output_contains="incorrectly-documented-target"
+    DO +RUN_EARTHLY --earthfile=target-docs.earth --extra_args="doc" --target="+documented-target" --post_command=">output.txt"
+    RUN pcregrep --multiline "\+documented-target
     documented-target is a target with documentation
     that spans multiple lines.
 
-    It also has a separator between paragraphs."
-    DO +RUN_EARTHLY --earthfile=target-docs.earth --extra_args="doc" --target="" --grep_flags="-v" --output_contains="undocumented-target"
-    DO +RUN_EARTHLY --earthfile=target-docs.earth --extra_args="doc" --target="" --grep_flags="-v" --output_contains="incorrectly-documented-target"
-    DO +RUN_EARTHLY --earthfile=target-docs.earth --extra_args="doc" --target="+documented-target" --output_contains="+documented-target
-  documented-target is a target with documentation
-  that spans multiple lines.
-
-  It also has a separator between paragraphs."
+    It also has a separator between paragraphs." output.txt
     DO +RUN_EARTHLY --earthfile=target-docs.earth --extra_args="doc" --target="+undocumented-target" --should_fail=true --output_contains="no doc comment found"
     DO +RUN_EARTHLY --earthfile=target-docs.earth --extra_args="doc" --target="+incorrectly-documented-target" --should_fail=true --output_contains="no doc comment found"
+
+doc-recipe-block:
+    DO +RUN_EARTHLY --earthfile=doc-recipe-block.earth --extra_args="doc" --target="" --post_command=">output.txt"
+    RUN pcregrep --multiline "TARGETS:
+  \+foo --requiredArg \[--withDefault=foo\] \[--withDocs\] \[--withoutDocs\]
+      foo is a target with documentation. Targets without documentation won't show
+      up in 'earthly doc' even if they have documented commands in their recipe." output.txt
+    DO +RUN_EARTHLY --earthfile=doc-recipe-block.earth --extra_args="doc" --target="+foo" --post_command=">output.txt"
+    RUN pcregrep --multiline "\+foo --requiredArg \[--withDefault=foo\] \[--withDocs\] \[--withoutDocs\]
+    foo is a target with documentation. Targets without documentation won't show
+    up in 'earthly doc' even if they have documented commands in their recipe.
+  REQUIRED ARGS:
+    --requiredArg
+  OPTIONAL ARGS:
+    --withDefault=foo
+      withDefault is a documented argument with a default.
+    --withDocs
+      withDocs is a documented argument.
+    --withoutDocs
+  ARTIFACTS:
+    bar.txt
+      bar.txt is a documented artifact.
+    baz.txt
+  LOCAL ARTIFACTS:
+    baz.txt -> out/baz.txt
+      out/baz.txt is a documented artifact that is saved locally.
+    bacon.txt -> out/eggs.txt
+      bacon.txt is also a documented artifact that is saved locally.
+  IMAGES:
+    baz
+      baz is a documented image.
+    bar
+    bacon, eggs
+      eggs is just one of the image names, and yet it should still be recognized for this multiple-name SAVE IMAGE format." output.txt
 
 cache-cmd:
     DO +RUN_EARTHLY --earthfile=cache-cmd.earth --target=+test

--- a/tests/doc-recipe-block.earth
+++ b/tests/doc-recipe-block.earth
@@ -1,0 +1,41 @@
+VERSION 0.7
+FROM alpine:3.15
+
+# foo is a target with documentation. Targets without documentation won't show
+# up in 'earthly doc' even if they have documented commands in their recipe.
+foo:
+    # withDefault is a documented argument with a default.
+    ARG withDefault = foo
+    # withDocs is a documented argument.
+    ARG withDocs
+    # this is an undocumented argument.
+    ARG withoutDocs
+    # and this is a required argument.
+    ARG --required requiredArg
+
+    RUN echo $withDefault > bar.txt
+    RUN echo $withDocs > baz.txt
+
+    # bar.txt is a documented artifact.
+    SAVE ARTIFACT bar.txt
+
+    # this is an undocumented artifact.
+    SAVE ARTIFACT baz.txt
+
+    # out/baz.txt is a documented artifact that is saved locally.
+    SAVE ARTIFACT baz.txt AS LOCAL out/baz.txt
+
+    # bacon.txt is also a documented artifact that is saved locally.
+    SAVE ARTIFACT baz.txt bacon.txt AS LOCAL out/eggs.txt
+
+    # baz is a documented image.
+    SAVE IMAGE baz
+
+    # this is an undocumented image.
+    SAVE IMAGE bar
+
+    # eggs is just one of the image names, and yet it should still be recognized for this multiple-name SAVE IMAGE format.
+    SAVE IMAGE bacon eggs
+
+    # cache-hint SAVE IMAGE is not currently added to the docs ouptut
+    SAVE IMAGE --cache-hint


### PR DESCRIPTION
This updates `earthly doc` with additional output for `ARG`, `SAVE ARTIFACT`, and `SAVE IMAGE`.

NOTE: this is a draft because I still need to deal with global `ARG`s.