### PR TITLE
Add support for cleaning cache by age

### DIFF
--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -37,6 +37,7 @@ buildkitd:
     COPY ./entrypoint.sh /usr/bin/entrypoint.sh
     COPY ./buildkitd.toml.template /etc/buildkitd.toml.template
     COPY ./buildkitd.cache.template /etc/buildkitd.cache.template
+    COPY ./buildkitd.cacheduration.template /etc/buildkitd.cacheduration.template
     COPY ./buildkitd.tcp.template /etc/buildkitd.tcp.template
     COPY ./buildkitd.pprof.template /etc/buildkitd.pprof.template
     COPY ./buildkitd.tls.template /etc/buildkitd.tls.template

--- a/buildkitd/buildkitd.cache.template
+++ b/buildkitd/buildkitd.cache.template
@@ -5,9 +5,7 @@
 
   [[worker.oci.gcpolicy]]
     keepBytes = ${SOURCE_FILE_KEEP_BYTES}
-    keepDuration = ${CACHE_KEEP_DURATION}
     filters = [ "type==source.local", "type==source.git.checkout"]
   [[worker.oci.gcpolicy]]
     all = true
     keepBytes = ${CATCH_ALL_KEEP_BYTES}
-    keepDuration = ${CACHE_KEEP_DURATION}

--- a/buildkitd/buildkitd.cache.template
+++ b/buildkitd/buildkitd.cache.template
@@ -5,7 +5,9 @@
 
   [[worker.oci.gcpolicy]]
     keepBytes = ${SOURCE_FILE_KEEP_BYTES}
+    keepDuration = ${CACHE_KEEP_DURATION}
     filters = [ "type==source.local", "type==source.git.checkout"]
   [[worker.oci.gcpolicy]]
     all = true
     keepBytes = ${CATCH_ALL_KEEP_BYTES}
+    keepDuration = ${CACHE_KEEP_DURATION}

--- a/buildkitd/buildkitd.cacheduration.template
+++ b/buildkitd/buildkitd.cacheduration.template
@@ -1,0 +1,5 @@
+   # Please note the required indentation to fit in buildkit.toml.template accordingly.
+
+  [[worker.oci.gcpolicy]]
+    all = true
+    keepDuration = ${CACHE_KEEP_DURATION}

--- a/buildkitd/buildkitd.go
+++ b/buildkitd/buildkitd.go
@@ -433,6 +433,10 @@ func Start(ctx context.Context, console conslogging.ConsoleLogger, image, contai
 		envOpts["CACHE_SIZE_PCT"] = strconv.FormatInt(int64(settings.CacheSizePct), 10)
 	}
 
+	if settings.CacheKeepDuration > 0 {
+		envOpts["CACHE_KEEP_DURATION"] = strconv.FormatInt(int64(settings.CacheKeepDuration), 10)
+	}
+
 	if settings.EnableProfiler {
 		envOpts["BUILDKIT_PPROF_ENABLED"] = strconv.FormatBool(true)
 	}

--- a/buildkitd/buildkitd.toml.template
+++ b/buildkitd/buildkitd.toml.template
@@ -14,6 +14,7 @@ ${TLS_ENABLED}
   networkMode = "${NETWORK_MODE}"
   cniBinaryPath = "/usr/libexec/cni"
   cniConfigPath = "/etc/cni/cni-conf.json"
+  ${CACHE_DURATION_SETTINGS}
   ${CACHE_SETTINGS}
 
 ${EARTHLY_ADDITIONAL_BUILDKIT_CONFIG}

--- a/buildkitd/entrypoint.sh
+++ b/buildkitd/entrypoint.sh
@@ -161,6 +161,9 @@ export BUILDKIT_ROOT_DIR="$EARTHLY_TMP_DIR"/buildkit
 mkdir -p "$BUILDKIT_ROOT_DIR"
 CACHE_SETTINGS=
 
+# Length of time (in seconds) to keep cache. Zero is the same as unset to buildkit.
+CACHE_KEEP_DURATION="${CACHE_KEEP_DURATION:-0}"
+
 # For clarity; this will be become CACHE_SIZE_MB after everything is calculated.  It is intentionally left unset
 # (and not "0") to simplify the logic.
 EFFECTIVE_CACHE_SIZE_MB=

--- a/buildkitd/entrypoint.sh
+++ b/buildkitd/entrypoint.sh
@@ -162,7 +162,11 @@ mkdir -p "$BUILDKIT_ROOT_DIR"
 CACHE_SETTINGS=
 
 # Length of time (in seconds) to keep cache. Zero is the same as unset to buildkit.
-CACHE_KEEP_DURATION="${CACHE_KEEP_DURATION:-0}"
+CACHE_DURATION_SETTINGS=
+if [ "$CACHE_KEEP_DURATION" -gt 0 ]; then
+  CACHE_DURATION_SETTINGS="$(envsubst </etc/buildkitd.cacheduration.template)"
+fi
+export CACHE_DURATION_SETTINGS
 
 # For clarity; this will be become CACHE_SIZE_MB after everything is calculated.  It is intentionally left unset
 # (and not "0") to simplify the logic.

--- a/buildkitd/settings.go
+++ b/buildkitd/settings.go
@@ -13,6 +13,7 @@ import (
 type Settings struct {
 	CacheSizeMb          int
 	CacheSizePct         int
+	CacheKeepDuration    int
 	Debug                bool
 	BuildkitAddress      string
 	LocalRegistryAddress string

--- a/cmd/earthly/buildkit.go
+++ b/cmd/earthly/buildkit.go
@@ -76,6 +76,7 @@ func (app *earthlyApp) initFrontend(cliCtx *cli.Context) error {
 	app.buildkitdSettings.MaxParallelism = app.cfg.Global.BuildkitMaxParallelism
 	app.buildkitdSettings.CacheSizeMb = app.cfg.Global.BuildkitCacheSizeMb
 	app.buildkitdSettings.CacheSizePct = app.cfg.Global.BuildkitCacheSizePct
+	app.buildkitdSettings.CacheKeepDuration = app.cfg.Global.BuildkitCacheKeepDurationS
 	app.buildkitdSettings.EnableProfiler = app.enableProfiler
 	app.buildkitdSettings.NoUpdate = app.noBuildkitUpdate
 

--- a/config/config.go
+++ b/config/config.go
@@ -55,29 +55,30 @@ var (
 
 // GlobalConfig contains global config values
 type GlobalConfig struct {
-	DisableAnalytics         bool     `yaml:"disable_analytics"          help:"Controls Earthly telemetry."`
-	BuildkitCacheSizeMb      int      `yaml:"cache_size_mb"              help:"Size of the buildkit cache in Megabytes."`
-	BuildkitCacheSizePct     int      `yaml:"cache_size_pct"             help:"Size of the buildkit cache, as percentage (0-100)."`
-	BuildkitImage            string   `yaml:"buildkit_image"             help:"Choose a specific image for your buildkitd."`
-	BuildkitRestartTimeoutS  int      `yaml:"buildkit_restart_timeout_s" help:"How long to wait for buildkit to (re)start, in seconds."`
-	BuildkitAdditionalArgs   []string `yaml:"buildkit_additional_args"   help:"Additional args to pass to buildkit when it starts. Useful for custom/self-signed certs, or user namespace complications."`
-	BuildkitAdditionalConfig string   `yaml:"buildkit_additional_config" help:"Additional config to use when starting the buildkit container; like using custom/self-signed certificates."`
-	BuildkitMaxParallelism   int      `yaml:"buildkit_max_parallelism"   help:"Max parallelism for buildkit workers"`
-	ConversionParallelism    int      `yaml:"conversion_parallelism"     help:"Set the conversion parallelism for speeding up the use of IF, WITH, DOCKER --load, FROMDOCKERFILE and others. A value of 0 disables the feature"`
-	CniMtu                   uint16   `yaml:"cni_mtu"                    help:"Override auto-detection of the default interface MTU, for all containers within buildkit"`
-	BuildkitHost             string   `yaml:"buildkit_host"              help:"The URL of your buildkit, remote or local."`
-	LocalRegistryHost        string   `yaml:"local_registry_host"        help:"The URL of the local registry used for image exports to Docker."`
-	TLSCA                    string   `yaml:"tlsca"                      help:"The path to the CA cert for verification. Relative paths are interpreted as relative to ~/.earthly."`
-	ClientTLSCert            string   `yaml:"tlscert"                    help:"The path to the client cert for verification. Relative paths are interpreted as relative to ~/.earthly."`
-	ClientTLSKey             string   `yaml:"tlskey"                     help:"The path to the client key for verification. Relative paths are interpreted as relative to ~/.earthly."`
-	ServerTLSCert            string   `yaml:"buildkitd_tlscert"          help:"The path to the server cert for verification. Relative paths are interpreted as relative to ~/.earthly. Only used when Earthly manages buildkit."`
-	ServerTLSKey             string   `yaml:"buildkitd_tlskey"           help:"The path to the server key for verification. Relative paths are interpreted as relative to ~/.earthly. Only used when Earthly manages buildkit."`
-	TLSEnabled               bool     `yaml:"tls_enabled"                help:"If TLS should be used to communicate with Buildkit. Only honored when BuildkitScheme is 'tcp'."`
-	ContainerFrontend        string   `yaml:"container_frontend"         help:"What program should be used to start and stop buildkitd, save images. Default is 'docker'. Valid options are 'docker' and 'podman' (experimental)."`
-	IPTables                 string   `yaml:"ip_tables"                  help:"Which iptables binary to use. Valid values are iptables-legacy or iptables-nft. Bypasses any autodetection."`
-	DisableLogSharing        bool     `yaml:"disable_log_sharing"        help:"Disable cloud log sharing when logged in with an Earthly account, see https://ci.earthly.dev for details."`
-	SecretProvider           string   `yaml:"secret_provider"            help:"Command to execute to retrieve secret."`
-	GitImage                 string   `yaml:"git_image"                  help:"Image used to resolve git repositories"`
+	DisableAnalytics           bool     `yaml:"disable_analytics"              help:"Controls Earthly telemetry."`
+	BuildkitCacheSizeMb        int      `yaml:"cache_size_mb"                  help:"Size of the buildkit cache in Megabytes."`
+	BuildkitCacheSizePct       int      `yaml:"cache_size_pct"                 help:"Size of the buildkit cache, as percentage (0-100)."`
+	BuildkitCacheKeepDurationS int      `yaml:"buildkit_cache_keep_duration_s" help:"The duration in seconds that buildkit will keep the cache. Anything older is thrown away. A value of 0 is the same as unset."`
+	BuildkitImage              string   `yaml:"buildkit_image"                 help:"Choose a specific image for your buildkitd."`
+	BuildkitRestartTimeoutS    int      `yaml:"buildkit_restart_timeout_s"     help:"How long to wait for buildkit to (re)start, in seconds."`
+	BuildkitAdditionalArgs     []string `yaml:"buildkit_additional_args"       help:"Additional args to pass to buildkit when it starts. Useful for custom/self-signed certs, or user namespace complications."`
+	BuildkitAdditionalConfig   string   `yaml:"buildkit_additional_config"     help:"Additional config to use when starting the buildkit container; like using custom/self-signed certificates."`
+	BuildkitMaxParallelism     int      `yaml:"buildkit_max_parallelism"       help:"Max parallelism for buildkit workers"`
+	ConversionParallelism      int      `yaml:"conversion_parallelism"         help:"Set the conversion parallelism for speeding up the use of IF, WITH, DOCKER --load, FROMDOCKERFILE and others. A value of 0 disables the feature"`
+	CniMtu                     uint16   `yaml:"cni_mtu"                        help:"Override auto-detection of the default interface MTU, for all containers within buildkit"`
+	BuildkitHost               string   `yaml:"buildkit_host"                  help:"The URL of your buildkit, remote or local."`
+	LocalRegistryHost          string   `yaml:"local_registry_host"            help:"The URL of the local registry used for image exports to Docker."`
+	TLSCA                      string   `yaml:"tlsca"                          help:"The path to the CA cert for verification. Relative paths are interpreted as relative to ~/.earthly."`
+	ClientTLSCert              string   `yaml:"tlscert"                        help:"The path to the client cert for verification. Relative paths are interpreted as relative to ~/.earthly."`
+	ClientTLSKey               string   `yaml:"tlskey"                         help:"The path to the client key for verification. Relative paths are interpreted as relative to ~/.earthly."`
+	ServerTLSCert              string   `yaml:"buildkitd_tlscert"              help:"The path to the server cert for verification. Relative paths are interpreted as relative to ~/.earthly. Only used when Earthly manages buildkit."`
+	ServerTLSKey               string   `yaml:"buildkitd_tlskey"               help:"The path to the server key for verification. Relative paths are interpreted as relative to ~/.earthly. Only used when Earthly manages buildkit."`
+	TLSEnabled                 bool     `yaml:"tls_enabled"                    help:"If TLS should be used to communicate with Buildkit. Only honored when BuildkitScheme is 'tcp'."`
+	ContainerFrontend          string   `yaml:"container_frontend"             help:"What program should be used to start and stop buildkitd, save images. Default is 'docker'. Valid options are 'docker' and 'podman' (experimental)."`
+	IPTables                   string   `yaml:"ip_tables"                      help:"Which iptables binary to use. Valid values are iptables-legacy or iptables-nft. Bypasses any autodetection."`
+	DisableLogSharing          bool     `yaml:"disable_log_sharing"            help:"Disable cloud log sharing when logged in with an Earthly account, see https://ci.earthly.dev for details."`
+	SecretProvider             string   `yaml:"secret_provider"                help:"Command to execute to retrieve secret."`
+	GitImage                   string   `yaml:"git_image"                      help:"Image used to resolve git repositories"`
 
 	// Obsolete.
 	CachePath      string `yaml:"cache_path"         help:" *Deprecated* The path to keep Earthly's cache."`


### PR DESCRIPTION
This exposes the buildkit `keepDuration` config as a gcpolicy. It is first in the list to impose a hard cap on cache age, regardless of size.