### PR TITLE
Modify color and location for log mesage+url

### DIFF
--- a/cmd/earthly/build_cmd.go
+++ b/cmd/earthly/build_cmd.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"github.com/fatih/color"
 	"io"
 	"net/url"
 	"os"
@@ -193,7 +194,7 @@ func (app *earthlyApp) actionBuildImp(cliCtx *cli.Context, flagArgs, nonFlagArgs
 				doLogstreamUpload = true
 				logstreamURL = fmt.Sprintf("%s/builds/%s", app.getCIHost(), app.logbusSetup.InitialManifest.GetBuildId())
 				defer func() {
-					app.console.Printf("View logs at %s\n", logstreamURL)
+					app.console.ColorPrintf(color.New(color.FgHiYellow), "View logs at %s\n", logstreamURL)
 				}()
 			} else {
 				// If you are logged in, then add the bundle builder code, and configure cleanup and post-build messages.
@@ -213,7 +214,7 @@ func (app *earthlyApp) actionBuildImp(cliCtx *cli.Context, flagArgs, nonFlagArgs
 						app.console.Warnf(err.Error())
 						return
 					}
-					app.console.Printf("Shareable link: %s\n", id)
+					app.console.ColorPrintf(color.New(color.FgHiYellow), "Shareable link: %s\n", id)
 				}()
 			}
 		} else {
@@ -571,11 +572,14 @@ func (app *earthlyApp) actionBuildImp(cliCtx *cli.Context, flagArgs, nonFlagArgs
 				app.logbusSetup.SetOrgAndProject(details.EarthlyOrgName, details.EarthlyProjectName)
 				if doLogstreamUpload {
 					app.logbusSetup.StartLogStreamer(cliCtx.Context, cloudClient)
-					app.console.Printf("Streaming logs to %s\n", logstreamURL)
 				}
 			}
 		}
 	}()
+
+	if app.logstream && doLogstreamUpload {
+		app.console.ColorPrintf(color.New(color.FgHiYellow), "Streaming logs to %s\n\n", logstreamURL)
+	}
 	_, err = b.BuildTarget(cliCtx.Context, target, buildOpts)
 	if err != nil {
 		return errors.Wrap(err, "build target")

--- a/cmd/earthly/build_cmd.go
+++ b/cmd/earthly/build_cmd.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/fatih/color"
 	"io"
 	"net/url"
 	"os"
@@ -37,6 +36,7 @@ import (
 	"github.com/earthly/earthly/util/syncutil/semutil"
 	"github.com/earthly/earthly/util/termutil"
 	"github.com/earthly/earthly/variables"
+	"github.com/fatih/color"
 	"github.com/joho/godotenv"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/session"

--- a/conslogging/conslogging.go
+++ b/conslogging/conslogging.go
@@ -323,6 +323,14 @@ func (cl ConsoleLogger) Warnf(format string, args ...interface{}) {
 
 // Printf prints formatted text to the console.
 func (cl ConsoleLogger) Printf(format string, args ...interface{}) {
+	c := cl.color(noColor)
+	if cl.metadataMode {
+		c = cl.color(metadataModeColor)
+	}
+	cl.ColorPrintf(c, format, args...)
+}
+
+func (cl ConsoleLogger) ColorPrintf(c *color.Color, format string, args ...interface{}) {
 	if cl.logLevel < Info {
 		return
 	}
@@ -333,10 +341,6 @@ func (cl ConsoleLogger) Printf(format string, args ...interface{}) {
 		cl.mu.Unlock()
 	}()
 
-	c := cl.color(noColor)
-	if cl.metadataMode {
-		c = cl.color(metadataModeColor)
-	}
 	text := fmt.Sprintf(format, args...)
 	text = strings.TrimSuffix(text, "\n")
 	for _, line := range strings.Split(text, "\n") {


### PR DESCRIPTION
A few things I wasn't sure about and would like to get your opinion on:
 - Should printing these messages be more opinionated (i.e create some special function to print log in a specific color, not expose `ColorPrintf`)?
 - Moving the location of `Streaming logs to` outside of the go routine, means that it might be printed before we start uploading the log, is that ok?
 - Is the color ok (see attached screenshots)?
 - Not directly related to this PR, but I noticed we have a private function `makeColor`, is it needed given `color.New` is available (the difference is the no color check in the latter)?

terminal - 
![image](https://user-images.githubusercontent.com/5618521/227290867-fc6e92a7-daf1-4b36-a696-e7512bbbc1d7.png)
ci - 
![image](https://user-images.githubusercontent.com/5618521/227291390-7f4cfa6f-325e-422c-a033-d36544de8fc2.png)

