### PR TITLE
Add command line options for time/size based partial cache pruning

### DIFF
--- a/cmd/earthly/common.go
+++ b/cmd/earthly/common.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/dustin/go-humanize"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -144,3 +145,16 @@ func profhandler() {
 		fmt.Printf("error listening for pprof: %v", err)
 	}
 }
+
+type byteSizeValue uint64
+
+func (b *byteSizeValue) Set(s string) error {
+	v, err := humanize.ParseBytes(s)
+	if err != nil {
+		return err
+	}
+	*b = byteSizeValue(v)
+	return nil
+}
+
+func (b *byteSizeValue) String() string { return humanize.Bytes(uint64(*b)) }

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -89,6 +89,8 @@ type cliFlags struct {
 	noCache                         bool
 	pruneAll                        bool
 	pruneReset                      bool
+	pruneTargetSize                 string
+	pruneKeepDuration               time.Duration
 	buildkitdSettings               buildkitd.Settings
 	allowPrivileged                 bool
 	enableProfiler                  bool

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -89,7 +89,7 @@ type cliFlags struct {
 	noCache                         bool
 	pruneAll                        bool
 	pruneReset                      bool
-	pruneTargetSize                 string
+	pruneTargetSize                 byteSizeValue
 	pruneKeepDuration               time.Duration
 	buildkitdSettings               buildkitd.Settings
 	allowPrivileged                 bool

--- a/cmd/earthly/root_cmds.go
+++ b/cmd/earthly/root_cmds.go
@@ -174,12 +174,12 @@ func (app *earthlyApp) rootCmds() []*cli.Command {
 					Destination: &app.pruneReset,
 				},
 				&cli.StringFlag{
-					Name:        "target-size",
+					Name:        "size",
 					Usage:       "Prune cache to specified size, starting from oldest",
 					Destination: &app.pruneTargetSize,
 				},
 				&cli.DurationFlag{
-					Name:        "keep-duration",
+					Name:        "age",
 					Usage:       "Prune cache older than the specified duration",
 					Destination: &app.pruneKeepDuration,
 				},
@@ -791,10 +791,10 @@ func (app *earthlyApp) actionPrune(cliCtx *cli.Context) error {
 	}
 
 	sizeInBytes := uint64(0)
-	if len(app.pruneTargetSize) > 0 {
+	if app.pruneTargetSize != "" {
 		sizeInBytes, err = humanize.ParseBytes(app.pruneTargetSize)
 		if err != nil {
-			return errors.Wrap(err, "parse prune target size")
+			return errors.Wrapf(err, "parse prune target size (%s)", app.pruneTargetSize)
 		}
 	}
 

--- a/cmd/earthly/root_cmds.go
+++ b/cmd/earthly/root_cmds.go
@@ -173,10 +173,10 @@ func (app *earthlyApp) rootCmds() []*cli.Command {
 					Usage:       "Reset cache entirely by wiping cache dir",
 					Destination: &app.pruneReset,
 				},
-				&cli.StringFlag{
-					Name:        "size",
-					Usage:       "Prune cache to specified size, starting from oldest",
-					Destination: &app.pruneTargetSize,
+				&cli.GenericFlag{
+					Name:  "size",
+					Usage: "Prune cache to specified size, starting from oldest",
+					Value: &app.pruneTargetSize,
 				},
 				&cli.DurationFlag{
 					Name:        "age",
@@ -790,16 +790,8 @@ func (app *earthlyApp) actionPrune(cliCtx *cli.Context) error {
 		opts = append(opts, client.PruneAll)
 	}
 
-	sizeInBytes := uint64(0)
-	if app.pruneTargetSize != "" {
-		sizeInBytes, err = humanize.ParseBytes(app.pruneTargetSize)
-		if err != nil {
-			return errors.Wrapf(err, "parse prune target size (%s)", app.pruneTargetSize)
-		}
-	}
-
-	if app.pruneKeepDuration > 0 || sizeInBytes > 0 {
-		opts = append(opts, client.WithKeepOpt(app.pruneKeepDuration, int64(sizeInBytes)))
+	if app.pruneKeepDuration > 0 || app.pruneTargetSize > 0 {
+		opts = append(opts, client.WithKeepOpt(app.pruneKeepDuration, int64(app.pruneTargetSize)))
 	}
 
 	ch := make(chan client.UsageInfo, 1)

--- a/docs/earthly-command/earthly-command.md
+++ b/docs/earthly-command/earthly-command.md
@@ -335,6 +335,14 @@ Instructs earthly to issue a "prune all" command to the BuildKit daemon.
 
 Restarts the BuildKit daemon and completely resets the cache directory.
 
+##### `--age`
+
+Prunes cache older than the specified duration. Accepts a duration string, which is a sequence of decimal numbers, each with optional fraction and a unit suffix, such as `300ms`. Valid time units are `ns`, `us`, `ms`, `s`, `m`, `h`.
+
+##### `--size`
+
+Prunes cache to specified size, starting with the oldest cache. It will eliminate cache until it reaches or exceeds the target size.
+
 ## earthly config
 
 #### Synopsis


### PR DESCRIPTION
This adds two command line options for pruning the cache.

* `--keep-duration`, which will drop all cache older than this duration. It expects a string parseable by `time.ParseDuration`.
* `--target-size`, which will drop the oldest items from the cache until the size is reached. It expects a string parseable by `humanize.ParseBytes` (which we already have in our `go.mod`).

I presume docs need to be added, I'll append those to this PR if these options look ok.