### PR TITLE
ast: fix lexer error in base target IF statements

### DIFF
--- a/ast/ast_test.go
+++ b/ast/ast_test.go
@@ -54,6 +54,11 @@ foo:
 VERSION 0.6 # Trailing comments do not cause parsing errors at the top level
 WORKDIR /tmp
 
+# a comment before an IF or a FOR does not cause parser errors
+IF foo
+    RUN echo foo
+END
+
 bar:
 
 baz:

--- a/ast/lexer.go
+++ b/ast/lexer.go
@@ -191,6 +191,11 @@ func (l *lexer) seek(line, column, index int) {
 // In these scenarios, the comment may be documentation and needs to trigger the
 // INDENT/DEDENT _before_ the comment in the token sequence.
 func (l *lexer) handleCommentIndentLevel(comment antlr.Token) bool {
+	if l.getMode() != parser.EarthLexerRECIPE {
+		// if we're not in RECIPE mode, INDENT/DEDENT tokens are not valid, so
+		// there's no scenario where we would want to consider either of them.
+		return false
+	}
 	line, col, idx := l.pos()
 	defer l.seek(line, col, idx)
 


### PR DESCRIPTION
When we're outside of RECIPE mode, there's no reason to consider adjusting the indentation level, because INDENT and DEDENT tokens aren't valid anyway.

Resolves #2826