### PR TITLE
Add http connection timeout

### DIFF
--- a/cloud/client.go
+++ b/cloud/client.go
@@ -56,6 +56,7 @@ type Client struct {
 	requestID                string
 	installationName         string
 	logstreamAddressOverride string
+	serverHTTPTimeout        int
 }
 
 type ClientOpt func(*Client)
@@ -67,16 +68,17 @@ func WithLogstreamGRPCAddressOverride(address string) ClientOpt {
 }
 
 // NewClient provides a new Earthly Cloud client
-func NewClient(httpAddr, grpcAddr string, useInsecure bool, agentSockPath, authCredsOverride, authJWTOverride, installationName, requestID string, warnFunc func(string, ...interface{}), opts ...ClientOpt) (*Client, error) {
+func NewClient(httpAddr, grpcAddr string, useInsecure bool, agentSockPath, authCredsOverride, authJWTOverride, installationName, requestID string, warnFunc func(string, ...interface{}), serverHTTPTimeout int, opts ...ClientOpt) (*Client, error) {
 	c := &Client{
 		httpAddr: httpAddr,
 		sshAgent: &lazySSHAgent{
 			sockPath: agentSockPath,
 		},
-		warnFunc:         warnFunc,
-		jum:              &protojson.UnmarshalOptions{DiscardUnknown: true},
-		installationName: installationName,
-		requestID:        requestID,
+		warnFunc:          warnFunc,
+		jum:               &protojson.UnmarshalOptions{DiscardUnknown: true},
+		installationName:  installationName,
+		requestID:         requestID,
+		serverHTTPTimeout: serverHTTPTimeout,
 	}
 	if authJWTOverride != "" {
 		c.authToken = authJWTOverride

--- a/cloud/client.go
+++ b/cloud/client.go
@@ -56,7 +56,7 @@ type Client struct {
 	requestID                string
 	installationName         string
 	logstreamAddressOverride string
-	serverHTTPTimeout        int
+	serverConnTimeout        int
 }
 
 type ClientOpt func(*Client)
@@ -68,7 +68,7 @@ func WithLogstreamGRPCAddressOverride(address string) ClientOpt {
 }
 
 // NewClient provides a new Earthly Cloud client
-func NewClient(httpAddr, grpcAddr string, useInsecure bool, agentSockPath, authCredsOverride, authJWTOverride, installationName, requestID string, warnFunc func(string, ...interface{}), serverHTTPTimeout int, opts ...ClientOpt) (*Client, error) {
+func NewClient(httpAddr, grpcAddr string, useInsecure bool, agentSockPath, authCredsOverride, authJWTOverride, installationName, requestID string, warnFunc func(string, ...interface{}), serverConnTimeout int, opts ...ClientOpt) (*Client, error) {
 	c := &Client{
 		httpAddr: httpAddr,
 		sshAgent: &lazySSHAgent{
@@ -78,7 +78,7 @@ func NewClient(httpAddr, grpcAddr string, useInsecure bool, agentSockPath, authC
 		jum:               &protojson.UnmarshalOptions{DiscardUnknown: true},
 		installationName:  installationName,
 		requestID:         requestID,
-		serverHTTPTimeout: serverHTTPTimeout,
+		serverConnTimeout: serverConnTimeout,
 	}
 	if authJWTOverride != "" {
 		c.authToken = authJWTOverride

--- a/cloud/client.go
+++ b/cloud/client.go
@@ -56,7 +56,7 @@ type Client struct {
 	requestID                string
 	installationName         string
 	logstreamAddressOverride string
-	serverConnTimeout        int
+	serverConnTimeout        time.Duration
 }
 
 type ClientOpt func(*Client)
@@ -68,7 +68,7 @@ func WithLogstreamGRPCAddressOverride(address string) ClientOpt {
 }
 
 // NewClient provides a new Earthly Cloud client
-func NewClient(httpAddr, grpcAddr string, useInsecure bool, agentSockPath, authCredsOverride, authJWTOverride, installationName, requestID string, warnFunc func(string, ...interface{}), serverConnTimeout int, opts ...ClientOpt) (*Client, error) {
+func NewClient(httpAddr, grpcAddr string, useInsecure bool, agentSockPath, authCredsOverride, authJWTOverride, installationName, requestID string, warnFunc func(string, ...interface{}), serverConnTimeout time.Duration, opts ...ClientOpt) (*Client, error) {
 	c := &Client{
 		httpAddr: httpAddr,
 		sshAgent: &lazySSHAgent{

--- a/cloud/http.go
+++ b/cloud/http.go
@@ -201,7 +201,7 @@ func (c *Client) doCallImp(ctx context.Context, r request, method, url, reqID st
 	client := &http.Client{
 		Transport: &http.Transport{
 			DialContext: (&net.Dialer{
-				Timeout: c.serverConnTimeout * time.Second,
+				Timeout: c.serverConnTimeout,
 			}).DialContext,
 		},
 	}

--- a/cloud/http.go
+++ b/cloud/http.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"strings"
@@ -197,7 +198,13 @@ func (c *Client) doCallImp(ctx context.Context, r request, method, url, reqID st
 	}
 	req.Header.Add(requestID, reqID)
 
-	client := &http.Client{}
+	client := &http.Client{
+		Transport: &http.Transport{
+			DialContext: (&net.Dialer{
+				Timeout: time.Duration(c.serverHTTPTimeout) * time.Second,
+			}).DialContext,
+		},
+	}
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/cloud/http.go
+++ b/cloud/http.go
@@ -201,7 +201,7 @@ func (c *Client) doCallImp(ctx context.Context, r request, method, url, reqID st
 	client := &http.Client{
 		Transport: &http.Transport{
 			DialContext: (&net.Dialer{
-				Timeout: time.Duration(c.serverConnTimeout) * time.Second,
+				Timeout: c.serverConnTimeout * time.Second,
 			}).DialContext,
 		},
 	}

--- a/cloud/http.go
+++ b/cloud/http.go
@@ -201,7 +201,7 @@ func (c *Client) doCallImp(ctx context.Context, r request, method, url, reqID st
 	client := &http.Client{
 		Transport: &http.Transport{
 			DialContext: (&net.Dialer{
-				Timeout: time.Duration(c.serverHTTPTimeout) * time.Second,
+				Timeout: time.Duration(c.serverConnTimeout) * time.Second,
 			}).DialContext,
 		},
 	}

--- a/cmd/earthly/common.go
+++ b/cmd/earthly/common.go
@@ -20,7 +20,7 @@ import (
 
 func (app *earthlyApp) newCloudClient(opts ...cloud.ClientOpt) (*cloud.Client, error) {
 	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock,
-		app.authToken, app.authJWT, app.installationName, app.requestID, app.console.Warnf, opts...)
+		app.authToken, app.authJWT, app.installationName, app.requestID, app.console.Warnf, app.serverHTTPTimeout, opts...)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create cloud client")
 	}

--- a/cmd/earthly/common.go
+++ b/cmd/earthly/common.go
@@ -20,7 +20,7 @@ import (
 
 func (app *earthlyApp) newCloudClient(opts ...cloud.ClientOpt) (*cloud.Client, error) {
 	cloudClient, err := cloud.NewClient(app.cloudHTTPAddr, app.cloudGRPCAddr, app.cloudGRPCInsecure, app.sshAuthSock,
-		app.authToken, app.authJWT, app.installationName, app.requestID, app.console.Warnf, app.serverHTTPTimeout, opts...)
+		app.authToken, app.authJWT, app.installationName, app.requestID, app.console.Warnf, app.serverConnTimeout, opts...)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create cloud client")
 	}

--- a/cmd/earthly/flags.go
+++ b/cmd/earthly/flags.go
@@ -218,12 +218,12 @@ func (app *earthlyApp) rootFlags() []cli.Flag {
 			Hidden:      true, // Internal.
 		},
 		&cli.IntFlag{
-			Name:        "server-http-timeout",
+			Name:        "server-conn-timeout",
 			Usage:       "The time to wait for the http client to establish a connection to the API server",
-			EnvVars:     []string{"EARTHLY_SERVER_HTTP_TIMEOUT"},
+			EnvVars:     []string{"EARTHLY_SERVER_CONN_TIMEOUT"},
 			Hidden:      true, // Internal.
 			Value:       5,
-			Destination: &app.serverHTTPTimeout,
+			Destination: &app.serverConnTimeout,
 		},
 	}
 }

--- a/cmd/earthly/flags.go
+++ b/cmd/earthly/flags.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"time"
 
 	"github.com/urfave/cli/v2"
 
@@ -219,10 +220,10 @@ func (app *earthlyApp) rootFlags() []cli.Flag {
 		},
 		&cli.DurationFlag{
 			Name:        "server-conn-timeout",
-			Usage:       "The time to wait in seconds for the http client to establish a connection to the API server",
+			Usage:       "Earthly API server connection timeout value",
 			EnvVars:     []string{"EARTHLY_SERVER_CONN_TIMEOUT"},
 			Hidden:      true, // Internal.
-			Value:       5,
+			Value:       5 * time.Second,
 			Destination: &app.serverConnTimeout,
 		},
 	}

--- a/cmd/earthly/flags.go
+++ b/cmd/earthly/flags.go
@@ -217,6 +217,14 @@ func (app *earthlyApp) rootFlags() []cli.Flag {
 			Destination: &app.buildID,
 			Hidden:      true, // Internal.
 		},
+		&cli.IntFlag{
+			Name:        "server-http-timeout",
+			Usage:       "The time to wait for the http client to establish a connection to the API server",
+			EnvVars:     []string{"EARTHLY_SERVER_HTTP_TIMEOUT"},
+			Hidden:      true, // Internal.
+			Value:       5,
+			Destination: &app.serverHTTPTimeout,
+		},
 	}
 }
 

--- a/cmd/earthly/flags.go
+++ b/cmd/earthly/flags.go
@@ -217,9 +217,9 @@ func (app *earthlyApp) rootFlags() []cli.Flag {
 			Destination: &app.buildID,
 			Hidden:      true, // Internal.
 		},
-		&cli.IntFlag{
+		&cli.DurationFlag{
 			Name:        "server-conn-timeout",
-			Usage:       "The time to wait for the http client to establish a connection to the API server",
+			Usage:       "The time to wait in seconds for the http client to establish a connection to the API server",
 			EnvVars:     []string{"EARTHLY_SERVER_CONN_TIMEOUT"},
 			Hidden:      true, // Internal.
 			Value:       5,

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -188,7 +188,7 @@ type cliFlags struct {
 	gcpServiceAccountKeyPath        string
 	gcpServiceAccountKey            string
 	gcpServiceAccountKeyStdin       bool
-	serverHTTPTimeout               int
+	serverConnTimeout               int
 }
 
 type analyticsMetadata struct {

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -188,7 +188,7 @@ type cliFlags struct {
 	gcpServiceAccountKeyPath        string
 	gcpServiceAccountKey            string
 	gcpServiceAccountKeyStdin       bool
-	serverConnTimeout               int
+	serverConnTimeout               time.Duration
 }
 
 type analyticsMetadata struct {

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -188,6 +188,7 @@ type cliFlags struct {
 	gcpServiceAccountKeyPath        string
 	gcpServiceAccountKey            string
 	gcpServiceAccountKeyStdin       bool
+	serverHTTPTimeout               int
 }
 
 type analyticsMetadata struct {

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -1393,7 +1393,7 @@ test-works-without-earthly-server:
     " > /tmp/precommand && chmod +x /tmp/precommand
     DO +RUN_EARTHLY --verbose=false --pre_command=/tmp/precommand --post_command=" && date +%s > end-time" --earthfile=true.earth --target=+true
     RUN if grep "failed sending analytics" earthly.output; then echo "analytics should have failed silently, but didnt" && exit 1; fi
-    RUN export duration=$(echo "$(cat end-time) - $(cat start-time)" | bc) && test "$duration" -lt 10 || (echo "it took $duration seconds to run +true, which is too long" && exit 1)
+    RUN export duration=$(echo "$(cat end-time) - $(cat start-time)" | bc) && test "$duration" -lt 20 || (echo "it took $duration seconds to run +true, which is too long" && exit 1)
 
 RUN_EARTHLY:
     COMMAND

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -1393,7 +1393,7 @@ test-works-without-earthly-server:
     " > /tmp/precommand && chmod +x /tmp/precommand
     DO +RUN_EARTHLY --verbose=false --pre_command=/tmp/precommand --post_command=" && date +%s > end-time" --earthfile=true.earth --target=+true
     RUN if grep "failed sending analytics" earthly.output; then echo "analytics should have failed silently, but didnt" && exit 1; fi
-    RUN export duration=$(echo "$(cat end-time) - $(cat start-time)" | bc) && test "$duration" -lt 45 || (echo "it took $duration seconds to run +true, which is too long" && exit 1)
+    RUN export duration=$(echo "$(cat end-time) - $(cat start-time)" | bc) && test "$duration" -lt 10 || (echo "it took $duration seconds to run +true, which is too long" && exit 1)
 
 RUN_EARTHLY:
     COMMAND


### PR DESCRIPTION
fix https://github.com/earthly/earthly/issues/2761

This change sets a timeout to establish a http connection to the API server.
Note that the issue this fixes did not seem to relate to analytics, even with analytics disabled, Earthly was stuck on trying to ping the API server.

Also note that this sets a timeout on connection errors such as Deadline exceeded, for which we do not retry.
Other types of connection errors do get retried and as a result the overall time might be bigger than the set timeout.