### PR TITLE
fully qualified earthly-buildkitd

### DIFF
--- a/.github/workflows/reusable-bootstrap-integrations.yml
+++ b/.github/workflows/reusable-bootstrap-integrations.yml
@@ -47,7 +47,7 @@ jobs:
         run: ${{inputs.SUDO}} apt-get purge docker-engine docker docker.io docker-ce docker-ce-cli ; ${{inputs.SUDO}} rm -rf /usr/bin/docker
         if: inputs.binary == 'podman'
       - name: Install Podman (with apt-get)
-        run: ${{inputs.SUDO}} apt-get update && ${{inputs.SUDO}} apt-get install -y podman
+        run: ${{inputs.SUDO}} apt-get update && ${{inputs.SUDO}} apt-get install -y podman && ${{inputs.SUDO}} rm -f /etc/containers/registries.conf
         if: inputs.binary == 'podman'
       - name: Podman debug info
         run: podman version && podman info && podman info --debug

--- a/.github/workflows/reusable-example.yml
+++ b/.github/workflows/reusable-example.yml
@@ -66,7 +66,7 @@ jobs:
         run: ${{inputs.SUDO}} apt-get purge docker-engine docker docker.io docker-ce docker-ce-cli ; ${{inputs.SUDO}} rm -rf /usr/bin/docker
         if: inputs.binary == 'podman'
       - name: Install Podman (with apt-get)
-        run: ${{inputs.SUDO}} apt-get update && ${{inputs.SUDO}} apt-get install -y podman
+        run: ${{inputs.SUDO}} apt-get update && ${{inputs.SUDO}} apt-get install -y podman && ${{inputs.SUDO}} rm -f /etc/containers/registries.conf
         if: inputs.binary == 'podman'
       - name: Podman debug info
         run: podman version && podman info && podman info --debug

--- a/.github/workflows/reusable-export-test.yml
+++ b/.github/workflows/reusable-export-test.yml
@@ -53,7 +53,7 @@ jobs:
         run: ${{inputs.SUDO}} apt-get purge docker-engine docker docker.io docker-ce docker-ce-cli ; ${{inputs.SUDO}} rm -rf /usr/bin/docker
         if: inputs.binary == 'podman'
       - name: Install Podman (with apt-get)
-        run: ${{inputs.SUDO}} apt-get update && ${{inputs.SUDO}} apt-get install -y podman
+        run: ${{inputs.SUDO}} apt-get update && ${{inputs.SUDO}} apt-get install -y podman && ${{inputs.SUDO}} rm -f /etc/containers/registries.conf
         if: inputs.binary == 'podman'
       - name: Podman debug info
         run: podman version && podman info && podman info --debug

--- a/.github/workflows/reusable-git-metadata-test.yml
+++ b/.github/workflows/reusable-git-metadata-test.yml
@@ -63,7 +63,7 @@ jobs:
         run: ${{inputs.SUDO}} apt-get purge docker-engine docker docker.io docker-ce docker-ce-cli ; ${{inputs.SUDO}} rm -rf /usr/bin/docker
         if: inputs.binary != 'docker'
       - name: Install Podman (with apt-get)
-        run: ${{inputs.SUDO}} apt-get update && ${{inputs.SUDO}} apt-get install -y podman
+        run: ${{inputs.SUDO}} apt-get update && ${{inputs.SUDO}} apt-get install -y podman && ${{inputs.SUDO}} rm -f /etc/containers/registries.conf
         if: inputs.binary == 'podman'
       - name: Podman debug info
         run: podman version && podman info && podman info --debug

--- a/.github/workflows/reusable-misc-tests.yml
+++ b/.github/workflows/reusable-misc-tests.yml
@@ -48,7 +48,7 @@ jobs:
         run: ${{inputs.SUDO}} apt-get purge docker-engine docker docker.io docker-ce docker-ce-cli ; ${{inputs.SUDO}} rm -rf /usr/bin/docker
         if: inputs.binary == 'podman'
       - name: Install Podman (with apt-get)
-        run: ${{inputs.SUDO}} apt-get update && ${{inputs.SUDO}} apt-get install -y podman
+        run: ${{inputs.SUDO}} apt-get update && ${{inputs.SUDO}} apt-get install -y podman && ${{inputs.SUDO}} rm -f /etc/containers/registries.conf
         if: inputs.binary == 'podman'
       - name: Podman debug info
         run: podman version && podman info && podman info --debug

--- a/.github/workflows/reusable-push-integrations.yml
+++ b/.github/workflows/reusable-push-integrations.yml
@@ -39,7 +39,7 @@ jobs:
         run: ${{inputs.SUDO}} apt-get purge docker-engine docker docker.io docker-ce docker-ce-cli ; ${{inputs.SUDO}} rm -rf /usr/bin/docker
         if: inputs.binary == 'podman'
       - name: Install Podman (with apt-get)
-        run: ${{inputs.SUDO}} apt-get update && ${{inputs.SUDO}} apt-get install -y podman
+        run: ${{inputs.SUDO}} apt-get update && ${{inputs.SUDO}} apt-get install -y podman && ${{inputs.SUDO}} rm -f /etc/containers/registries.conf
         if: inputs.binary == 'podman'
       - name: Podman debug info
         run: podman version && podman info && podman info --debug

--- a/.github/workflows/reusable-repo-auth-tests.yml
+++ b/.github/workflows/reusable-repo-auth-tests.yml
@@ -47,7 +47,7 @@ jobs:
         run: ${{inputs.SUDO}} apt-get purge docker-engine docker docker.io docker-ce docker-ce-cli ; ${{inputs.SUDO}} rm -rf /usr/bin/docker
         if: inputs.binary == 'podman'
       - name: Install Podman (with apt-get)
-        run: ${{inputs.SUDO}} apt-get update && ${{inputs.SUDO}} apt-get install -y podman
+        run: ${{inputs.SUDO}} apt-get update && ${{inputs.SUDO}} apt-get install -y podman && ${{inputs.SUDO}} rm -f /etc/containers/registries.conf
         if: inputs.binary == 'podman'
       - name: Podman debug info
         run: podman version && podman info && podman info --debug

--- a/.github/workflows/reusable-secrets-integrations.yml
+++ b/.github/workflows/reusable-secrets-integrations.yml
@@ -40,7 +40,7 @@ jobs:
         run: ${{inputs.SUDO}} apt-get purge docker-engine docker docker.io docker-ce docker-ce-cli ; ${{inputs.SUDO}} rm -rf /usr/bin/docker
         if: inputs.binary == 'podman'
       - name: Install Podman (with apt-get)
-        run: ${{inputs.SUDO}} apt-get update && ${{inputs.SUDO}} apt-get install -y podman
+        run: ${{inputs.SUDO}} apt-get update && ${{inputs.SUDO}} apt-get install -y podman && ${{inputs.SUDO}} rm -f /etc/containers/registries.conf
         if: inputs.binary == 'podman'
       - name: Podman debug info
         run: podman version && podman info && podman info --debug

--- a/.github/workflows/reusable-test-local.yml
+++ b/.github/workflows/reusable-test-local.yml
@@ -63,7 +63,7 @@ jobs:
         run: ${{inputs.SUDO}} apt-get purge docker-engine docker docker.io docker-ce docker-ce-cli ; ${{inputs.SUDO}} rm -rf /usr/bin/docker
         if: inputs.binary == 'podman'
       - name: Install Podman (with apt-get)
-        run: ${{inputs.SUDO}} apt-get update && ${{inputs.SUDO}} apt-get install -y podman
+        run: ${{inputs.SUDO}} apt-get update && ${{inputs.SUDO}} apt-get install -y podman && ${{inputs.SUDO}} rm -f /etc/containers/registries.conf
         if: inputs.binary == 'podman'
       - name: Install Podman Compose
         run: sudo pip3 install podman-compose

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -63,7 +63,7 @@ jobs:
         run: ${{inputs.SUDO}} apt-get purge docker-engine docker docker.io docker-ce docker-ce-cli ; ${{inputs.SUDO}} rm -rf /usr/bin/docker
         if: inputs.binary != 'docker'
       - name: Install Podman (with apt-get)
-        run: ${{inputs.SUDO}} apt-get update && ${{inputs.SUDO}} apt-get install -y podman
+        run: ${{inputs.SUDO}} apt-get update && ${{inputs.SUDO}} apt-get install -y podman && ${{inputs.SUDO}} rm -f /etc/containers/registries.conf
         if: inputs.binary == 'podman'
       - name: Podman debug info
         run: podman version && podman info && podman info --debug

--- a/release/Earthfile
+++ b/release/Earthfile
@@ -88,6 +88,7 @@ release-github:
     ARG --required RELEASE_TAG
     ARG GITHUB_USER="earthly"
     ARG EARTHLY_REPO="earthly"
+    ARG DOCKERHUB_HOST="docker.io"
     ARG DOCKERHUB_USER="earthly"
     ARG DOCKERHUB_BUILDKIT_IMG="buildkitd"
     ARG PRERELEASE="false"
@@ -96,7 +97,7 @@ release-github:
     COPY +release-notes/notes.txt release-notes.txt
     COPY (../+earthly-all/* \
          --VERSION=$RELEASE_TAG \
-         --DEFAULT_BUILDKITD_IMAGE="$DOCKERHUB_USER/$DOCKERHUB_BUILDKIT_IMG:$RELEASE_TAG" \
+         --DEFAULT_BUILDKITD_IMAGE="$DOCKERHUB_HOST/$DOCKERHUB_USER/$DOCKERHUB_BUILDKIT_IMG:$RELEASE_TAG" \
          --DEFAULT_INSTALLATION_NAME="earthly" \
          ) ./release/
     RUN ls ./release
@@ -112,6 +113,19 @@ release-github:
     RUN file ./release/earthly-linux-arm64 | grep "aarch64"
     RUN file ./release/earthly-linux-arm64 | grep "ELF 64-bit"
     RUN file ./release/earthly-windows-amd64.exe | grep "PE32"
+
+    # TODO: at this point, we should run (some of?) the binaries through
+    # end-to-end or acceptance tests. This would guarantee that the release
+    # binaries pass our tests. Right now, all we guarantee is that we built our
+    # release binaries from a commit that passed our tests, which has caused
+    # some bugs in the past.
+    #
+    # This may require work on the "variable types" proposal so that we can pass
+    # our artifacts to our test targets.
+    FOR release IN linux-amd64 linux-arm64 darwin-amd64 darwin-arm64 windows-amd64.exe
+        RUN grep "$DOCKERHUB_HOST/$DOCKERHUB_USER/$DOCKERHUB_BUILDKIT_IMG:$RELEASE_TAG" ./release/earthly-$release
+    END
+
     ARG GITHUB_SECRET_PATH="littleredcorvette-github-token"
     RUN --push \
         --secret GITHUB_TOKEN="$GITHUB_SECRET_PATH" \

--- a/release/release.sh
+++ b/release/release.sh
@@ -62,6 +62,7 @@ fi
 
 # Set default values
 export GITHUB_USER=${GITHUB_USER:-earthly}
+export DOCKERHUB_HOST=${DOCKERHUB_HOST:-docker.io}
 export DOCKERHUB_USER=${DOCKERHUB_USER:-earthly}
 export DOCKERHUB_IMG=${DOCKERHUB_IMG:-earthly}
 export DOCKERHUB_BUILDKIT_IMG=${DOCKERHUB_BUILDKIT_IMG:-buildkitd}
@@ -86,6 +87,10 @@ fi
 PRODUCTION_RELEASE="false"
 if [ "$GITHUB_USER" = "earthly" ] && [ "$EARTHLY_REPO" = "earthly" ]; then
     PRODUCTION_RELEASE="true"
+    if [ "$DOCKERHUB_HOST" != "docker.io" ]; then
+        echo "expected DOCKERHUB_HOST=docker.io but got $DOCKERHUB_HOST"
+        exit 1
+    fi
     if [ "$DOCKERHUB_USER" != "earthly" ]; then
         echo "expected DOCKERHUB_USER=earthly but got $DOCKERHUB_USER"
         exit 1
@@ -95,7 +100,7 @@ if [ "$GITHUB_USER" = "earthly" ] && [ "$EARTHLY_REPO" = "earthly" ]; then
         exit 1
     fi
     if [ "$DOCKERHUB_BUILDKIT_IMG" != "buildkitd" ]; then
-        echo "expected DOCKERHUB_BUILDKIT_IMG=earthly but got $DOCKERHUB_BUILDKIT_IMG"
+        echo "expected DOCKERHUB_BUILDKIT_IMG=buildkitd but got $DOCKERHUB_BUILDKIT_IMG"
         exit 1
     fi
     if [ "$S3_BUCKET" != "production-pkg" ]; then


### PR DESCRIPTION
Since most users will not have 'docker.io' added to podman's search registries by default, we need to fully qualify the earthly-buildkitd image by default.

Resolves #2834 