### PR TITLE
Change Earthly AMI releases to use Amazon Linux 2

### DIFF
--- a/release/ami/cleanup.sh
+++ b/release/ami/cleanup.sh
@@ -3,7 +3,6 @@
 set -e
  
 echo 'Cleaning up after bootstrapping...'
-sudo apt-get -y autoremove
-sudo apt-get -y clean
+sudo yum clean all
 sudo rm -rf /tmp/*
 cat /dev/null > ~/.bash_history

--- a/release/ami/image.pkr.hcl
+++ b/release/ami/image.pkr.hcl
@@ -12,43 +12,41 @@ variable "earthly_version" {
 }
 
 locals {
-  timestamp           = replace(timestamp(), ":", "-")
-  earthly_version_apt = trimprefix(var.earthly_version, "v")
+  timestamp       = replace(timestamp(), ":", "-")
+  earthly_version = trimprefix(var.earthly_version, "v")
 }
 
-# https://cloud-images.ubuntu.com/locator/ec2/
-
 source "amazon-ebs" "x86_64" {
-  ami_name      = "earthly-${var.earthly_version}-amd64-${local.timestamp}"
+  ami_name      = "earthly-${var.earthly_version}-amzn-amd64-${local.timestamp}"
   instance_type = "t2.micro"
   region        = "us-west-2"
   source_ami_filter {
     filters = {
-      name                = "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"
+      name                = "amzn2-ami-kernel-5.10-hvm-2.0.*-x86_64-gp2"
       root-device-type    = "ebs"
       virtualization-type = "hvm"
     }
     most_recent = true
-    owners      = ["099720109477"]
+    owners      = ["137112412989"]
   }
-  ssh_username           = "ubuntu"
+  ssh_username           = "ec2-user"
   ssh_read_write_timeout = "5m" # Allow reboots
 }
 
 source "amazon-ebs" "arm64" {
-  ami_name      = "earthly-${var.earthly_version}-arm64-${local.timestamp}"
+  ami_name      = "earthly-${var.earthly_version}-amzn-arm64-${local.timestamp}"
   instance_type = "a1.medium"
   region        = "us-west-2"
   source_ami_filter {
     filters = {
-      name                = "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-*"
+      name                = "amzn2-ami-kernel-5.10-hvm-2.0.*-arm64-gp2"
       root-device-type    = "ebs"
       virtualization-type = "hvm"
     }
     most_recent = true
-    owners      = ["099720109477"]
+    owners      = ["137112412989"]
   }
-  ssh_username           = "ubuntu"
+  ssh_username           = "ec2-user"
   ssh_read_write_timeout = "5m" # Allow reboots
 }
 
@@ -62,7 +60,7 @@ build {
   # https://developer.hashicorp.com/packer/docs/debugging#issues-installing-ubuntu-packages
   provisioner "shell" {
     inline = [
-      "cloud-init status --wait"
+      "sudo cloud-init status --wait"
     ]
   }
 
@@ -73,7 +71,7 @@ build {
   }
   provisioner "shell" {
     environment_vars = [
-      "EARTHLY_VERSION=${local.earthly_version_apt}"
+      "EARTHLY_VERSION=${local.earthly_version}"
     ]
     inline = [
       "cd /tmp",

--- a/release/ami/install.sh
+++ b/release/ami/install.sh
@@ -2,35 +2,13 @@
 
 set -xe
 
-export DEBIAN_FRONTEND=noninteractive
+sudo yum-config-manager --add-repo https://pkg.earthly.dev/earthly.repo
+sudo yum update -y
+sudo amazon-linux-extras install docker
 
-sudo apt-get update
-sudo apt-get -y install \
-    apt-transport-https \
-    ca-certificates \
-    curl \
-    gnupg-agent \
-    software-properties-common \
-    lsb-release
- 
-sudo mkdir -p /etc/apt/keyrings
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
- 
-echo \
-  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
-  $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-
-sudo mkdir -p /etc/apt/keyrings
-curl -fsSL https://pkg.earthly.dev/earthly.pgp | sudo gpg --dearmor -o /etc/apt/keyrings/earthly-archive-keyring.gpg
-
-echo \
-  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/earthly-archive-keyring.gpg] https://pkg.earthly.dev/deb \
-  stable main" | sudo tee /etc/apt/sources.list.d/earthly.list > /dev/null
-
-sudo apt-get update
-sudo apt-get install -y docker-ce docker-ce-cli containerd.io earthly="$EARTHLY_VERSION"
+sudo yum install -y earthly
 
 docker -v
 earthly -v
 
-sudo usermod -a -G docker ubuntu
+sudo usermod -a -G docker ec2-user

--- a/release/ami/install.sh
+++ b/release/ami/install.sh
@@ -6,7 +6,7 @@ sudo yum-config-manager --add-repo https://pkg.earthly.dev/earthly.repo
 sudo yum update -y
 sudo amazon-linux-extras install docker
 
-sudo yum install -y earthly
+sudo yum install -y earthly-$EARTHLY_VERSION-1
 
 docker -v
 earthly -v


### PR DESCRIPTION
Amazon Linux is proving to be more stable in many instances; future releases (and some past) need to be updated.