### PR TITLE
Allow `COPY --if-exists` to work with target sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.interp
 .antlr/
 .env
+.arg
 .vscode
 .idea
 .tmp-earthly-out*

--- a/ast/tests/if-exists.ast.json
+++ b/ast/tests/if-exists.ast.json
@@ -361,6 +361,57 @@
           }
         }
       ]
+    },
+    {
+      "name": "artifact-copy-exists",
+      "recipe": [
+        {
+          "command": {
+            "args": [
+              "--if-exists",
+              "+save/ok",
+              "."
+            ],
+            "name": "COPY"
+          }
+        },
+        {
+          "command": {
+            "args": [
+              "test",
+              "-f",
+              "ok"
+            ],
+            "name": "RUN"
+          }
+        }
+      ]
+    },
+    {
+      "name": "artifact-copy-not-exist",
+      "recipe": [
+        {
+          "command": {
+            "args": [
+              "--if-exists",
+              "+save/not_ok",
+              "."
+            ],
+            "name": "COPY"
+          }
+        },
+        {
+          "command": {
+            "args": [
+              "test",
+              "!",
+              "-f",
+              "not_ok"
+            ],
+            "name": "RUN"
+          }
+        }
+      ]
     }
   ],
   "version": {

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -759,6 +759,8 @@ if-exists:
       --output_contains="bad-wildcard-copy"
     DO +RUN_EARTHLY --earthfile=if-exists.earth --should_fail=true --target=+bad-wildcard-save \
       --output_contains="bad-wildcard-save"
+    DO +RUN_EARTHLY --earthfile=if-exists.earth --target=+artifact-copy-exists
+    DO +RUN_EARTHLY --earthfile=if-exists.earth --target=+artifact-copy-not-exist
     RUN mkdir in && \
         echo "this-file-does-exist" > ./in/this-file-does-exist && \
         echo "so-does-this-one" > so-does-this-one

--- a/tests/if-exists.earth
+++ b/tests/if-exists.earth
@@ -55,3 +55,11 @@ classic-copy-exists:
 classic-copy-not-exist:
     COPY --if-exists ./in/this-file-does-not-exist .
     RUN test ! -f this-file-does-not-exist
+
+artifact-copy-exists:
+    COPY --if-exists +save/ok .
+    RUN test -f ok
+
+artifact-copy-not-exist:
+    COPY --if-exists +save/not_ok .
+    RUN test ! -f not_ok

--- a/util/llbutil/copyop.go
+++ b/util/llbutil/copyop.go
@@ -39,6 +39,8 @@ func CopyOp(ctx context.Context, srcState pllb.State, srcs []string, destState p
 
 			//Normalize path by dropping './'
 			src = strings.TrimPrefix(src, "./")
+			// A target source will always have a leading '/' and never match, so strip that as well
+			src = strings.TrimPrefix(src, "/")
 			src = fmt.Sprintf("[%s]%s", string(src[0]), string(src[1:]))
 		}
 		copyOpts := append([]llb.CopyOption{


### PR DESCRIPTION
Fixes #2541 

Given source `+target/data`, the current code translates that to wildcard `[/]data`, which never matches.  This translates it to `[d]ata` (analogous to how it works for classical copies).

I'm not sure what I'm supposed to "carefully look for" in regards to the AST changes (or if I was even right to generate them); the activity on #1557 (a very similar issue/solution) was my guide.