### PR TITLE
fix missing digest error for some docker.io images

### DIFF
--- a/builder/image_solver.go
+++ b/builder/image_solver.go
@@ -233,12 +233,15 @@ func (m *multiImageSolver) SolveImages(ctx context.Context, imageDefs []*states.
 			for k, v := range resp {
 				pref1 := result.FinalImageName + "|"
 				pref2 := fmt.Sprintf("docker.io/library/%s|", result.FinalImageName)
+				pref3 := fmt.Sprintf("docker.io/%s|", result.FinalImageName)
 				var k2 string
 				switch {
 				case strings.HasPrefix(k, pref1):
 					k2 = strings.TrimPrefix(k, pref1)
 				case strings.HasPrefix(k, pref2):
 					k2 = strings.TrimPrefix(k, pref2)
+				case strings.HasPrefix(k, pref3):
+					k2 = strings.TrimPrefix(k, pref3)
 				default:
 					continue
 				}


### PR DESCRIPTION
Fixes the `Warning: Could not detect digest for image %s. Please update your buildkit installation.` error which prevented the digest from being loaded for image names of the form `docker.io/<user>/<img>` (where as previously images were prefixed with `docker.io/library/<user>/<img>`).