### PR TITLE
bugfix: set TargetPlatform in ConvertOpt

### DIFF
--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -53,7 +53,6 @@ import (
 	"github.com/moby/buildkit/session/localhost"
 	solverpb "github.com/moby/buildkit/solver/pb"
 	"github.com/moby/buildkit/util/apicaps"
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -382,10 +381,10 @@ func (c *Converter) FromDockerfile(ctx context.Context, contextPath string, dfPa
 		Config: dockerui.Config{
 			BuildArgs:        overriding.Map(),
 			Target:           dfTarget,
-			TargetPlatforms:  []specs.Platform{plat},
 			ImageResolveMode: c.opt.ImageResolveMode,
 		},
-		Client: bc,
+		TargetPlatform: &plat,
+		Client:         bc,
 	})
 	done()
 	if err != nil {


### PR DESCRIPTION
Fixes regression introduced in 4b139f43db7de4bb801e5070d304a469ed4b758a which incorrectly set TargetPlatforms in the dockerui Config rather than keeping it in ConvertOpt. This resulted in implicitTargetPlatform being set to true, which caused the host platform (e.g. darwin) to be propigated to the target platform.