### PR TITLE
Allow build args to auto-complete in artifact mode

### DIFF
--- a/tests/autocompletion/Earthfile
+++ b/tests/autocompletion/Earthfile
@@ -70,9 +70,6 @@ test-target-with-build-args:
     RUN echo "--city=
 --country=" > expected
     DO +COMPLETION_TEST --COMP_LINE="earthly +othertargetwithargs -"
-
-    RUN echo "--city=
---country=" > expected
     DO +COMPLETION_TEST --COMP_LINE="earthly +othertargetwithargs --c"
 
     RUN echo "--city=" > expected
@@ -80,8 +77,6 @@ test-target-with-build-args:
 
     RUN > expected
     DO +COMPLETION_TEST --COMP_LINE="earthly +othertargetwithargs --city="
-
-    RUN > expected
     DO +COMPLETION_TEST --COMP_LINE="earthly +othertargetwithargs --city=foo"
 
 test-target-with-build-args-artifact-mode:
@@ -92,17 +87,8 @@ test-target-with-build-args-artifact-mode:
     RUN echo "--city=
 --country=" > expected
     DO +COMPLETION_TEST --COMP_LINE="earthly +othertargetwithargs/out -"
-
-    RUN echo "--city=
---country=" > expected
     DO +COMPLETION_TEST --COMP_LINE="earthly -a +othertargetwithargs/out -"
-
-    RUN echo "--city=
---country=" > expected
     DO +COMPLETION_TEST --COMP_LINE="earthly -a +othertargetwithargs/some/directory/out -"
-
-    RUN echo "--city=
---country=" > expected
     DO +COMPLETION_TEST --COMP_LINE="earthly -a +othertargetwithargs/out --c"
 
     RUN echo "--city=" > expected
@@ -110,8 +96,6 @@ test-target-with-build-args-artifact-mode:
 
     RUN > expected
     DO +COMPLETION_TEST --COMP_LINE="earthly -a +othertargetwithargs/out --city="
-
-    RUN > expected
     DO +COMPLETION_TEST --COMP_LINE="earthly -a +othertargetwithargs/out --city=foo"
 
 test-targets-from-other-dir:
@@ -134,9 +118,6 @@ test-target-with-build-args-from-other-dir:
     RUN echo "--city=
 --country=" > expected
     DO +COMPLETION_TEST --COMP_LINE="earthly ./child/dir+othertargetwithargs -"
-
-    RUN echo "--city=
---country=" > expected
     DO +COMPLETION_TEST --COMP_LINE="earthly ./child/dir+othertargetwithargs --c"
 
     RUN echo "--city=" > expected

--- a/tests/autocompletion/Earthfile
+++ b/tests/autocompletion/Earthfile
@@ -82,11 +82,9 @@ test-target-with-build-args:
 test-target-with-build-args-artifact-mode:
     COPY fake.earth ./Earthfile
 
-    # autocomplete doesn't actually enforce artifact mode when offering completions
-    # for a target with an (assumed) artifact path
     RUN echo "--city=
 --country=" > expected
-    DO +COMPLETION_TEST --COMP_LINE="earthly +othertargetwithargs/out -"
+    DO +COMPLETION_TEST --COMP_LINE="earthly --artifact +othertargetwithargs/out -"
     DO +COMPLETION_TEST --COMP_LINE="earthly -a +othertargetwithargs/out -"
     DO +COMPLETION_TEST --COMP_LINE="earthly -a +othertargetwithargs/some/directory/out -"
     DO +COMPLETION_TEST --COMP_LINE="earthly -a +othertargetwithargs/out --c"
@@ -97,6 +95,25 @@ test-target-with-build-args-artifact-mode:
     RUN > expected
     DO +COMPLETION_TEST --COMP_LINE="earthly -a +othertargetwithargs/out --city="
     DO +COMPLETION_TEST --COMP_LINE="earthly -a +othertargetwithargs/out --city=foo"
+
+    # All previous scenarios should never complete without '-a' or '--artifact'
+    RUN > expected
+    DO +COMPLETION_TEST --should_fail='true' --COMP_LINE="earthly +othertargetwithargs/out -"
+    DO +COMPLETION_TEST --should_fail='true' --COMP_LINE="earthly +othertargetwithargs/out -"
+    DO +COMPLETION_TEST --should_fail='true' --COMP_LINE="earthly +othertargetwithargs/some/directory/out -"
+    DO +COMPLETION_TEST --should_fail='true' --COMP_LINE="earthly +othertargetwithargs/out --c"
+    DO +COMPLETION_TEST --should_fail='true' --COMP_LINE="earthly +othertargetwithargs/out --ci"
+    # This is also an 'invalid' scenarios, but special.  The previous tests should fail because the
+    # command is at a point where a completion is warranted, but there's nothing to offer up as the command
+    # is invalid up to that point.  This commands is also invalid, but is at a 'terminal' point; there
+    # are no completions that could possibly be offered, even if the command was valid.
+    DO +COMPLETION_TEST --should_fail='false' --COMP_LINE="earthly +othertargetwithargs/out --city="
+    # This test should probably be deleted, as it more documents existing behavior rather than asserting
+    # expectations; it may break in the future.  You'd think this is also a 'terminal' state, since even
+    # a legitimate command does not offer up suggestions.  But it's not terminal; completions are still
+    # calculated (thus why this is --should_fail), but nothing is actually offered unless an actual '-'
+    # was typed first.
+    DO +COMPLETION_TEST --should_fail='true' --COMP_LINE="earthly +othertargetwithargs/out --city=foo"
 
 test-targets-from-other-dir:
     RUN mkdir -p child/dir
@@ -201,7 +218,21 @@ COMPLETION_TEST:
     ARG COMP_POINT="$(echo -n "$COMP_LINE" | wc -m)"
     ARG expected_file='expected'
     ARG actual_file='actual'
-    RUN COMP_LINE="$COMP_LINE" COMP_POINT=$COMP_POINT earthly > "$actual_file"
+    ARG should_fail='false'
+    RUN COMP_LINE="$COMP_LINE" COMP_POINT=$COMP_POINT earthly > "$actual_file"; ret=$?; \
+        if $should_fail; then \
+            if [ $ret -eq 0 ]; then \
+                echo 'completion should have failed (but passed)'; \
+                exit 1; \
+            fi; \
+            exit 0; \
+        else \
+            if [ $ret -ne 0 ]; then \
+                echo 'completion should have passed (but failed)'; \
+                exit $ret; \
+            fi; \
+            exit 0; \
+        fi
     RUN diff "$expected_file" "$actual_file"
 
 test-all:

--- a/tests/autocompletion/Earthfile
+++ b/tests/autocompletion/Earthfile
@@ -27,8 +27,7 @@ prune
 registry 
 satellite 
 secret " > expected
-    RUN COMP_LINE="earthly " COMP_POINT=8 earthly > actual
-    RUN diff expected actual
+    DO +COMPLETION_TEST --COMP_LINE="earthly "
 
 test-hidden-root-commands:
     ENV EARTHLY_SHOW_HIDDEN=1
@@ -48,8 +47,7 @@ registry
 satellite 
 secret 
 web " > expected
-    RUN COMP_LINE="earthly " COMP_POINT=8 earthly > actual
-    RUN diff expected actual
+    DO +COMPLETION_TEST --COMP_LINE="earthly "
 
 test-build-flags:
     RUN COMP_LINE="earthly --" COMP_POINT=10 earthly | grep -- "--allow-privileged"
@@ -61,37 +59,30 @@ test-targets:
 +othertarget 
 +othertargetwithargs 
 +targetwithrequiredarg " > expected
-    RUN COMP_LINE="earthly +" COMP_POINT=9 earthly > actual
-    RUN diff expected actual
+    DO +COMPLETION_TEST --COMP_LINE="earthly +"
 
     RUN echo "+mytarget " > expected
-    RUN COMP_LINE="earthly +m" COMP_POINT=10 earthly > actual
-    RUN diff expected actual
+    DO +COMPLETION_TEST --COMP_LINE="earthly +m"
 
 test-target-with-build-args:
     COPY fake.earth ./Earthfile
 
     RUN echo "--city=
 --country=" > expected
-    RUN COMP_LINE="earthly +othertargetwithargs -" COMP_POINT=30 earthly > actual
-    RUN diff expected actual
+    DO +COMPLETION_TEST --COMP_LINE="earthly +othertargetwithargs -"
 
     RUN echo "--city=
 --country=" > expected
-    RUN COMP_LINE="earthly +othertargetwithargs --c" COMP_POINT=32 earthly > actual
-    RUN diff expected actual
+    DO +COMPLETION_TEST --COMP_LINE="earthly +othertargetwithargs --c"
 
     RUN echo "--city=" > expected
-    RUN COMP_LINE="earthly +othertargetwithargs --ci" COMP_POINT=33 earthly > actual
-    RUN diff expected actual
+    DO +COMPLETION_TEST --COMP_LINE="earthly +othertargetwithargs --ci"
 
     RUN > expected
-    RUN COMP_LINE="earthly +othertargetwithargs --city=" COMP_POINT=36 earthly > actual
-    RUN diff expected actual
+    DO +COMPLETION_TEST --COMP_LINE="earthly +othertargetwithargs --city="
 
     RUN > expected
-    RUN COMP_LINE="earthly +othertargetwithargs --city=foo" COMP_POINT=39 earthly > actual
-    RUN diff expected actual
+    DO +COMPLETION_TEST --COMP_LINE="earthly +othertargetwithargs --city=foo"
 
 test-target-with-build-args-artifact-mode:
     COPY fake.earth ./Earthfile
@@ -100,35 +91,28 @@ test-target-with-build-args-artifact-mode:
     # for a target with an (assumed) artifact path
     RUN echo "--city=
 --country=" > expected
-    RUN COMP_LINE="earthly +othertargetwithargs/out -" COMP_POINT=34 earthly > actual
-    RUN diff expected actual
+    DO +COMPLETION_TEST --COMP_LINE="earthly +othertargetwithargs/out -"
 
     RUN echo "--city=
 --country=" > expected
-    RUN COMP_LINE="earthly -a +othertargetwithargs/out -" COMP_POINT=37 earthly > actual
-    RUN diff expected actual
+    DO +COMPLETION_TEST --COMP_LINE="earthly -a +othertargetwithargs/out -"
 
     RUN echo "--city=
 --country=" > expected
-    RUN COMP_LINE="earthly -a +othertargetwithargs/some/directory/out -" COMP_POINT=52 earthly > actual
-    RUN diff expected actual
+    DO +COMPLETION_TEST --COMP_LINE="earthly -a +othertargetwithargs/some/directory/out -"
 
     RUN echo "--city=
 --country=" > expected
-    RUN COMP_LINE="earthly -a +othertargetwithargs/out --c" COMP_POINT=39 earthly > actual
-    RUN diff expected actual
+    DO +COMPLETION_TEST --COMP_LINE="earthly -a +othertargetwithargs/out --c"
 
     RUN echo "--city=" > expected
-    RUN COMP_LINE="earthly -a +othertargetwithargs/out --ci" COMP_POINT=40 earthly > actual
-    RUN diff expected actual
+    DO +COMPLETION_TEST --COMP_LINE="earthly -a +othertargetwithargs/out --ci"
 
     RUN > expected
-    RUN COMP_LINE="earthly -a +othertargetwithargs/out --city=" COMP_POINT=43 earthly > actual
-    RUN diff expected actual
+    DO +COMPLETION_TEST --COMP_LINE="earthly -a +othertargetwithargs/out --city="
 
     RUN > expected
-    RUN COMP_LINE="earthly -a +othertargetwithargs/out --city=foo" COMP_POINT=46 earthly > actual
-    RUN diff expected actual
+    DO +COMPLETION_TEST --COMP_LINE="earthly -a +othertargetwithargs/out --city=foo"
 
 test-targets-from-other-dir:
     RUN mkdir -p child/dir
@@ -138,12 +122,10 @@ test-targets-from-other-dir:
 ./child/dir+othertarget 
 ./child/dir+othertargetwithargs 
 ./child/dir+targetwithrequiredarg " > expected
-    RUN COMP_LINE="earthly ./child/dir+" COMP_POINT=20 earthly > actual
-    RUN diff expected actual
+    DO +COMPLETION_TEST --COMP_LINE="earthly ./child/dir+"
 
     RUN echo "./child/dir+mytarget " > expected
-    RUN COMP_LINE="earthly ./child/dir+m" COMP_POINT=21 earthly > actual
-    RUN diff expected actual
+    DO +COMPLETION_TEST --COMP_LINE="earthly ./child/dir+m"
 
 test-target-with-build-args-from-other-dir:
     RUN mkdir -p child/dir
@@ -151,36 +133,30 @@ test-target-with-build-args-from-other-dir:
 
     RUN echo "--city=
 --country=" > expected
-    RUN COMP_LINE="earthly ./child/dir+othertargetwithargs -" COMP_POINT=41 earthly > actual
-    RUN diff expected actual
+    DO +COMPLETION_TEST --COMP_LINE="earthly ./child/dir+othertargetwithargs -"
 
     RUN echo "--city=
 --country=" > expected
-    RUN COMP_LINE="earthly ./child/dir+othertargetwithargs --c" COMP_POINT=43 earthly > actual
-    RUN diff expected actual
+    DO +COMPLETION_TEST --COMP_LINE="earthly ./child/dir+othertargetwithargs --c"
 
     RUN echo "--city=" > expected
-    RUN COMP_LINE="earthly ./child/dir+othertargetwithargs --ci" COMP_POINT=44 earthly > actual
-    RUN diff expected actual
+    DO +COMPLETION_TEST --COMP_LINE="earthly ./child/dir+othertargetwithargs --ci"
 
 test-target-with-required-arg:
     COPY fake.earth Earthfile
 
     RUN echo "--musthave=" > expected
-    RUN COMP_LINE="earthly +targetwithrequiredarg -" COMP_POINT=32 earthly > actual
-    RUN diff expected actual
+    DO +COMPLETION_TEST --COMP_LINE="earthly +targetwithrequiredarg -"
 
 test-base-only-target:
     COPY base.earth ./Earthfile
     RUN echo "+base " > expected
-    RUN COMP_LINE="earthly +" COMP_POINT=9 earthly > actual
-    RUN diff expected actual
+    DO +COMPLETION_TEST --COMP_LINE="earthly +"
 
 test-no-parent-at-root:
     WORKDIR /
     RUN echo "./" > expected
-    RUN COMP_LINE="earthly ." COMP_POINT=9 earthly > actual
-    RUN diff expected actual
+    DO +COMPLETION_TEST --COMP_LINE="earthly ."
 
 test-no-parent-at-root-from-home:
     WORKDIR /home
@@ -194,22 +170,19 @@ test-no-parent-at-root-from-home:
 ../sys/
 ../usr/
 ../var/" > expected
-    RUN COMP_LINE="earthly ../" COMP_POINT=11 earthly > actual
-    RUN diff expected actual
+    DO +COMPLETION_TEST --COMP_LINE="earthly ../"
 
 test-relative-dir-targets:
     RUN mkdir -p /test/foo
     COPY fake.earth /test/foo/Earthfile
     WORKDIR /test/
     RUN echo "./foo+" > expected
-    RUN COMP_LINE="earthly ./" COMP_POINT=10 earthly > actual
-    RUN diff expected actual
+    DO +COMPLETION_TEST --COMP_LINE="earthly ./"
     RUN echo "./foo+mytarget 
 ./foo+othertarget 
 ./foo+othertargetwithargs 
 ./foo+targetwithrequiredarg " > expected
-    RUN COMP_LINE="earthly ./foo+" COMP_POINT=14 earthly > actual
-    RUN diff expected actual
+    DO +COMPLETION_TEST --COMP_LINE="earthly ./foo+"
 
 test-targets-in-dir-and-subdir:
     RUN mkdir -p /test/foo/subdir
@@ -219,14 +192,9 @@ test-targets-in-dir-and-subdir:
     WORKDIR /test/
     RUN echo "./foo+
 ./foo/" > expected
-    RUN COMP_LINE="earthly ./" COMP_POINT=10 earthly > actual
-    RUN diff expected actual
-
-    RUN COMP_LINE="earthly ./f" COMP_POINT=11 earthly > actual
-    RUN diff expected actual
-
-    RUN COMP_LINE="earthly ./foo" COMP_POINT=13 earthly > actual
-    RUN diff expected actual
+    DO +COMPLETION_TEST --COMP_LINE="earthly ./"
+    DO +COMPLETION_TEST --COMP_LINE="earthly ./f"
+    DO +COMPLETION_TEST --COMP_LINE="earthly ./foo"
 
 test-targets-in-two-subdirs-that-are-similar:
     COPY fake.earth /test/foo/subdir/Earthfile
@@ -235,14 +203,9 @@ test-targets-in-two-subdirs-that-are-similar:
     WORKDIR /test/
     RUN echo "./foo/
 ./food/" > expected
-    RUN COMP_LINE="earthly ./" COMP_POINT=10 earthly > actual
-    RUN diff expected actual
-
-    RUN COMP_LINE="earthly ./f" COMP_POINT=11 earthly > actual
-    RUN diff expected actual
-
-    RUN COMP_LINE="earthly ./foo" COMP_POINT=13 earthly > actual
-    RUN diff expected actual
+    DO +COMPLETION_TEST --COMP_LINE="earthly ./"
+    DO +COMPLETION_TEST --COMP_LINE="earthly ./f"
+    DO +COMPLETION_TEST --COMP_LINE="earthly ./foo"
 
 test-no-errors-are-displayed:
     COPY bad-version-flag.earth ./Earthfile
@@ -250,6 +213,15 @@ test-no-errors-are-displayed:
     RUN > expected
     RUN ! COMP_LINE="earthly +" COMP_POINT=9 earthly > actual
     RUN diff expected actual
+
+COMPLETION_TEST:
+    COMMAND
+    ARG --required COMP_LINE
+    ARG COMP_POINT="$(echo -n "$COMP_LINE" | wc -m)"
+    ARG expected_file='expected'
+    ARG actual_file='actual'
+    RUN COMP_LINE="$COMP_LINE" COMP_POINT=$COMP_POINT earthly > "$actual_file"
+    RUN diff "$expected_file" "$actual_file"
 
 test-all:
     BUILD +test-root-commands

--- a/tests/autocompletion/Earthfile
+++ b/tests/autocompletion/Earthfile
@@ -93,6 +93,43 @@ test-target-with-build-args:
     RUN COMP_LINE="earthly +othertargetwithargs --city=foo" COMP_POINT=39 earthly > actual
     RUN diff expected actual
 
+test-target-with-build-args-artifact-mode:
+    COPY fake.earth ./Earthfile
+
+    # autocomplete doesn't actually enforce artifact mode when offering completions
+    # for a target with an (assumed) artifact path
+    RUN echo "--city=
+--country=" > expected
+    RUN COMP_LINE="earthly +othertargetwithargs/out -" COMP_POINT=34 earthly > actual
+    RUN diff expected actual
+
+    RUN echo "--city=
+--country=" > expected
+    RUN COMP_LINE="earthly -a +othertargetwithargs/out -" COMP_POINT=37 earthly > actual
+    RUN diff expected actual
+
+    RUN echo "--city=
+--country=" > expected
+    RUN COMP_LINE="earthly -a +othertargetwithargs/some/directory/out -" COMP_POINT=52 earthly > actual
+    RUN diff expected actual
+
+    RUN echo "--city=
+--country=" > expected
+    RUN COMP_LINE="earthly -a +othertargetwithargs/out --c" COMP_POINT=39 earthly > actual
+    RUN diff expected actual
+
+    RUN echo "--city=" > expected
+    RUN COMP_LINE="earthly -a +othertargetwithargs/out --ci" COMP_POINT=40 earthly > actual
+    RUN diff expected actual
+
+    RUN > expected
+    RUN COMP_LINE="earthly -a +othertargetwithargs/out --city=" COMP_POINT=43 earthly > actual
+    RUN diff expected actual
+
+    RUN > expected
+    RUN COMP_LINE="earthly -a +othertargetwithargs/out --city=foo" COMP_POINT=46 earthly > actual
+    RUN diff expected actual
+
 test-targets-from-other-dir:
     RUN mkdir -p child/dir
     COPY fake.earth child/dir/Earthfile
@@ -221,6 +258,7 @@ test-all:
     BUILD +test-targets
     BUILD +test-targets-from-other-dir
     BUILD +test-target-with-build-args
+    BUILD +test-target-with-build-args-artifact-mode
     BUILD +test-target-with-build-args-from-other-dir
     BUILD +test-target-with-required-arg
     BUILD +test-base-only-target


### PR DESCRIPTION
Given
```Earthfile
VERSION 0.7
FROM alpine

test:
    ARG --required input
    RUN echo "$input" > file
    SAVE ARTIFACT file
```
the command `earthly +test -<TAB>` will autocomplete (`--input`), but `earthly -a +test/file -<TAB>` will not.  This change makes them behave identically.

If the item in target position does not parse as a target, it will try parsing it as an artifact.  If it does parse, the artifact's target will then be used to offer build arg completion.