### PR TITLE
clarify default cache size

### DIFF
--- a/docs/earthly-config/earthly-config.md
+++ b/docs/earthly-config/earthly-config.md
@@ -56,7 +56,8 @@ earthly config global.cache_size_mb 20000
 
 ### cache_size_mb
 
-Specifies the total size of the BuildKit cache, in MB. The BuildKit daemon uses this setting to configure automatic garbage collection of old cache. A value of 0 causes the size to be adaptive depending on how much space is available on your system. The default is 0.
+Specifies the total size of the BuildKit cache, in MB. The BuildKit daemon uses this setting to configure automatic garbage collection of old cache.
+Setting this to 0, either explicitly or by omission, will cause buildkit to use its internal default of 10% of the root filesystem.
 
 ### cache_size_pct
 


### PR DESCRIPTION
If no value is specificed in buildkit.toml, buildkit will set it adaptively: https://github.com/moby/buildkit/blob/54b8ff2fc8648c86b1b8c35e5cd07517b56ac2d5/cmd/buildkitd/config/gcpolicy_unix.go#L16