### PR TITLE
loosen the tests required for a pre-release

### DIFF
--- a/.github/workflows/ci-docker-ubuntu.yml
+++ b/.github/workflows/ci-docker-ubuntu.yml
@@ -476,21 +476,8 @@ jobs:
     name: --push +prerelease
     if: github.event_name == 'push'
     needs:
-      - docker-tests
-      - docker-examples-1
-      - docker-examples-2
-      - docker-test-local
-      - docker-push-integrations
-      - docker-secret-integrations
-      - docker-bootstrap-integrations
-      - docker-repo-auth-tests
-      - docker-export-test
-      - docker-misc-test
-      - race-tests
-      - tutorial
       - buildkitd-amd64
       - buildkitd-arm64
-      - all-dind
       - prerelease
       - earthly
     runs-on: ubuntu-latest


### PR DESCRIPTION
Due to flaky tests, our pre-release workflow is not running; this means we are no longer dogfooding our code in main via the ./earthly script.

If the code is merged into main; then we need to be dogfooding it -- even if it causes tests to fail -- otherwise we won't ever taste bad dogfood.