### PR TITLE
variables: support builtins in --arg-scope-and-set

### DIFF
--- a/buildcontext/parsefeatures.go
+++ b/buildcontext/parsefeatures.go
@@ -19,7 +19,7 @@ func parseFeatures(buildFilePath string, featureFlagOverrides string, projectRef
 		return nil, err
 	}
 
-	ftrs, hasVersion, err := features.GetFeatures(version)
+	ftrs, hasVersion, err := features.Get(version)
 	if err != nil {
 		return nil, err
 	}

--- a/features/features.go
+++ b/features/features.go
@@ -158,8 +158,8 @@ func instrumentVersion(_ string, opt *goflags.Option, s *string) (*string, error
 	return s, nil // don't modify the flag, just pass it back.
 }
 
-// GetFeatures returns a features struct for a particular version
-func GetFeatures(version *spec.Version) (*Features, bool, error) {
+// Get returns a features struct for a particular version
+func Get(version *spec.Version) (*Features, bool, error) {
 	var ftrs Features
 	hasVersion := (version != nil)
 	if !hasVersion {

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -342,15 +342,24 @@ git-clone-test:
 
 builtin-args-test:
     DO +RUN_EARTHLY --earthfile=builtin-args.earth --target=+builtin-args-test
+    RUN sed -i "1s/VERSION \(.*\)/VERSION --arg-scope-and-set \1/" Earthfile
+    DO +RUN_EARTHLY --target=+builtin-args-test
 
 builtin-args-invalid-default-test:
     DO +RUN_EARTHLY --earthfile=builtin-args-invalid-default.earth --should_fail=true --target=+test --output_contains="arg default value supplied for built-in ARG"
+    RUN sed -i "1s/VERSION \(.*\)/VERSION --arg-scope-and-set \1/" Earthfile
+    DO +RUN_EARTHLY --should_fail=true --target=+test --output_contains="arg default value supplied for built-in ARG"
 
 builtin-args-invalid-pass-test:
     DO +RUN_EARTHLY --earthfile=builtin-args-invalid-pass.earth --should_fail=true --target=+test --output_contains="value cannot be specified for built-in build arg EARTHLY_VERSION"
+    RUN sed -i "1s/VERSION \(.*\)/VERSION --arg-scope-and-set \1/" Earthfile
+    DO +RUN_EARTHLY --should_fail=true --target=+test --output_contains="value cannot be specified for built-in build arg EARTHLY_VERSION"
 
 builtin-args-cli-tests:
     DO +RUN_EARTHLY --earthfile=builtin-args.earth --should_fail=true --extra_args="--build-arg EARTHLY_VERSION=123" --target=+builtin-args-test \
+        --output_contains="cannot be passed on the command line"
+    RUN sed -i "1s/VERSION \(.*\)/VERSION --arg-scope-and-set \1/" Earthfile
+    DO +RUN_EARTHLY --should_fail=true --extra_args="--build-arg EARTHLY_VERSION=123" --target=+builtin-args-test \
         --output_contains="cannot be passed on the command line"
 
 smoke-test:

--- a/variables/collection.go
+++ b/variables/collection.go
@@ -89,6 +89,9 @@ type NewCollectionOpt struct {
 func NewCollection(opts NewCollectionOpt) *Collection {
 	target := opts.Target
 	console := opts.Console
+	if opts.OverridingVars == nil {
+		opts.OverridingVars = NewScope()
+	}
 	return &Collection{
 		builtin:          BuiltinArgs(target, opts.PlatformResolver, opts.GitMeta, opts.BuiltinArgs, opts.Features, opts.Push, opts.CI),
 		envs:             NewScope(),
@@ -213,6 +216,9 @@ func (c *Collection) Expand(word string, shellOut shell.EvalShellOutFn) (string,
 
 func (c *Collection) overridingOrDefault(name string, defaultValue string, pncvf ProcessNonConstantVariableFunc) (string, error) {
 	if v, ok := c.overriding().Get(name); ok {
+		return v, nil
+	}
+	if v, ok := c.builtin.Get(name); ok {
 		return v, nil
 	}
 	return parseArgValue(name, defaultValue, pncvf)

--- a/variables/collection_test.go
+++ b/variables/collection_test.go
@@ -1,0 +1,104 @@
+package variables_test
+
+import (
+	"testing"
+
+	"github.com/earthly/earthly/ast/spec"
+	"github.com/earthly/earthly/features"
+	"github.com/earthly/earthly/util/platutil"
+	"github.com/earthly/earthly/variables"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/poy/onpar"
+	"github.com/poy/onpar/expect"
+)
+
+func TestCollection(topT *testing.T) {
+	type testCtx struct {
+		expect   expect.Expectation
+		coll     *variables.Collection
+		features *features.Features
+	}
+	o := onpar.BeforeEach(onpar.New(topT), func(t *testing.T) testCtx {
+		expect := expect.New(t)
+		f, _, err := features.Get(&spec.Version{Args: []string{"0.7"}})
+		expect(err).To(not(haveOccurred()))
+		return testCtx{
+			expect:   expect,
+			features: f,
+		}
+	})
+	defer o.Run()
+
+	registerBaseSpecs := func(o *onpar.Onpar[testCtx, testCtx]) {
+		// This is a quick and dirty workaround for registering the same specs
+		// with multiple setup/teardown functions. It should be a first class
+		// feature in onpar some day, but for now this will do.
+
+		o.Spec("builtins are used for newly registered variables", func(tc testCtx) {
+			name := "EARTHLY_VERSION"
+			_, ok := tc.coll.Get(name, variables.WithActive())
+			tc.expect(ok).To(beFalse())
+
+			_, _, err := tc.coll.DeclareVar("EARTHLY_VERSION", variables.AsArg())
+			tc.expect(err).To(not(haveOccurred()))
+			v, ok := tc.coll.Get(name, variables.WithActive())
+			tc.expect(ok).To(beTrue())
+			tc.expect(v).To(equal("some version"))
+		})
+	}
+
+	o.Group("Defaults", func() {
+		o := onpar.BeforeEach(o, func(tc testCtx) testCtx {
+			tc.coll = variables.NewCollection(variables.NewCollectionOpt{
+				PlatformResolver: platutil.NewResolver(specs.Platform{
+					Architecture: "foo",
+					OS:           "bar",
+					OSVersion:    "baz",
+					OSFeatures:   []string{"stub"},
+					Variant:      "bacon",
+				}),
+				BuiltinArgs: variables.DefaultArgs{
+					EarthlyVersion: "some version",
+				},
+				Features: tc.features,
+			})
+			return tc
+		})
+
+		registerBaseSpecs(o)
+	})
+
+	o.Group("ArgScopeSet", func() {
+		o := onpar.BeforeEach(o, func(tc testCtx) testCtx {
+			tc.features.ArgScopeSet = true
+			tc.coll = variables.NewCollection(variables.NewCollectionOpt{
+				PlatformResolver: platutil.NewResolver(specs.Platform{
+					Architecture: "foo",
+					OS:           "bar",
+					OSVersion:    "baz",
+					OSFeatures:   []string{"stub"},
+					Variant:      "bacon",
+				}),
+				BuiltinArgs: variables.DefaultArgs{
+					EarthlyVersion: "some version",
+				},
+				Features: tc.features,
+			})
+			return tc
+		})
+
+		registerBaseSpecs(o)
+
+		o.Spec("non-ARG variables ignore builtin values", func(tc testCtx) {
+			name := "EARTHLY_VERSION"
+			_, ok := tc.coll.Get(name, variables.WithActive())
+			tc.expect(ok).To(beFalse())
+
+			_, _, err := tc.coll.DeclareVar("EARTHLY_VERSION")
+			tc.expect(err).To(not(haveOccurred()))
+			v, ok := tc.coll.Get(name, variables.WithActive())
+			tc.expect(ok).To(beTrue())
+			tc.expect(v).To(equal(""))
+		})
+	})
+}

--- a/variables/imports_test.go
+++ b/variables/imports_test.go
@@ -6,9 +6,11 @@ import (
 )
 
 var (
-	beTrue  = matchers.BeTrue
-	beFalse = matchers.BeFalse
-	equal   = matchers.Equal
+	beTrue       = matchers.BeTrue
+	beFalse      = matchers.BeFalse
+	equal        = matchers.Equal
+	not          = matchers.Not
+	haveOccurred = matchers.HaveOccurred
 )
 
 var (


### PR DESCRIPTION
This also includes a very rudimentary first pass at unit tests for `variables.Collection`.

Resolves #2879 