### PR TITLE
Ensure certificates are generated when using podman

### DIFF
--- a/cmd/earthly/root_cmds.go
+++ b/cmd/earthly/root_cmds.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"github.com/earthly/earthly/util/containerutil"
 	"net/url"
 	"os"
 	"path"
@@ -24,6 +23,7 @@ import (
 	"github.com/earthly/earthly/domain"
 	"github.com/earthly/earthly/earthfile2llb"
 	"github.com/earthly/earthly/util/cliutil"
+	"github.com/earthly/earthly/util/containerutil"
 	"github.com/earthly/earthly/util/fileutil"
 	"github.com/earthly/earthly/util/termutil"
 )

--- a/cmd/earthly/root_cmds.go
+++ b/cmd/earthly/root_cmds.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/earthly/earthly/util/containerutil"
 	"net/url"
 	"os"
 	"path"
@@ -429,7 +430,7 @@ func (app *earthlyApp) bootstrap(cliCtx *cli.Context) error {
 		if err != nil {
 			return errors.Wrapf(err, "invalid buildkit_host: %s", app.buildkitHost)
 		}
-		if bkURL.Scheme == "tcp" && app.cfg.Global.TLSEnabled {
+		if (bkURL.Scheme == "tcp" || app.cfg.Global.ContainerFrontend == containerutil.FrontendPodmanShell) && app.cfg.Global.TLSEnabled {
 			root, err := cliutil.GetOrCreateEarthlyDir(app.installationName)
 			if err != nil {
 				return err


### PR DESCRIPTION
Not sure if we _should_ use TLS for podman, but this is (hopefully) a way to keep the TLS default behavior aligned, whether podman is used or not.

The issue has been that we deduce whether to generate certificates according to the buildkit host, which for podman, is set later in the code, so I changed the condition to generate the certificates in case podman is used.