### PR TITLE
Initialize log streaming upfront if org/project envs set

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -102,7 +102,7 @@ type BuildOpt struct {
 	GlobalWaitBlockFtr         bool
 	LocalArtifactWhiteList     *gatewaycrafter.LocalArtifactWhiteList
 	Logbus                     *logbus.Bus
-	MainTargetDetailsFuture    chan earthfile2llb.TargetDetails
+	MainTargetDetailsFunc      func(earthfile2llb.TargetDetails) error
 	Runner                     string
 	CloudStoredAuthProvider    cloudauth.ProjectBasedAuthProvider
 }
@@ -215,7 +215,7 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 				InteractiveDebuggerEnabled:           b.opt.InteractiveDebugging,
 				InteractiveDebuggerDebugLevelLogging: b.opt.InteractiveDebuggingDebugLevelLogging,
 				Logbus:                               opt.Logbus,
-				MainTargetDetailsFuture:              opt.MainTargetDetailsFuture,
+				MainTargetDetailsFunc:                opt.MainTargetDetailsFunc,
 				Runner:                               opt.Runner,
 				CloudStoredAuthProvider:              opt.CloudStoredAuthProvider,
 			}

--- a/cmd/earthly/build_cmd.go
+++ b/cmd/earthly/build_cmd.go
@@ -556,7 +556,7 @@ func (app *earthlyApp) actionBuildImp(cliCtx *cli.Context, flagArgs, nonFlagArgs
 			app.console.VerbosePrintf("Logbus: hit context deadline at %s (%s later)", now.Format(time.RFC3339Nano), now.Sub(beforeSelect))
 			return
 		case details := <-buildOpts.MainTargetDetailsFuture:
-			if app.logbusSetup.OrgAndProjectSet() {
+			if app.logbusSetup.LogStreamer.Started() {
 				app.console.VerbosePrintf("Organization and project already set via environmental")
 				return
 			}
@@ -578,7 +578,7 @@ func (app *earthlyApp) actionBuildImp(cliCtx *cli.Context, flagArgs, nonFlagArgs
 		}
 	}()
 
-	if app.logstream && doLogstreamUpload && !app.logbusSetup.OrgAndProjectSet() {
+	if app.logstream && doLogstreamUpload && !app.logbusSetup.LogStreamer.Started() {
 		app.console.ColorPrintf(color.New(color.FgHiYellow), "Streaming logs to %s\n\n", logstreamURL)
 	}
 	_, err = b.BuildTarget(cliCtx.Context, target, buildOpts)

--- a/cmd/earthly/build_cmd.go
+++ b/cmd/earthly/build_cmd.go
@@ -553,16 +553,16 @@ func (app *earthlyApp) actionBuildImp(cliCtx *cli.Context, flagArgs, nonFlagArgs
 		select {
 		case <-cliCtx.Context.Done():
 			now := time.Now()
-			app.console.VerbosePrintf(
-				"========== CONTEXT DONE BEFORE LOGSTREAMER STARTED AT %s (%s later) ==========",
-				now.Format(time.RFC3339Nano),
-				now.Sub(beforeSelect),
-			)
+			app.console.VerbosePrintf("Logbus: hit context deadline at %s (%s later)", now.Format(time.RFC3339Nano), now.Sub(beforeSelect))
 			return
 		case details := <-buildOpts.MainTargetDetailsFuture:
+			if app.logbusSetup.OrgAndProjectSet() {
+				app.console.VerbosePrintf("Organization and project already set via environmental")
+				return
+			}
 			now := time.Now()
 			app.console.VerbosePrintf(
-				"========== SETTING ORG AND PROJECT %s/%s AT %s (%s later) ==========",
+				"Logbus: setting organization %q and project %q at %s (%s later)",
 				details.EarthlyOrgName,
 				details.EarthlyProjectName,
 				now.Format(time.RFC3339Nano),
@@ -578,7 +578,7 @@ func (app *earthlyApp) actionBuildImp(cliCtx *cli.Context, flagArgs, nonFlagArgs
 		}
 	}()
 
-	if app.logstream && doLogstreamUpload {
+	if app.logstream && doLogstreamUpload && !app.logbusSetup.OrgAndProjectSet() {
 		app.console.ColorPrintf(color.New(color.FgHiYellow), "Streaming logs to %s\n\n", logstreamURL)
 	}
 	_, err = b.BuildTarget(cliCtx.Context, target, buildOpts)

--- a/cmd/earthly/build_cmd.go
+++ b/cmd/earthly/build_cmd.go
@@ -550,7 +550,7 @@ func (app *earthlyApp) actionBuildImp(cliCtx *cli.Context, flagArgs, nonFlagArgs
 	// information to logbusSetup. This function will be called right at the
 	// beginning of the build within earthfile2llb.
 	buildOpts.MainTargetDetailsFunc = func(d earthfile2llb.TargetDetails) error {
-		if app.logbusSetup.LogStreamer.Started() {
+		if app.logbusSetup.LogStreamerStarted() {
 			// If the org & project have been provided by envs, let's verify
 			// that they're correct once we've parsed them from the Earthfile.
 			if app.orgName != d.EarthlyOrgName || app.projectName != d.EarthlyProjectName {
@@ -570,7 +570,7 @@ func (app *earthlyApp) actionBuildImp(cliCtx *cli.Context, flagArgs, nonFlagArgs
 		return nil
 	}
 
-	if app.logstream && doLogstreamUpload && !app.logbusSetup.LogStreamer.Started() {
+	if app.logstream && doLogstreamUpload && !app.logbusSetup.LogStreamerStarted() {
 		app.console.ColorPrintf(color.New(color.FgHiYellow), "Streaming logs to %s\n\n", logstreamURL)
 	}
 	_, err = b.BuildTarget(cliCtx.Context, target, buildOpts)

--- a/cmd/earthly/flags.go
+++ b/cmd/earthly/flags.go
@@ -324,6 +324,13 @@ func (app *earthlyApp) buildFlags() []cli.Flag {
 			Destination: &app.orgName,
 		},
 		&cli.StringFlag{
+			Name:        "project",
+			EnvVars:     []string{"EARTHLY_PROJECT"},
+			Usage:       wrap("The name of the organization the satellite belongs to. ", "Required when using --satellite and user is a member of multiple organizations."),
+			Required:    false,
+			Destination: &app.projectName,
+		},
+		&cli.StringFlag{
 			Name:        "satellite",
 			Aliases:     []string{"sat"},
 			EnvVars:     []string{"EARTHLY_SATELLITE"},

--- a/cmd/earthly/flags.go
+++ b/cmd/earthly/flags.go
@@ -322,6 +322,7 @@ func (app *earthlyApp) buildFlags() []cli.Flag {
 			Usage:       wrap("The name of the organization that the satellite belongs to. ", "Required when using --satellite and user is a member of multiple organizations."),
 			Required:    false,
 			Destination: &app.orgName,
+			Hidden:      true,
 		},
 		&cli.StringFlag{
 			Name:        "project",

--- a/cmd/earthly/flags.go
+++ b/cmd/earthly/flags.go
@@ -319,16 +319,17 @@ func (app *earthlyApp) buildFlags() []cli.Flag {
 		&cli.StringFlag{
 			Name:        "org",
 			EnvVars:     []string{"EARTHLY_ORG"},
-			Usage:       wrap("The name of the organization the satellite belongs to. ", "Required when using --satellite and user is a member of multiple organizations."),
+			Usage:       wrap("The name of the organization that the satellite belongs to. ", "Required when using --satellite and user is a member of multiple organizations."),
 			Required:    false,
 			Destination: &app.orgName,
 		},
 		&cli.StringFlag{
 			Name:        "project",
 			EnvVars:     []string{"EARTHLY_PROJECT"},
-			Usage:       wrap("The name of the organization the satellite belongs to. ", "Required when using --satellite and user is a member of multiple organizations."),
+			Usage:       "The name of the project that may be used during log streaming.",
 			Required:    false,
 			Destination: &app.projectName,
+			Hidden:      true,
 		},
 		&cli.StringFlag{
 			Name:        "satellite",

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -620,6 +620,7 @@ func (app *earthlyApp) run(ctx context.Context, args []string) int {
 			}
 		}
 	}()
+	app.logbus.Run().SetStart(time.Now())
 	// Initialize log streaming early if we're passed the organization and
 	// project names as environmental variables. This will allow nearly all
 	// initialization errors to be surfaced to the log streaming service. Access
@@ -639,7 +640,6 @@ func (app *earthlyApp) run(ctx context.Context, args []string) int {
 			app.console.ColorPrintf(color.New(color.FgHiYellow), "Streaming logs to %s\n\n", logstreamURL)
 		}
 	}
-	app.logbus.Run().SetStart(time.Now())
 	defer func() {
 		// Just in case this is forgotten somewhere else.
 		app.logbus.Run().SetFatalError(

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -631,7 +631,7 @@ func (app *earthlyApp) run(ctx context.Context, args []string) int {
 			return 1
 		}
 		if cloudClient.IsLoggedIn(ctx) {
-			app.console.VerbosePrintf("Logbus: setting organization %q and project %q at %s (%s later)", app.orgName, app.projectName)
+			app.console.VerbosePrintf("Logbus: setting organization %q and project %q", app.orgName, app.projectName)
 			analytics.AddEarthfileProject(app.orgName, app.projectName)
 			app.logbusSetup.SetOrgAndProject(app.orgName, app.projectName)
 			app.logbusSetup.StartLogStreamer(ctx, cloudClient)

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/earthly/earthly/analytics"
 	"github.com/earthly/earthly/builder"
 	"github.com/earthly/earthly/buildkitd"
+	"github.com/earthly/earthly/cloud"
 	"github.com/earthly/earthly/config"
 	"github.com/earthly/earthly/conslogging"
 	"github.com/earthly/earthly/earthfile2llb"
@@ -619,6 +620,25 @@ func (app *earthlyApp) run(ctx context.Context, args []string) int {
 			}
 		}
 	}()
+	// Initialize log streaming early if we're passed the organization and
+	// project names as environmental variables. This will allow nearly all
+	// initialization errors to be surfaced to the log streaming service. Access
+	// to this organization and project will be verified when the stream begins.
+	if app.orgName != "" && app.projectName != "" && !app.cfg.Global.DisableLogSharing && app.logstreamUpload {
+		cloudClient, err := app.newCloudClient(cloud.WithLogstreamGRPCAddressOverride(app.logstreamAddressOverride))
+		if err != nil {
+			app.console.Warnf("Failed to initialize cloud client: %v", err)
+			return 1
+		}
+		if cloudClient.IsLoggedIn(ctx) {
+			app.console.VerbosePrintf("Logbus: setting organization %q and project %q at %s (%s later)", app.orgName, app.projectName)
+			analytics.AddEarthfileProject(app.orgName, app.projectName)
+			app.logbusSetup.SetOrgAndProject(app.orgName, app.projectName)
+			app.logbusSetup.StartLogStreamer(ctx, cloudClient)
+			logstreamURL := fmt.Sprintf("%s/builds/%s", app.getCIHost(), app.logbusSetup.InitialManifest.GetBuildId())
+			app.console.ColorPrintf(color.New(color.FgHiYellow), "Streaming logs to %s\n\n", logstreamURL)
+		}
+	}
 	app.logbus.Run().SetStart(time.Now())
 	defer func() {
 		// Just in case this is forgotten somewhere else.

--- a/earthfile2llb/earthfile2llb.go
+++ b/earthfile2llb/earthfile2llb.go
@@ -8,6 +8,7 @@ import (
 	"github.com/earthly/earthly/cleanup"
 	"github.com/earthly/earthly/conslogging"
 	"github.com/earthly/earthly/domain"
+	"github.com/earthly/earthly/earthfile2llb"
 	"github.com/earthly/earthly/features"
 	"github.com/earthly/earthly/logbus"
 	"github.com/earthly/earthly/states"
@@ -155,8 +156,8 @@ type ConvertOpt struct {
 	// LLBCaps indicates that builder's capabilities
 	LLBCaps *apicaps.CapSet
 
-	// MainTargetDetailsFuture is a channel that is used to signal the main target details, once known.
-	MainTargetDetailsFuture chan TargetDetails
+	// MainTargetDetailsFunc is a custom function used to handle the target details, once known.
+	MainTargetDetailsFunc func(TargetDetails) error
 
 	// Logbus is the bus used for logging and metadata reporting.
 	Logbus *logbus.Bus
@@ -236,13 +237,15 @@ func Earthfile2LLB(ctx context.Context, target domain.Target, opt ConvertOpt, in
 	if err != nil {
 		return nil, err
 	}
-	if opt.MainTargetDetailsFuture != nil {
-		// TODO (vladaionescu): These should perhaps be passed back via logbus instead.
-		opt.MainTargetDetailsFuture <- TargetDetails{
+	if opt.MainTargetDetailsFunc != nil {
+		err := opt.MainTargetDetailsFunc(TargetDetails{
 			EarthlyOrgName:     bc.EarthlyOrgName,
 			EarthlyProjectName: bc.EarthlyProjectName,
+		})
+		if err != nil {
+			return nil, errors.Wrapf(err, "target details handler error: %v", err)
 		}
-		opt.MainTargetDetailsFuture = nil
+		opt.MainTargetDetailsFunc = nil
 	}
 	if found {
 		// The found target may have initially been created by a FROM or a COPY;

--- a/earthfile2llb/earthfile2llb.go
+++ b/earthfile2llb/earthfile2llb.go
@@ -8,7 +8,6 @@ import (
 	"github.com/earthly/earthly/cleanup"
 	"github.com/earthly/earthly/conslogging"
 	"github.com/earthly/earthly/domain"
-	"github.com/earthly/earthly/earthfile2llb"
 	"github.com/earthly/earthly/features"
 	"github.com/earthly/earthly/logbus"
 	"github.com/earthly/earthly/states"

--- a/logbus/logstreamer/logstreamer_orchestrator.go
+++ b/logbus/logstreamer/logstreamer_orchestrator.go
@@ -22,7 +22,6 @@ type Orchestrator struct {
 	doneCH chan struct{}
 	subCH  chan struct{}
 
-	started     bool
 	errors      []error
 	startOnce   sync.Once
 	closed      atomic.Bool
@@ -67,17 +66,11 @@ func NewOrchestrator(bus LogBus, c CloudClient, initialManifest *logstream.RunMa
 	return ls
 }
 
-// Started will return true if Start has been called.
-func (l *Orchestrator) Started() bool {
-	return l.started
-}
-
 // Start will restart streaming to the cloud retrying up the retry count
 // Callers should listen to Done to be notified when the streaming contract completes
 // Start may only be called once
 func (l *Orchestrator) Start(ctx context.Context) {
 	l.startOnce.Do(func() {
-		l.started = true
 		go func() {
 			defer l.markDone()
 			for i := 0; i < l.retries; i++ {

--- a/logbus/logstreamer/logstreamer_orchestrator.go
+++ b/logbus/logstreamer/logstreamer_orchestrator.go
@@ -22,6 +22,7 @@ type Orchestrator struct {
 	doneCH chan struct{}
 	subCH  chan struct{}
 
+	started     bool
 	errors      []error
 	startOnce   sync.Once
 	closed      atomic.Bool
@@ -66,11 +67,17 @@ func NewOrchestrator(bus LogBus, c CloudClient, initialManifest *logstream.RunMa
 	return ls
 }
 
+// Started will return true if Start has been called.
+func (l *Orchestrator) Started() bool {
+	return l.started
+}
+
 // Start will restart streaming to the cloud retrying up the retry count
 // Callers should listen to Done to be notified when the streaming contract completes
 // Start may only be called once
 func (l *Orchestrator) Start(ctx context.Context) {
 	l.startOnce.Do(func() {
+		l.started = true
 		go func() {
 			defer l.markDone()
 			for i := 0; i < l.retries; i++ {

--- a/logbus/setup/setup.go
+++ b/logbus/setup/setup.go
@@ -30,7 +30,8 @@ type BusSetup struct {
 	LogStreamer     *logstreamer.Orchestrator
 	InitialManifest *logstream.RunManifest
 
-	verbose bool
+	logStreamerStarted bool
+	verbose            bool
 }
 
 // New creates a new BusSetup.
@@ -74,11 +75,17 @@ func (bs *BusSetup) SetOrgAndProject(orgName, projectName string) {
 	bs.InitialManifest.ProjectName = projectName
 }
 
+// LogStreamerStarted returns true if the log streamer has been started.
+func (bs *BusSetup) LogStreamerStarted() bool {
+	return bs.logStreamerStarted
+}
+
 // StartLogStreamer starts a LogStreamer for the given build. The
 // LogStreamer streams logs to the cloud.
 func (bs *BusSetup) StartLogStreamer(ctx context.Context, c *cloud.Client) {
 	bs.LogStreamer = logstreamer.NewOrchestrator(bs.Bus, c, bs.InitialManifest, logstreamer.WithVerbose(bs.verbose))
 	bs.LogStreamer.Start(ctx)
+	bs.logStreamerStarted = true
 }
 
 // DumpManifestToFile dumps the manifest to the given file.

--- a/logbus/setup/setup.go
+++ b/logbus/setup/setup.go
@@ -77,6 +77,9 @@ func (bs *BusSetup) SetOrgAndProject(orgName, projectName string) {
 
 // LogStreamerStarted returns true if the log streamer has been started.
 func (bs *BusSetup) LogStreamerStarted() bool {
+	if bs == nil {
+		return false
+	}
 	return bs.logStreamerStarted
 }
 

--- a/logbus/setup/setup.go
+++ b/logbus/setup/setup.go
@@ -68,11 +68,6 @@ func (bs *BusSetup) SetDefaultPlatform(platform string) {
 	bs.Formatter.SetDefaultPlatform(platform)
 }
 
-// OrgAndProjectSet returns true if the org and project have already been set.
-func (bs *BusSetup) OrgAndProjectSet() bool {
-	return bs.InitialManifest.GetOrgName() != "" && bs.InitialManifest.GetProjectName() != ""
-}
-
 // SetOrgAndProject sets the org and project for the manifest.
 func (bs *BusSetup) SetOrgAndProject(orgName, projectName string) {
 	bs.InitialManifest.OrgName = orgName

--- a/logbus/setup/setup.go
+++ b/logbus/setup/setup.go
@@ -68,6 +68,11 @@ func (bs *BusSetup) SetDefaultPlatform(platform string) {
 	bs.Formatter.SetDefaultPlatform(platform)
 }
 
+// OrgAndProjectSet returns true if the org and project have already been set.
+func (bs *BusSetup) OrgAndProjectSet() bool {
+	return bs.InitialManifest.GetOrgName() != "" && bs.InitialManifest.GetProjectName() != ""
+}
+
 // SetOrgAndProject sets the org and project for the manifest.
 func (bs *BusSetup) SetOrgAndProject(orgName, projectName string) {
 	bs.InitialManifest.OrgName = orgName


### PR DESCRIPTION
This PR will help ensure that logs are (almost) always sent to the log streaming service when streaming is enabled. It does so by looking for `EARTHLY_ORG` and `EARTHLY_PROJECT` and initializing the stream using those values when present. The remote end will verify that the currently logged-in user has permission to write logs for the given org/project combination.