### PR TITLE
fix podman tests

### DIFF
--- a/.github/workflows/ci-podman-ubuntu.yml
+++ b/.github/workflows/ci-podman-ubuntu.yml
@@ -15,7 +15,7 @@ jobs:
       BUILD_EARTHLY_TARGET: "+for-linux"
       RUNS_ON: "ubuntu-latest"
       BINARY: "podman"
-      SUDO: "sudo"
+      SUDO: "sudo -E"
     secrets: inherit
 
   podman-examples-1:
@@ -27,7 +27,7 @@ jobs:
       BUILD_EARTHLY_TARGET: "+for-linux"
       RUNS_ON: "ubuntu-latest"
       BINARY: "podman"
-      SUDO: "sudo"
+      SUDO: "sudo -E"
       EXAMPLE_NAME: "+examples1"
     secrets: inherit
 
@@ -40,7 +40,7 @@ jobs:
       BUILD_EARTHLY_TARGET: "+for-linux"
       RUNS_ON: "ubuntu-latest"
       BINARY: "podman"
-      SUDO: "sudo"
+      SUDO: "sudo -E"
       EXAMPLE_NAME: "+examples2"
     secrets: inherit
 
@@ -53,8 +53,8 @@ jobs:
 #      BUILD_EARTHLY_TARGET: "+for-linux"
 #      RUNS_ON: "ubuntu-latest"
 #      BINARY: "podman"
-#      BINARY_COMPOSE: "\"sudo podman-compose\""
-#      SUDO: "sudo"
+#      BINARY_COMPOSE: "\"sudo -E podman-compose\""
+#      SUDO: "sudo -E"
 #    secrets: inherit
 #
 # TODO: Fix and bring back the below tests
@@ -66,7 +66,7 @@ jobs:
 #      BUILD_EARTHLY_TARGET: "+for-linux"
 #      RUNS_ON: "ubuntu-latest"
 #      BINARY: "podman"
-#      SUDO: "sudo"
+#      SUDO: "sudo -E"
 #    secrets: inherit
 #
 #  podman-secret-integrations:
@@ -78,7 +78,7 @@ jobs:
 #      BUILD_EARTHLY_TARGET: "+for-linux"
 #      RUNS_ON: "ubuntu-latest"
 #      BINARY: "podman"
-#      SUDO: "sudo"
+#      SUDO: "sudo -E"
 #    secrets: inherit
 #
 #  podman-bootstrap-integrations:
@@ -90,7 +90,7 @@ jobs:
 #      BUILD_EARTHLY_TARGET: "+for-linux"
 #      RUNS_ON: "ubuntu-latest"
 #      BINARY: "podman"
-#      SUDO: "sudo"
+#      SUDO: "sudo -E"
 #    secrets: inherit
 #
 #  podman-repo-auth-tests:
@@ -102,7 +102,7 @@ jobs:
 #      BUILD_EARTHLY_TARGET: "+for-linux"
 #      RUNS_ON: "ubuntu-latest"
 #      BINARY: "podman"
-#      SUDO: "sudo"
+#      SUDO: "sudo -E"
 #    secrets: inherit
 #
 #  podman-export-tests:
@@ -114,7 +114,7 @@ jobs:
 #      BUILD_EARTHLY_TARGET: "+for-linux"
 #      RUNS_ON: "ubuntu-latest"
 #      BINARY: "podman"
-#      SUDO: "sudo"
+#      SUDO: "sudo -E"
 #    secrets: inherit
 #
 #  podman-misc-tests:
@@ -126,5 +126,5 @@ jobs:
 #      BUILD_EARTHLY_TARGET: "+for-linux"
 #      RUNS_ON: "ubuntu-latest"
 #      BINARY: "podman"
-#      SUDO: "sudo"
+#      SUDO: "sudo -E"
 #    secrets: inherit

--- a/.github/workflows/reusable-example.yml
+++ b/.github/workflows/reusable-example.yml
@@ -102,6 +102,9 @@ jobs:
           set -euo pipefail
           EARTHLY_VERSION_FLAG_OVERRIDES="$(tr -d '\n' < .earthly_version_flag_overrides)"
           echo "EARTHLY_VERSION_FLAG_OVERRIDES=$EARTHLY_VERSION_FLAG_OVERRIDES" >> "$GITHUB_ENV"
+      - name: Re-bootstrap Earthly using latest earthly build
+        run: ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} bootstrap
+        if: inputs.binary == 'podman'
       - name: Build ${{inputs.EXAMPLE_NAME}} (PR build)
         run: ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} --ci -P ${{inputs.EXAMPLE_NAME}}
         if: github.event_name != 'push'


### PR DESCRIPTION
This is a follow-up to #2895, finally getting our podman tests green again. The two final problems:

1. We need to pass along the environment when using `sudo`, using `sudo -E`.
2. Due to changes in podman setup, we need to re-bootstrap after rebuilding earthly.

After those changes, we should :crossed_fingers: have green podman tests again.