### PR TITLE
Inform Logstream of the build invocation type

### DIFF
--- a/cmd/earthly/flags.go
+++ b/cmd/earthly/flags.go
@@ -212,6 +212,13 @@ func (app *earthlyApp) rootFlags() []cli.Flag {
 			Hidden:      true, // Internal.
 		},
 		&cli.StringFlag{
+			Name:        "logstream-run-type",
+			EnvVars:     []string{"EARTHLY_LOGSTREAM_RUN_TYPE"},
+			Usage:       "Instruct Logstream of the invocation type of the build.",
+			Destination: &app.logstreamRunType,
+			Hidden:      true, // Internal.
+		},
+		&cli.StringFlag{
 			Name:        "build-id",
 			EnvVars:     []string{"EARTHLY_BUILD_ID"},
 			Usage:       "The build ID to use for identifying the build in Earthly Cloud. If not specified, a random ID will be generated",

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -173,6 +173,7 @@ type cliFlags struct {
 	logstreamDebugFile              string
 	logstreamDebugManifestFile      string
 	logstreamAddressOverride        string
+	logstreamRunType                string
 	requestID                       string
 	buildID                         string
 	loginProvider                   string

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/docker/distribution v2.8.1+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/dustin/go-humanize v1.0.1
-	github.com/earthly/cloud-api v1.0.1-0.20230316192913-d68000c20ba2
+	github.com/earthly/cloud-api v1.0.1-0.20230502202233-84ee3fd70e50
 	github.com/earthly/earthly/ast v0.0.0-00010101000000-000000000000
 	github.com/earthly/earthly/util/deltautil v0.0.0-00010101000000-000000000000
 	github.com/elastic/go-sysinfo v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -160,8 +160,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/earthly/buildkit v0.0.0-20230422145224-4e601edf402b h1:ixzP40Ihz7i4RJeQEJWy225BKMLGdZ04P97liVOVH4s=
 github.com/earthly/buildkit v0.0.0-20230422145224-4e601edf402b/go.mod h1:RCqn8ESzIWtwwWfWNrSV5uuOJ+/rPrNBnxrlNUcC95w=
-github.com/earthly/cloud-api v1.0.1-0.20230316192913-d68000c20ba2 h1:y8CxVdQxC4as1PmzmFBWRDCMwBragbxgLh9iTzzcFeg=
-github.com/earthly/cloud-api v1.0.1-0.20230316192913-d68000c20ba2/go.mod h1:rU/tYJ7GFBjdKAITV2heDbez++glpGSbtJaZcp73rNI=
+github.com/earthly/cloud-api v1.0.1-0.20230502202233-84ee3fd70e50 h1:HpROCIYvlAPc8m3qE68y8UD5GHKzN8hq0+EBLpmwHsc=
+github.com/earthly/cloud-api v1.0.1-0.20230502202233-84ee3fd70e50/go.mod h1:rU/tYJ7GFBjdKAITV2heDbez++glpGSbtJaZcp73rNI=
 github.com/earthly/fsutil v0.0.0-20230322211606-d14130b24a8e h1:xaXCt5r88E8DGaja88qq1Lk3Uv9r1vb/9Adw/+K5YjM=
 github.com/earthly/fsutil v0.0.0-20230322211606-d14130b24a8e/go.mod h1:AvLEd1LEIl64G2Jpgwo7aVV5lGH0ePcKl0ygGIHNYl8=
 github.com/elastic/go-sysinfo v1.9.0 h1:usICqY/Nw4Mpn9f4LdtpFrKxXroJDe81GaxxUlCckIo=

--- a/logbus/setup/setup.go
+++ b/logbus/setup/setup.go
@@ -69,6 +69,11 @@ func (bs *BusSetup) SetDefaultPlatform(platform string) {
 	bs.Formatter.SetDefaultPlatform(platform)
 }
 
+// SetRunType sets the overall build invocation type.
+func (bs *BusSetup) SetRunType(runType logstream.RunType) {
+	bs.InitialManifest.Type = runType
+}
+
 // SetOrgAndProject sets the org and project for the manifest.
 func (bs *BusSetup) SetOrgAndProject(orgName, projectName string) {
 	bs.InitialManifest.OrgName = orgName


### PR DESCRIPTION
This PR adds support for a new env called `EARTHLY_LOGSTREAM_RUN_TYPE` that will be used to inform the Logstream service of the build invocation type. This type can then be used by Logstream to tag the builds appropriately and control other behavior.