### PR TITLE
earthfile2llb: when entering a DO scope, ensure existing overrides are passed through

### DIFF
--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -1581,7 +1581,11 @@ func (c *Converter) ResolveReference(ctx context.Context, ref domain.Reference) 
 
 // EnterScopeDo introduces a new variable scope. Globals and imports are fetched from baseTarget.
 func (c *Converter) EnterScopeDo(ctx context.Context, command domain.Command, baseTarget domain.Target, allowPrivileged bool, scopeName string, buildArgs []string) error {
-	baseMts, err := c.buildTarget(ctx, baseTarget.String(), c.platr.Current(), allowPrivileged, buildArgs, true, enterScopeDoCmd)
+	topArgs := buildArgs
+	if c.ftrs.ArgScopeSet {
+		topArgs = c.varCollection.TopOverriding().BuildArgs()
+	}
+	baseMts, err := c.buildTarget(ctx, baseTarget.String(), c.platr.Current(), allowPrivileged, topArgs, true, enterScopeDoCmd)
 	if err != nil {
 		return err
 	}

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -203,6 +203,7 @@ ga-no-qemu:
     BUILD +platform-output
     BUILD +command
     BUILD +command-explicit-global
+    BUILD +command-nested-global
     BUILD +duplicate
     BUILD +reserved
     BUILD +quotes-test
@@ -1085,6 +1086,9 @@ command:
 
 command-explicit-global:
     DO +RUN_EARTHLY --earthfile=command-explicit-global.earth
+
+command-nested-global:
+    DO +RUN_EARTHLY --earthfile=command-nested-global.earth --target="+test-overriding --foo=expected"
 
 duplicate:
     DO +RUN_EARTHLY --earthfile=duplicate-target-names.earth --should_fail=true --target=+duplicate

--- a/tests/command-nested-global.earth
+++ b/tests/command-nested-global.earth
@@ -10,7 +10,8 @@ ARG --global foo=default
 
 SHARED:
     COMMAND
-    RUN test "$foo" == "expected"
+    # Note that foo has not yet been declared in the command, therefore we reference the globally declared arg
+    RUN test "$foo" == "expected" 
 
     # foo should be passed in as "baz" when DO +SHARED is called for the
     # purposes of this test. This ensures that DO args do not impact globals but

--- a/tests/command-nested-global.earth
+++ b/tests/command-nested-global.earth
@@ -1,0 +1,31 @@
+VERSION --arg-scope-and-set 0.7
+
+FROM alpine:3.15
+WORKDIR /test
+
+# foo should be overridden with the value "expected" to run this test.
+# This asserts that the overriding scope impacts the global scope through nested
+# DO calls.
+ARG --global foo=default
+
+SHARED:
+    COMMAND
+    RUN test "$foo" == "expected"
+
+    # foo should be passed in as "baz" when DO +SHARED is called for the
+    # purposes of this test. This ensures that DO args do not impact globals but
+    # do impact ARGs that are declared in the COMMAND.
+    ARG foo
+    RUN test "$foo" == "baz"
+
+CALLER:
+    COMMAND
+    RUN test "$foo" == "expected"
+
+    ARG foo = "bar"
+    RUN test "$foo" == "bar"
+    DO +SHARED --foo="baz"
+
+test-overriding:
+    RUN test "$foo" == "expected"
+    DO +CALLER

--- a/variables/collection.go
+++ b/variables/collection.go
@@ -155,6 +155,16 @@ func (c *Collection) SetGlobals(globals *Scope) {
 	c.effectiveCache = nil
 }
 
+// TopOverriding returns a copy of the top-level overriding args, for use in
+// commands that may need to re-parse the base target but have drastically
+// different variable scopes.
+func (c *Collection) TopOverriding() *Scope {
+	if len(c.stack) == 0 {
+		return NewScope()
+	}
+	return c.stack[0].overriding.Clone()
+}
+
 // Overriding returns a copy of the overriding args.
 func (c *Collection) Overriding() *Scope {
 	return c.overriding().Clone()

--- a/variables/scope.go
+++ b/variables/scope.go
@@ -1,6 +1,7 @@
 package variables
 
 import (
+	"fmt"
 	"sort"
 )
 
@@ -91,6 +92,18 @@ func (s *Scope) Sorted(opts ...ScopeOpt) []string {
 	}
 	sort.Strings(sorted)
 	return sorted
+}
+
+// BuildArgs returns s as a slice of build args, as they would have been passed
+// in originally at the CLI or in a BUILD command.
+func (s *Scope) BuildArgs(opts ...ScopeOpt) []string {
+	vars := s.Sorted(opts...)
+	var args []string
+	for _, v := range vars {
+		val, _ := s.Get(v)
+		args = append(args, fmt.Sprintf("%v=%v", v, val))
+	}
+	return args
 }
 
 // CombineScopes combines all the variables across all scopes, with the


### PR DESCRIPTION
When calling `DO +SOME_CMD`, we were dropping the existing overrides. This meant that globals were (sometimes?) losing their overrides if any UDC called `DO +SOME_OTHER_CMD`.

This updates DO scopes to include existing overrides, while still letting the `DO` call's args take precedence.

Resolves #2920 