### PR TITLE
fix: SAVE IMAGE --push flag was ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 ### Added
 - Experimental support for performing a `git lfs pull --include=<path>` when referencing a remote target on the cli, when used with the new `--git-lfs-pull-include` flag. [#2992](https://github.com/earthly/earthly/pull/2922)
 
+### Fixed
+- `SAVE IMAGE <img>` was incorrectly pushed when earthly was run with the `--push` cli flag (this restores the requirement that images that are pushed must be defined with `SAVE IMAGE --push <img>`).  [#2923](https://github.com/earthly/earthly/issues/2923)
+
 ## v0.7.4 - 2023-04-12
 
 ### Changed

--- a/earthfile2llb/save_image_wait_item.go
+++ b/earthfile2llb/save_image_wait_item.go
@@ -11,17 +11,18 @@ type saveImageWaitItem struct {
 	c  *Converter
 	si states.SaveImage
 
-	push        bool
+	allowPush   bool
+	doPush      bool
 	localExport bool
 
 	mu sync.Mutex
 }
 
-func newSaveImage(si states.SaveImage, c *Converter, push, localExport bool) waitutil.WaitItem {
+func newSaveImage(si states.SaveImage, c *Converter, allowPush, localExport bool) waitutil.WaitItem {
 	return &saveImageWaitItem{
 		c:           c,
 		si:          si,
-		push:        push,
+		allowPush:   allowPush,
 		localExport: localExport,
 	}
 }
@@ -38,6 +39,6 @@ func (siwi *saveImageWaitItem) SetDoPush() {
 	siwi.mu.Lock()
 	defer siwi.mu.Unlock()
 	if siwi.si.DockerTag != "" {
-		siwi.push = true
+		siwi.doPush = siwi.allowPush
 	}
 }

--- a/earthfile2llb/wait_block.go
+++ b/earthfile2llb/wait_block.go
@@ -111,7 +111,7 @@ func (wb *waitBlock) saveImages(ctx context.Context, pushesAllowed, localExports
 			continue
 		}
 
-		if !saveImage.push && !saveImage.localExport {
+		if !saveImage.doPush && !saveImage.localExport {
 			continue
 		}
 
@@ -189,7 +189,7 @@ func (wb *waitBlock) saveImages(ctx context.Context, pushesAllowed, localExports
 			}
 		}
 
-		refPrefix, err := gwCrafter.AddPushImageEntry(ref, refID, item.si.DockerTag, item.push, item.si.InsecurePush, item.si.Image, platformBytes)
+		refPrefix, err := gwCrafter.AddPushImageEntry(ref, refID, item.si.DockerTag, item.doPush, item.si.InsecurePush, item.si.Image, platformBytes)
 		if err != nil {
 			return err
 		}

--- a/tests/wait-block/save-image/test.sh
+++ b/tests/wait-block/save-image/test.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 set -e
-
 cd "$(dirname "$0")"
+
+echo "first running without the --push flag"
 ../common/test.sh
+
+echo "re-running test with --push flag"
+../common/test.sh --push


### PR DESCRIPTION
An image should only be pushed when the `SAVE IMAGE --push ...` command is used in combination with earthly being run with the --push flag on the cli; this fixes a regression where simply running `earthly --push` would cause all `SAVE IMAGE ...` commands to be pushed regardless of if the command had a `--push` or not.

Fixes #2923