### PR TITLE
prevent panic when conversion_parallelism <= 0

### DIFF
--- a/cmd/earthly/build_cmd.go
+++ b/cmd/earthly/build_cmd.go
@@ -464,10 +464,10 @@ func (app *earthlyApp) actionBuildImp(cliCtx *cli.Context, flagArgs, nonFlagArgs
 			cacheExport = app.remoteCache
 		}
 	}
-	var parallelism semutil.Semaphore
-	if app.cfg.Global.ConversionParallelism != 0 {
-		parallelism = semutil.NewWeighted(int64(app.cfg.Global.ConversionParallelism))
+	if app.cfg.Global.ConversionParallelism <= 0 {
+		return fmt.Errorf("configuration error: \"conversion_parallelism\" must be larger than zero")
 	}
+	parallelism := semutil.NewWeighted(int64(app.cfg.Global.ConversionParallelism))
 	localRegistryAddr := ""
 	if isLocal && app.localRegistryHost != "" {
 		lrURL, err := url.Parse(app.localRegistryHost)


### PR DESCRIPTION
If a user really wants to disable limitting of conversion_parallelism, then the use can just set this to 99999999.

fixes #2898