### PR TITLE
Support changing size of satellites and CI runners

### DIFF
--- a/cloud/satellite.go
+++ b/cloud/satellite.go
@@ -275,6 +275,7 @@ type UpdateSatelliteOpt struct {
 	Name                    string
 	OrgID                   string
 	PinnedVersion           string
+	Size                    string
 	MaintenanceWindowStart  string
 	MaintenanceWeekendsOnly bool
 	DropCache               bool
@@ -290,6 +291,7 @@ func (c *Client) UpdateSatellite(ctx context.Context, opt UpdateSatelliteOpt) er
 		FeatureFlags:            opt.FeatureFlags,
 		MaintenanceWindowStart:  opt.MaintenanceWindowStart,
 		MaintenanceWeekendsOnly: opt.MaintenanceWeekendsOnly,
+		Size:                    opt.Size,
 	}
 	_, err := c.compute.UpdateSatellite(c.withAuth(ctx), req)
 	if err != nil {

--- a/cmd/earthly/satellite_cmds.go
+++ b/cmd/earthly/satellite_cmds.go
@@ -41,7 +41,7 @@ func (app *earthlyApp) satelliteCmds() []*cli.Command {
 				},
 				&cli.StringFlag{
 					Name:        "size",
-					Usage:       "The size of the satellite. See https://earthly.dev/pricing#compute for details on each size. Supported values: small, medium, large.",
+					Usage:       "The size of the satellite. See https://earthly.dev/pricing for details on each size. Supported values: xsmall, small, medium, large, xlarge.",
 					Required:    false,
 					Value:       cloud.SatelliteSizeMedium,
 					Destination: &app.satelliteSize,
@@ -162,7 +162,7 @@ func (app *earthlyApp) satelliteCmds() []*cli.Command {
 			Flags: []cli.Flag{
 				&cli.StringFlag{
 					Name:        "size",
-					Usage:       "Change the size of the satellite. See https://earthly.dev/pricing#compute for details on each size. Supported values: small, medium, large.",
+					Usage:       "Change the size of the satellite. See https://earthly.dev/pricing for details on each size. Supported values: xsmall, small, medium, large, xlarge.",
 					Required:    false,
 					Value:       cloud.SatelliteSizeMedium,
 					Destination: &app.satelliteSize,

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/docker/distribution v2.8.1+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/dustin/go-humanize v1.0.1
-	github.com/earthly/cloud-api v1.0.1-0.20230505151542-8f55d3a49564
+	github.com/earthly/cloud-api v1.0.1-0.20230509135033-ab3df26f706b
 	github.com/earthly/earthly/ast v0.0.0-00010101000000-000000000000
 	github.com/earthly/earthly/util/deltautil v0.0.0-00010101000000-000000000000
 	github.com/elastic/go-sysinfo v1.9.0

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/docker/distribution v2.8.1+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/dustin/go-humanize v1.0.1
-	github.com/earthly/cloud-api v1.0.1-0.20230316192913-d68000c20ba2
+	github.com/earthly/cloud-api v1.0.1-0.20230505151542-8f55d3a49564
 	github.com/earthly/earthly/ast v0.0.0-00010101000000-000000000000
 	github.com/earthly/earthly/util/deltautil v0.0.0-00010101000000-000000000000
 	github.com/elastic/go-sysinfo v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -160,8 +160,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/earthly/buildkit v0.0.0-20230422145224-4e601edf402b h1:ixzP40Ihz7i4RJeQEJWy225BKMLGdZ04P97liVOVH4s=
 github.com/earthly/buildkit v0.0.0-20230422145224-4e601edf402b/go.mod h1:RCqn8ESzIWtwwWfWNrSV5uuOJ+/rPrNBnxrlNUcC95w=
-github.com/earthly/cloud-api v1.0.1-0.20230316192913-d68000c20ba2 h1:y8CxVdQxC4as1PmzmFBWRDCMwBragbxgLh9iTzzcFeg=
-github.com/earthly/cloud-api v1.0.1-0.20230316192913-d68000c20ba2/go.mod h1:rU/tYJ7GFBjdKAITV2heDbez++glpGSbtJaZcp73rNI=
+github.com/earthly/cloud-api v1.0.1-0.20230505151542-8f55d3a49564 h1:QejCkJpZFHa0xQDfBuAC7q39D97TwDwxcdC3h7JLUGo=
+github.com/earthly/cloud-api v1.0.1-0.20230505151542-8f55d3a49564/go.mod h1:rU/tYJ7GFBjdKAITV2heDbez++glpGSbtJaZcp73rNI=
 github.com/earthly/fsutil v0.0.0-20230322211606-d14130b24a8e h1:xaXCt5r88E8DGaja88qq1Lk3Uv9r1vb/9Adw/+K5YjM=
 github.com/earthly/fsutil v0.0.0-20230322211606-d14130b24a8e/go.mod h1:AvLEd1LEIl64G2Jpgwo7aVV5lGH0ePcKl0ygGIHNYl8=
 github.com/elastic/go-sysinfo v1.9.0 h1:usICqY/Nw4Mpn9f4LdtpFrKxXroJDe81GaxxUlCckIo=

--- a/go.sum
+++ b/go.sum
@@ -160,8 +160,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/earthly/buildkit v0.0.0-20230422145224-4e601edf402b h1:ixzP40Ihz7i4RJeQEJWy225BKMLGdZ04P97liVOVH4s=
 github.com/earthly/buildkit v0.0.0-20230422145224-4e601edf402b/go.mod h1:RCqn8ESzIWtwwWfWNrSV5uuOJ+/rPrNBnxrlNUcC95w=
-github.com/earthly/cloud-api v1.0.1-0.20230505151542-8f55d3a49564 h1:QejCkJpZFHa0xQDfBuAC7q39D97TwDwxcdC3h7JLUGo=
-github.com/earthly/cloud-api v1.0.1-0.20230505151542-8f55d3a49564/go.mod h1:rU/tYJ7GFBjdKAITV2heDbez++glpGSbtJaZcp73rNI=
+github.com/earthly/cloud-api v1.0.1-0.20230509135033-ab3df26f706b h1:mBt64zr6Be12ERlA98uS6mvd/jcik/FFoVKWBs2hfJ0=
+github.com/earthly/cloud-api v1.0.1-0.20230509135033-ab3df26f706b/go.mod h1:rU/tYJ7GFBjdKAITV2heDbez++glpGSbtJaZcp73rNI=
 github.com/earthly/fsutil v0.0.0-20230322211606-d14130b24a8e h1:xaXCt5r88E8DGaja88qq1Lk3Uv9r1vb/9Adw/+K5YjM=
 github.com/earthly/fsutil v0.0.0-20230322211606-d14130b24a8e/go.mod h1:AvLEd1LEIl64G2Jpgwo7aVV5lGH0ePcKl0ygGIHNYl8=
 github.com/elastic/go-sysinfo v1.9.0 h1:usICqY/Nw4Mpn9f4LdtpFrKxXroJDe81GaxxUlCckIo=


### PR DESCRIPTION
The following command can now be used to alter the size of the satellite:
```
earthly satellite update --size <new-size> <existing-satellite>
```
This is important for CI runners, which currently have no other way to specify a size other than medium.

Changing size will also drop the existing cache. I will explain that in a separate docs PR.