### PR TITLE
runc-ps script for earthly-buildkitd container

### DIFF
--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -22,11 +22,12 @@ buildkitd:
     RUN apk add --update --no-cache \
         cni-plugins@edge-community \
         gettext \
+        git-lfs \
         iptables \
+        jq \
         openssh-client \
         pigz \
         util-linux \
-        git-lfs \
         xz
 
     # Add github and gitlab to known hosts.
@@ -60,6 +61,7 @@ buildkitd:
     COPY ./dockerd-wrapper.sh /var/earthly/dockerd-wrapper.sh
     COPY ./docker-auto-install.sh /var/earthly/docker-auto-install.sh
     COPY ./oom-adjust.sh.template /bin/oom-adjust.sh.template
+    COPY ./runc-ps /bin/runc-ps
 
     ENV EARTHLY_RESET_TMP_DIR=false
     ENV EARTHLY_TMP_DIR=/tmp/earthly

--- a/buildkitd/runc-ps
+++ b/buildkitd/runc-ps
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+for bundle in $(ps auxw | grep 'runc.*bundle' | grep -v grep | awk '{print $11}'); do
+  data="$(cat "$bundle/config.json")"
+  if [ -n "$data" ]; then
+    echo "=== $bundle ==="
+    echo "$data" | jq .process.args
+  fi
+done


### PR DESCRIPTION
A small script which displays all runc instances and displays what program they are running. This is useful for debugging buildkit instances which are under heavy load.