### PR TITLE
earthly-image test: lookup secrets when missing

### DIFF
--- a/scripts/tests/earthly-image.sh
+++ b/scripts/tests/earthly-image.sh
@@ -4,8 +4,19 @@ set -euo pipefail # don't use -x as it will leak the mirror credentials
 FRONTEND=${FRONTEND:-docker}
 EARTHLY_IMAGE=${EARTHLY_IMAGE:-earthly/earthly:dev-main}
 
+if [ -z "${DOCKERHUB_MIRROR_USERNAME:-}" ] && [ -z "${DOCKERHUB_MIRROR_PASSWORD:-}" ]; then
+  echo "using dockerhub credentials from earthly secrets"
+  export DOCKERHUB_MIRROR_USERNAME="$(earthly secrets --org earthly-technologies --project core get dockerhub-mirror/user)"
+  export DOCKERHUB_MIRROR_PASSWORD="$(earthly secrets --org earthly-technologies --project core get dockerhub-mirror/pass)"
+fi
 test -n "$DOCKERHUB_MIRROR_USERNAME" || (echo "error: DOCKERHUB_MIRROR_USERNAME is not set" && exit 1)
 test -n "$DOCKERHUB_MIRROR_PASSWORD" || (echo "error: DOCKERHUB_MIRROR_PASSWORD is not set" && exit 1)
+
+if [ -z "${EARTHLY_TOKEN:-}" ]; then
+  echo "using EARTHLY_TOKEN from earthly secrets"
+  export EARTHLY_TOKEN="$(earthly secrets --org earthly-technologies --project core get earthly-token-for-satellite-tests)"
+fi
+test -n "$EARTHLY_TOKEN" || (echo "error: EARTHLY_TOKEN is not set" && exit 1)
 
 ENCODED_AUTH="$(echo -n "$DOCKERHUB_MIRROR_USERNAME:$DOCKERHUB_MIRROR_PASSWORD" | base64 -w 0)"
 


### PR DESCRIPTION
Typically github actions exposes the dockerhub credentials and earthly token; however, this makes it more difficult to run locally -- when they are missing, we will pull them in from earthly secrets.