### PR TITLE
fix: context with timeout of 0s

### DIFF
--- a/buildkitd/buildkitd.go
+++ b/buildkitd/buildkitd.go
@@ -604,6 +604,10 @@ func waitForConnection(ctx context.Context, containerName, address string, opTim
 			if err != nil {
 				// Try again.
 				attemptTimeout *= 2
+				// keep timeout reasonable
+				if attemptTimeout > opTimeout {
+					attemptTimeout = opTimeout
+				}
 				continue
 			}
 			return info, workerInfo, nil


### PR DESCRIPTION
Fix a context timeout value that, during constant retrying of an operation, is 'overflowing' and eventually reaching 0s. The 0s timeout caused unexpected behavior like not registering the true error.

Fixes #2942

I logged the value of attemptTimeout variable during an earthly invocation to a remote buildkitd which did not respond. Note the value eventually settling to 0s:

buildkitd | Connecting to tcp://some_server:8372
...
attempt timeout 596523h14m8s
attempt timeout 1193046h28m16s
attempt timeout 2386092h56m32s
attempt timeout -351909h41m29.709551616s
attempt timeout -703819h22m59.419103232s
attempt timeout -1407638h45m58.838206464s
attempt timeout 2308818h2m36.033138688s
attempt timeout -506459h29m21.64327424s
attempt timeout -1012918h58m43.28654848s
attempt timeout -2025837h57m26.57309696s
attempt timeout 1072419h39m40.563357696s
attempt timeout 2144839h19m21.126715392s
attempt timeout -834416h55m51.456120832s
attempt timeout -1668833h51m42.912241664s
attempt timeout 1786427h51m7.885068288s
attempt timeout -1551239h52m17.93941504s
attempt timeout 2021615h49m57.830721536s
attempt timeout -1080863h54m38.048108544s
attempt timeout -2161727h49m16.096217088s
attempt timeout 800639h56m1.51711744s
attempt timeout 1601279h52m3.03423488s
attempt timeout -1921535h50m27.641081856s
attempt timeout 1281023h53m38.427387904s
attempt timeout -2562047h47m16.854775808s
attempt timeout 0s
attempt timeout 0s

After this fix:

buildkitd | Connecting to tcp://some_server:8372
attempt timeout 1s
attempt timeout 2s
attempt timeout 4s
attempt timeout 8s
attempt timeout 16s
attempt timeout 32s
attempt timeout 1m0s
attempt timeout 1m0s
attempt timeout 1m0s
...