### PR TITLE
Improve error reporting in satellite auth

### DIFF
--- a/cmd/earthly/buildkit.go
+++ b/cmd/earthly/buildkit.go
@@ -115,11 +115,11 @@ func (app *earthlyApp) configureSatellite(cliCtx *cli.Context, cloudClient *clou
 
 	orgID, err := app.getSatelliteOrgID(cliCtx.Context, cloudClient)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed getting org")
 	}
 	satelliteName, err := app.getSatelliteName(cliCtx.Context, orgID, app.satelliteName, cloudClient)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed getting satellite name")
 	}
 	app.buildkitdSettings.SatelliteName = satelliteName
 	app.buildkitdSettings.SatelliteDisplayName = app.satelliteName

--- a/cmd/earthly/satellite_cmds.go
+++ b/cmd/earthly/satellite_cmds.go
@@ -384,7 +384,7 @@ func (app *earthlyApp) getSatelliteOrgID(ctx context.Context, cloudClient *cloud
 	// TODO Eventually we should be able to remove this cheat.
 	err := cloudClient.Authenticate(ctx)
 	if err != nil {
-		return "", errors.New("unable to authenticate")
+		return "", errors.Wrap(err, "unable to authenticate")
 	}
 	var orgID string
 	if app.orgName == "" {


### PR DESCRIPTION
Some context was missing in a recent auth error reported by satellite users. 

The error reported by the user was:
```
Error: could not construct new buildkit client: unable to authenticate
```

The additional context added here should help both us and the user debug similar auth issues.