### PR TITLE
test cloud client can be created without network

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -1,4 +1,4 @@
-VERSION --shell-out-anywhere --use-copy-link 0.6
+VERSION --no-network 0.7
 
 FROM golang:1.20-alpine3.17
 
@@ -254,6 +254,10 @@ unit-test:
 chaos-test:
     FROM +code
     RUN go test -tags chaos ./...
+
+offline-test:
+    FROM +code
+    RUN --network=none go test -tags offline ./...
 
 # submodule-decouple-check checks that go submodules within earthly do not
 # depend on the core earthly project.
@@ -599,6 +603,7 @@ lint-docs:
 test-no-qemu:
     BUILD +unit-test
     BUILD +chaos-test
+    BUILD +offline-test
     BUILD +earthly-script-no-stdout
     ARG DOCKERHUB_MIRROR
     ARG DOCKERHUB_MIRROR_INSECURE=false

--- a/Earthfile
+++ b/Earthfile
@@ -1,4 +1,5 @@
-VERSION --no-network 0.7
+# TODO: we must change the DOCKERHUB_USER_SECRET args to be project-based before we can change to 0.7
+VERSION --shell-out-anywhere --use-copy-link --no-network 0.6
 
 FROM golang:1.20-alpine3.17
 

--- a/Earthfile
+++ b/Earthfile
@@ -257,7 +257,7 @@ chaos-test:
 
 offline-test:
     FROM +code
-    RUN --network=none go test -tags offline ./...
+    RUN --network=none go test -run TestOffline ./...
 
 # submodule-decouple-check checks that go submodules within earthly do not
 # depend on the core earthly project.

--- a/cloud/client_offline_test.go
+++ b/cloud/client_offline_test.go
@@ -1,0 +1,18 @@
+//go:build offline
+
+package cloud_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/earthly/earthly/cloud"
+	"github.com/poy/onpar/expect"
+)
+
+// TestClientConnectionIsLazy tests that creating a NewCLient doesn't perform any network I/O
+func TestClientConnectionIsLazy(t *testing.T) {
+	expect := expect.New(t)
+	c, err := cloud.NewClient("https://this", "shouldnt.matter:443", false, "", "", "", "", "", nil, time.Second)
+	expect(err).To(not(haveOccurred()))
+}

--- a/cloud/client_offline_test.go
+++ b/cloud/client_offline_test.go
@@ -1,5 +1,3 @@
-//go:build offline
-
 package cloud_test
 
 import (
@@ -7,12 +5,17 @@ import (
 	"time"
 
 	"github.com/earthly/earthly/cloud"
+	"github.com/poy/onpar"
 	"github.com/poy/onpar/expect"
 )
 
-// TestClientConnectionIsLazy tests that creating a NewCLient doesn't perform any network I/O
-func TestClientConnectionIsLazy(t *testing.T) {
-	expect := expect.New(t)
-	c, err := cloud.NewClient("https://this", "shouldnt.matter:443", false, "", "", "", "", "", nil, time.Second)
-	expect(err).To(not(haveOccurred()))
+// TestOffline tests that creating a NewCLient doesn't perform any network I/O
+func TestOffline(t *testing.T) {
+	o := onpar.New(t)
+	defer o.Run()
+	o.Spec("ClientConnectionIsLazy", func(t *testing.T) {
+		expect := expect.New(t)
+		_, err := cloud.NewClient("https://this", "shouldnt.matter:443", false, "", "", "", "", "", nil, time.Second)
+		expect(err).To(not(haveOccurred()))
+	})
 }

--- a/cloud/imports_test.go
+++ b/cloud/imports_test.go
@@ -1,5 +1,3 @@
-//go:build offline
-
 package cloud_test
 
 import (

--- a/cloud/imports_test.go
+++ b/cloud/imports_test.go
@@ -1,0 +1,12 @@
+//go:build offline
+
+package cloud_test
+
+import (
+	"github.com/poy/onpar/matchers"
+)
+
+var (
+	not          = matchers.Not
+	haveOccurred = matchers.HaveOccurred
+)


### PR DESCRIPTION
This creates a new +offline-test target, which is used to validate the cloud client can be created without performing any network I/O (which is important for autocompletion and cases where a user has set DO_NOT_TRACK).