### PR TITLE
Check http errors via http code when listing secrets

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -56,7 +56,7 @@ code:
     END
     COPY ./ast/parser+parser/*.go ./ast/parser/
     COPY --dir analytics autocomplete buildcontext builder logbus cleanup cmd config conslogging debugger \
-        dockertar docker2earthly domain features outmon slog cloud states util variables ./
+        dockertar docker2earthly domain features outmon slog cloud states util variables error ./
     COPY --dir buildkitd/buildkitd.go buildkitd/settings.go buildkitd/certificates.go buildkitd/
     COPY --dir earthfile2llb/*.go earthfile2llb/
     COPY --dir ast/antlrhandler ast/spec ast/hint ast/command ast/commandflag ast/*.go ast/

--- a/cloud/secret_new.go
+++ b/cloud/secret_new.go
@@ -44,7 +44,7 @@ func (c *Client) ListSecrets(ctx context.Context, path string) ([]*Secret, error
 	}
 
 	if status != http.StatusOK {
-		return nil, errors.Wrap(httperror.New(status, string(body)), "failed to list secrets")
+		return nil, fmt.Errorf("failed to list secrets: %w", httperror.New(status, string(body)))
 	}
 
 	var secrets []*Secret

--- a/cloud/secret_new.go
+++ b/cloud/secret_new.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	secretsapi "github.com/earthly/cloud-api/secrets"
+	httperror "github.com/earthly/earthly/error/http"
+
 	"github.com/pkg/errors"
 )
 
@@ -42,7 +44,7 @@ func (c *Client) ListSecrets(ctx context.Context, path string) ([]*Secret, error
 	}
 
 	if status != http.StatusOK {
-		return nil, errors.Errorf("failed to list secrets: %s", body)
+		return nil, errors.Wrap(httperror.New(status, string(body)), "failed to list secrets")
 	}
 
 	var secrets []*Secret
@@ -103,6 +105,9 @@ func (c *Client) GetUserOrProjectSecret(ctx context.Context, path string) (*Secr
 func (c *Client) getSecretV2(ctx context.Context, path string) (*Secret, error) {
 	res, err := c.ListSecrets(ctx, path)
 	if err != nil {
+		if httperror.Code(err) == http.StatusNotFound {
+			return nil, ErrNotFound
+		}
 		return nil, err
 	}
 	for _, sec := range res {

--- a/error/http/error.go
+++ b/error/http/error.go
@@ -1,0 +1,38 @@
+package http
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type Error struct {
+	msg  string
+	code int
+}
+
+func (e *Error) Error() string {
+	return fmt.Sprintf("%s, code: %d", e.msg, e.code)
+}
+
+func (e *Error) Code() int {
+	return e.code
+}
+
+func New(code int, msg string) error {
+	return &Error{
+		msg:  msg,
+		code: code,
+	}
+}
+
+func Code(err error) int {
+	if err == nil {
+		return http.StatusOK
+	}
+	if se, ok := err.(interface {
+		Code() int
+	}); ok {
+		return se.Code()
+	}
+	return http.StatusInternalServerError
+}

--- a/error/http/error.go
+++ b/error/http/error.go
@@ -29,10 +29,10 @@ func Code(err error) int {
 	if err == nil {
 		return http.StatusOK
 	}
-	if se, ok := err.(interface {
+	if httErr, ok := err.(interface {
 		Code() int
 	}); ok {
-		return se.Code()
+		return httErr.Code()
 	}
 	return http.StatusInternalServerError
 }

--- a/error/http/error_test.go
+++ b/error/http/error_test.go
@@ -1,0 +1,49 @@
+package http
+
+import (
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"testing"
+)
+
+func TestCode(t *testing.T) {
+	type args struct {
+		err error
+	}
+	tests := []struct {
+		name string
+		args args
+		want int
+	}{
+		{name: "nil returns ok", args: args{err: nil}, want: http.StatusOK},
+		{name: "http error returns the code", args: args{err: &Error{code: http.StatusNotExtended}}, want: http.StatusNotExtended},
+		{name: "non http error returns 500", args: args{err: errors.New("not http")}, want: http.StatusInternalServerError},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Code(tt.args.err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestError_Code(t *testing.T) {
+	err := &Error{code: 123}
+	want := 123
+	got := err.Code()
+	assert.Equal(t, want, got)
+}
+
+func TestError_Error(t *testing.T) {
+	err := &Error{msg: "err message", code: 123}
+	want := "err message, code: 123"
+	got := err.Error()
+	assert.Equal(t, want, got)
+}
+
+func TestNew(t *testing.T) {
+	want := &Error{msg: "err message", code: 123}
+	got := New(123, "err message")
+	assert.Equal(t, want, got)
+}


### PR DESCRIPTION
Using a new type of Error similar to gRPC error which contains the status code.
This is used to check of server error according to code instead of string.
Currently this is only used when listing secrets, though I think overtime we can use it for other methods (I didn't want to increase the scope of this PR).

Also wrapping a few other errors to make it easier to track the call stack.