### PR TITLE
Use .dockerignore in FROM DOCKERFILE targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 
 ## Unreleased
 
+### Changed
+- `FROM DOCKERFILE` will use `.dockerignore` file when using a build context from the host system and both `.earthlyignore` and `.earthignore` do not exist. Enable with `VERSION --use-docker-ignore 0.7`.
+
 ## v0.7.7 - 2023-06-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 ## Unreleased
 
 ### Changed
-- `FROM DOCKERFILE` will use `.dockerignore` file when using a build context from the host system and both `.earthlyignore` and `.earthignore` do not exist. Enable with `VERSION --use-docker-ignore 0.7`.
+- `FROM DOCKERFILE` will use a `.dockerignore` file when using a build context from the host system and both `.earthlyignore` and `.earthignore` do not exist. Enable with `VERSION --use-docker-ignore 0.7`.
 
 ## v0.7.7 - 2023-06-01
 

--- a/buildcontext/excludes.go
+++ b/buildcontext/excludes.go
@@ -1,7 +1,6 @@
 package buildcontext
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 
@@ -47,7 +46,6 @@ func readExcludes(dir string, noImplicitIgnore bool, excludeFromDockerIgnore boo
 	dockerExists := false
 	if excludeFromDockerIgnore {
 		dockerExists, err = fileutil.FileExists(dockerIgnoreFilePath)
-		fmt.Printf("docker exists = %v for %s\n", dockerExists, dockerIgnoreFilePath)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to check if %s exists", dockerIgnoreFilePath)
 		}

--- a/buildcontext/excludes.go
+++ b/buildcontext/excludes.go
@@ -24,7 +24,7 @@ var ImplicitExcludes = []string{
 	earthlyIgnoreFile,
 }
 
-func readExcludes(dir string, noImplicitIgnore bool, excludeFromDockerIgnore bool) ([]string, error) {
+func readExcludes(dir string, noImplicitIgnore bool, useDockerIgnore bool) ([]string, error) {
 	var ignoreFile = earthIgnoreFile
 
 	//earthIgnoreFile
@@ -44,7 +44,7 @@ func readExcludes(dir string, noImplicitIgnore bool, excludeFromDockerIgnore boo
 	//dockerIgnoreFile
 	var dockerIgnoreFilePath = filepath.Join(dir, dockerIgnoreFile)
 	dockerExists := false
-	if excludeFromDockerIgnore {
+	if useDockerIgnore {
 		dockerExists, err = fileutil.FileExists(dockerIgnoreFilePath)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to check if %s exists", dockerIgnoreFilePath)

--- a/buildcontext/local.go
+++ b/buildcontext/local.go
@@ -92,13 +92,13 @@ func (lr *localResolver) resolveLocal(ctx context.Context, gwClient gwclient.Cli
 		if _, isTarget := ref.(domain.Target); isTarget {
 			noImplicitIgnore := bf.ftrs != nil && bf.ftrs.NoImplicitIgnore
 
-			excludeFromDockerIgnore := isDockerfile
+			useDockerIgnore := isDockerfile
 			ftrs := features.FromContext(ctx)
 			if ftrs != nil {
-				excludeFromDockerIgnore = excludeFromDockerIgnore && ftrs.UseDockerIgnore
+				useDockerIgnore = useDockerIgnore && ftrs.UseDockerIgnore
 			}
 
-			excludes, err := readExcludes(ref.GetLocalPath(), noImplicitIgnore, excludeFromDockerIgnore)
+			excludes, err := readExcludes(ref.GetLocalPath(), noImplicitIgnore, useDockerIgnore)
 			if err != nil {
 				return nil, err
 			}

--- a/buildcontext/local.go
+++ b/buildcontext/local.go
@@ -91,7 +91,14 @@ func (lr *localResolver) resolveLocal(ctx context.Context, gwClient gwclient.Cli
 	if gwClient != nil {
 		if _, isTarget := ref.(domain.Target); isTarget {
 			noImplicitIgnore := bf.ftrs != nil && bf.ftrs.NoImplicitIgnore
-			excludes, err := readExcludes(ref.GetLocalPath(), noImplicitIgnore)
+
+			excludeFromDockerIgnore := isDockerfile
+			ftrs := features.FromContext(ctx)
+			if ftrs != nil {
+				excludeFromDockerIgnore = excludeFromDockerIgnore && ftrs.UseDockerIgnore
+			}
+
+			excludes, err := readExcludes(ref.GetLocalPath(), noImplicitIgnore, excludeFromDockerIgnore)
 			if err != nil {
 				return nil, err
 			}

--- a/docs/earthfile/earthfile.md
+++ b/docs/earthfile/earthfile.md
@@ -883,6 +883,7 @@ Instructs Earthly to not overwrite the file creation timestamps with a constant.
 The `FROM DOCKERFILE` command initializes a new build environment, inheriting from an existing Dockerfile. This allows the use of Dockerfiles in Earthly builds.
 
 The `<context-path>` is the path where the Dockerfile build context exists. By default, it is assumed that a file named `Dockerfile` exists in that directory. The context path can be either a path on the host system, or an [artifact reference](../guides/target-ref.md#artifact-reference), pointing to a directory containing a `Dockerfile`.
+Additionally, when using a `<context-path>` from the host system, a `.dockerignore` in the directory root will be used to exclude files (unless `.earthlyignore` or `.earthignore` are present). Use `--use-docker-ignore` feature flag to enable.
 
 #### Options
 

--- a/docs/earthfile/earthfile.md
+++ b/docs/earthfile/earthfile.md
@@ -883,7 +883,7 @@ Instructs Earthly to not overwrite the file creation timestamps with a constant.
 The `FROM DOCKERFILE` command initializes a new build environment, inheriting from an existing Dockerfile. This allows the use of Dockerfiles in Earthly builds.
 
 The `<context-path>` is the path where the Dockerfile build context exists. By default, it is assumed that a file named `Dockerfile` exists in that directory. The context path can be either a path on the host system, or an [artifact reference](../guides/target-ref.md#artifact-reference), pointing to a directory containing a `Dockerfile`.
-Additionally, when using a `<context-path>` from the host system, a `.dockerignore` in the directory root will be used to exclude files (unless `.earthlyignore` or `.earthignore` are present). Use `--use-docker-ignore` feature flag to enable.
+Additionally, when using a `<context-path>` from the host system, a `.dockerignore` in the directory root will be used to exclude files (unless `.earthlyignore` or `.earthignore` are present). Use `VERSION --use-docker-ignore 0.7` to enable.
 
 #### Options
 

--- a/docs/earthfile/features.md
+++ b/docs/earthfile/features.md
@@ -57,6 +57,8 @@ to require version `0.X` (or later), and could be rewritten as `VERSION 0.X`.
 | `--use-pipelines` | 0.7 | Enable the `PIPELINE` and `TRIGGER` commands |
 | `--earthly-git-author-args` | 0.7 | Enable the `EARTHLY_GIT_AUTHOR` and `EARTHLY_GIT_CO_AUTHORS` args |
 | `--wait-block` | 0.7 | Enable the `WAIT` / `END` block commands |
+| `--earthly-ci-runner-arg` | 0.7 | Enable the `EARTHLY_CI_RUNNER` builtin ARG |
+| `--use-docker-ignore` | 0.7 | Enable the use of `.dockerignore` files in `FROM DOCKERFILE` targets |
 | `--try` | Experimental | Enable the `TRY` / `FINALLY` / `END` block commands |
 | `--arg-scope-and-set` | Experimental | Enable the `LET` / `SET` commands and nested `ARG` scoping |
 

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -255,7 +255,12 @@ func (c *Converter) fromTarget(ctx context.Context, targetName string, platform 
 
 // FromDockerfile applies the earthly FROM DOCKERFILE command.
 func (c *Converter) FromDockerfile(ctx context.Context, contextPath string, dfPath string, dfTarget string, platform platutil.Platform, buildArgs []string) error {
-	err := c.checkAllowed(fromDockerfileCmd)
+	var err error
+	ctx, err = c.ftrs.WithContext(ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to add feature flags to context")
+	}
+	err = c.checkAllowed(fromDockerfileCmd)
 	if err != nil {
 		return err
 	}

--- a/features/features.go
+++ b/features/features.go
@@ -269,7 +269,7 @@ func processNegativeFlags(ftrs *Features) {
 // WithContext adds the current *Features into the given context and returns a new context.
 // Trying to add the *Features to the context more than once will result in an error.
 func (f *Features) WithContext(ctx context.Context) (context.Context, error) {
-	if _, ok := ctx.Value(ctxKey{}).(*Features); ok {
+	if ctx.Value(ctxKey{}) != nil {
 		return ctx, errors.New("features is already set")
 	}
 	return context.WithValue(ctx, ctxKey{}, f), nil

--- a/features/features.go
+++ b/features/features.go
@@ -266,8 +266,8 @@ func processNegativeFlags(ftrs *Features) {
 	}
 }
 
-// WithContext adds the current *Features into the given context and returns a new context
-// Trying to add the *Features to the context more than once would result in an error
+// WithContext adds the current *Features into the given context and returns a new context.
+// Trying to add the *Features to the context more than once will result in an error.
 func (f *Features) WithContext(ctx context.Context) (context.Context, error) {
 	if _, ok := ctx.Value(ctxKey{}).(*Features); ok {
 		return ctx, errors.New("features is already set")
@@ -275,8 +275,8 @@ func (f *Features) WithContext(ctx context.Context) (context.Context, error) {
 	return context.WithValue(ctx, ctxKey{}, f), nil
 }
 
-// FromContext returns the Features associated with the ctx. If no features
-// is associated, nil is returned
+// FromContext returns the *Features associated with the ctx.
+// If no features is found, nil is returned.
 func FromContext(ctx context.Context) *Features {
 	if f, ok := ctx.Value(ctxKey{}).(*Features); ok {
 		return f

--- a/features/features.go
+++ b/features/features.go
@@ -1,6 +1,7 @@
 package features
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"sort"
@@ -57,10 +58,13 @@ type Features struct {
 	NoNetwork                  bool `long:"no-network" description:"allow the use of RUN --network=none commands"`
 	ArgScopeSet                bool `long:"arg-scope-and-set" description:"enable SET to reassign ARGs and prevent ARGs from being redeclared in the same scope"`
 	EarthlyCIRunnerArg         bool `long:"earthly-ci-runner-arg" description:"includes EARTHLY_CI_RUNNER ARG"`
+	UseDockerIgnore            bool `long:"use-docker-ignore" description:"fallback to .dockerignore incase .earthlyignore or .earthignore do not exist in a local \"FROM DOCKERFILE\" target"`
 
 	Major int
 	Minor int
 }
+
+type ctxKey struct{}
 
 // Version returns the current version
 func (f *Features) Version() string {
@@ -260,4 +264,22 @@ func processNegativeFlags(ftrs *Features) {
 	if ftrs.NoUseRegistryForWithDocker {
 		ftrs.UseRegistryForWithDocker = false
 	}
+}
+
+// WithContext adds the current *Features into the given context and returns a new context
+// Trying to add the *Features to the context more than once would result in an error
+func (f *Features) WithContext(ctx context.Context) (context.Context, error) {
+	if _, ok := ctx.Value(ctxKey{}).(*Features); ok {
+		return ctx, errors.New("features is already set")
+	}
+	return context.WithValue(ctx, ctxKey{}, f), nil
+}
+
+// FromContext returns the Features associated with the ctx. If no features
+// is associated, nil is returned
+func FromContext(ctx context.Context) *Features {
+	if f, ok := ctx.Value(ctxKey{}).(*Features); ok {
+		return f
+	}
+	return nil
 }

--- a/features/features_test.go
+++ b/features/features_test.go
@@ -1,6 +1,7 @@
 package features_test
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -118,6 +119,7 @@ func TestAvailableFlags(t *testing.T) {
 		{"no-network", "NoNetwork"},
 		{"arg-scope-and-set", "ArgScopeSet"},
 		{"earthly-ci-runner-arg", "EarthlyCIRunnerArg"},
+		{"use-docker-ignore", "UseDockerIgnore"},
 	} {
 		tt := tt
 		t.Run(tt.flag, func(t *testing.T) {
@@ -133,4 +135,30 @@ func TestAvailableFlags(t *testing.T) {
 			True(t, val, "expected field %v to be set to true by flag %v", tt.field, tt.flag)
 		})
 	}
+}
+
+func TestContext(t *testing.T) {
+
+	fts := &features.Features{}
+
+	t.Run("features can be set and retrieved from context", func(t *testing.T) {
+		ctx := context.Background()
+		newCtx, err := fts.WithContext(ctx)
+		Equal(t, fts, features.FromContext(newCtx))
+		NoError(t, err)
+	})
+
+	t.Run("context cannot be set more than once", func(t *testing.T) {
+		ctx := context.Background()
+		ctx2, err := fts.WithContext(ctx)
+		NoError(t, err)
+		ctx3, err := fts.WithContext(ctx2)
+		Error(t, err)
+		Equal(t, ctx2, ctx3)
+	})
+
+	t.Run("returns nil when not set in context", func(t *testing.T) {
+		ctx := context.Background()
+		Nil(t, features.FromContext(ctx))
+	})
 }

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -1140,32 +1140,43 @@ from-dockerfile-arg:
     RUN test "$(cat ./arg-value-bar)" = "bar"
 
 from-dockerfile-dockerignore:
-    # no ignore files
-    DO +RUN_EARTHLY --earthfile=from-dockerfile-dockerignore.earth --target=+create-files
+    # feature flag off
+    DO +RUN_EARTHLY --earthfile=from-dockerfile-dockerignore.earth --target="+create-files --with_docker_ignore=\"true\""
     DO +RUN_EARTHLY --earthfile=from-dockerfile-dockerignore.earth --target=+image
     RUN test "$(cat output)" = "a.txt
 b.txt
 c.txt"
     RUN rm -rf .*ignore output
 
+    # enable feature flag
+    RUN sed -i "1s/VERSION \(.*\)/VERSION --use-docker-ignore \1/" Earthfile
+
+    # no ignore files
+    DO +RUN_EARTHLY --target=+create-files
+    DO +RUN_EARTHLY --target=+image
+    RUN test "$(cat output)" = "a.txt
+b.txt
+c.txt"
+    RUN rm -rf .*ignore output
+
     # with only .dockerignore present
-    DO +RUN_EARTHLY --earthfile=from-dockerfile-dockerignore.earth --target="+create-files --with_docker_ignore=\"true\""
-    DO +RUN_EARTHLY --earthfile=from-dockerfile-dockerignore.earth --target=+image
+    DO +RUN_EARTHLY --target="+create-files --with_docker_ignore=\"true\""
+    DO +RUN_EARTHLY --target=+image
     RUN cat output
     RUN test "$(cat output)" = "b.txt
 c.txt"
     RUN rm -rf .*ignore output
 
     # with .earthlyignore present
-    DO +RUN_EARTHLY --earthfile=from-dockerfile-dockerignore.earth --target="+create-files --with_docker_ignore=\"true\" --with_earthly_ignore=\"true\""
-    DO +RUN_EARTHLY --earthfile=from-dockerfile-dockerignore.earth --target=+image
+    DO +RUN_EARTHLY --target="+create-files --with_docker_ignore=\"true\" --with_earthly_ignore=\"true\""
+    DO +RUN_EARTHLY --target=+image
     RUN cat output
     RUN test "$(cat output)" = "a.txt
 c.txt"
     RUN rm -rf .*ignore output
     # with .earthignore present
-    DO +RUN_EARTHLY --earthfile=from-dockerfile-dockerignore.earth --target="+create-files --with_docker_ignore=\"true\" --with_earth_ignore=\"true\""
-    DO +RUN_EARTHLY --earthfile=from-dockerfile-dockerignore.earth --target=+image
+    DO +RUN_EARTHLY --target="+create-files --with_docker_ignore=\"true\" --with_earth_ignore=\"true\""
+    DO +RUN_EARTHLY --target=+image
     RUN cat output
     RUN test "$(cat output)" = "a.txt
 b.txt"

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -1139,6 +1139,38 @@ from-dockerfile-arg:
     RUN test "$(cat ./arg-value-foo)" = "foo"
     RUN test "$(cat ./arg-value-bar)" = "bar"
 
+from-dockerfile-dockerignore:
+    # no ignore files
+    DO +RUN_EARTHLY --earthfile=from-dockerfile-dockerignore.earth --target=+create-files
+    DO +RUN_EARTHLY --earthfile=from-dockerfile-dockerignore.earth --target=+image
+    RUN test "$(cat output)" = "a.txt
+b.txt
+c.txt"
+    RUN rm -rf .*ignore output
+
+    # with only .dockerignore present
+    DO +RUN_EARTHLY --earthfile=from-dockerfile-dockerignore.earth --target="+create-files --with_docker_ignore=\"true\""
+    DO +RUN_EARTHLY --earthfile=from-dockerfile-dockerignore.earth --target=+image
+    RUN cat output
+    RUN test "$(cat output)" = "b.txt
+c.txt"
+    RUN rm -rf .*ignore output
+
+    # with .earthlyignore present
+    DO +RUN_EARTHLY --earthfile=from-dockerfile-dockerignore.earth --target="+create-files --with_docker_ignore=\"true\" --with_earthly_ignore=\"true\""
+    DO +RUN_EARTHLY --earthfile=from-dockerfile-dockerignore.earth --target=+image
+    RUN cat output
+    RUN test "$(cat output)" = "a.txt
+c.txt"
+    RUN rm -rf .*ignore output
+    # with .earthignore present
+    DO +RUN_EARTHLY --earthfile=from-dockerfile-dockerignore.earth --target="+create-files --with_docker_ignore=\"true\" --with_earth_ignore=\"true\""
+    DO +RUN_EARTHLY --earthfile=from-dockerfile-dockerignore.earth --target=+image
+    RUN cat output
+    RUN test "$(cat output)" = "a.txt
+b.txt"
+    RUN rm -rf .*ignore output
+
 cache-mount-arg:
     DO +RUN_EARTHLY --earthfile=cache-mount-arg.earth --use_tmpfs=false --target="+b-nomount --MYARG=123"
     DO +RUN_EARTHLY --earthfile=cache-mount-arg.earth --use_tmpfs=false --target="+b-nomount --MYARG=1234" --post_command="2>output-nomount.txt"

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -1162,7 +1162,6 @@ c.txt"
     # with only .dockerignore present
     DO +RUN_EARTHLY --target="+create-files --with_docker_ignore=\"true\""
     DO +RUN_EARTHLY --target=+image
-    RUN cat output
     RUN test "$(cat output)" = "b.txt
 c.txt"
     RUN rm -rf .*ignore output
@@ -1170,7 +1169,6 @@ c.txt"
     # with .earthlyignore present
     DO +RUN_EARTHLY --target="+create-files --with_docker_ignore=\"true\" --with_earthly_ignore=\"true\""
     DO +RUN_EARTHLY --target=+image
-    RUN cat output
     RUN test "$(cat output)" = "a.txt
 c.txt"
     RUN rm -rf .*ignore output
@@ -1178,7 +1176,6 @@ c.txt"
     # with .earthignore present
     DO +RUN_EARTHLY --target="+create-files --with_docker_ignore=\"true\" --with_earth_ignore=\"true\""
     DO +RUN_EARTHLY --target=+image
-    RUN cat output
     RUN test "$(cat output)" = "a.txt
 b.txt"
     RUN rm -rf .*ignore output

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -1174,6 +1174,7 @@ c.txt"
     RUN test "$(cat output)" = "a.txt
 c.txt"
     RUN rm -rf .*ignore output
+
     # with .earthignore present
     DO +RUN_EARTHLY --target="+create-files --with_docker_ignore=\"true\" --with_earth_ignore=\"true\""
     DO +RUN_EARTHLY --target=+image

--- a/tests/from-dockerfile-dockerignore.earth
+++ b/tests/from-dockerfile-dockerignore.earth
@@ -12,9 +12,7 @@ create-files:
     ARG with_earth_ignore="false"
     ARG with_docker_ignore="false"
     WORKDIR /output
-    RUN echo "a" > a.txt
-    RUN echo "b" > b.txt
-    RUN echo "c" > c.txt
+    RUN touch a.txt b.txt c.txt
     RUN echo "
 FROM alpine:3.15
 WORKDIR /app

--- a/tests/from-dockerfile-dockerignore.earth
+++ b/tests/from-dockerfile-dockerignore.earth
@@ -1,0 +1,33 @@
+VERSION --use-docker-ignore 0.7
+
+image:
+    FROM DOCKERFILE .
+    WORKDIR /app
+    RUN ls *.txt > output
+    SAVE ARTIFACT output AS LOCAL .
+
+create-files:
+    FROM alpine:3.15
+    ARG with_earthly_ignore="false"
+    ARG with_earth_ignore="false"
+    ARG with_docker_ignore="false"
+    WORKDIR /output
+    RUN echo "a" > a.txt
+    RUN echo "b" > b.txt
+    RUN echo "c" > c.txt
+    RUN echo "
+FROM alpine:3.15
+WORKDIR /app
+COPY *.txt* .
+ENTRYPOINT ls -1
+" > Dockerfile
+    IF [ "$with_docker_ignore" = "true" ]
+        RUN echo "a.txt" > .dockerignore
+    END
+    IF [ "$with_earthly_ignore" = "true" ]
+        RUN echo "b.txt" > .earthlyignore
+    END
+    IF [ "$with_earth_ignore" = "true" ]
+        RUN echo "c.txt" > .earthignore
+    END
+    SAVE ARTIFACT /output/* AS LOCAL .

--- a/tests/from-dockerfile-dockerignore.earth
+++ b/tests/from-dockerfile-dockerignore.earth
@@ -1,4 +1,4 @@
-VERSION --use-docker-ignore 0.7
+VERSION 0.7
 
 image:
     FROM DOCKERFILE .


### PR DESCRIPTION
This PR adds support for using a `.dockerignore` file in target using `FROM DOCKERFILE` with <build context> from the host system.
The feature is enabled using `--use-docker-ignore` feature flag.
The `.dockerignore` file will not be used if the <build context> contains an `.earthlyignore` or `.earthignore` file.