### PR TITLE
Remove default size in satellite update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to [Earthly](https://github.com/earthly/earthly) will be documented in this file.
 
+### Fixed
+- Fixed a bug in satellite update command which was incorrectly changing satellites to medium size.
+
 ## Unreleased
 
 ## v0.7.8 - 2023-06-07

--- a/cmd/earthly/satellite_cmds.go
+++ b/cmd/earthly/satellite_cmds.go
@@ -164,7 +164,6 @@ func (app *earthlyApp) satelliteCmds() []*cli.Command {
 					Name:        "size",
 					Usage:       "Change the size of the satellite. See https://earthly.dev/pricing for details on each size. Supported values: xsmall, small, medium, large, xlarge.",
 					Required:    false,
-					Value:       cloud.SatelliteSizeMedium,
 					Destination: &app.satelliteSize,
 				},
 				&cli.StringFlag{


### PR DESCRIPTION
This fixes a bug that was causing manual updates to revert the size to medium if the user previously had a different size set.