### PR TITLE
.github: add a workflow to sync issue state from the board

### DIFF
--- a/.github/workflows/project-sync.yml
+++ b/.github/workflows/project-sync.yml
@@ -1,0 +1,19 @@
+name: Project State Sync
+
+on:
+  schedule:
+  - cron: 0 0-23 * * *
+
+jobs:
+  issue-state-sync:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Sync issue states from board state
+      uses: dasmerlon/project-issue-state-sync@v2
+      with:
+        github_token: ${{secrets.GITHUB_TOKEN}}
+        owner: earthly
+        project_number: 3
+        closed_statuses: Done
+        open_statuses: No Status,Icebox,Todo,In Progress


### PR DESCRIPTION
We already have (built-in) workflows in our project that will update issues' place on the board when their state changes. Closed issues will move to Done, reopened issues will move to Todo.

However, the opposite is not true. When we move an issue to Done, it will not be automatically closed.

This workflow solves that by polling the board (once per hour) and updating any tickets that have been moved so that their state matches their place on the board.