### PR TITLE
.github: spread out multiple test targets across multiple workflows

### DIFF
--- a/.github/workflows/ci-docker-satellites.yml
+++ b/.github/workflows/ci-docker-satellites.yml
@@ -32,17 +32,59 @@ jobs:
       EARTHLY_ORG: "earthly-technologies"
     secrets: inherit
 
-  docker-tests-no-qemu:
+  docker-tests-quick:
     needs: build-earthly
     uses: ./.github/workflows/reusable-test.yml
     with:
-      TEST_TARGET: "+test-no-qemu"
+      TEST_TARGET: "+test-quick"
       BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
       RUNS_ON: "ubuntu-latest"
       BINARY: "docker"
       SUDO: ""
       USE_SATELLITE: true
-      SATELLITE_NAME: "core-examples"
+      SATELLITE_NAME: "core-test"
+      EARTHLY_ORG: "earthly-technologies"
+    secrets: inherit
+
+  docker-tests-no-qemu-quick:
+    needs: build-earthly
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      TEST_TARGET: "+test-no-qemu-quick"
+      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
+      RUNS_ON: "ubuntu-latest"
+      BINARY: "docker"
+      SUDO: ""
+      USE_SATELLITE: true
+      SATELLITE_NAME: "core-test"
+      EARTHLY_ORG: "earthly-technologies"
+    secrets: inherit
+
+  docker-tests-no-qemu-normal:
+    needs: build-earthly
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      TEST_TARGET: "+test-no-qemu-normal"
+      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
+      RUNS_ON: "ubuntu-latest"
+      BINARY: "docker"
+      SUDO: ""
+      USE_SATELLITE: true
+      SATELLITE_NAME: "core-test"
+      EARTHLY_ORG: "earthly-technologies"
+    secrets: inherit
+
+  docker-tests-no-qemu-slow:
+    needs: build-earthly
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      TEST_TARGET: "+test-no-qemu-slow"
+      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
+      RUNS_ON: "ubuntu-latest"
+      BINARY: "docker"
+      SUDO: ""
+      USE_SATELLITE: true
+      SATELLITE_NAME: "core-test"
       EARTHLY_ORG: "earthly-technologies"
     secrets: inherit
 

--- a/.github/workflows/ci-docker-satellites.yml
+++ b/.github/workflows/ci-docker-satellites.yml
@@ -18,16 +18,61 @@ jobs:
       SUDO: ""
     secrets: inherit
 
-  docker-satellites-tests:
+  docker-lint:
     needs: build-earthly
     uses: ./.github/workflows/reusable-test.yml
     with:
+      TEST_TARGET: "+lint-all"
       BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
       RUNS_ON: "ubuntu-latest"
       BINARY: "docker"
       SUDO: ""
       USE_SATELLITE: true
-      SATELLITE_NAME: "core-test"
+      SATELLITE_NAME: "core-examples"
+      EARTHLY_ORG: "earthly-technologies"
+    secrets: inherit
+
+  docker-tests-no-qemu:
+    needs: build-earthly
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      TEST_TARGET: "+test-no-qemu"
+      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
+      RUNS_ON: "ubuntu-latest"
+      BINARY: "docker"
+      SUDO: ""
+      USE_SATELLITE: true
+      SATELLITE_NAME: "core-examples"
+      EARTHLY_ORG: "earthly-technologies"
+    secrets: inherit
+
+  docker-tests-require-account-access:
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    needs: build-earthly
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      TEST_TARGET: "./tests+tests-that-require-earthly-technologies-account-access"
+      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
+      RUNS_ON: "ubuntu-latest"
+      BINARY: "docker"
+      SUDO: ""
+      USE_SATELLITE: true
+      SATELLITE_NAME: "core-examples"
+      EARTHLY_ORG: "earthly-technologies"
+    secrets: inherit
+
+  docker-tests-qemu:
+    needs: build-earthly
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      TEST_TARGET: "+test-qemu"
+      USE_QEMU: true
+      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
+      RUNS_ON: "ubuntu-latest"
+      BINARY: "docker"
+      SUDO: ""
+      USE_SATELLITE: true
+      SATELLITE_NAME: "core-examples"
       EARTHLY_ORG: "earthly-technologies"
     secrets: inherit
 

--- a/.github/workflows/ci-docker-ubuntu.yml
+++ b/.github/workflows/ci-docker-ubuntu.yml
@@ -17,10 +17,46 @@ jobs:
       SUDO: ""
     secrets: inherit
 
-  docker-tests:
+  docker-lint:
     needs: build-earthly
     uses: ./.github/workflows/reusable-test.yml
     with:
+      TEST_TARGET: "+lint-all"
+      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
+      RUNS_ON: "ubuntu-latest"
+      BINARY: "docker"
+      SUDO: ""
+    secrets: inherit
+
+  docker-tests-no-qemu:
+    needs: build-earthly
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      TEST_TARGET: "+test-no-qemu"
+      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
+      RUNS_ON: "ubuntu-latest"
+      BINARY: "docker"
+      SUDO: ""
+    secrets: inherit
+
+  docker-tests-require-account-access:
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    needs: build-earthly
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      TEST_TARGET: "./tests+tests-that-require-earthly-technologies-account-access"
+      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
+      RUNS_ON: "ubuntu-latest"
+      BINARY: "docker"
+      SUDO: ""
+    secrets: inherit
+
+  docker-tests-qemu:
+    needs: build-earthly
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      TEST_TARGET: "+test-qemu"
+      USE_QEMU: true
       BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
       RUNS_ON: "ubuntu-latest"
       BINARY: "docker"
@@ -194,13 +230,13 @@ jobs:
             --build-arg DOCKERHUB_USER_SECRET=+secrets/earthly-technologies/dockerhub-mirror/user \
             --build-arg DOCKERHUB_TOKEN_SECRET=+secrets/earthly-technologies/dockerhub-mirror/pass \
             --build-arg DOCKERHUB_MIRROR=registry-1.docker.io.mirror.corp.earthly.dev \
-          +test
+            +test
         if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
       - name: Execute tests (Fork Only)
         run: |-
           GORACE="halt_on_error=1" go run -race ./cmd/earthly/*.go --buildkit-image earthly/buildkitd:race-test -P --no-output \
             --build-arg DOCKERHUB_AUTH=false \
-          +test
+            +test
         if: github.event_name != 'push' && github.event.pull_request.head.repo.full_name != github.repository
       - name: Buildkit logs (runs on failure)
         run: docker logs earthly-buildkitd

--- a/.github/workflows/ci-docker-ubuntu.yml
+++ b/.github/workflows/ci-docker-ubuntu.yml
@@ -218,62 +218,41 @@ jobs:
       SUDO: ""
     secrets: inherit
 
-  race-tests:
+  race-tests-quick:
     needs: build-earthly
-    name: +test (-race)
-    runs-on: ubuntu-latest
-    env:
-      FORCE_COLOR: 1
-      EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"
-      EARTHLY_INSTALL_ID: "earthly-githubactions"
-      # Used in our github action as the token - TODO: look to change it into an input
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - name: Set up QEMU
-        id: qemu
-        uses: docker/setup-qemu-action@v1
-        with:
-          image: tonistiigi/binfmt:latest
-          platforms: all
-      - uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/setup-go@v1
-        with:
-          go-version: 1.20
-      - name: Docker mirror login (Earthly Only)
-        run: docker login registry-1.docker.io.mirror.corp.earthly.dev --username "${{ secrets.DOCKERHUB_MIRROR_USERNAME }}" --password "${{ secrets.DOCKERHUB_MIRROR_PASSWORD }}"
-        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-      - name: Retrieve earthly from build-earthly job
-        run: |-
-          BUILDKITD_IMAGE=docker.io/earthly/buildkitd-staging TAG=${GITHUB_SHA}-ubuntu-latest-docker ./earthly upgrade
-          mkdir -p $(dirname "./build/earthly")
-          mv ${HOME}/.earthly/earthly-${GITHUB_SHA}-ubuntu-latest-docker ./build/earthly
-      - name: Configure Earthly to use mirror (Earthly Only)
-        run: |-
-          ./build/earthly config global.buildkit_additional_config "'[registry.\"docker.io\"]
-          mirrors = [\"registry-1.docker.io.mirror.corp.earthly.dev\"]'"
-        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-      - name: Build latest earthly/buildkitd image using released earthly
-        run: ./build/earthly --use-inline-cache ./buildkitd+buildkitd --TAG=race-test
-      - name: Execute tests (Earthly Only)
-        run: |-
-          GORACE="halt_on_error=1" go run -race ./cmd/earthly/*.go --buildkit-image earthly/buildkitd:race-test -P --no-output \
-            --build-arg DOCKERHUB_AUTH=true \
-            --build-arg DOCKERHUB_USER_SECRET=+secrets/earthly-technologies/dockerhub-mirror/user \
-            --build-arg DOCKERHUB_TOKEN_SECRET=+secrets/earthly-technologies/dockerhub-mirror/pass \
-            --build-arg DOCKERHUB_MIRROR=registry-1.docker.io.mirror.corp.earthly.dev \
-            +test
-        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-      - name: Execute tests (Fork Only)
-        run: |-
-          GORACE="halt_on_error=1" go run -race ./cmd/earthly/*.go --buildkit-image earthly/buildkitd:race-test -P --no-output \
-            --build-arg DOCKERHUB_AUTH=false \
-            +test-quick
-        if: github.event_name != 'push' && github.event.pull_request.head.repo.full_name != github.repository
-      - name: Buildkit logs (runs on failure)
-        run: docker logs earthly-buildkitd
-        if: ${{ failure() }}
+    uses: ./.github/workflows/reusable-race-test.yml
+    with:
+      TEST_TARGET: "+test-quick"
+      RUNS_ON: "ubuntu-latest"
+      USE_QEMU: false
+    secrets: inherit
+
+  race-tests-no-qemu-quick:
+    needs: build-earthly
+    uses: ./.github/workflows/reusable-race-test.yml
+    with:
+      TEST_TARGET: "+test-no-qemu-quick"
+      RUNS_ON: "ubuntu-latest"
+      USE_QEMU: false
+    secrets: inherit
+
+  race-tests-no-qemu-normal:
+    needs: build-earthly
+    uses: ./.github/workflows/reusable-race-test.yml
+    with:
+      TEST_TARGET: "+test-no-qemu-normal"
+      RUNS_ON: "ubuntu-latest"
+      USE_QEMU: false
+    secrets: inherit
+
+  race-tests-no-qemu-slow:
+    needs: build-earthly
+    uses: ./.github/workflows/reusable-race-test.yml
+    with:
+      TEST_TARGET: "+test-no-qemu-slow"
+      RUNS_ON: "ubuntu-latest"
+      USE_QEMU: false
+    secrets: inherit
 
   tutorial:
     needs: build-earthly

--- a/.github/workflows/ci-docker-ubuntu.yml
+++ b/.github/workflows/ci-docker-ubuntu.yml
@@ -28,11 +28,44 @@ jobs:
       SUDO: ""
     secrets: inherit
 
-  docker-tests-no-qemu:
+  docker-tests-quick:
     needs: build-earthly
     uses: ./.github/workflows/reusable-test.yml
     with:
-      TEST_TARGET: "+test-no-qemu"
+      TEST_TARGET: "+test-quick"
+      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
+      RUNS_ON: "ubuntu-latest"
+      BINARY: "docker"
+      SUDO: ""
+    secrets: inherit
+
+  docker-tests-no-qemu-quick:
+    needs: build-earthly
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      TEST_TARGET: "+test-no-qemu-quick"
+      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
+      RUNS_ON: "ubuntu-latest"
+      BINARY: "docker"
+      SUDO: ""
+    secrets: inherit
+
+  docker-tests-no-qemu-normal:
+    needs: build-earthly
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      TEST_TARGET: "+test-no-qemu-normal"
+      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
+      RUNS_ON: "ubuntu-latest"
+      BINARY: "docker"
+      SUDO: ""
+    secrets: inherit
+
+  docker-tests-no-qemu-slow:
+    needs: build-earthly
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      TEST_TARGET: "+test-no-qemu-slow"
       BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
       RUNS_ON: "ubuntu-latest"
       BINARY: "docker"
@@ -236,7 +269,7 @@ jobs:
         run: |-
           GORACE="halt_on_error=1" go run -race ./cmd/earthly/*.go --buildkit-image earthly/buildkitd:race-test -P --no-output \
             --build-arg DOCKERHUB_AUTH=false \
-            +test
+            +test-quick
         if: github.event_name != 'push' && github.event.pull_request.head.repo.full_name != github.repository
       - name: Buildkit logs (runs on failure)
         run: docker logs earthly-buildkitd

--- a/.github/workflows/ci-podman-ubuntu.yml
+++ b/.github/workflows/ci-podman-ubuntu.yml
@@ -17,10 +17,46 @@ jobs:
       SUDO: "sudo -E"
     secrets: inherit
 
-  podman-tests:
+  podman-lint:
     needs: build-earthly
     uses: ./.github/workflows/reusable-test.yml
     with:
+      TEST_TARGET: "+lint-all"
+      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
+      RUNS_ON: "ubuntu-latest"
+      BINARY: "podman"
+      SUDO: "sudo -E"
+    secrets: inherit
+
+  podman-tests-no-qemu:
+    needs: build-earthly
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      TEST_TARGET: "+test-no-qemu"
+      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
+      RUNS_ON: "ubuntu-latest"
+      BINARY: "podman"
+      SUDO: "sudo -E"
+    secrets: inherit
+
+  podman-tests-require-account-access:
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    needs: build-earthly
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      TEST_TARGET: "./tests+tests-that-require-earthly-technologies-account-access"
+      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
+      RUNS_ON: "ubuntu-latest"
+      BINARY: "podman"
+      SUDO: "sudo -E"
+    secrets: inherit
+
+  podman-tests-qemu:
+    needs: build-earthly
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      TEST_TARGET: "+test-qemu"
+      USE_QEMU: true
       BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
       RUNS_ON: "ubuntu-latest"
       BINARY: "podman"
@@ -31,7 +67,6 @@ jobs:
     # TODO: Figure out how to run multiple Podman instances in parallel with different ports for buildkitd
     needs:
     - build-earthly
-    - podman-tests
     uses: ./.github/workflows/reusable-example.yml
     with:
       BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
@@ -45,7 +80,6 @@ jobs:
     # TODO: Figure out how to run multiple Podman instances in parallel with different ports for buildkitd
     needs:
     - build-earthly
-    - podman-examples-1
     uses: ./.github/workflows/reusable-example.yml
     with:
       BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
@@ -59,7 +93,6 @@ jobs:
 #    # TODO: Figure out how to run multiple Podman instances in parallel with different ports for buildkitd
 #    needs:
 #    - build-earthly
-#    - podman-examples-2
 #    uses: ./.github/workflows/reusable-test-local.yml
 #    with:
 #      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
@@ -85,7 +118,6 @@ jobs:
 #    # TODO: Figure out how to run multiple Podman instances in parallel with different ports for buildkitd
 #    needs:
 #    - build-earthly
-#    - podman-push-integrations
 #    uses: ./.github/workflows/reusable-secrets-integrations.yml
 #    with:
 #      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
@@ -98,7 +130,6 @@ jobs:
 #    # TODO: Figure out how to run multiple Podman instances in parallel with different ports for buildkitd
 #    needs:
 #    - build-earthly
-#    - podman-secret-integrations
 #    uses: ./.github/workflows/reusable-bootstrap-integrations.yml
 #    with:
 #      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
@@ -111,7 +142,6 @@ jobs:
 #    # TODO: Figure out how to run multiple Podman instances in parallel with different ports for buildkitd
 #    needs:
 #    - build-earthly
-#    - podman-bootstrap-integrations
 #    uses: ./.github/workflows/reusable-repo-auth-tests.yml
 #    with:
 #      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
@@ -124,7 +154,6 @@ jobs:
 #    # TODO: Figure out how to run multiple Podman instances in parallel with different ports for buildkitd
 #    needs:
 #    - build-earthly
-#    - podman-repo-auth-tests
 #    uses: ./.github/workflows/reusable-export-test.yml
 #    with:
 #      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
@@ -137,7 +166,6 @@ jobs:
 #    # TODO: Figure out how to run multiple Podman instances in parallel with different ports for buildkitd
 #    needs:
 #    - build-earthly
-#    - podman-export-tests
 #    uses: ./.github/workflows/reusable-misc-tests.yml
 #    with:
 #      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"

--- a/.github/workflows/ci-podman-ubuntu.yml
+++ b/.github/workflows/ci-podman-ubuntu.yml
@@ -28,11 +28,44 @@ jobs:
       SUDO: "sudo -E"
     secrets: inherit
 
-  podman-tests-no-qemu:
+  podman-tests-quick:
     needs: build-earthly
     uses: ./.github/workflows/reusable-test.yml
     with:
-      TEST_TARGET: "+test-no-qemu"
+      TEST_TARGET: "+test-quick"
+      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
+      RUNS_ON: "ubuntu-latest"
+      BINARY: "podman"
+      SUDO: "sudo -E"
+    secrets: inherit
+
+  podman-tests-no-qemu-quick:
+    needs: build-earthly
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      TEST_TARGET: "+test-no-qemu-quick"
+      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
+      RUNS_ON: "ubuntu-latest"
+      BINARY: "podman"
+      SUDO: "sudo -E"
+    secrets: inherit
+
+  podman-tests-no-qemu-normal:
+    needs: build-earthly
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      TEST_TARGET: "+test-no-qemu-normal"
+      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
+      RUNS_ON: "ubuntu-latest"
+      BINARY: "podman"
+      SUDO: "sudo -E"
+    secrets: inherit
+
+  podman-tests-no-qemu-slow:
+    needs: build-earthly
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      TEST_TARGET: "+test-no-qemu-slow"
       BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
       RUNS_ON: "ubuntu-latest"
       BINARY: "podman"

--- a/.github/workflows/reusable-race-test.yml
+++ b/.github/workflows/reusable-race-test.yml
@@ -1,0 +1,71 @@
+name: Test Earthly (-race)
+
+on:
+  workflow_call:
+    inputs:
+      TEST_TARGET:
+        required: true
+        type: string
+      RUNS_ON:
+        required: true
+        type: string
+      USE_QEMU:
+        required: false
+        type: boolean
+
+jobs:
+  test-race:
+    name: ${{inputs.TEST_TARGET}} (-race)
+    runs-on: ${{inputs.RUNS_ON}}
+    env:
+      FORCE_COLOR: 1
+      EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"
+      EARTHLY_INSTALL_ID: "earthly-githubactions"
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@v1
+        with:
+          image: tonistiigi/binfmt:latest
+          platforms: all
+        if: inputs.USE_QEMU
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/setup-go@v1
+        with:
+          go-version: 1.20
+      - name: Docker mirror login (Earthly Only)
+        run: docker login registry-1.docker.io.mirror.corp.earthly.dev --username "${{ secrets.DOCKERHUB_MIRROR_USERNAME }}" --password "${{ secrets.DOCKERHUB_MIRROR_PASSWORD }}"
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+      - name: Retrieve earthly from build-earthly job
+        run: |-
+          BUILDKITD_IMAGE=docker.io/earthly/buildkitd-staging TAG=${GITHUB_SHA}-ubuntu-latest-docker ./earthly upgrade
+          mkdir -p $(dirname "./build/earthly")
+          mv ${HOME}/.earthly/earthly-${GITHUB_SHA}-ubuntu-latest-docker ./build/earthly
+      - name: Configure Earthly to use mirror (Earthly Only)
+        run: |-
+          ./build/earthly config global.buildkit_additional_config "'[registry.\"docker.io\"]
+          mirrors = [\"registry-1.docker.io.mirror.corp.earthly.dev\"]'"
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+      - name: Build latest earthly/buildkitd image using released earthly
+        run: ./build/earthly --use-inline-cache ./buildkitd+buildkitd --TAG=race-test
+      - name: Execute tests (Earthly Only)
+        run: |-
+          GORACE="halt_on_error=1" go run -race ./cmd/earthly/*.go --buildkit-image earthly/buildkitd:race-test -P --no-output \
+            --build-arg DOCKERHUB_AUTH=true \
+            --build-arg DOCKERHUB_USER_SECRET=+secrets/earthly-technologies/dockerhub-mirror/user \
+            --build-arg DOCKERHUB_TOKEN_SECRET=+secrets/earthly-technologies/dockerhub-mirror/pass \
+            --build-arg DOCKERHUB_MIRROR=registry-1.docker.io.mirror.corp.earthly.dev \
+            ${{inputs.TEST_TARGET}}
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+      - name: Execute tests (Fork Only)
+        run: |-
+          GORACE="halt_on_error=1" go run -race ./cmd/earthly/*.go --buildkit-image earthly/buildkitd:race-test -P --no-output \
+            --build-arg DOCKERHUB_AUTH=false \
+            ${{inputs.TEST_TARGET}}
+        if: github.event_name != 'push' && github.event.pull_request.head.repo.full_name != github.repository
+      - name: Buildkit logs (runs on failure)
+        run: docker logs earthly-buildkitd
+        if: ${{ failure() }}

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -3,6 +3,9 @@ name: Test Earthly
 on:
   workflow_call:
     inputs:
+      TEST_TARGET:
+        required: true
+        type: string
       BUILT_EARTHLY_PATH:
         required: true
         type: string
@@ -15,6 +18,9 @@ on:
       RUNS_ON:
         required: true
         type: string
+      USE_QEMU:
+        required: false
+        type: boolean
       USE_SATELLITE:
         required: false
         type: boolean
@@ -50,7 +56,7 @@ jobs:
         with:
           image: tonistiigi/binfmt:latest
           platforms: all
-        if: inputs.BINARY == 'docker'
+        if: inputs.USE_QEMU
       - name: remove Docker
         run: ${{inputs.SUDO}} apt-get purge docker-engine docker docker.io docker-ce docker-ce-cli ; ${{inputs.SUDO}} rm -rf /usr/bin/docker
         if: inputs.BINARY != 'docker'
@@ -67,7 +73,6 @@ jobs:
           mv ${HOME}/.earthly/earthly-${GITHUB_SHA}-${{inputs.RUNS_ON}}-${{inputs.BINARY}} ${{inputs.BUILT_EARTHLY_PATH}}
       - name: Bootstrap Earthly
         run: ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} bootstrap
-        if: inputs.BINARY == 'podman'
       - name: Configure Satellites (Earthly Only)
         run: ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} sat ls && ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} satellite select ${{inputs.SATELLITE_NAME}}
         if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) && inputs.USE_SATELLITE
@@ -84,59 +89,27 @@ jobs:
           set -euo pipefail
           EARTHLY_VERSION_FLAG_OVERRIDES="$(tr -d '\n' < .earthly_version_flag_overrides)"
           echo "EARTHLY_VERSION_FLAG_OVERRIDES=$EARTHLY_VERSION_FLAG_OVERRIDES" >> "$GITHUB_ENV"
-      - name: Execute lint (Earthly Only)
-        run: |-
-          ${{inputs.SUDO}} ${{ inputs.BUILT_EARTHLY_PATH }} --ci -P \
-            --build-arg DOCKERHUB_AUTH=true \
-            --build-arg DOCKERHUB_USER_SECRET=+secrets/earthly-technologies/dockerhub-mirror/user \
-            --build-arg DOCKERHUB_TOKEN_SECRET=+secrets/earthly-technologies/dockerhub-mirror/pass \
-            --build-arg DOCKERHUB_MIRROR=registry-1.docker.io.mirror.corp.earthly.dev \
-          +lint-all
-      - name: Execute tests-no-qemu (Earthly Only)
-        run: |-
-          ${{inputs.SUDO}} ${{ inputs.BUILT_EARTHLY_PATH }} --ci -P \
-            --build-arg DOCKERHUB_AUTH=true \
-            --build-arg DOCKERHUB_USER_SECRET=+secrets/earthly-technologies/dockerhub-mirror/user \
-            --build-arg DOCKERHUB_TOKEN_SECRET=+secrets/earthly-technologies/dockerhub-mirror/pass \
-            --build-arg DOCKERHUB_MIRROR=registry-1.docker.io.mirror.corp.earthly.dev \
-          +test-no-qemu
-        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-      - name: Execute tests-no-qemu (Fork)
-        run: |-
-          ${{inputs.SUDO}} ${{ inputs.BUILT_EARTHLY_PATH }} --ci -P \
-            --build-arg DOCKERHUB_AUTH=false \
-          +test-no-qemu
-        if: github.event_name != 'push' && github.event.pull_request.head.repo.full_name != github.repository
-      - name: Execute tests-that-require-earthly-technologies-account-access
-        run: |-
-          ${{inputs.SUDO}} ${{ inputs.BUILT_EARTHLY_PATH }} --ci -P \
-            --build-arg DOCKERHUB_AUTH=true \
-            --build-arg DOCKERHUB_USER_SECRET=+secrets/earthly-technologies/dockerhub-mirror/user \
-            --build-arg DOCKERHUB_TOKEN_SECRET=+secrets/earthly-technologies/dockerhub-mirror/pass \
-            --build-arg DOCKERHUB_MIRROR=registry-1.docker.io.mirror.corp.earthly.dev \
-          ./tests+tests-that-require-earthly-technologies-account-access
-        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
       - name: Install QEMU for Podman multi-arch building
         # qemu-user-static needed for cross-compilation (--platform) targets
         run: ${{inputs.SUDO}} apt-get update && ${{inputs.SUDO}} apt-get install -y qemu-user-static
-        if: inputs.BINARY == 'podman'
-      - name: Execute tests-qemu (Earthly Only)
+        if: inputs.BINARY == 'podman' && inputs.USE_QEMU
+      - name: Execute ${{ inputs.TEST_TARGET }} (Earthly Only)
         run: |-
           ${{inputs.SUDO}} ${{ inputs.BUILT_EARTHLY_PATH }} --ci -P \
             --build-arg DOCKERHUB_AUTH=true \
             --build-arg DOCKERHUB_USER_SECRET=+secrets/earthly-technologies/dockerhub-mirror/user \
             --build-arg DOCKERHUB_TOKEN_SECRET=+secrets/earthly-technologies/dockerhub-mirror/pass \
             --build-arg DOCKERHUB_MIRROR=registry-1.docker.io.mirror.corp.earthly.dev \
-          +test-qemu
+            ${{inputs.TEST_TARGET}}
         if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-      - name: Execute tests-qemu (Fork)
+      - name: Execute ${{ inputs.TEST_TARGET }} (Fork)
         run: |-
           ${{inputs.SUDO}} ${{ inputs.BUILT_EARTHLY_PATH }} --ci -P \
             --build-arg DOCKERHUB_AUTH=false \
-          +test-qemu
+            ${{inputs.TEST_TARGET}}
         if: github.event_name != 'push' && github.event.pull_request.head.repo.full_name != github.repository
       - name: Execute fail test
-        run: "! ${{ inputs.BUILT_EARTHLY_PATH }} --ci ./tests/fail+test-fail"
+        run: "! ${{inputs.SUDO}} ${{ inputs.BUILT_EARTHLY_PATH }} --ci ./tests/fail+test-fail"
       - name: Buildkit logs (runs on failure)
         run: ${{inputs.SUDO}} ${{inputs.BINARY}} logs earthly-buildkitd
-        if: ${{ failure() }}
+        if: ${{ failure() }} && ! inputs.USE_SATELLITE

--- a/Earthfile
+++ b/Earthfile
@@ -616,8 +616,13 @@ lint-docs:
     BUILD +lint-newline-ending
     BUILD +lint-changelog
 
-# TODO: Document qemu vs non-qemu
 test-no-qemu:
+    BUILD +test-quick
+    BUILD +test-no-qemu-quick
+    BUILD +test-no-qemu-normal
+    BUILD +test-no-qemu-slow
+
+test-quick:
     BUILD +unit-test
     BUILD +chaos-test
     BUILD +offline-test
@@ -628,6 +633,7 @@ test-no-qemu:
     ARG DOCKERHUB_AUTH=true
     ARG DOCKERHUB_USER_SECRET=+secrets/DOCKERHUB_USER
     ARG DOCKERHUB_TOKEN_SECRET=+secrets/DOCKERHUB_TOKEN
+
     BUILD ./ast/tests+all \
         --DOCKERHUB_AUTH=$DOCKERHUB_AUTH \
         --DOCKERHUB_USER_SECRET=$DOCKERHUB_USER_SECRET \
@@ -635,8 +641,29 @@ test-no-qemu:
         --DOCKERHUB_MIRROR=$DOCKERHUB_MIRROR \
         --DOCKERHUB_MIRROR_INSECURE=$DOCKERHUB_MIRROR_INSECURE \
         --DOCKERHUB_MIRROR_HTTP=$DOCKERHUB_MIRROR_HTTP
-    ARG GLOBAL_WAIT_END="false"
-    BUILD ./tests+ga-no-qemu \
+
+test-no-qemu-quick:
+    BUILD ./tests+ga-no-qemu-quick \
+        --DOCKERHUB_AUTH=$DOCKERHUB_AUTH \
+        --DOCKERHUB_USER_SECRET=$DOCKERHUB_USER_SECRET \
+        --DOCKERHUB_TOKEN_SECRET=$DOCKERHUB_TOKEN_SECRET \
+        --DOCKERHUB_MIRROR=$DOCKERHUB_MIRROR \
+        --DOCKERHUB_MIRROR_INSECURE=$DOCKERHUB_MIRROR_INSECURE \
+        --DOCKERHUB_MIRROR_HTTP=$DOCKERHUB_MIRROR_HTTP \
+        --GLOBAL_WAIT_END="$GLOBAL_WAIT_END"
+
+test-no-qemu-normal:
+    BUILD ./tests+ga-no-qemu-normal \
+        --DOCKERHUB_AUTH=$DOCKERHUB_AUTH \
+        --DOCKERHUB_USER_SECRET=$DOCKERHUB_USER_SECRET \
+        --DOCKERHUB_TOKEN_SECRET=$DOCKERHUB_TOKEN_SECRET \
+        --DOCKERHUB_MIRROR=$DOCKERHUB_MIRROR \
+        --DOCKERHUB_MIRROR_INSECURE=$DOCKERHUB_MIRROR_INSECURE \
+        --DOCKERHUB_MIRROR_HTTP=$DOCKERHUB_MIRROR_HTTP \
+        --GLOBAL_WAIT_END="$GLOBAL_WAIT_END"
+
+test-no-qemu-slow:
+    BUILD ./tests+ga-no-qemu-slow \
         --DOCKERHUB_AUTH=$DOCKERHUB_AUTH \
         --DOCKERHUB_USER_SECRET=$DOCKERHUB_USER_SECRET \
         --DOCKERHUB_TOKEN_SECRET=$DOCKERHUB_TOKEN_SECRET \

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -27,7 +27,7 @@ ga:
 ga-qemu:
     BUILD ./platform+test
 
-ga-no-qemu:
+ga-no-qemu-quick:
     BUILD ./autocompletion+test-all \
         --DOCKERHUB_AUTH=$DOCKERHUB_AUTH \
         --DOCKERHUB_USER_SECRET=$DOCKERHUB_USER_SECRET \
@@ -35,40 +35,8 @@ ga-no-qemu:
         --DOCKERHUB_MIRROR=$DOCKERHUB_MIRROR \
         --DOCKERHUB_MIRROR_INSECURE=$DOCKERHUB_MIRROR_INSECURE \
         --DOCKERHUB_MIRROR_HTTP=$DOCKERHUB_MIRROR_HTTP
-    BUILD ./autocompletion/install+test-all \
-        --DOCKERHUB_AUTH=$DOCKERHUB_AUTH \
-        --DOCKERHUB_USER_SECRET=$DOCKERHUB_USER_SECRET \
-        --DOCKERHUB_TOKEN_SECRET=$DOCKERHUB_TOKEN_SECRET \
-        --DOCKERHUB_MIRROR=$DOCKERHUB_MIRROR \
-        --DOCKERHUB_MIRROR_INSECURE=$DOCKERHUB_MIRROR_INSECURE \
-        --DOCKERHUB_MIRROR_HTTP=$DOCKERHUB_MIRROR_HTTP
-    BUILD ./autoskip+test-all \
-        --DOCKERHUB_AUTH=$DOCKERHUB_AUTH \
-        --DOCKERHUB_USER_SECRET=$DOCKERHUB_USER_SECRET \
-        --DOCKERHUB_TOKEN_SECRET=$DOCKERHUB_TOKEN_SECRET \
-        --DOCKERHUB_MIRROR=$DOCKERHUB_MIRROR \
-        --DOCKERHUB_MIRROR_INSECURE=$DOCKERHUB_MIRROR_INSECURE \
-        --DOCKERHUB_MIRROR_HTTP=$DOCKERHUB_MIRROR_HTTP
-    BUILD ./scrub-https-credentials+all \
-        --DOCKERHUB_AUTH=$DOCKERHUB_AUTH \
-        --DOCKERHUB_USER_SECRET=$DOCKERHUB_USER_SECRET \
-        --DOCKERHUB_TOKEN_SECRET=$DOCKERHUB_TOKEN_SECRET \
-        --DOCKERHUB_MIRROR=$DOCKERHUB_MIRROR \
-        --DOCKERHUB_MIRROR_INSECURE=$DOCKERHUB_MIRROR_INSECURE \
-        --DOCKERHUB_MIRROR_HTTP=$DOCKERHUB_MIRROR_HTTP
-    BUILD ./with-docker+all
-    BUILD ./with-docker-registry+all
-    BUILD ./with-docker-compose+all
-    BUILD ./with-docker-expose+all
     BUILD ./dockerfile+test
     BUILD ./dockerfile2/subdir+test
-    BUILD ./version+test-all \
-        --DOCKERHUB_AUTH=$DOCKERHUB_AUTH \
-        --DOCKERHUB_USER_SECRET=$DOCKERHUB_USER_SECRET \
-        --DOCKERHUB_TOKEN_SECRET=$DOCKERHUB_TOKEN_SECRET \
-        --DOCKERHUB_MIRROR=$DOCKERHUB_MIRROR \
-        --DOCKERHUB_MIRROR_INSECURE=$DOCKERHUB_MIRROR_INSECURE \
-        --DOCKERHUB_MIRROR_HTTP=$DOCKERHUB_MIRROR_HTTP
     BUILD ./locally-in-command+all \
         --DOCKERHUB_AUTH=$DOCKERHUB_AUTH \
         --DOCKERHUB_USER_SECRET=$DOCKERHUB_USER_SECRET \
@@ -82,8 +50,189 @@ ga-no-qemu:
     BUILD +copy-test
     BUILD +copy-test-verbose-output
     BUILD +copy-keep-own-test
-    BUILD +cache-test
     BUILD +git-clone-test
+    BUILD +builtin-args-invalid-default-test
+    BUILD +builtin-args-invalid-pass-test
+    BUILD +builtin-args-cli-tests
+    BUILD +smoke-test
+    BUILD ./invalid+test-all \
+        --DOCKERHUB_AUTH=$DOCKERHUB_AUTH \
+        --DOCKERHUB_USER_SECRET=$DOCKERHUB_USER_SECRET \
+        --DOCKERHUB_TOKEN_SECRET=$DOCKERHUB_TOKEN_SECRET \
+        --DOCKERHUB_MIRROR=$DOCKERHUB_MIRROR \
+        --DOCKERHUB_MIRROR_INSECURE=$DOCKERHUB_MIRROR_INSECURE \
+        --DOCKERHUB_MIRROR_HTTP=$DOCKERHUB_MIRROR_HTTP
+    BUILD +excludes-test
+    BUILD +secrets-test
+    BUILD +secrets-optional-prefix-test
+    BUILD +secrets-args-precedence-test
+    BUILD +project-secrets-test
+    BUILD +build-arg-test
+    BUILD +build-arg-explicit-global-test
+    BUILD +build-arg-dynamic-with-empty-base
+    BUILD +lc-test
+    BUILD +from-expose-test
+    BUILD +scratch-test
+    BUILD +build-earthly-test
+    BUILD +host-bind-test
+    BUILD +transitive-args-test
+    BUILD +transitive-args-test2
+    BUILD +non-transitive-args-test
+    BUILD +star-test
+    BUILD +dockerfile-test
+    BUILD +fail-test
+    BUILD +fail-push-test
+    BUILD +allow-privileged-import-test
+    BUILD +reject-privileged-import-test
+    BUILD +required-arg-test
+    BUILD +push-test
+    BUILD +push-arg-test
+    BUILD +ci-arg-test
+    BUILD +gen-dockerfile-test
+    BUILD +chown-test
+    BUILD +env-test
+    BUILD +env-home-test
+    BUILD +stack-failure-test
+    BUILD +multi-stack-failure-test
+    BUILD +no-cache-local-artifact-test
+    BUILD +empty-git-test
+    BUILD +escape-test
+    BUILD +escape-test --EARTHFILE=escape-v0.5.earth
+    BUILD +escape-dir-test
+    BUILD +fail-invalid-artifact-test
+    BUILD +target-first-line
+    BUILD +absolute-reference-with-relative
+    BUILD +end-comment
+    BUILD +file-copying
+    BUILD +run-no-cache
+    BUILD +save-artifact-file-as-dot
+    BUILD +save-artifact-dir-as-dot
+    BUILD +save-artifact-force-overwrite
+    BUILD +save-artifact-selective-legacy
+    BUILD +save-remote-artifact-selective-legacy
+    BUILD +save-remote-artifact-selective
+    BUILD +push-build
+    BUILD +build-arg-repeat
+    BUILD +arg-scope-requires-shellout-anywhere
+    BUILD +arg-set
+    BUILD +if
+    BUILD +for
+    BUILD +first-command
+    BUILD +platform-output
+    BUILD +command
+    BUILD +command-explicit-global
+    BUILD +command-nested-global
+    BUILD +duplicate
+    BUILD +reserved
+    BUILD +quotes-test
+    BUILD +new-args
+    BUILD +import
+    BUILD +from-dockerfile-arg
+    BUILD +true-false-flag
+    BUILD +true-false-flag-invalid
+    BUILD +dont-save-indirect-remote-artifact
+    BUILD +remote-earthfile-must-have-version
+    BUILD +sequential-locally-test
+    BUILD +version-flag-test
+    BUILD +implicit-ignores
+    BUILD +help
+    BUILD +ls
+    BUILD +ls-subdir
+    BUILD +host
+    BUILD +host-invalid
+    BUILD +mtime
+    BUILD +build-after-from
+    BUILD +pipelines
+    BUILD +doc
+    BUILD +doc-recipe-block
+    BUILD +no-network
+    BUILD +test-works-without-earthly-server
+
+    # Forcing the implicit global wait/end block, causes some tests, which rely
+    # on the ability to have two different targets issue the same SAVE IMAGE tag name
+    # (with the last SAVE IMAGE command taking presidence)
+    # Earthly, when using the wait-end feature, will return an error for such cases.
+    # As a result, the following tests are incompatible with WAIT/END block.
+    # Once version 0.7 is released AND support for 0.6 has been dropped,
+    # these tests can be removed, along with deprecated code from the builder.go's bf.
+    ARG GLOBAL_WAIT_END="false"
+    IF [ "$GLOBAL_WAIT_END" = "false" ]
+        BUILD +save-artifact-after-push
+        BUILD ./with-docker-via-command+test
+    END
+
+ga-no-qemu-normal:
+    BUILD +cache-test
+    BUILD ./do-not-track+test-all \
+        --DOCKERHUB_AUTH=$DOCKERHUB_AUTH \
+        --DOCKERHUB_USER_SECRET=$DOCKERHUB_USER_SECRET \
+        --DOCKERHUB_TOKEN_SECRET=$DOCKERHUB_TOKEN_SECRET \
+        --DOCKERHUB_MIRROR=$DOCKERHUB_MIRROR \
+        --DOCKERHUB_MIRROR_INSECURE=$DOCKERHUB_MIRROR_INSECURE \
+        --DOCKERHUB_MIRROR_HTTP=$DOCKERHUB_MIRROR_HTTP
+    BUILD ./scrub-https-credentials+all \
+        --DOCKERHUB_AUTH=$DOCKERHUB_AUTH \
+        --DOCKERHUB_USER_SECRET=$DOCKERHUB_USER_SECRET \
+        --DOCKERHUB_TOKEN_SECRET=$DOCKERHUB_TOKEN_SECRET \
+        --DOCKERHUB_MIRROR=$DOCKERHUB_MIRROR \
+        --DOCKERHUB_MIRROR_INSECURE=$DOCKERHUB_MIRROR_INSECURE \
+        --DOCKERHUB_MIRROR_HTTP=$DOCKERHUB_MIRROR_HTTP
+    BUILD ./autocompletion/install+test-all \
+        --DOCKERHUB_AUTH=$DOCKERHUB_AUTH \
+        --DOCKERHUB_USER_SECRET=$DOCKERHUB_USER_SECRET \
+        --DOCKERHUB_TOKEN_SECRET=$DOCKERHUB_TOKEN_SECRET \
+        --DOCKERHUB_MIRROR=$DOCKERHUB_MIRROR \
+        --DOCKERHUB_MIRROR_INSECURE=$DOCKERHUB_MIRROR_INSECURE \
+        --DOCKERHUB_MIRROR_HTTP=$DOCKERHUB_MIRROR_HTTP
+    BUILD +cache-cmd
+    BUILD ./config+test \
+        --DOCKERHUB_AUTH=$DOCKERHUB_AUTH \
+        --DOCKERHUB_USER_SECRET=$DOCKERHUB_USER_SECRET \
+        --DOCKERHUB_TOKEN_SECRET=$DOCKERHUB_TOKEN_SECRET \
+        --DOCKERHUB_MIRROR=$DOCKERHUB_MIRROR \
+        --DOCKERHUB_MIRROR_INSECURE=$DOCKERHUB_MIRROR_INSECURE \
+        --DOCKERHUB_MIRROR_HTTP=$DOCKERHUB_MIRROR_HTTP
+    BUILD +arg-redeclare-error
+    BUILD +ssh
+    BUILD +builtin-args-test
+    BUILD +remote-test
+    BUILD +save-artifact-dont-overwrite
+    BUILD ./with-docker-expose+all
+    BUILD +cache-mount-arg
+    BUILD +infinite-recursion
+    BUILD +save-artifact-selective
+    BUILD ./autoskip+test-all \
+        --DOCKERHUB_AUTH=$DOCKERHUB_AUTH \
+        --DOCKERHUB_USER_SECRET=$DOCKERHUB_USER_SECRET \
+        --DOCKERHUB_TOKEN_SECRET=$DOCKERHUB_TOKEN_SECRET \
+        --DOCKERHUB_MIRROR=$DOCKERHUB_MIRROR \
+        --DOCKERHUB_MIRROR_INSECURE=$DOCKERHUB_MIRROR_INSECURE \
+        --DOCKERHUB_MIRROR_HTTP=$DOCKERHUB_MIRROR_HTTP
+    BUILD +if-exists
+    BUILD +let-set
+    BUILD +save-artifact-selective-referencing-remote
+    BUILD ./secret-provider-config+test-all \
+        --DOCKERHUB_AUTH=$DOCKERHUB_AUTH \
+        --DOCKERHUB_USER_SECRET=$DOCKERHUB_USER_SECRET \
+        --DOCKERHUB_TOKEN_SECRET=$DOCKERHUB_TOKEN_SECRET \
+        --DOCKERHUB_MIRROR=$DOCKERHUB_MIRROR \
+        --DOCKERHUB_MIRROR_INSECURE=$DOCKERHUB_MIRROR_INSECURE \
+        --DOCKERHUB_MIRROR_HTTP=$DOCKERHUB_MIRROR_HTTP
+    BUILD ./shell-out+test-all \
+        --DOCKERHUB_AUTH=$DOCKERHUB_AUTH \
+        --DOCKERHUB_USER_SECRET=$DOCKERHUB_USER_SECRET \
+        --DOCKERHUB_TOKEN_SECRET=$DOCKERHUB_TOKEN_SECRET \
+        --DOCKERHUB_MIRROR=$DOCKERHUB_MIRROR \
+        --DOCKERHUB_MIRROR_INSECURE=$DOCKERHUB_MIRROR_INSECURE \
+        --DOCKERHUB_MIRROR_HTTP=$DOCKERHUB_MIRROR_HTTP
+    BUILD ./with-docker-compose+all
+    BUILD +dotenv-test
+    BUILD +allow-privileged-test
+    BUILD ./with-docker-registry+all
+
+ga-no-qemu-slow:
+    BUILD +server
+    BUILD ./with-docker+all
     # this has been moved to a seperate target until we get the flakey "tell me who you are" bug
     # fixed; see https://github.com/earthly/earthly/issues/2567
     #BUILD ./git-metadata+test \
@@ -107,158 +256,18 @@ ga-no-qemu:
         --DOCKERHUB_MIRROR=$DOCKERHUB_MIRROR \
         --DOCKERHUB_MIRROR_INSECURE=$DOCKERHUB_MIRROR_INSECURE \
         --DOCKERHUB_MIRROR_HTTP=$DOCKERHUB_MIRROR_HTTP
-    BUILD +builtin-args-test
-    BUILD +builtin-args-invalid-default-test
-    BUILD +builtin-args-invalid-pass-test
-    BUILD +builtin-args-cli-tests
-    BUILD +smoke-test
-    BUILD ./config+test \
+    BUILD ./version+test-all \
         --DOCKERHUB_AUTH=$DOCKERHUB_AUTH \
         --DOCKERHUB_USER_SECRET=$DOCKERHUB_USER_SECRET \
         --DOCKERHUB_TOKEN_SECRET=$DOCKERHUB_TOKEN_SECRET \
         --DOCKERHUB_MIRROR=$DOCKERHUB_MIRROR \
         --DOCKERHUB_MIRROR_INSECURE=$DOCKERHUB_MIRROR_INSECURE \
         --DOCKERHUB_MIRROR_HTTP=$DOCKERHUB_MIRROR_HTTP
-    BUILD ./invalid+test-all \
-        --DOCKERHUB_AUTH=$DOCKERHUB_AUTH \
-        --DOCKERHUB_USER_SECRET=$DOCKERHUB_USER_SECRET \
-        --DOCKERHUB_TOKEN_SECRET=$DOCKERHUB_TOKEN_SECRET \
-        --DOCKERHUB_MIRROR=$DOCKERHUB_MIRROR \
-        --DOCKERHUB_MIRROR_INSECURE=$DOCKERHUB_MIRROR_INSECURE \
-        --DOCKERHUB_MIRROR_HTTP=$DOCKERHUB_MIRROR_HTTP
-    BUILD ./secret-provider-config+test-all \
-        --DOCKERHUB_AUTH=$DOCKERHUB_AUTH \
-        --DOCKERHUB_USER_SECRET=$DOCKERHUB_USER_SECRET \
-        --DOCKERHUB_TOKEN_SECRET=$DOCKERHUB_TOKEN_SECRET \
-        --DOCKERHUB_MIRROR=$DOCKERHUB_MIRROR \
-        --DOCKERHUB_MIRROR_INSECURE=$DOCKERHUB_MIRROR_INSECURE \
-        --DOCKERHUB_MIRROR_HTTP=$DOCKERHUB_MIRROR_HTTP
-    BUILD ./shell-out+test-all \
-        --DOCKERHUB_AUTH=$DOCKERHUB_AUTH \
-        --DOCKERHUB_USER_SECRET=$DOCKERHUB_USER_SECRET \
-        --DOCKERHUB_TOKEN_SECRET=$DOCKERHUB_TOKEN_SECRET \
-        --DOCKERHUB_MIRROR=$DOCKERHUB_MIRROR \
-        --DOCKERHUB_MIRROR_INSECURE=$DOCKERHUB_MIRROR_INSECURE \
-        --DOCKERHUB_MIRROR_HTTP=$DOCKERHUB_MIRROR_HTTP
-    BUILD ./do-not-track+test-all \
-        --DOCKERHUB_AUTH=$DOCKERHUB_AUTH \
-        --DOCKERHUB_USER_SECRET=$DOCKERHUB_USER_SECRET \
-        --DOCKERHUB_TOKEN_SECRET=$DOCKERHUB_TOKEN_SECRET \
-        --DOCKERHUB_MIRROR=$DOCKERHUB_MIRROR \
-        --DOCKERHUB_MIRROR_INSECURE=$DOCKERHUB_MIRROR_INSECURE \
-        --DOCKERHUB_MIRROR_HTTP=$DOCKERHUB_MIRROR_HTTP
-    BUILD +excludes-test
-    BUILD +secrets-test
-    BUILD +secrets-optional-prefix-test
-    BUILD +secrets-args-precedence-test
-    BUILD +project-secrets-test
-    BUILD +build-arg-test
-    BUILD +build-arg-explicit-global-test
-    BUILD +build-arg-dynamic-with-empty-base
-    BUILD +lc-test
-    BUILD +from-expose-test
-    BUILD +scratch-test
-    BUILD +build-earthly-test
-    BUILD +host-bind-test
-    BUILD +remote-test
-    BUILD +transitive-args-test
-    BUILD +transitive-args-test2
-    BUILD +non-transitive-args-test
-    BUILD +star-test
-    BUILD +dockerfile-test
-    BUILD +fail-test
-    BUILD +fail-push-test
-    BUILD +allow-privileged-test
-    BUILD +allow-privileged-import-test
-    BUILD +reject-privileged-import-test
-    BUILD +required-arg-test
-    BUILD +push-test
-    BUILD +push-arg-test
-    BUILD +ci-arg-test
-    BUILD +gen-dockerfile-test
-    BUILD +chown-test
-    BUILD +dotenv-test
-    BUILD +env-test
-    BUILD +env-home-test
-    BUILD +stack-failure-test
-    BUILD +multi-stack-failure-test
-    BUILD +no-cache-local-artifact-test
-    BUILD +empty-git-test
-    BUILD +escape-test
-    BUILD +escape-test --EARTHFILE=escape-v0.5.earth
-    BUILD +escape-dir-test
-    BUILD +fail-invalid-artifact-test
-    BUILD +target-first-line
-    BUILD +absolute-reference-with-relative
-    BUILD +end-comment
-    BUILD +if-exists
-    BUILD +file-copying
-    BUILD +run-no-cache
-    BUILD +save-artifact-file-as-dot
-    BUILD +save-artifact-dir-as-dot
-    BUILD +save-artifact-dont-overwrite
-    BUILD +save-artifact-force-overwrite
-    BUILD +save-artifact-selective
-    BUILD +save-artifact-selective-legacy
-    BUILD +save-artifact-selective-referencing-remote
-    BUILD +save-remote-artifact-selective-legacy
-    BUILD +save-remote-artifact-selective
-    BUILD +push-build
-    BUILD +build-arg-repeat
-    BUILD +arg-redeclare-error
-    BUILD +arg-scope-requires-shellout-anywhere
-    BUILD +arg-set
-    BUILD +let-set
-    BUILD +if
-    BUILD +for
-    BUILD +first-command
-    BUILD +platform-output
-    BUILD +command
-    BUILD +command-explicit-global
-    BUILD +command-nested-global
-    BUILD +duplicate
-    BUILD +reserved
-    BUILD +quotes-test
-    BUILD +new-args
-    BUILD +import
-    BUILD +infinite-recursion
-    BUILD +from-dockerfile-arg
-    BUILD +cache-mount-arg
-    BUILD +true-false-flag
-    BUILD +true-false-flag-invalid
-    BUILD +dont-save-indirect-remote-artifact
-    BUILD +remote-earthfile-must-have-version
-    BUILD +sequential-locally-test
-    BUILD +version-flag-test
-    BUILD +implicit-ignores
-    BUILD +help
-    BUILD +cache-cmd
-    BUILD +ls
-    BUILD +ls-subdir
-    BUILD +ssh
-    BUILD +host
-    BUILD +host-invalid
-    BUILD +mtime
-    BUILD +server
-    BUILD +build-after-from
-    BUILD +pipelines
-    BUILD +doc
-    BUILD +doc-recipe-block
-    BUILD +no-network
-    BUILD +test-works-without-earthly-server
 
-    # Forcing the implicit global wait/end block, causes some tests, which rely
-    # on the ability to have two different targets issue the same SAVE IMAGE tag name
-    # (with the last SAVE IMAGE command taking presidence)
-    # Earthly, when using the wait-end feature, will return an error for such cases.
-    # As a result, the following tests are incompatible with WAIT/END block.
-    # Once version 0.7 is released AND support for 0.6 has been dropped,
-    # these tests can be removed, along with deprecated code from the builder.go's bf.
-    ARG GLOBAL_WAIT_END="false"
-    IF [ "$GLOBAL_WAIT_END" = "false" ]
-        BUILD +save-artifact-after-push
-        BUILD ./with-docker-via-command+test
-    END
+ga-no-qemu:
+    BUILD +ga-no-qemu-quick
+    BUILD +ga-no-qemu-normal
+    BUILD +ga-no-qemu-slow
 
 tests-that-require-earthly-technologies-account-access:
     BUILD ./web+test \


### PR DESCRIPTION
This splits up some of our longest-running (and most likely to flake) GHA jobs into smaller chunks. This helps specifically in the case where a test flakes, requiring us to re-run the job - taking around 10 minutes each retry instead of 45.

Hopefully, this will also give us a clearer picture of which tests are flaking most often, so we know which ones need to be fixed.