### PR TITLE
keep track of which authprovider responded

### DIFF
--- a/tests/registry-command/Earthfile
+++ b/tests/registry-command/Earthfile
@@ -61,7 +61,23 @@ test-gcp:
         --entrypoint \
         --mount=type=tmpfs,target=/tmp/earthly
 
+test-multi:
+    COPY lock.sh unlock.sh \
+        test-multi.sh \
+        .
+
+    ENV EARTHLY_EXEC_CMD=/test/test-multi.sh
+    RUN --secret EARTHLY_TOKEN=fake-user-write-token \
+        --secret GCP_KEY=gcp/ci-cd-key \
+        --secret AWS_ACCESS_KEY_ID=aws/ci-cd-access-key \
+        --secret AWS_SECRET_ACCESS_KEY=aws/ci-cd-access-secret \
+        --mount=type=tmpfs,target=/tmp/earthly \
+        --privileged \
+        --entrypoint \
+        --mount=type=tmpfs,target=/tmp/earthly
+
 test:
     BUILD +test-dockerhub
     BUILD +test-ecr
     BUILD +test-gcp
+    BUILD +test-multi

--- a/tests/registry-command/test-multi.sh
+++ b/tests/registry-command/test-multi.sh
@@ -1,0 +1,80 @@
+#!/bin/sh
+set -ex
+
+# WARNING -- RACE-CONDITION: this test is not thread-safe (since it makes use of a shared user's secrets)
+# the lock.sh and unlock.sh scripts must first be run
+
+./lock.sh
+
+finish() {
+  status="$?"
+  ./unlock.sh
+  if [ "$status" = "0" ]; then
+    echo "$0 passed"
+  else
+    echo "$0 failed with $status"
+  fi
+}
+trap finish EXIT
+
+
+# ECR details
+export ECR_REGISTRY_HOST="404851345508.dkr.ecr.us-west-2.amazonaws.com"
+
+# Google artifact registry details
+export GCP_SERVER="us-west1-docker.pkg.dev"
+export GCP_FULL_ADDRESS="$GCP_SERVER/ci-cd-302220"
+export IMAGE="integration-test/test"
+
+clearusersecrets() {
+    earthly secrets ls /user/std/ | xargs -r -n 1 earthly secrets rm
+}
+
+# clear out secrets from previous test
+clearusersecrets
+
+
+echo "Setting up ECR credentials"
+set +x # don't remove, or keys will be leaked
+test -n "$AWS_ACCESS_KEY_ID" || (echo "AWS_ACCESS_KEY_ID is empty" && exit 1)
+test -n "$AWS_SECRET_ACCESS_KEY" || (echo "AWS_SECRET_ACCESS_KEY is empty" && exit 1)
+set -x
+earthly registry setup --cred-helper=ecr-login "$ECR_REGISTRY_HOST"
+
+echo "Setting up GCP credentials"
+set +x # don't remove, or keys will be leaked
+test -n "$GCP_KEY" || (echo "GCP_KEY is empty" && exit 1)
+export GCP_SERVICE_ACCOUNT_KEY="$GCP_KEY" # registry setup reads from this env
+set -x
+earthly registry setup --cred-helper=gcloud "$GCP_SERVER"
+
+
+echo "done setting up cred helper (and secrets)"
+
+earthly registry list | grep "$ECR_REGISTRY_HOST"
+earthly registry list | grep "$GCP_SERVER"
+
+cat > Earthfile <<EOF
+VERSION 0.7
+pull-dockerhub:
+  FROM earthly/rot13
+  RUN which ncat # installed on earthly/rot13
+
+pull-ecr:
+  FROM $ECR_REGISTRY_HOST/integration-test:latest
+  RUN test -f /etc/passwd
+
+pull-gcp:
+  FROM $GCP_FULL_ADDRESS/$IMAGE:latest
+  RUN test -f /etc/passwd
+
+pull:
+  BUILD +pull-dockerhub
+  BUILD +pull-ecr
+  BUILD +pull-gcp
+EOF
+
+earthly --config "$earthly_config" --verbose +pull
+
+# clear out secrets (just in case project-based registry accidentally uses user-based)
+clearusersecrets

--- a/util/llbutil/authprovider/authprovider.go
+++ b/util/llbutil/authprovider/authprovider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/auth"
@@ -16,58 +17,126 @@ var ErrAuthProviderNoResponse = fmt.Errorf("AuthServerNoResponse")
 
 func NewAuthProvider(authServers []auth.AuthServer) session.Attachable {
 	return &authProvider{
-		authServers: authServers,
+		authServers:     authServers,
+		foundAuthServer: map[string]auth.AuthServer{},
+		skipAuthServer:  map[string][]auth.AuthServer{},
 	}
 }
 
 type authProvider struct {
 	authServers []auth.AuthServer
+
+	mu sync.Mutex
+
+	// once an authServer has responded succcessfully, only that auth server will be used
+	// for all subsequent calls -- this is to prevent accidentally mixing credentials and using them inconsistently
+	foundAuthServer map[string]auth.AuthServer
+
+	// if an authServer returns a ErrAuthProviderNoResponse, dont call it again for this host
+	skipAuthServer map[string][]auth.AuthServer
 }
 
 func (ap *authProvider) Register(server *grpc.Server) {
 	auth.RegisterAuthServer(server, ap)
 }
 
-func (ap *authProvider) FetchToken(ctx context.Context, req *auth.FetchTokenRequest) (rr *auth.FetchTokenResponse, err error) {
+func (ap *authProvider) getAuthServers(host string) []auth.AuthServer {
+	as, ok := ap.foundAuthServer[host]
+	if ok {
+		return []auth.AuthServer{as}
+	}
+	res := []auth.AuthServer{}
 	for _, as := range ap.authServers {
-		a, err := as.FetchToken(ctx, req)
-		if errors.Is(err, ErrAuthProviderNoResponse) {
-			continue
+		if !ap.shouldSkip(host, as) {
+			res = append(res, as)
 		}
-		return a, err
+	}
+	return res
+}
+func (ap *authProvider) setSkipAuthServer(host string, as auth.AuthServer) {
+	if ap.shouldSkip(host, as) {
+		return // already exists in skip list
+	}
+	ap.skipAuthServer[host] = append(ap.skipAuthServer[host], as)
+}
+
+func (ap *authProvider) shouldSkip(host string, as auth.AuthServer) bool {
+	for _, x := range ap.skipAuthServer[host] {
+		if x == as {
+			return true
+		}
+	}
+	return false
+}
+
+func (ap *authProvider) FetchToken(ctx context.Context, req *auth.FetchTokenRequest) (rr *auth.FetchTokenResponse, err error) {
+	ap.mu.Lock()
+	defer ap.mu.Unlock()
+	for _, as := range ap.getAuthServers(req.Host) {
+		a, err := as.FetchToken(ctx, req)
+		if err != nil {
+			if errors.Is(err, ErrAuthProviderNoResponse) {
+				ap.setSkipAuthServer(req.Host, as)
+				continue
+			}
+			return nil, err
+		}
+		ap.foundAuthServer[req.Host] = as
+		return a, nil
 	}
 	return nil, status.Errorf(codes.Unavailable, "no configured auth servers in the list of client-side configs responded")
 }
 
 func (ap *authProvider) Credentials(ctx context.Context, req *auth.CredentialsRequest) (*auth.CredentialsResponse, error) {
-	for _, as := range ap.authServers {
+	ap.mu.Lock()
+	defer ap.mu.Unlock()
+	for _, as := range ap.getAuthServers(req.Host) {
 		a, err := as.Credentials(ctx, req)
-		if errors.Is(err, ErrAuthProviderNoResponse) {
-			continue
+		if err != nil {
+			if errors.Is(err, ErrAuthProviderNoResponse) {
+				ap.setSkipAuthServer(req.Host, as)
+				continue
+			}
+			return nil, err
 		}
-		return a, err
+		ap.foundAuthServer[req.Host] = as
+		return a, nil
 	}
 	return nil, status.Errorf(codes.Unavailable, "no configured auth servers in the list of client-side configs responded")
 }
 
 func (ap *authProvider) GetTokenAuthority(ctx context.Context, req *auth.GetTokenAuthorityRequest) (*auth.GetTokenAuthorityResponse, error) {
-	for _, as := range ap.authServers {
+	ap.mu.Lock()
+	defer ap.mu.Unlock()
+	for _, as := range ap.getAuthServers(req.Host) {
 		a, err := as.GetTokenAuthority(ctx, req)
-		if errors.Is(err, ErrAuthProviderNoResponse) {
-			continue
+		if err != nil {
+			if errors.Is(err, ErrAuthProviderNoResponse) {
+				ap.setSkipAuthServer(req.Host, as)
+				continue
+			}
+			return nil, err
 		}
-		return a, err
+		ap.foundAuthServer[req.Host] = as
+		return a, nil
 	}
 	return nil, status.Errorf(codes.Unavailable, "no configured auth servers in the list of client-side configs responded")
 }
 
 func (ap *authProvider) VerifyTokenAuthority(ctx context.Context, req *auth.VerifyTokenAuthorityRequest) (*auth.VerifyTokenAuthorityResponse, error) {
-	for _, as := range ap.authServers {
+	ap.mu.Lock()
+	defer ap.mu.Unlock()
+	for _, as := range ap.getAuthServers(req.Host) {
 		a, err := as.VerifyTokenAuthority(ctx, req)
-		if errors.Is(err, ErrAuthProviderNoResponse) {
-			continue
+		if err != nil {
+			if errors.Is(err, ErrAuthProviderNoResponse) {
+				ap.setSkipAuthServer(req.Host, as)
+				continue
+			}
+			return nil, err
 		}
-		return a, err
+		ap.foundAuthServer[req.Host] = as
+		return a, nil
 	}
 	return nil, status.Errorf(codes.Unavailable, "no configured auth servers in the list of client-side configs responded")
 }


### PR DESCRIPTION
Once an authprovider responds for a specific host, only subsequent requests should be sent to that authprovider; similarlly if an authserver has responded with ErrAuthProviderNoResponse (indicating it doesnt have credentials) it shouldn't be requeried for credentials.