### PR TITLE
Configure Buildkit Session Timeout

### DIFF
--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -12,7 +12,7 @@ buildkitd:
             ARG BUILDKIT_BASE_IMAGE=$BUILDKIT_PROJECT+build
         END
     ELSE
-        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:5bcd24917b40a55bbeb4752604ca6863ad384283+build
+        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:3e28920475eb5b6ca3f9643fd5df7b9c784e470c+build
     END
     ARG EARTHLY_TARGET_TAG_DOCKER
     ARG TAG="dev-$EARTHLY_TARGET_TAG_DOCKER"

--- a/buildkitd/entrypoint.sh
+++ b/buildkitd/entrypoint.sh
@@ -227,11 +227,18 @@ export TLS_ENABLED
 
 envsubst </etc/buildkitd.toml.template >/etc/buildkitd.toml
 
-# Set up session history, if requested
+# Session history is 1h by default unless otherwise specified
 if [ -z "$BUILDKIT_SESSION_HISTORY_DURATION" ]; then
   BUILDKIT_SESSION_HISTORY_DURATION="1h"
 fi
 export BUILDKIT_SESSION_HISTORY_DURATION
+
+# Session timeout will automatically cancel builds that run for too long
+# Configured to 1 day by default unless otherwise specified
+if [ -z "$BUILDKIT_SESSION_TIMEOUT" ]; then
+  BUILDKIT_SESSION_TIMEOUT="24h"
+fi
+export BUILDKIT_SESSION_TIMEOUT
 
 # Set up OOM
 OOM_SCORE_ADJ="${BUILDKIT_OOM_SCORE_ADJ:-0}"

--- a/go.mod
+++ b/go.mod
@@ -137,6 +137,6 @@ replace (
 	github.com/jdxcode/netrc => github.com/mikejholly/netrc v0.0.0-20221121193719-a154cb29ec2a
 	github.com/jessevdk/go-flags => github.com/alexcb/go-flags v0.0.0-20210722203016-f11d7ecb5ee5
 
-	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.0-20230608234240-5bcd24917b40
+	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.0-20230616140114-3e28920475eb
 	github.com/tonistiigi/fsutil => github.com/earthly/fsutil v0.0.0-20230530182746-82567e6e2a92
 )

--- a/go.sum
+++ b/go.sum
@@ -167,8 +167,8 @@ github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
-github.com/earthly/buildkit v0.0.0-20230608234240-5bcd24917b40 h1:SYCML5hTtXgtUIzLAoycAvwwJbpVDGLC6xHZiUxh2dQ=
-github.com/earthly/buildkit v0.0.0-20230608234240-5bcd24917b40/go.mod h1:O3Wy78M7g6gs8FvwGcdNd1q+QSJaCw2Pc9k/EWZ6hL0=
+github.com/earthly/buildkit v0.0.0-20230616140114-3e28920475eb h1:oi3McGm4YnlKSiToVFGZR0EsoYWvZj6T4eo045jgka0=
+github.com/earthly/buildkit v0.0.0-20230616140114-3e28920475eb/go.mod h1:O3Wy78M7g6gs8FvwGcdNd1q+QSJaCw2Pc9k/EWZ6hL0=
 github.com/earthly/cloud-api v1.0.1-0.20230509135033-ab3df26f706b h1:mBt64zr6Be12ERlA98uS6mvd/jcik/FFoVKWBs2hfJ0=
 github.com/earthly/cloud-api v1.0.1-0.20230509135033-ab3df26f706b/go.mod h1:rU/tYJ7GFBjdKAITV2heDbez++glpGSbtJaZcp73rNI=
 github.com/earthly/fsutil v0.0.0-20230530182746-82567e6e2a92 h1:dy3w3B4OiDyQS+iHi/beUgMDJ1+fAAgbtr7OZ0d9ks0=


### PR DESCRIPTION
This will automatically cancel builds that have run for longer than the configured timeout. Set to 24 hours by default (I think this reasonable, but up for debate).

<img width="788" alt="Screen Shot 2023-06-14 at 4 22 25 PM" src="https://github.com/earthly/earthly/assets/3247216/1a4eff01-25be-4fb9-b77d-70c77a633ca7">
