### PR TITLE
Remove default size in satellite launch

### DIFF
--- a/cmd/earthly/satellite_cmds.go
+++ b/cmd/earthly/satellite_cmds.go
@@ -43,7 +43,6 @@ func (app *earthlyApp) satelliteCmds() []*cli.Command {
 					Name:        "size",
 					Usage:       "The size of the satellite. See https://earthly.dev/pricing for details on each size. Supported values: xsmall, small, medium, large, xlarge.",
 					Required:    false,
-					Value:       cloud.SatelliteSizeMedium,
 					Destination: &app.satelliteSize,
 				},
 				&cli.StringSliceFlag{


### PR DESCRIPTION
This will now be determined by the backend when size is empty. The defaults are small for free tier, medium for paid tiers.

It is especially important to remove this for free tier users, as it will cause errors with it set to medium by default since their plan doesn't allow that size.