### PR TITLE
authprovider: invalidate cache when AddProject is called

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -24,7 +24,6 @@ import (
 	"github.com/earthly/earthly/util/gatewaycrafter"
 	"github.com/earthly/earthly/util/gwclientlogger"
 	"github.com/earthly/earthly/util/llbutil"
-	"github.com/earthly/earthly/util/llbutil/authprovider/cloudauth"
 	"github.com/earthly/earthly/util/llbutil/pllb"
 	"github.com/earthly/earthly/util/llbutil/secretprovider"
 	"github.com/earthly/earthly/util/platutil"
@@ -88,6 +87,10 @@ type Opt struct {
 	GitLogLevel                           llb.GitLogLevel
 }
 
+type ProjectAdder interface {
+	AddProject(org, project string)
+}
+
 // BuildOpt is a collection of build options.
 type BuildOpt struct {
 	PlatformResolver           *platutil.Resolver
@@ -106,7 +109,7 @@ type BuildOpt struct {
 	Logbus                     *logbus.Bus
 	MainTargetDetailsFunc      func(earthfile2llb.TargetDetails) error
 	Runner                     string
-	CloudStoredAuthProvider    cloudauth.ProjectBasedAuthProvider
+	ProjectAdder               ProjectAdder
 	EarthlyCIRunner            bool
 }
 
@@ -221,7 +224,7 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 				Logbus:                               opt.Logbus,
 				MainTargetDetailsFunc:                opt.MainTargetDetailsFunc,
 				Runner:                               opt.Runner,
-				CloudStoredAuthProvider:              opt.CloudStoredAuthProvider,
+				ProjectAdder:                         opt.ProjectAdder,
 			}
 			mts, err = earthfile2llb.Earthfile2LLB(childCtx, target, opt, true)
 			if err != nil {

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -1553,7 +1553,7 @@ func (c *Converter) Project(ctx context.Context, org, project string) error {
 	c.nonSaveCommand()
 	c.varCollection.SetOrg(org)
 	c.varCollection.SetProject(project)
-	c.opt.CloudStoredAuthProvider.AddProject(org, project)
+	c.opt.ProjectAdder.AddProject(org, project)
 	return nil
 }
 

--- a/earthfile2llb/earthfile2llb.go
+++ b/earthfile2llb/earthfile2llb.go
@@ -13,7 +13,6 @@ import (
 	"github.com/earthly/earthly/states"
 	"github.com/earthly/earthly/util/containerutil"
 	"github.com/earthly/earthly/util/gatewaycrafter"
-	"github.com/earthly/earthly/util/llbutil/authprovider/cloudauth"
 	"github.com/earthly/earthly/util/llbutil/secretprovider"
 	"github.com/earthly/earthly/util/platutil"
 	"github.com/earthly/earthly/util/syncutil/semutil"
@@ -24,6 +23,10 @@ import (
 	"github.com/moby/buildkit/util/apicaps"
 	"github.com/pkg/errors"
 )
+
+type ProjectAdder interface {
+	AddProject(org, proj string)
+}
 
 // ConvertOpt holds conversion parameters.
 type ConvertOpt struct {
@@ -170,7 +173,7 @@ type ConvertOpt struct {
 	// * "sat:<org-name>/<sat-name>" - remote builds via satellite
 	Runner string
 
-	CloudStoredAuthProvider cloudauth.ProjectBasedAuthProvider
+	ProjectAdder ProjectAdder
 }
 
 // TargetDetails contains details about the target being built.

--- a/util/llbutil/authprovider/doc.go
+++ b/util/llbutil/authprovider/doc.go
@@ -1,0 +1,3 @@
+//go:generate hel --output helheim_mocks_test.go
+
+package authprovider

--- a/util/llbutil/authprovider/imports_test.go
+++ b/util/llbutil/authprovider/imports_test.go
@@ -1,8 +1,15 @@
 package authprovider_test
 
 import (
+	"time"
+
 	"git.sr.ht/~nelsam/hel/pkg/pers"
 	"github.com/poy/onpar/matchers"
+)
+
+const (
+	timeout     = time.Second
+	mockTimeout = 5 * time.Second
 )
 
 var (
@@ -12,6 +19,7 @@ var (
 	equal        = matchers.Equal
 	beClosed     = matchers.BeClosed
 	matchRegexp  = matchers.MatchRegexp
+	beNil        = matchers.BeNil
 
 	haveMethodExecuted = pers.HaveMethodExecuted
 	within             = pers.Within

--- a/util/llbutil/authprovider/multiauthprovider_test.go
+++ b/util/llbutil/authprovider/multiauthprovider_test.go
@@ -1,0 +1,174 @@
+package authprovider_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"git.sr.ht/~nelsam/hel/pkg/pers"
+	"github.com/earthly/earthly/util/llbutil/authprovider"
+	"github.com/moby/buildkit/session/auth"
+	"github.com/poy/onpar"
+	"github.com/poy/onpar/expect"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestMultiAuth(t *testing.T) {
+	type testCtx struct {
+		*testing.T
+		expect   expect.Expectation
+		children []*mockChild
+		multi    *authprovider.MultiAuthProvider
+	}
+
+	o := onpar.BeforeEach(onpar.New(t), func(t *testing.T) testCtx {
+		children := []*mockChild{
+			newMockChild(t, mockTimeout),
+			newMockChild(t, mockTimeout),
+		}
+		var srv []authprovider.Child
+		for _, c := range children {
+			srv = append(srv, c)
+		}
+		return testCtx{
+			T:        t,
+			expect:   expect.New(t),
+			children: children,
+			multi:    authprovider.New(srv),
+		}
+	})
+	defer o.Run()
+
+	type fetchResult struct {
+		resp *auth.FetchTokenResponse
+		err  error
+	}
+
+	o.Spec("it calls child ProjectAdders", func(t testCtx) {
+		type projectProvider struct {
+			*mockChild
+			*mockProjectAdder
+		}
+		p := projectProvider{
+			mockChild:        newMockChild(t, mockTimeout),
+			mockProjectAdder: newMockProjectAdder(t, mockTimeout),
+		}
+		t.multi = authprovider.New([]authprovider.Child{p})
+		t.multi.AddProject("foo", "bar")
+		t.expect(p.mockProjectAdder).To(haveMethodExecuted("AddProject", withArgs("foo", "bar")))
+	})
+
+	o.Spec("it does not continue to contact servers with no credentials for a given host", func(t testCtx) {
+		const host = "foo.bar"
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+
+		res := make(chan fetchResult)
+		go func() {
+			resp, err := t.multi.FetchToken(ctx, &auth.FetchTokenRequest{Host: host})
+			res <- fetchResult{resp, err}
+		}()
+
+		for _, c := range t.children {
+			t.expect(c).To(haveMethodExecuted(
+				"FetchToken",
+				within(timeout),
+				withArgs(pers.Any, equal(&auth.FetchTokenRequest{Host: host})),
+				returning(nil, authprovider.ErrAuthProviderNoResponse),
+			))
+		}
+
+		select {
+		case result := <-res:
+			t.expect(result.resp).To(beNil())
+			t.expect(status.Code(result.err)).To(equal(codes.Unavailable))
+		case <-time.After(timeout):
+			t.Fatal("timed out waiting for FetchToken to return")
+		}
+
+		go func() {
+			resp, err := t.multi.FetchToken(ctx, &auth.FetchTokenRequest{Host: host})
+			res <- fetchResult{resp, err}
+		}()
+
+		for _, c := range t.children {
+			t.expect(c).To(not(haveMethodExecuted(
+				"FetchToken",
+				within(10*time.Millisecond),
+			)))
+		}
+
+		select {
+		case result := <-res:
+			t.expect(result.resp).To(beNil())
+			t.expect(status.Code(result.err)).To(equal(codes.Unavailable))
+		case <-time.After(timeout):
+			t.Fatal("timed out waiting for FetchToken to return")
+		}
+	})
+
+	o.Spec("it resets its knowledge of which servers it should contact after a project is added", func(t testCtx) {
+		const host = "foo.bar"
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+
+		res := make(chan fetchResult)
+		go func() {
+			resp, err := t.multi.FetchToken(ctx, &auth.FetchTokenRequest{Host: host})
+			res <- fetchResult{resp, err}
+		}()
+
+		for i, c := range t.children {
+			ret := []any{
+				nil,
+				authprovider.ErrAuthProviderNoResponse,
+			}
+			if i == len(t.children)-1 {
+				// ensure one child responds so that we can prove that
+				// successful results are also cache-busted.
+				ret = []any{
+					&auth.FetchTokenResponse{},
+					nil,
+				}
+			}
+			t.expect(c).To(haveMethodExecuted(
+				"FetchToken",
+				within(timeout),
+				withArgs(pers.Any, equal(&auth.FetchTokenRequest{Host: host})),
+				returning(ret...),
+			))
+		}
+
+		select {
+		case result := <-res:
+			t.expect(status.Code(result.err)).To(not(haveOccurred()))
+		case <-time.After(timeout):
+			t.Fatal("timed out waiting for FetchToken to return")
+		}
+
+		t.multi.AddProject("foo", "bar")
+
+		go func() {
+			resp, err := t.multi.FetchToken(ctx, &auth.FetchTokenRequest{Host: host})
+			res <- fetchResult{resp, err}
+		}()
+
+		for _, c := range t.children {
+			t.expect(c).To(haveMethodExecuted(
+				"FetchToken",
+				within(timeout),
+				withArgs(pers.Any, equal(&auth.FetchTokenRequest{Host: host})),
+				returning(nil, authprovider.ErrAuthProviderNoResponse),
+			))
+		}
+
+		select {
+		case result := <-res:
+			t.expect(result.resp).To(beNil())
+			t.expect(status.Code(result.err)).To(equal(codes.Unavailable))
+		case <-time.After(timeout):
+			t.Fatal("timed out waiting for FetchToken to return")
+		}
+	})
+}

--- a/util/llbutil/authprovider/podman.go
+++ b/util/llbutil/authprovider/podman.go
@@ -1,5 +1,3 @@
-//go:generate hel --output helheim_mocks_test.go
-
 package authprovider
 
 import (

--- a/util/llbutil/authprovider/podman_test.go
+++ b/util/llbutil/authprovider/podman_test.go
@@ -19,9 +19,6 @@ import (
 )
 
 const (
-	timeout     = time.Second
-	mockTimeout = 5 * time.Second
-
 	authFmt = `
 {
   "auths": {


### PR DESCRIPTION
Part of the improvements in PR #3026 was a form of caching authproviders that don't have any credentials configured for a given host. This did not account for the project being set *after* the first attempt at loading credentials.

This commit updates the aggregated authprovider to invalidate its cache of per-host child auth providers when AddProject is called.