### PR TITLE
Implement `org select` command

### DIFF
--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -557,6 +557,9 @@ func (app *earthlyApp) before(cliCtx *cli.Context) error {
 		}
 	}
 
+	if !cliCtx.IsSet("org") {
+		app.orgName = app.cfg.Global.Org
+	}
 	return nil
 }
 
@@ -613,6 +616,11 @@ func (app *earthlyApp) processDeprecatedCommandOptions(cliCtx *cli.Context, cfg 
 			}
 			cfg.Git[k] = v
 		}
+	}
+
+	if cfg.Satellite.Org != "" {
+		app.console.Warnf("Warning: the setting global.satellite.org is deprecated. Please use 'earthly config global.org <my-id>' instead")
+		cfg.Global.Org = cfg.Satellite.Org
 	}
 
 	return nil

--- a/cmd/earthly/root_cmds.go
+++ b/cmd/earthly/root_cmds.go
@@ -128,9 +128,10 @@ func (app *earthlyApp) rootCmds() []*cli.Command {
 			},
 		},
 		{
-			Name:        "org",
-			Aliases:     []string{"orgs"},
-			Usage:       "Earthly organization administration *beta*",
+			Name:    "org",
+			Aliases: []string{"orgs"},
+			Usage:   "Earthly organization administration *beta*",
+			//Before:      subcommandBefore(app.setupOrgName),
 			Subcommands: app.orgCmds(),
 		},
 		{
@@ -265,6 +266,7 @@ Set up a whole custom git repository for a server called example.com, using a si
 				"	If you'd like to try it out, please contact us at support@earthly.dev or by visiting https://earthly.dev/slack.",
 			UsageText:   "earthly satellite (launch|ls|inspect|select|unselect|rm)",
 			Description: "Create and manage Earthly Satellites *beta*",
+			//Before:      subcommandBefore(app.setupOrgName),
 			Flags: []cli.Flag{
 				&cli.StringFlag{
 					Name:        "org",
@@ -282,6 +284,7 @@ Set up a whole custom git repository for a server called example.com, using a si
 			Description: "Manage Earthly projects *beta*",
 			Usage:       "Manage Earthly projects *beta*",
 			UsageText:   "earthly project (ls|rm|create|member)",
+			//Before:      subcommandBefore(app.setupOrgName),
 			Flags: []cli.Flag{
 				&cli.StringFlag{
 					Name:        "org",
@@ -306,6 +309,7 @@ Set up a whole custom git repository for a server called example.com, using a si
 			Aliases:     []string{"secrets"},
 			Description: "Manage cloud secrets *beta*",
 			Usage:       "Manage cloud secrets *beta*",
+			//Before:      subcommandBefore(app.setupOrgName),
 			Flags: []cli.Flag{
 				&cli.StringFlag{
 					Name:        "org",
@@ -329,6 +333,7 @@ Set up a whole custom git repository for a server called example.com, using a si
 			Aliases:     []string{"registries"},
 			Description: "Manage registry access *beta*",
 			Usage:       "Manage registry access *beta*",
+			//Before:      subcommandBefore(app.setupOrgName),
 			Flags: []cli.Flag{
 				&cli.StringFlag{
 					Name:        "org",

--- a/cmd/earthly/satellite_cmds.go
+++ b/cmd/earthly/satellite_cmds.go
@@ -220,11 +220,6 @@ func (app *earthlyApp) useSatellite(cliCtx *cli.Context, satelliteName, orgName 
 	// Update in-place so we can use it later, assuming the config change was successful.
 	app.cfg.Satellite.Name = satelliteName
 
-	newConfig, err = config.Upsert(newConfig, "satellite.org", orgName)
-	if err != nil {
-		return errors.Wrap(err, "could not update satellite name")
-	}
-	app.cfg.Satellite.Org = orgName
 	err = config.WriteConfigFile(app.configPath, newConfig)
 	if err != nil {
 		return errors.Wrap(err, "could not save config")

--- a/config/config.go
+++ b/config/config.go
@@ -84,6 +84,7 @@ type GlobalConfig struct {
 	DisableLogSharing          bool     `yaml:"disable_log_sharing"            help:"Disable cloud log sharing when logged in with an Earthly account, see https://ci.earthly.dev for details."`
 	SecretProvider             string   `yaml:"secret_provider"                help:"Command to execute to retrieve secret."`
 	GitImage                   string   `yaml:"git_image"                      help:"Image used to resolve git repositories"`
+	Org                        string   `yaml:"org"                            help:"The currently selected argument. Overridden by the EARTHLY_ORG environment variable, or the CLI --org options, in that order."`
 
 	// Obsolete.
 	CachePath      string `yaml:"cache_path"         help:" *Deprecated* The path to keep Earthly's cache."`
@@ -99,7 +100,7 @@ type GitConfig struct {
 	Auth                  string `yaml:"auth"                         help:"What authentication method do you use? Valid options are: http, https, ssh."` // http, https, ssh
 	User                  string `yaml:"user"                         help:"The username to use when auth is set to git or https."`
 	Port                  int    `yaml:"port"                         help:"The port to connect to when using git; has no effect for http(s)."`
-	Prefix                string `yaml:"prefix"                  help:"This path is prefixed to the git clone url, e.g. ssh://user@host:port/prefix/project/repo.git"`
+	Prefix                string `yaml:"prefix"                       help:"This path is prefixed to the git clone url, e.g. ssh://user@host:port/prefix/project/repo.git"`
 	Password              string `yaml:"password"                     help:"The https password to use when auth is set to https. This setting is ignored when auth is ssh."`
 	ServerKey             string `yaml:"serverkey"                    help:"SSH fingerprints, like you would add in your known hosts file, or get from ssh-keyscan."`
 	StrictHostKeyChecking *bool  `yaml:"strict_host_key_checking"     help:"Allow ssh access to hosts with unknown server keys (e.g. no entries in known_hosts), defaults to true."`
@@ -108,7 +109,7 @@ type GitConfig struct {
 // Satellite contains satellite config values
 type Satellite struct {
 	Name string `yaml:"name" help:"The name of the satellite to use"`
-	Org  string `yaml:"org"  help:"The org name to whom the satellite belongs"`
+	Org  string `yaml:"org"  help:"*Deprecated* The org name to whom the satellite belongs"`
 }
 
 // Config contains user's configuration values from ~/earthly/config.yml


### PR DESCRIPTION
Implement `org select`. This provides a default org in the config file that can be used when either the CLI `--org` is not provided, or when the `EARTHLY_ORG` environment variable is not set.

Unify org selection across Satellites and other commands.