### PR TITLE
Unbreak builds from artifacts

### DIFF
--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -327,7 +327,7 @@ func (c *Converter) FromDockerfile(ctx context.Context, contextPath string, dfPa
 		}
 		copyState, err := llbutil.CopyOp(ctx,
 			mts.Final.ArtifactsState, []string{contextArtifact.Artifact},
-			c.platr.Scratch(), "/", true, true, false, "", nil, false, false,
+			c.platr.Scratch(), "/", true, true, false, "", nil, false, true,
 			c.ftrs.UseCopyLink,
 			llb.WithCustomNamef(
 				"%sFROM DOCKERFILE (copy build context from) %s%s",


### PR DESCRIPTION
Currently builds from artefacts that contain symlinks that point to non-existing files fail.

This patch disables the "follow symlink" option of the copy command, resolving the problem.