### PR TITLE
Misleading issues when Docker is not running

### DIFF
--- a/buildkitd/buildkitd.go
+++ b/buildkitd/buildkitd.go
@@ -77,7 +77,6 @@ func NewClient(ctx context.Context, console conslogging.ConsoleLogger, image, co
 	if err != nil {
 		return nil, errors.Wrap(err, "add required client opts")
 	}
-
 	isLocal := containerutil.IsLocal(settings.BuildkitAddress)
 	if !isLocal {
 		remoteConsole := console

--- a/cmd/earthly/build_cmd.go
+++ b/cmd/earthly/build_cmd.go
@@ -38,18 +38,6 @@ import (
 	"github.com/earthly/earthly/util/syncutil/semutil"
 	"github.com/earthly/earthly/util/termutil"
 	"github.com/earthly/earthly/variables"
-	"github.com/fatih/color"
-	"github.com/joho/godotenv"
-	"github.com/moby/buildkit/client/llb"
-	"github.com/moby/buildkit/session"
-	"github.com/moby/buildkit/session/auth"
-	dockerauthprovider "github.com/moby/buildkit/session/auth/authprovider"
-	"github.com/moby/buildkit/session/localhost/localhostprovider"
-	"github.com/moby/buildkit/session/socketforward/socketprovider"
-	"github.com/moby/buildkit/session/sshforward/sshprovider"
-	"github.com/moby/buildkit/util/entitlements"
-	"github.com/pkg/errors"
-	"github.com/urfave/cli/v2"
 )
 
 func (app *earthlyApp) actionBuild(cliCtx *cli.Context) error {
@@ -272,6 +260,12 @@ func (app *earthlyApp) actionBuildImp(cliCtx *cli.Context, flagArgs, nonFlagArgs
 	err = app.configureSatellite(cliCtx, cloudClient, gitCommitAuthor, gitConfigEmail)
 	if err != nil {
 		return errors.Wrapf(err, "could not configure satellite")
+	}
+
+	// After configuring frontend and satellites, buildkit address should not be empty.
+	// It should be set to a local container, remote address, or satellite address at this point.
+	if app.buildkitdSettings.BuildkitAddress == "" {
+		return errors.New("could not determine buildkit address - is Docker or Podman running?")
 	}
 
 	var runnerName string

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -448,7 +448,7 @@ func (app *earthlyApp) parseFrontend(cliCtx *cli.Context, cfg *config.Config) er
 		app.containerFrontend = stub
 
 		if !app.verbose {
-			console.Printf("No frontend initialized. Use --verbose to see details\n")
+			console.Printf("No frontend initialized. Docker or Podman not detected or had errors. Use --verbose to see details\n")
 		}
 		console.VerbosePrintf("%s frontend initialization failed due to %s", app.cfg.Global.ContainerFrontend, origErr.Error())
 		return nil

--- a/cmd/earthly/org_cmds.go
+++ b/cmd/earthly/org_cmds.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"github.com/earthly/earthly/config"
 	"os"
 	"strings"
 	"text/tabwriter"
@@ -11,6 +10,7 @@ import (
 	"github.com/urfave/cli/v2"
 
 	"github.com/earthly/earthly/cloud"
+	"github.com/earthly/earthly/config"
 )
 
 func (app *earthlyApp) orgCmds() []*cli.Command {
@@ -120,12 +120,14 @@ func (app *earthlyApp) orgCmds() []*cli.Command {
 			Name:      "select",
 			Usage:     "Select the default organization *beta*",
 			UsageText: "earthly [options] org select <org-name>",
+			Aliases:   []string{"s"},
 			Action:    app.actionOrgSelect,
 		},
 		{
 			Name:      "unselect",
 			Usage:     "Unselects the default organization *beta*",
 			UsageText: "earthly [options] org select <org-name>",
+			Aliases:   []string{"uns"},
 			Action:    app.actionOrgUnselect,
 		},
 	}

--- a/cmd/earthly/satellite_cmds.go
+++ b/cmd/earthly/satellite_cmds.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/dustin/go-humanize"
 	"math/rand"
 	"os"
 	"strings"
 	"text/tabwriter"
 	"time"
 
+	"github.com/dustin/go-humanize"
 	"github.com/fatih/color"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"
@@ -404,6 +404,14 @@ func (app *earthlyApp) getSatelliteOrg(ctx context.Context, cloudClient *cloud.C
 		}
 		return app.orgName, orgID, nil
 	}
+	if orgName = app.cfg.Global.Org; orgName != "" {
+		g
+		orgID, err = cloudClient.GetOrgID(ctx, orgName)
+		if err != nil {
+			return "", "", errors.Wrapf(err, "failed resolving ID for org '%s'", orgName)
+		}
+		return orgName, orgID, nil
+	}
 	orgName, orgID, err = cloudClient.GuessOrgMembership(ctx)
 	if err != nil {
 		return "", "", errors.Wrap(err, "could not guess default org")
@@ -506,7 +514,7 @@ func (app *earthlyApp) actionSatelliteLaunch(cliCtx *cli.Context) error {
 
 	app.console.Printf("Launching Satellite %q with auto-updates set to run at %s (%s)\n",
 		app.satelliteName, localWindow, zone)
-	app.console.Printf("Please wait...\n")
+	app.console.Printf("This may take a few minutes...\n")
 
 	err = cloudClient.LaunchSatellite(cliCtx.Context, cloud.LaunchSatelliteOpt{
 		Name:                    app.satelliteName,
@@ -617,7 +625,7 @@ func (app *earthlyApp) actionSatelliteRemove(cliCtx *cli.Context) error {
 		return fmt.Errorf("could not find %q for deletion", app.satelliteName)
 	}
 
-	app.console.Printf("Destroying Satellite %q. This could take a moment...\n", app.satelliteName)
+	app.console.Printf("Destroying Satellite %q. This may take a few minutes...\n", app.satelliteName)
 	err = cloudClient.DeleteSatellite(cliCtx.Context, app.satelliteName, orgName)
 	if err != nil {
 		if errors.Is(err, context.Canceled) {

--- a/cmd/earthly/satellite_cmds.go
+++ b/cmd/earthly/satellite_cmds.go
@@ -405,7 +405,6 @@ func (app *earthlyApp) getSatelliteOrg(ctx context.Context, cloudClient *cloud.C
 		return app.orgName, orgID, nil
 	}
 	if orgName = app.cfg.Global.Org; orgName != "" {
-		g
 		orgID, err = cloudClient.GetOrgID(ctx, orgName)
 		if err != nil {
 			return "", "", errors.Wrapf(err, "failed resolving ID for org '%s'", orgName)


### PR DESCRIPTION
A user reported issues with misleading errors and hanging when trying to run a local build with no Docker daemon.

This now shows the following in that case:
<img width="970" alt="Screen Shot 2023-07-12 at 3 21 43 PM" src="https://github.com/earthly/earthly/assets/3247216/8ba83fa7-5263-40ac-82c1-ae6cc8583d03">

However, if using satellites without docker running, the connection still works:
<img width="970" alt="Screen Shot 2023-07-12 at 3 22 21 PM" src="https://github.com/earthly/earthly/assets/3247216/5792df70-65c2-4593-9a34-2496378647bd">

Same with remote buildkit:
<img width="970" alt="Screen Shot 2023-07-12 at 3 23 20 PM" src="https://github.com/earthly/earthly/assets/3247216/4bd3be7e-ce0a-4440-957d-85d6f947d3bd">

I didn't test Podman, however, I assume we should have a buildkit address set to something similar as with docker in that case. 