### PR TITLE
Misleading issues when Docker is not running 

### DIFF
--- a/cmd/earthly/build_cmd.go
+++ b/cmd/earthly/build_cmd.go
@@ -274,6 +274,12 @@ func (app *earthlyApp) actionBuildImp(cliCtx *cli.Context, flagArgs, nonFlagArgs
 		return errors.Wrapf(err, "could not configure satellite")
 	}
 
+	// After configuring frontend and satellites, buildkit address should not be empty.
+	// It should be set to a local container, remote address, or satellite address at this point.
+	if app.buildkitdSettings.BuildkitAddress == "" {
+		return errors.New("could not determine buildkit address - is Docker or Podman running?")
+	}
+
 	var runnerName string
 	isLocal := containerutil.IsLocal(app.buildkitdSettings.BuildkitAddress)
 	if isLocal {

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -448,7 +448,7 @@ func (app *earthlyApp) parseFrontend(cliCtx *cli.Context, cfg *config.Config) er
 		app.containerFrontend = stub
 
 		if !app.verbose {
-			console.Printf("No frontend initialized. Use --verbose to see details\n")
+			console.Printf("Unable to detect Docker or Podman. Use --verbose to see details (or errors)\n")
 		}
 		console.VerbosePrintf("%s frontend initialization failed due to %s", app.cfg.Global.ContainerFrontend, origErr.Error())
 		return nil


### PR DESCRIPTION
A user reported issues with misleading errors and hanging when trying to run a local build with no Docker daemon.

This now shows the following in that case:
<img width="970" alt="Screen Shot 2023-07-12 at 3 21 43 PM" src="https://github.com/earthly/earthly/assets/3247216/8ba83fa7-5263-40ac-82c1-ae6cc8583d03">

However, if using satellites without docker running, the connection still works:
<img width="970" alt="Screen Shot 2023-07-12 at 3 22 21 PM" src="https://github.com/earthly/earthly/assets/3247216/5792df70-65c2-4593-9a34-2496378647bd">

Same with remote buildkit:
<img width="970" alt="Screen Shot 2023-07-12 at 3 23 20 PM" src="https://github.com/earthly/earthly/assets/3247216/4bd3be7e-ce0a-4440-957d-85d6f947d3bd">

I didn't test Podman, however, I assume we should have a buildkit address set to something similar as with docker in that case. 