### PR TITLE
Tests to verify correct (local) overwrite behavior

### DIFF
--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -12,7 +12,7 @@ buildkitd:
             ARG BUILDKIT_BASE_IMAGE=$BUILDKIT_PROJECT+build
         END
     ELSE
-        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:e0f2b80558fa91b090bf9f489e033e995ca1106a+build
+        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:cf348cf54d34478bb7c0ac62b0036802a6d59dd8+build
     END
     ARG EARTHLY_TARGET_TAG_DOCKER
     ARG TAG="dev-$EARTHLY_TARGET_TAG_DOCKER"

--- a/go.mod
+++ b/go.mod
@@ -138,6 +138,6 @@ replace (
 	github.com/jdxcode/netrc => github.com/mikejholly/netrc v0.0.0-20221121193719-a154cb29ec2a
 	github.com/jessevdk/go-flags => github.com/alexcb/go-flags v0.0.0-20210722203016-f11d7ecb5ee5
 
-	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.0-20230704190112-e0f2b80558fa
+	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.0-20230714193834-cf348cf54d34
 	github.com/tonistiigi/fsutil => github.com/earthly/fsutil v0.0.0-20230530182746-82567e6e2a92
 )

--- a/go.sum
+++ b/go.sum
@@ -169,8 +169,8 @@ github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
-github.com/earthly/buildkit v0.0.0-20230704190112-e0f2b80558fa h1:vppzdv09XOZhRltj7tMYewzx7GWngqneR4O6grSlcYU=
-github.com/earthly/buildkit v0.0.0-20230704190112-e0f2b80558fa/go.mod h1:RV8GAHclVvcjdPGdNAL4DnV/Mca1Lv5JnOwWuvw/IPo=
+github.com/earthly/buildkit v0.0.0-20230714193834-cf348cf54d34 h1:CczFcEbYRQzV/3wQz2I9YIGNBrFNVFeTeIiDd9tocwg=
+github.com/earthly/buildkit v0.0.0-20230714193834-cf348cf54d34/go.mod h1:RV8GAHclVvcjdPGdNAL4DnV/Mca1Lv5JnOwWuvw/IPo=
 github.com/earthly/cloud-api v1.0.1-0.20230630163439-87d5d086c73e h1:KqVWx6pQM+pfQraEw/YNj4lExUqd58Z6GSyWsYhwkk8=
 github.com/earthly/cloud-api v1.0.1-0.20230630163439-87d5d086c73e/go.mod h1:rU/tYJ7GFBjdKAITV2heDbez++glpGSbtJaZcp73rNI=
 github.com/earthly/fsutil v0.0.0-20230530182746-82567e6e2a92 h1:dy3w3B4OiDyQS+iHi/beUgMDJ1+fAAgbtr7OZ0d9ks0=

--- a/tests/local/Earthfile
+++ b/tests/local/Earthfile
@@ -90,6 +90,30 @@ test-save-local-artifact-with-workdir:
     COPY +save-local-artifact-with-workdir/data .
     RUN cat data | grep '^ddd$'
 
+#################################################################################################################
+# tests for testing overwriting existing local files
+
+some-artifact:
+    RUN printf '4321' > four-bytes.txt
+    SAVE ARTIFACT four-bytes.txt
+
+test-local-overwrites:
+    LOCALLY
+    RUN rm -fr              /tmp/earthly-test-21f37581-de77-4f81-ac78-4a2a617f7eda && \
+        mkdir -p            /tmp/earthly-test-21f37581-de77-4f81-ac78-4a2a617f7eda && \
+        printf "12345678" > /tmp/earthly-test-21f37581-de77-4f81-ac78-4a2a617f7eda/eight.txt && \
+        printf "1234"     > /tmp/earthly-test-21f37581-de77-4f81-ac78-4a2a617f7eda/four.txt && \
+        printf "12"       > /tmp/earthly-test-21f37581-de77-4f81-ac78-4a2a617f7eda/two.txt
+    # In previous releases this would result in "43215678"
+    COPY +some-artifact/four-bytes.txt /tmp/earthly-test-21f37581-de77-4f81-ac78-4a2a617f7eda/eight.txt
+    # These always worked fine
+    COPY +some-artifact/four-bytes.txt /tmp/earthly-test-21f37581-de77-4f81-ac78-4a2a617f7eda/four.txt
+    COPY +some-artifact/four-bytes.txt /tmp/earthly-test-21f37581-de77-4f81-ac78-4a2a617f7eda/two.txt
+    RUN set -e; \
+        for i in eight four two; do \
+            cat /tmp/earthly-test-21f37581-de77-4f81-ac78-4a2a617f7eda/${i}.txt | grep '^4321$'; \
+        done
+
 
 #################################################################################################################
 # tests for testing containerized artifacts can be referenced by local targets

--- a/tests/local/Earthfile
+++ b/tests/local/Earthfile
@@ -231,6 +231,7 @@ all:
     BUILD +test-save-unnamed-local-artifact
     BUILD +test-save-unnamed-local-artifact-dir
     BUILD +test-save-unnamed-local-artifact-dir2
+    BUILD +test-local-overwrites
     BUILD +test-with-docker --FRONTEND=$FRONTEND
     BUILD +test-with-two-dockers --FRONTEND=$FRONTEND
     BUILD ./with-docker-compose-local+all --FRONTEND=$FRONTEND --FRONTEND_COMPOSE=$FRONTEND_COMPOSE


### PR DESCRIPTION
Verifies https://github.com/earthly/buildkit/pull/19, which in turn fixes https://github.com/earthly/earthly/issues/3094.

This ensures that an existing file is truncated prior to writing; otherwise, if the source (`X`) is smaller than the destination (`Y`), the destination contains all of `X` bytes at the beginning, and `Y-X` bytes of the original destination at the end.