### PR TITLE
local-tests: display contents of docker compose up

### DIFF
--- a/tests/local/Earthfile
+++ b/tests/local/Earthfile
@@ -193,21 +193,27 @@ test-with-two-dockers:
 all:
     ARG FRONTEND=docker
     ARG FRONTEND_COMPOSE="docker compose"
-    BUILD +test-copy-dir-from-local
-    BUILD +test-copy-file-from-local
-    BUILD +test-copy-from-busybox-to-local
-    BUILD +test-copy-from-busybox-to-local-with-workdir
-    BUILD +test-local
-    BUILD +test-local-with-arg --pattern=memory --FRONTEND=$FRONTEND
-    BUILD +test-locally-can-copy-dir
-    BUILD +test-locally-can-copy-dir-contents
-    BUILD +test-locally-workdir
-    BUILD +test-locally-workdir
-    BUILD +test-multi-copy-from-alpine-to-local
-    BUILD +test-save-unnamed-local-artifact
-    BUILD +test-save-unnamed-local-artifact-dir
-    BUILD +test-save-unnamed-local-artifact-dir2
-    BUILD +test-with-docker --FRONTEND=$FRONTEND
-    BUILD +test-with-two-dockers --FRONTEND=$FRONTEND
-    BUILD ./with-docker-compose-local+all --FRONTEND=$FRONTEND --FRONTEND_COMPOSE=$FRONTEND_COMPOSE
-    BUILD ./with-docker-compose-local-reg+all --FRONTEND=$FRONTEND --FRONTEND_COMPOSE=$FRONTEND_COMPOSE
+    WAIT
+        BUILD +test-copy-dir-from-local
+        BUILD +test-copy-file-from-local
+        BUILD +test-copy-from-busybox-to-local
+        BUILD +test-copy-from-busybox-to-local-with-workdir
+        BUILD +test-local
+        BUILD +test-local-with-arg --pattern=memory --FRONTEND=$FRONTEND
+        BUILD +test-locally-can-copy-dir
+        BUILD +test-locally-can-copy-dir-contents
+        BUILD +test-locally-workdir
+        BUILD +test-locally-workdir
+        BUILD +test-multi-copy-from-alpine-to-local
+        BUILD +test-save-unnamed-local-artifact
+        BUILD +test-save-unnamed-local-artifact-dir
+        BUILD +test-save-unnamed-local-artifact-dir2
+        BUILD +test-with-docker --FRONTEND=$FRONTEND
+        BUILD +test-with-two-dockers --FRONTEND=$FRONTEND
+    END
+    WAIT
+        BUILD ./with-docker-compose-local+all --FRONTEND=$FRONTEND --FRONTEND_COMPOSE=$FRONTEND_COMPOSE
+    END
+    WAIT
+        BUILD ./with-docker-compose-local-reg+all --FRONTEND=$FRONTEND --FRONTEND_COMPOSE=$FRONTEND_COMPOSE
+    END

--- a/tests/local/with-docker-compose-local-reg/Earthfile
+++ b/tests/local/with-docker-compose-local-reg/Earthfile
@@ -19,5 +19,5 @@ test:
             --compose docker-compose.yml \
             --service webserver \
             --load fetch:latest=+fetch
-        RUN $FRONTEND_COMPOSE up --exit-code-from fetch fetch | grep 'Hello World'
+        RUN $FRONTEND_COMPOSE up --exit-code-from fetch fetch
     END

--- a/tests/local/with-docker-compose-local-reg/docker-compose.yml
+++ b/tests/local/with-docker-compose-local-reg/docker-compose.yml
@@ -11,3 +11,9 @@ services:
 
   webserver:
     image: nginxdemos/hello
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost"]
+      interval: 1m30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s

--- a/tests/local/with-docker-compose-local-reg/fetch.sh
+++ b/tests/local/with-docker-compose-local-reg/fetch.sh
@@ -1,8 +1,14 @@
 #!/bin/sh
 set -e
+sleep 10
+output="$(mktemp)"
 curl --connect-timeout 1 \
     --max-time 1 \
     --retry 5 \
     --retry-delay 0 \
     --retry-max-time 10 \
-    "http://${WEBHOST}:${WEBPORT}"
+    "http://${WEBHOST}:${WEBPORT}" | tee "$output"
+echo "curl command worked"
+echo "checking $output contains the magic string"
+grep "hello world" "$output"
+echo "grep command worked"

--- a/tests/local/with-docker-compose-local-reg/fetch.sh
+++ b/tests/local/with-docker-compose-local-reg/fetch.sh
@@ -10,5 +10,5 @@ curl --connect-timeout 1 \
     "http://${WEBHOST}:${WEBPORT}" | tee "$output"
 echo "curl command worked"
 echo "checking $output contains the magic string"
-grep "hello world" "$output"
+grep "Hello World" "$output"
 echo "grep command worked"

--- a/tests/local/with-docker-compose-local/Earthfile
+++ b/tests/local/with-docker-compose-local/Earthfile
@@ -19,5 +19,5 @@ test:
             --compose docker-compose.yml \
             --service webserver \
             --load fetch:latest=+fetch
-        RUN $FRONTEND_COMPOSE up --exit-code-from fetch fetch | grep 'Hello World'
+        RUN $FRONTEND_COMPOSE up --exit-code-from fetch fetch
     END

--- a/tests/local/with-docker-compose-local/docker-compose.yml
+++ b/tests/local/with-docker-compose-local/docker-compose.yml
@@ -11,3 +11,9 @@ services:
 
   webserver:
     image: nginxdemos/hello
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost"]
+      interval: 1m30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s

--- a/tests/local/with-docker-compose-local/fetch.sh
+++ b/tests/local/with-docker-compose-local/fetch.sh
@@ -1,8 +1,14 @@
 #!/bin/sh
 set -e
+sleep 10
+output="$(mktemp)"
 curl --connect-timeout 1 \
     --max-time 1 \
     --retry 5 \
     --retry-delay 0 \
     --retry-max-time 10 \
-    "http://${WEBHOST}:${WEBPORT}"
+    "http://${WEBHOST}:${WEBPORT}" | tee "$output"
+echo "curl command worked"
+echo "checking $output contains the magic string"
+grep "hello world" "$output"
+echo "grep command worked"

--- a/tests/local/with-docker-compose-local/fetch.sh
+++ b/tests/local/with-docker-compose-local/fetch.sh
@@ -10,5 +10,5 @@ curl --connect-timeout 1 \
     "http://${WEBHOST}:${WEBPORT}" | tee "$output"
 echo "curl command worked"
 echo "checking $output contains the magic string"
-grep "hello world" "$output"
+grep "Hello World" "$output"
 echo "grep command worked"


### PR DESCRIPTION
`grep` is hiding failures, which makes it difficult to debug.