### PR TITLE
Improve output for indefinite auth tokens

### DIFF
--- a/cmd/earthly/account_cmds.go
+++ b/cmd/earthly/account_cmds.go
@@ -498,11 +498,9 @@ func (app *earthlyApp) actionAccountCreateToken(cliCtx *cli.Context) error {
 		return errors.Wrap(err, "failed to create token")
 	}
 
-	expiryStr := ""
+	expiryStr := "will never expire"
 	if expiry != nil {
 		expiryStr = fmt.Sprintf("will expire in %s", humanize.Time(*expiry))
-	} else {
-		expiryStr = fmt.Sprintf("will never expire")
 	}
 
 	fmt.Printf("created token %q which %s; save this token somewhere, it can't be viewed again (only reset)\n", token, expiryStr)

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/docker/distribution v2.8.2+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/dustin/go-humanize v1.0.1
-	github.com/earthly/cloud-api v1.0.1-0.20230712185334-e8d697a6547b
+	github.com/earthly/cloud-api v1.0.1-0.20230713215837-16652981281f
 	github.com/earthly/earthly/ast v0.0.0-00010101000000-000000000000
 	github.com/earthly/earthly/util/deltautil v0.0.0-00010101000000-000000000000
 	github.com/elastic/go-sysinfo v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -176,6 +176,8 @@ github.com/earthly/cloud-api v1.0.1-0.20230630163439-87d5d086c73e h1:KqVWx6pQM+p
 github.com/earthly/cloud-api v1.0.1-0.20230630163439-87d5d086c73e/go.mod h1:rU/tYJ7GFBjdKAITV2heDbez++glpGSbtJaZcp73rNI=
 github.com/earthly/cloud-api v1.0.1-0.20230712185334-e8d697a6547b h1:xQlQ1/NeVLsGR3dOw6JKOw3NFTotsLN4EIovuUo+9mU=
 github.com/earthly/cloud-api v1.0.1-0.20230712185334-e8d697a6547b/go.mod h1:rU/tYJ7GFBjdKAITV2heDbez++glpGSbtJaZcp73rNI=
+github.com/earthly/cloud-api v1.0.1-0.20230713215837-16652981281f h1:y5CnRNBnbEqxVbI3w9aAOKW/zLxGCGnGRUq8z2RZF1E=
+github.com/earthly/cloud-api v1.0.1-0.20230713215837-16652981281f/go.mod h1:rU/tYJ7GFBjdKAITV2heDbez++glpGSbtJaZcp73rNI=
 github.com/earthly/fsutil v0.0.0-20230530182746-82567e6e2a92 h1:dy3w3B4OiDyQS+iHi/beUgMDJ1+fAAgbtr7OZ0d9ks0=
 github.com/earthly/fsutil v0.0.0-20230530182746-82567e6e2a92/go.mod h1:q1CxMSzcAbjUkVGHoZeQUcCaALnaE4XdWk+zJcgMYFw=
 github.com/elastic/go-sysinfo v1.9.0 h1:usICqY/Nw4Mpn9f4LdtpFrKxXroJDe81GaxxUlCckIo=


### PR DESCRIPTION
```
$ ./build/linux/amd64/earthly account create-token --expiry never delete-me-4
created token "UEBvw7Yau1WvDBu9BJQhQNJGX7JE8pmrmjeAwXMfYxKTMvXGC8SwS1PbWWnRLe29" which will never expire; save this token somewhere, it can't be viewed again (only reset)

$ ./build/linux/amd64/earthly account create-token delete-me-5 
created token "ELdaUHXyXMbEJ86PLQgI6hsxzwqjg6DcWXiYyAqIZ7XjmqUvtKNrcVjBAwZTux1y" which will never expire; save this token somewhere, it can't be viewed again (only reset)

$ ./build/linux/amd64/earthly account list-tokens             
Token Name   Read/Write  Expiry
local        r           2023-06-14T23:38 UTC *expired*
delete-me    r           2024-07-12T22:12 UTC
local-2      rw          2023-09-13T21:43 UTC
delete-me-2  r           Never
local-3      rw          2023-09-28T18:08 UTC
delete-me-4  r           Never
delete-me-5  r           Never
```