### PR TITLE
use acbgrep to make test failures more clear

### DIFF
--- a/scripts/acbtest/acbgrep
+++ b/scripts/acbtest/acbgrep
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -e
+if [ "$#" = "1" ]; then
+  inp="$(cat)"
+  set +e
+  echo "$inp" | grep "$@"
+  status=$?
+  set -e
+else
+  set +e
+  grep "$@"
+  status=$?
+  set -e
+fi
+if [ "$status" -ne 0 ]; then
+  if [ -n "$inp" ] && [ -z "$ACBGREP_NO_ECHO" ]; then
+    echo >&2 "$inp"
+  fi
+  echo >&2 -n 2>&1 "grep "
+  for var in "$@"; do
+    echo >&2 -n 2>&1 "${var@Q} "
+  done
+  echo >&2 "failed"
+fi
+exit $status

--- a/scripts/acbtest/acbtest
+++ b/scripts/acbtest/acbtest
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+test "$@"
+status=$?
+if [ "$status" -ne 0 ]; then
+  echo -n 2>&1 "test "
+  for var in "$@"; do
+    echo -n 2>&1 "${var@Q} "
+  done
+  echo 2>&1 "failed"
+fi
+exit $status

--- a/scripts/acbtest/update.sh
+++ b/scripts/acbtest/update.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e
+
+if ! which curl 2>/dev/null >&2; then
+  echo >&2 "curl is required; please install it."
+  exit 1
+fi
+
+cd "$(dirname "$0")"
+curl https://raw.githubusercontent.com/alexcb/acbtest/main/acbgrep > acbgrep && chmod +x acbgrep
+curl https://raw.githubusercontent.com/alexcb/acbtest/main/acbtest > acbtest && chmod +x acbtest

--- a/scripts/tests/cloud-docker-credentials-integration.sh
+++ b/scripts/tests/cloud-docker-credentials-integration.sh
@@ -2,15 +2,29 @@
 set -eu
 
 earthly=${earthly:=earthly}
-earthly=$(realpath "$earthly")
+if [ "$earthly" != "earthly" ]; then
+  earthly=$(realpath "$earthly")
+fi
 echo "running tests with $earthly"
+"$earthly" --version
 
 # prevent the self-update of earthly from running (this ensures no bogus data is printed to stdout,
 # which would mess with the secrets data being fetched)
 date +%s > /tmp/last-earthly-prerelease-check
 
+set +x # dont remove or the token will be leaked
+if [ -z "${EARTHLY_TOKEN:-}" ]; then
+  echo "using EARTHLY_TOKEN from earthly secrets"
+  EARTHLY_TOKEN="$(earthly secrets --org earthly-technologies --project core get earthly-token-for-satellite-tests)"
+  export EARTHLY_TOKEN
+fi
+test -n "$EARTHLY_TOKEN" || (echo "error: EARTHLY_TOKEN is not set" && exit 1)
+set -x
+
+EARTHLY_INSTALLATION_NAME="integration"
+export EARTHLY_INSTALLATION_NAME
+
 # ensure earthly login works (and print out who gets logged in)
-test -n "$EARTHLY_TOKEN"
 "$earthly" account login
 
 # A username / password has been stored in the cloud to a docker hub user (that is not part of earthly) via:
@@ -51,3 +65,5 @@ fi
 
 # then test that earthly can access the verygoodimage (by using the cloud-hosted registry credentials)
 "$earthly" --no-cache +test1
+
+echo "=== All tests have passed ==="

--- a/scripts/tests/earthly-image.sh
+++ b/scripts/tests/earthly-image.sh
@@ -6,6 +6,7 @@ set -euo pipefail # don't use -x as it will leak the mirror credentials
 
 FRONTEND=${FRONTEND:-docker}
 EARTHLY_IMAGE=${EARTHLY_IMAGE:-earthly/earthly:dev-main}
+PATH="$(realpath "$(dirname "$0")/../acbtest"):$PATH"
 
 if [ -z "${DOCKERHUB_MIRROR_USERNAME:-}" ] && [ -z "${DOCKERHUB_MIRROR_PASSWORD:-}" ]; then
   echo "using dockerhub credentials from earthly secrets"
@@ -60,21 +61,21 @@ if "$FRONTEND" run --rm "${EARTHLY_IMAGE}" 2>&1 | tee output.txt; then
     echo "expected failure"
     exit 1
 fi
-grep "Container appears to be running unprivileged" output.txt
+acbgrep "Container appears to be running unprivileged" output.txt
 
 echo "Test no target provided -> fail."
 if "$FRONTEND" run --rm --privileged "${EARTHLY_IMAGE}" 2>&1 | tee output.txt; then
     echo "expected failure"
     exit 1
 fi
-grep "Executes Earthly builds" output.txt # Display help
-grep "Error: no target reference provided" output.txt # Show error
+acbgrep "Executes Earthly builds" output.txt # Display help
+acbgrep "Error: no target reference provided" output.txt # Show error
 if "$FRONTEND" run --rm -e NO_BUILDKIT=1 "${EARTHLY_IMAGE}" 2>&1 | tee output.txt; then
     echo "expected failure"
     exit 1
 fi
-grep "Executes Earthly builds" output.txt # Display help
-grep "Error: no target reference provided" output.txt # Show error
+acbgrep "Executes Earthly builds" output.txt # Display help
+acbgrep "Error: no target reference provided" output.txt # Show error
 
 echo "Test --version (smoke test)."
 "$FRONTEND" run --rm --privileged "${EARTHLY_IMAGE}" --version 2>&1
@@ -82,26 +83,28 @@ echo "Test --version (smoke test)."
 
 echo "Test --help."
 "$FRONTEND" run --rm --privileged "${EARTHLY_IMAGE}" --help 2>&1 | tee output.txt
-grep "Executes Earthly builds" output.txt # Display help
+acbgrep "Executes Earthly builds" output.txt # Display help
 "$FRONTEND" run --rm -e NO_BUILDKIT=1 "${EARTHLY_IMAGE}" --help 2>&1 | tee output.txt
-grep "Executes Earthly builds" output.txt # Display help
+acbgrep "Executes Earthly builds" output.txt # Display help
+
+# TODO move satellite tests into a separate test (since they are flakey)
 
 echo "Test earthly sat inspect."
 "$FRONTEND" run --rm --privileged -e EARTHLY_TOKEN="${EARTHLY_TOKEN}" "${EARTHLY_IMAGE}" sat --org earthly-technologies inspect core-test 2>&1 | tee output.txt
-grep "core-test" output.txt
+acbgrep "core-test" output.txt
 "$FRONTEND" run --rm -e EARTHLY_TOKEN="${EARTHLY_TOKEN}" -e NO_BUILDKIT=1 "${EARTHLY_IMAGE}" sat --org earthly-technologies inspect core-test 2>&1 | tee output.txt
-grep "core-test" output.txt
+acbgrep "core-test" output.txt
 
 echo "Test hello world with embedded buildkit."
 "$FRONTEND" run --rm --privileged -e EARTHLY_ADDITIONAL_BUILDKIT_CONFIG -v "$dockerconfig:/root/.docker/config.json" "${EARTHLY_IMAGE}" --no-cache github.com/earthly/hello-world:4d466d524f768a379374c785fdef30470e87721d+hello 2>&1 | tee output.txt
-grep "Hello World" output.txt
-grep "Earthly installation is working correctly" output.txt
+acbgrep "Hello World" output.txt
+acbgrep "Earthly installation is working correctly" output.txt
 
 if [ "$FRONTEND" = "docker" ]; then
     echo "Test use /var/run/docker.sock, but not privileged."
     "$FRONTEND" run --rm -e EARTHLY_ADDITIONAL_BUILDKIT_CONFIG -v "$dockerconfig:/root/.docker/config.json" -e NO_BUILDKIT=1 -e EARTHLY_NO_BUILDKIT_UPDATE=1 -v /var/run/docker.sock:/var/run/docker.sock "${EARTHLY_IMAGE}" --no-cache github.com/earthly/hello-world:4d466d524f768a379374c785fdef30470e87721d+hello 2>&1 | tee output.txt
-    grep "Hello World" output.txt
-    grep "Earthly installation is working correctly" output.txt
+    acbgrep "Hello World" output.txt
+    acbgrep "Earthly installation is working correctly" output.txt
 fi
 
 echo "Test satellite (not privileged, no buildkit)."
@@ -122,9 +125,11 @@ if [ -n "${DOCKERHUB_USERNAME:-}" ] && [ -n "${DOCKERHUB_PASSWORD:-}" ]; then
 EOF
 fi
 
+# TODO FIXME test that the above credentials are actually used by the satellite
+
 "$FRONTEND" run --rm -e EARTHLY_TOKEN="${EARTHLY_TOKEN}" -v "$satconfig:/root/.docker/config.json" -e NO_BUILDKIT=1 "${EARTHLY_IMAGE}" --org earthly-technologies --sat core-test --no-cache github.com/earthly/hello-world:4d466d524f768a379374c785fdef30470e87721d+hello 2>&1 | tee output.txt
-grep "Hello World" output.txt
-grep "Earthly installation is working correctly" output.txt
+acbgrep "Hello World" output.txt
+acbgrep "Earthly installation is working correctly" output.txt
 
 rm output.txt
-echo "Success"
+echo "=== All tests have passed ==="

--- a/scripts/tests/export.sh
+++ b/scripts/tests/export.sh
@@ -2,18 +2,35 @@
 set -xeu
 
 earthly=${earthly:=earthly}
-earthly=$(realpath "$earthly")
+if [ "$earthly" != "earthly" ]; then
+  earthly=$(realpath "$earthly")
+fi
 echo "running tests with $earthly"
+"$earthly" --version
 frontend="${frontend:-$(which docker || which podman)}"
 test -n "$frontend" || (>&2 echo "Error: frontend is empty" && exit 1)
 echo "using frontend $frontend"
+
+PATH="$(realpath "$(dirname "$0")/../acbtest"):$PATH"
 
 # prevent the self-update of earthly from running (this ensures no bogus data is printed to stdout,
 # which would mess with the secrets data being fetched)
 date +%s > /tmp/last-earthly-prerelease-check
 
+set +x # dont remove or the token will be leaked
+if [ -z "${EARTHLY_TOKEN:-}" ]; then
+  echo "using EARTHLY_TOKEN from earthly secrets"
+  EARTHLY_TOKEN="$(earthly secrets --org earthly-technologies --project core get earthly-token-for-satellite-tests)"
+  export EARTHLY_TOKEN
+fi
+test -n "$EARTHLY_TOKEN" || (echo "error: EARTHLY_TOKEN is not set" && exit 1)
+set -x
+
+EARTHLY_INSTALLATION_NAME="integration"
+export EARTHLY_INSTALLATION_NAME
+
+echo "$earthly"
 # ensure earthly login works (and print out who gets logged in)
-test -n "$EARTHLY_TOKEN"
 "$earthly" account login
 
 # Test 1: export without anything
@@ -53,7 +70,7 @@ EOF
 "$earthly" prune --reset
 "$earthly" +test2
 
-"$frontend" run --rm earthly-export-test-2:test | grep "running default cmd"
+"$frontend" run --rm earthly-export-test-2:test | acbgrep "running default cmd"
 
 # Test 3: export with a single RUN
 echo ==== Running test 3 ====
@@ -73,7 +90,7 @@ EOF
 "$earthly" prune --reset
 "$earthly" +test3
 
-"$frontend" run --rm earthly-export-test-3:test cat /data | grep "hello my world"
+"$frontend" run --rm earthly-export-test-3:test cat /data | acbgrep "hello my world"
 
 
 # Test 4: export multiplatform image
@@ -104,14 +121,14 @@ EOF
 "$earthly" prune --reset
 "$earthly" +multi4
 
-"$frontend" run --rm earthly-export-test-4:test cat /data | grep "hello my world"
-"$frontend" run --rm earthly-export-test-4:test cat /data | grep "$(uname -m)"
-"$frontend" run --rm earthly-export-test-4:test_linux_amd64 cat /data | grep "hello my world"
-"$frontend" run --rm earthly-export-test-4:test_linux_amd64 cat /data | grep "x86_64"
-"$frontend" run --rm earthly-export-test-4:test_linux_arm64 cat /data | grep "hello my world"
-"$frontend" run --rm earthly-export-test-4:test_linux_arm64 cat /data | grep "aarch64"
-"$frontend" run --rm earthly-export-test-4:test_linux_arm_v7 cat /data | grep "hello my world"
-"$frontend" run --rm earthly-export-test-4:test_linux_arm_v7 cat /data | grep "armv7l"
+"$frontend" run --rm earthly-export-test-4:test cat /data | acbgrep "hello my world"
+"$frontend" run --rm earthly-export-test-4:test cat /data | acbgrep "$(uname -m)"
+"$frontend" run --rm earthly-export-test-4:test_linux_amd64 cat /data | acbgrep "hello my world"
+"$frontend" run --rm earthly-export-test-4:test_linux_amd64 cat /data | acbgrep "x86_64"
+"$frontend" run --rm earthly-export-test-4:test_linux_arm64 cat /data | acbgrep "hello my world"
+"$frontend" run --rm earthly-export-test-4:test_linux_arm64 cat /data | acbgrep "aarch64"
+"$frontend" run --rm earthly-export-test-4:test_linux_arm_v7 cat /data | acbgrep "hello my world"
+"$frontend" run --rm earthly-export-test-4:test_linux_arm_v7 cat /data | acbgrep "armv7l"
 
 
 # Test 5: export multiple images
@@ -143,8 +160,8 @@ EOF
 "$earthly" prune --reset
 "$earthly" +all5
 
-"$frontend" run --rm earthly-export-test-5:test-img1 cat /data | grep "hello my world 1"
-"$frontend" run --rm earthly-export-test-5:test-img2 cat /data | grep "hello my world 2"
+"$frontend" run --rm earthly-export-test-5:test-img1 cat /data | acbgrep "hello my world 1"
+"$frontend" run --rm earthly-export-test-5:test-img2 cat /data | acbgrep "hello my world 2"
 
 # Test 6: no manifest list
 echo ==== Running test 6 ====
@@ -170,8 +187,8 @@ EOF
 "$earthly" prune --reset
 "$earthly" +multi6
 
-"$frontend" run --rm earthly-export-test-6:test cat /data | grep "hello my world"
-"$frontend" run --rm earthly-export-test-6:test cat /data | grep "aarch64"
+"$frontend" run --rm earthly-export-test-6:test cat /data | acbgrep "hello my world"
+"$frontend" run --rm earthly-export-test-6:test cat /data | acbgrep "aarch64"
 if "$frontend" inspect earthly-export-test-6:test_linux_arm64 >/dev/null 2>&1 ; then
     echo "Expected failure"
     exit 1
@@ -179,6 +196,7 @@ fi
 
 # Test 7: remote cache on target with only BUILDs
 echo ==== Running test 7 ====
+rm -rf /tmp/earthly-export-test-7
 mkdir /tmp/earthly-export-test-7
 cd /tmp/earthly-export-test-7
 cat >> Earthfile <<EOF
@@ -191,3 +209,5 @@ EOF
 
 # This simply tests that this does not hang (#1945).
 timeout -k 11m 10m "$earthly" --ci --push --remote-cache earthly/test-cache:export-test-7 +test7
+
+echo "=== All tests have passed ==="

--- a/scripts/tests/satellites-integration.sh
+++ b/scripts/tests/satellites-integration.sh
@@ -2,7 +2,12 @@
 set -euo pipefail
 
 earthly=${earthly:=earthly}
-earthly=$(realpath "$earthly")
+if [ "$earthly" != "earthly" ]; then
+  earthly=$(realpath "$earthly")
+fi
+"$earthly" --version
+PATH="$(realpath "$(dirname "$0")/../acbtest"):$PATH"
+
 echo "running tests with $earthly"
 "$earthly" --version
 
@@ -18,6 +23,9 @@ fi
 test -n "$EARTHLY_TOKEN" || (echo "error: EARTHLY_TOKEN is not set" && exit 1)
 
 set -x # don't move this to the top; or we'll leak the token
+
+EARTHLY_INSTALLATION_NAME="integration"
+export EARTHLY_INSTALLATION_NAME
 
 # ensure earthly login works (and print out who gets logged in)
 "$earthly" account login
@@ -37,4 +45,6 @@ EARTHLY_ORG=earthly-technologies "$earthly" sat inspect core-test
 
 #TODO fix this.... satellite ls does NOT use the org from the config file
 "$earthly" satellite ls
-#"$earthly" satellite ls | grep '^\* \+core-test'
+#"$earthly" satellite ls | acbgrep '^\* \+core-test'
+
+echo "=== All tests have passed ==="

--- a/tests/local/with-docker-compose-local-reg/Earthfile
+++ b/tests/local/with-docker-compose-local-reg/Earthfile
@@ -15,9 +15,11 @@ test:
     LOCALLY
     ARG FRONTEND=docker
     ARG FRONTEND_COMPOSE="docker compose"
+    ARG acbgrep=../../../scripts/acbtest/acbgrep
+    RUN test -f "$acbgrep"
     WITH DOCKER \
             --compose docker-compose.yml \
             --service webserver \
             --load fetch:latest=+fetch
-        RUN $FRONTEND_COMPOSE up --exit-code-from fetch fetch | grep 'Hello World'
+        RUN $FRONTEND_COMPOSE up --exit-code-from fetch fetch | "$acbgrep" 'Hello World'
     END

--- a/tests/local/with-docker-compose-local/Earthfile
+++ b/tests/local/with-docker-compose-local/Earthfile
@@ -15,9 +15,11 @@ test:
     LOCALLY
     ARG FRONTEND=docker
     ARG FRONTEND_COMPOSE="docker compose"
+    ARG acbgrep=../../../scripts/acbtest/acbgrep
+    RUN test -f "$acbgrep"
     WITH DOCKER \
             --compose docker-compose.yml \
             --service webserver \
             --load fetch:latest=+fetch
-        RUN $FRONTEND_COMPOSE up --exit-code-from fetch fetch | grep 'Hello World'
+        RUN $FRONTEND_COMPOSE up --exit-code-from fetch fetch | "$acbgrep" 'Hello World'
     END


### PR DESCRIPTION
`acbgrep` from https://github.com/alexcb/acbtest; is a wrapper around grep which will display a failure message if grep fails (rather than silently exiting with an error code).

When data is pipped in, it will also display the contents of the data that is being grepped -- this makes it easier to see the full output of earthly if grep fails to find an expected string.