### PR TITLE
don't change the currently logged in user

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -433,6 +433,7 @@ earthly-docker:
 earthly-integration-test-base:
     FROM +earthly-docker
     RUN apk update && apk add pcre-tools curl python3 bash perl findutils
+    COPY scripts/acbtest/acbtest scripts/acbtest/acbgrep /bin/
     ENV NO_DOCKER=1
     ENV NETWORK_MODE=host # Note that this breaks access to embedded registry in WITH DOCKER.
     ENV EARTHLY_VERSION_FLAG_OVERRIDES=no-use-registry-for-with-docker # Use tar-based due to above.

--- a/cloud/account.go
+++ b/cloud/account.go
@@ -19,10 +19,10 @@ import (
 type AuthMethod string
 
 const (
-	SSHAuthMethod       AuthMethod = "ssh"
-	PasswordAuthMethod  AuthMethod = "password"
-	TokenAuthMethod     AuthMethod = "token"
-	CachedJWTAuthMethod AuthMethod = "cached jwt"
+	AuthMethodSSH       AuthMethod = "ssh"
+	AuthMethodPassword  AuthMethod = "password"
+	AuthMethodToken     AuthMethod = "token"
+	AuthMethodCachedJWT AuthMethod = "cached jwt"
 )
 
 // TokenDetail contains token information
@@ -163,7 +163,7 @@ func (c *Client) WhoAmI(ctx context.Context) (string, AuthMethod, bool, error) {
 	}
 	authMethod := c.lastAuthMethod
 	if authMethod == "" {
-		authMethod = CachedJWTAuthMethod
+		authMethod = AuthMethodCachedJWT
 	}
 	return email, authMethod, writeAccess, nil
 }

--- a/cloud/auth_test.go
+++ b/cloud/auth_test.go
@@ -36,8 +36,8 @@ func TestClient_Authenticate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected authentication error: %+v", err)
 	}
-	if authMethod != PasswordAuthMethod {
-		t.Errorf("expected [%s] got [%s]", PasswordAuthMethod, authMethod)
+	if authMethod != AuthMethodPassword {
+		t.Errorf("expected [%s] got [%s]", AuthMethodPassword, authMethod)
 	}
 
 	if cc.authToken != testToken {

--- a/cloud/auth_test.go
+++ b/cloud/auth_test.go
@@ -32,8 +32,12 @@ func TestClient_Authenticate(t *testing.T) {
 	}
 	ctx := context.Background()
 
-	if err := cc.Authenticate(ctx); err != nil {
+	authMethod, err := cc.Authenticate(ctx)
+	if err != nil {
 		t.Fatalf("unexpected authentication error: %+v", err)
+	}
+	if authMethod != PasswordAuthMethod {
+		t.Errorf("expected [%s] got [%s]", PasswordAuthMethod, authMethod)
 	}
 
 	if cc.authToken != testToken {

--- a/cloud/client.go
+++ b/cloud/client.go
@@ -61,6 +61,7 @@ type Client struct {
 	logstreamAddressOverride string
 	serverConnTimeout        time.Duration
 	orgIDCache               sync.Map // orgName -> orgID
+	lastAuthMethod           AuthMethod
 }
 
 type ClientOpt func(*Client)

--- a/cloud/grpc.go
+++ b/cloud/grpc.go
@@ -119,7 +119,7 @@ func (c *Client) StreamInterceptor() grpc.StreamClientInterceptor {
 
 func (c *Client) reAuthIfExpired(ctx context.Context) (context.Context, error) {
 	if time.Now().UTC().After(c.authTokenExpiry) {
-		err := c.Authenticate(ctx)
+		_, err := c.Authenticate(ctx)
 		if err != nil {
 			return ctx, errors.Wrap(err, "failed refreshing expired token")
 		}
@@ -129,7 +129,7 @@ func (c *Client) reAuthIfExpired(ctx context.Context) (context.Context, error) {
 }
 
 func (c *Client) reAuthCtx(ctx context.Context) (context.Context, error) {
-	err := c.Authenticate(ctx)
+	_, err := c.Authenticate(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed re-authenticating")
 	}

--- a/cloud/http.go
+++ b/cloud/http.go
@@ -97,7 +97,7 @@ func (c *Client) doCall(ctx context.Context, method, url string, opts ...request
 
 	alreadyReAuthed := false
 	if r.hasAuth && time.Now().UTC().After(c.authTokenExpiry) {
-		if err := c.Authenticate(ctx); err != nil {
+		if _, err := c.Authenticate(ctx); err != nil {
 			if errors.Is(err, ErrUnauthorized) {
 				return 0, nil, ErrUnauthorized
 			}
@@ -125,7 +125,7 @@ func (c *Client) doCall(ctx context.Context, method, url string, opts ...request
 			if !r.hasAuth || alreadyReAuthed {
 				return status, body, ErrUnauthorized
 			}
-			err := c.Authenticate(ctx)
+			_, err := c.Authenticate(ctx)
 			if err != nil {
 				return status, body, errors.Wrap(err, "auth credentials not valid")
 			}

--- a/cloud/org.go
+++ b/cloud/org.go
@@ -203,7 +203,7 @@ func (c *Client) GuessOrgMembership(ctx context.Context) (orgName, orgID string,
 	// This is because there is an issue on the backend where the token might be outdated
 	// if a user was invited to an org recently after already logging-in.
 	// TODO Eventually we should be able to remove this cheat.
-	err = c.Authenticate(ctx)
+	_, err = c.Authenticate(ctx)
 	if err != nil {
 		return "", "", errors.Wrap(err, "unable to authenticate")
 	}

--- a/scripts/tests/cloud-docker-credentials-integration.sh
+++ b/scripts/tests/cloud-docker-credentials-integration.sh
@@ -21,8 +21,9 @@ fi
 test -n "$EARTHLY_TOKEN" || (echo "error: EARTHLY_TOKEN is not set" && exit 1)
 set -x
 
-EARTHLY_INSTALLATION_NAME="integration"
+EARTHLY_INSTALLATION_NAME="earthly-integration"
 export EARTHLY_INSTALLATION_NAME
+rm -rf "$HOME/.earthly.integration/"
 
 # ensure earthly login works (and print out who gets logged in)
 "$earthly" account login

--- a/scripts/tests/export.sh
+++ b/scripts/tests/export.sh
@@ -26,8 +26,9 @@ fi
 test -n "$EARTHLY_TOKEN" || (echo "error: EARTHLY_TOKEN is not set" && exit 1)
 set -x
 
-EARTHLY_INSTALLATION_NAME="integration"
+EARTHLY_INSTALLATION_NAME="earthly-integration"
 export EARTHLY_INSTALLATION_NAME
+rm -rf "$HOME/.earthly.integration/"
 
 echo "$earthly"
 # ensure earthly login works (and print out who gets logged in)

--- a/scripts/tests/satellites-integration.sh
+++ b/scripts/tests/satellites-integration.sh
@@ -24,8 +24,9 @@ test -n "$EARTHLY_TOKEN" || (echo "error: EARTHLY_TOKEN is not set" && exit 1)
 
 set -x # don't move this to the top; or we'll leak the token
 
-EARTHLY_INSTALLATION_NAME="integration"
+EARTHLY_INSTALLATION_NAME="earthly-integration"
 export EARTHLY_INSTALLATION_NAME
+rm -rf "$HOME/.earthly.integration/"
 
 # ensure earthly login works (and print out who gets logged in)
 "$earthly" account login

--- a/scripts/tests/secrets-integration.sh
+++ b/scripts/tests/secrets-integration.sh
@@ -21,8 +21,9 @@ if [ -z "${EARTHLY_TOKEN:-}" ]; then
 fi
 test -n "$EARTHLY_TOKEN" || (echo "error: EARTHLY_TOKEN is not set" && exit 1)
 
-EARTHLY_INSTALLATION_NAME="integration"
+EARTHLY_INSTALLATION_NAME="earthly.integration"
 export EARTHLY_INSTALLATION_NAME
+rm -rf "$HOME/.earthly.integration/"
 
 # ensure earthly login works (and print out who gets logged in)
 "$earthly" account login
@@ -40,6 +41,7 @@ ID_RSA=$("$earthly" secrets --org earthly-technologies --project core get -n sec
 
 # now that we grabbed the manitou credentials, unset our token, to ensure that we're only testing using manitou's credentials
 unset EARTHLY_TOKEN
+"$earthly" account logout
 
 echo starting new instance of ssh-agent, and loading credentials
 eval "$(ssh-agent)"
@@ -58,7 +60,7 @@ echo testing that the ssh-agent only contains a single key
 test "$(ssh-add -l | wc -l)" = "1"
 
 echo "testing earthly account login works (and is using the earthly-manitou account)"
-"$earthly" account login 2>&1 | acbgrep 'other-service+earthly-manitou@earthly.dev'
+"$earthly" account login 2>&1 | acbgrep 'Logged in as "other-service+earthly-manitou@earthly.dev" using ssh auth'
 
 mkdir -p /tmp/earthtest
 cat << EOF > /tmp/earthtest/Earthfile

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -282,6 +282,12 @@ tests-that-require-earthly-technologies-account-access:
         --DOCKERHUB_TOKEN_SECRET=$DOCKERHUB_TOKEN_SECRET \
         --DOCKERHUB_MIRROR=$DOCKERHUB_MIRROR \
         --DOCKERHUB_MIRROR_INSECURE=$DOCKERHUB_MIRROR_INSECURE
+    BUILD ./account+test \
+        --DOCKERHUB_AUTH=$DOCKERHUB_AUTH \
+        --DOCKERHUB_USER_SECRET=$DOCKERHUB_USER_SECRET \
+        --DOCKERHUB_TOKEN_SECRET=$DOCKERHUB_TOKEN_SECRET \
+        --DOCKERHUB_MIRROR=$DOCKERHUB_MIRROR \
+        --DOCKERHUB_MIRROR_INSECURE=$DOCKERHUB_MIRROR_INSECURE
 
 # tests that only run on linux amd64
 # Note: this target is used to validate the USERPLATFORM user arg,

--- a/tests/account/Earthfile
+++ b/tests/account/Earthfile
@@ -1,0 +1,31 @@
+VERSION 0.7
+PROJECT earthly-technologies/core
+
+ARG --global DOCKERHUB_USER_SECRET=+secrets/DOCKERHUB_USER
+ARG --global DOCKERHUB_TOKEN_SECRET=+secrets/DOCKERHUB_TOKEN
+ARG --global DOCKERHUB_MIRROR
+ARG --global DOCKERHUB_MIRROR_INSECURE=false
+ARG --global DOCKERHUB_MIRROR_HTTP=false
+ARG --global DOCKERHUB_AUTH=true
+FROM ../..+earthly-integration-test-base \
+    --DOCKERHUB_AUTH=$DOCKERHUB_AUTH \
+    --DOCKERHUB_USER_SECRET=$DOCKERHUB_USER_SECRET \
+    --DOCKERHUB_TOKEN_SECRET=$DOCKERHUB_TOKEN_SECRET \
+    --DOCKERHUB_MIRROR=$DOCKERHUB_MIRROR \
+    --DOCKERHUB_MIRROR_INSECURE=$DOCKERHUB_MIRROR_INSECURE \
+    --DOCKERHUB_MIRROR_HTTP=$DOCKERHUB_MIRROR_HTTP
+
+IMPORT .. AS tests
+
+WORKDIR /test
+
+test:
+    BUILD +test-login
+
+test-login:
+    COPY test-login.sh .
+    RUN \
+        --secret USER1_TOKEN=test-user1/token \
+        --secret USER2_TOKEN=test-user2/token \
+        --secret USER2_SSH_KEY=test-user2/ssh-key \
+        ./test-login.sh

--- a/tests/account/test-login.sh
+++ b/tests/account/test-login.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+set -eo pipefail # DONT add a set -x or you will leak the key
+
+acbtest -n "$USER1_TOKEN"
+acbtest -n "$USER2_TOKEN"
+acbtest -n "$USER2_SSH_KEY"
+acbtest -z "$SSH_AUTH_SOCK"
+
+echo "== it should login to user1 with token =="
+EARTHLY_TOKEN="$USER1_TOKEN" earthly account login 2>&1 | acbgrep 'Logged in as "other-service.earthly-user1@earthly.dev" using token auth'
+
+echo "== it should stay logged in as user1 even though EARTHLY_TOKEN is no longer set =="
+earthly account login 2>&1 | acbgrep 'Logged in as "other-service.earthly-user1@earthly.dev" using cached jwt auth'
+
+echo "== it should stay logged in as user1 since the cached jwt is used (even though user2's ssh key is available via ssh keys) =="
+eval "$(ssh-agent)"
+echo "$USER2_SSH_KEY" | ssh-add -
+ssh-add -l | acbgrep '(ED25519)'
+
+earthly account login 2>&1 | acbgrep 'Logged in as "other-service.earthly-user1@earthly.dev" using cached jwt auth'
+
+ssh-add -D # remove the key
+
+echo "== forcing a logout should allow us to change users =="
+earthly account logout
+EARTHLY_TOKEN="$USER2_TOKEN" earthly account login 2>&1 | acbgrep 'Logged in as "other-service.earthly-user2@earthly.dev" using token auth'
+
+echo "== it should stay logged in as user2 =="
+earthly account login 2>&1 | acbgrep 'Logged in as "other-service.earthly-user2@earthly.dev" using cached jwt auth'
+
+echo "== it should be able to login as user2 with ssh =="
+earthly account logout
+echo "$USER2_SSH_KEY" | ssh-add -
+earthly account login 2>&1 | acbgrep 'Logged in as "other-service.earthly-user2@earthly.dev" using ssh auth'


### PR DESCRIPTION
if there's a valid auth.jwt, earthly should not re-login (potentially with different credentials).