### PR TITLE
Fix code error with token expiry parsing

### DIFF
--- a/cmd/earthly/account_cmds.go
+++ b/cmd/earthly/account_cmds.go
@@ -478,8 +478,10 @@ func (app *earthlyApp) actionAccountCreateToken(cliCtx *cli.Context) error {
 
 		var err error
 		for _, layout := range layouts {
-			*expiry, err = time.Parse(layout, app.expiry)
+			var parsedTime time.Time
+			parsedTime, err = time.Parse(layout, app.expiry)
 			if err == nil {
+				expiry = &parsedTime
 				break
 			}
 		}
@@ -500,7 +502,7 @@ func (app *earthlyApp) actionAccountCreateToken(cliCtx *cli.Context) error {
 
 	expiryStr := "will never expire"
 	if expiry != nil {
-		expiryStr = fmt.Sprintf("will expire in %s", humanize.Time(*expiry))
+		expiryStr = fmt.Sprintf("will expire %s", humanize.Time(*expiry))
 	}
 
 	fmt.Printf("created token %q which %s; save this token somewhere, it can't be viewed again (only reset)\n", token, expiryStr)


### PR DESCRIPTION
This PR fixes the following issue with v0.7.12.

```
$ earthly account create-token --write --expiry 2023-12-01 some-token2c
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x1015d1fb0]

goroutine 1 [running]:
main.(*earthlyApp).actionAccountCreateToken(0x14000514800, 0x1400034a680)
        github.com/earthly/earthly/cmd/earthly/account_cmds.go:481 +0x2c0
github.com/urfave/cli/v2.(*Command).Run(0x14000568240, 0x1400034a240)
        github.com/urfave/cli/v2@v2.3.0/command.go:163 +0x4f8
github.com/urfave/cli/v2.(*App).RunAsSubcommand(0x14000003ba0, 0x1400055f600)
        github.com/urfave/cli/v2@v2.3.0/app.go:434 +0x948
github.com/urfave/cli/v2.(*Command).startApp(0x1400056d560, 0x1400055f600)
        github.com/urfave/cli/v2@v2.3.0/command.go:278 +0x750
github.com/urfave/cli/v2.(*Command).Run(0x1400037c6a8?, 0x1400044e1d0?)
        github.com/urfave/cli/v2@v2.3.0/command.go:94 +0x7c
github.com/urfave/cli/v2.(*App).RunContext(0x1400058a820, {0x101b693d0?, 0x1400009a2d0}, {0x14000136000, 0x7, 0x7})
        github.com/urfave/cli/v2@v2.3.0/app.go:313 +0x828
main.(*earthlyApp).run(0x14000514800, {0x101b693d0, 0x1400009a2d0}, {0x14000136000, 0x7, 0x7})
        github.com/earthly/earthly/cmd/earthly/main.go:716 +0x4e4
main.main()
        github.com/earthly/earthly/cmd/earthly/main.go:323 +0x75c
```