### PR TITLE
print summary of interactive debugger tests

### DIFF
--- a/scripts/tests/interactive-debugger/interactive-run/test-interactive-run.py
+++ b/scripts/tests/interactive-debugger/interactive-run/test-interactive-run.py
@@ -27,6 +27,7 @@ def test_with_exit_code(earthly_path, timeout, exit_code_to_send):
             except Exception as e:
                 raise RuntimeError(f'failed to find {question_text} in output')
 
+            print(f'sending "{exit_code_to_send}" as response to "What exit code do you want" prompt')
             c.sendline(str(exit_code_to_send))
 
             if exit_code_to_send:
@@ -39,7 +40,7 @@ def test_with_exit_code(earthly_path, timeout, exit_code_to_send):
             status = c.wait()
             print(f'earthly exited with code={status}')
             if exit_code_to_send and not status:
-                raise RuntimeError('earthly should have failed, but didnt')
+                raise RuntimeError(f'earthly should have failed (due to requested exit {exit_code_to_send}), but didnt')
             if not exit_code_to_send and status:
                 raise RuntimeError('earthly should not have failed')
 

--- a/scripts/tests/interactive-debugger/test-interactive.py
+++ b/scripts/tests/interactive-debugger/test-interactive.py
@@ -37,20 +37,34 @@ if __name__ == '__main__':
     earthly_path = os.path.realpath(get_earthly_binary(args.earthly))
     print(f'Running interactive tests against "{earthly_path}"')
 
+    tests = (
+        ('test-simple', import_test_func(os.path.join(script_dir, 'simple', 'test-simple.py'))),
+        ('test-interactive-run', import_test_func(os.path.join(script_dir, 'interactive-run', 'test-interactive-run.py'))),
+        ('test-docker-compose', import_test_func(os.path.join(script_dir, 'docker-compose', 'test-docker-compose.py'))),
+        )
+
+    num_passed = 0
+    num_tests = len(tests)
     exit_code = 0
-    for test_name, test in (
-            ('test-simple', import_test_func(os.path.join(script_dir, 'simple', 'test-simple.py'))),
-            ('test-interactive-run', import_test_func(os.path.join(script_dir, 'interactive-run', 'test-interactive-run.py'))),
-            ('test-docker-compose', import_test_func(os.path.join(script_dir, 'docker-compose', 'test-docker-compose.py'))),
-            ):
+    summary_msgs = []
+    for test_name, test in tests:
         print(f'Running {test_name}')
         test_exit_code = test(earthly_path, args.timeout)
         if test_exit_code == 2:
-            print(f'{test_name} timed out')
+            msg = f'{test_name} timed out'
+            print(msg)
+            summary_msgs.append(msg)
             exit_code = test_exit_code
         elif test_exit_code:
-            print(f'{test_name} failed with exit code={test_exit_code}')
+            msg = f'{test_name} failed with exit code={test_exit_code}'
+            print(msg)
+            summary_msgs.append(msg)
             exit_code = test_exit_code
         else:
             print(f'{test_name} passed')
+            num_passed += 1
+    print('== Summary ==')
+    print(f'{num_passed}/{num_tests} interactive-debugger tests passed')
+    for msg in summary_msgs:
+        print(msg)
     sys.exit(exit_code)


### PR DESCRIPTION
Display a summary of the total number of tests that passed, and display which ones failed at the end of the test runner.

Without this, a user might have a previous test fail, but the final test passes and displays:

    /test # cat /data.txt | base64 -d
    e88cc2b8-c179-4ed7-8eae-207a0ef7546c/test # [6n
    test-docker-compose passed
    Error: Process completed with exit code 1.

which is confusing, as they might not know to scroll up looking for a previous test failure.

Now we will display:

    == Summary ==
    2/3 tests passed
    test-interactive-run failed with exit code=1