### PR TITLE
util/proj: allow for an empty prefix

### DIFF
--- a/cmd/earthly/init_cmds.go
+++ b/cmd/earthly/init_cmds.go
@@ -72,24 +72,12 @@ func (app *earthlyApp) actionInit(cliCtx *cli.Context) error {
 }
 
 func initSingleProject(ctx context.Context, w io.Writer, p proj.Project) error {
-	base, err := p.BaseBlock(ctx)
-	if err != nil {
-		return errors.Wrapf(err, "could not generate base target for project type %T", p)
-	}
-	err = base.Format(ctx, w, efIndent, 0)
-	if err != nil {
-		return errors.Wrapf(err, "could not format base target for project type %T", p)
-	}
-	_, err = w.Write([]byte("\n"))
-	if err != nil {
-		return errors.Wrapf(err, "could not write newline separator between targets")
-	}
-
-	tgts, err := p.Targets(ctx, "")
+	tgts, err := p.Targets(ctx)
 	if err != nil {
 		return errors.Wrapf(err, "could not generate targets for project type %T", p)
 	}
 	for i, tgt := range tgts {
+		tgt.SetPrefix(ctx, "")
 		if i > 0 {
 			_, err = w.Write([]byte("\n"))
 			if err != nil {

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -1508,8 +1508,8 @@ test-init-golang:
         echo "Earthfile (from 'earthly init') has trailing newlines"; \
         exit 1; \
     fi
-    DO +RUN_EARTHLY --target "+go-build"
-    DO +RUN_EARTHLY --target "+go-test"
+    DO +RUN_EARTHLY --target "+build"
+    DO +RUN_EARTHLY --target "+test"
 
 RUN_EARTHLY:
     COMMAND

--- a/util/proj/golang_golden_test.go
+++ b/util/proj/golang_golden_test.go
@@ -81,20 +81,20 @@ func matchGolden(t *testing.T, actualBytes []byte, path string) {
 func TestGolang_Targets_Base(t *testing.T) {
 	buf := bytes.NewBufferString(version)
 	g := proj.NewGolang(proj.StdFS(), proj.StdExecer())
-	base, err := g.BaseBlock(context.TODO())
-	if err != nil {
-		t.Fatalf("failed to load golang base target: %v", err)
-	}
-	tgts, err := g.Targets(context.TODO(), "")
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	tgts, err := g.Targets(ctx)
 	if err != nil {
 		t.Fatalf("failed to load golang targets: %v", err)
 	}
-	tgts = append([]proj.Formatter{base}, tgts...)
 	for i, tgt := range tgts {
+		tgt.SetPrefix(ctx, "")
 		if i > 0 {
 			buf.WriteString("\n")
 		}
-		err := tgt.Format(context.TODO(), buf, "    ", 0)
+		err := tgt.Format(ctx, buf, "    ", 0)
 		if err != nil {
 			t.Fatalf("failed to format code: %v", err)
 		}
@@ -108,27 +108,22 @@ func TestGolang_Targets_Base(t *testing.T) {
 func TestGolang_Targets_Named(t *testing.T) {
 	buf := bytes.NewBufferString(version)
 	g := proj.NewGolang(proj.StdFS(), proj.StdExecer())
-	base, err := g.BaseBlock(context.TODO())
-	if err != nil {
-		t.Fatalf("failed to load golang base target: %v", err)
-	}
-	baseName := "go-base"
-	buf.WriteString(baseName + ":\n")
-	err = base.Format(context.TODO(), buf, "    ", 1)
-	if err != nil {
-		t.Fatalf("failed to write base target block: %v", err)
-	}
-	buf.WriteString("\n")
 
-	tgts, err := g.Targets(context.TODO(), baseName)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	pfx := g.Type(ctx)
+
+	tgts, err := g.Targets(ctx)
 	if err != nil {
 		t.Fatalf("failed to load golang targets: %v", err)
 	}
 	for i, tgt := range tgts {
+		tgt.SetPrefix(ctx, pfx)
 		if i > 0 {
 			buf.WriteString("\n")
 		}
-		err := tgt.Format(context.TODO(), buf, "    ", 0)
+		err := tgt.Format(ctx, buf, "    ", 0)
 		if err != nil {
 			t.Fatalf("failed to format code: %v", err)
 		}

--- a/util/proj/golang_test.go
+++ b/util/proj/golang_test.go
@@ -52,6 +52,10 @@ func TestGolang(t *testing.T) {
 		t.cancel()
 	})
 
+	o.Spec("Type", func(t testCtx) {
+		t.expect(t.golang.Type(t.ctx)).To(equal("go"))
+	})
+
 	o.Group("ForDir", func() {
 		o.Spec("it skips projects without a go.mod", func(t testCtx) {
 			pers.Return(t.fs.StatOutput, nil, fs.ErrNotExist)

--- a/util/proj/imports_test.go
+++ b/util/proj/imports_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 var (
+	equal        = matchers.Equal
 	haveOccurred = matchers.HaveOccurred
 	not          = matchers.Not
 

--- a/util/proj/proj.go
+++ b/util/proj/proj.go
@@ -82,9 +82,13 @@ func StdExecer() Execer {
 // ErrSkip is an error that means that the project should skip this generator.
 var ErrSkip = errors.New("proj: this project is not a supported type")
 
-// Formatter is a type that can return formatted code with a given indent string
+// Target is a type that can write a formatted target with a given indent string
 // and indentation level
-type Formatter interface {
+type Target interface {
+	// SetPrefix sets a prefix to prepend to this target's name.
+	SetPrefix(context.Context, string)
+
+	// Format writes out the target with the given indentation string and level.
 	Format(ctx context.Context, w io.Writer, indent string, level int) error
 }
 
@@ -101,17 +105,13 @@ type Project interface {
 	// Root returns the root directory for this Project.
 	Root(context.Context) string
 
-	// BaseBlock returns the block of commands that will be used as a base
-	// target for this Project. If the generated Earthfile is for one Project,
-	// then these commands will be part of the base target; otherwise they will
-	// be added to a named target for this project.
-	BaseBlock(context.Context) (Formatter, error)
+	// Type returns a unique name for this project type. It will be used for
+	// conflict avoidance (i.e. making sure we don't have two go modules loaded)
+	// and as a prefix for targets in multi-project-type Earthfiles.
+	Type(context.Context) string
 
-	// Targets returns a list of targets for this Project. The baseTargetName
-	// will be the name of the target that the BaseBlock commands were added to.
-	// If the baseTargetName is empty, then the commands were added to the
-	// actual base target, and no FROM command should be necessary to use it.
-	Targets(ctx context.Context, baseTargetName string) ([]Formatter, error)
+	// Targets returns a list of targets for this Project.
+	Targets(ctx context.Context) ([]Target, error)
 }
 
 // All returns all available project types for the given dir.

--- a/util/proj/testdata/golang_base.out
+++ b/util/proj/testdata/golang_base.out
@@ -6,7 +6,7 @@ LET distro = alpine3.18
 FROM golang:${go_version}-${distro}
 WORKDIR /go-workdir
 
-go-deps:
+deps:
     # These cache dirs will be used in later test and build targets
     # to persist cached go packages.
     #
@@ -23,8 +23,8 @@ go-deps:
     COPY --if-exists go.sum .
     RUN go mod download
 
-go-test-base:
-    FROM +go-deps
+test-base:
+    FROM +deps
 
     # gcc and g++ are required for -race.
     RUN apk add --update gcc g++
@@ -33,9 +33,9 @@ go-test-base:
     # limiting this to _just_ files required by your go tests.
     COPY . .
 
-# go-test-race runs 'go test -race'.
-go-test-race:
-    FROM +go-test-base
+# test-race runs 'go test -race'.
+test-race:
+    FROM +test-base
 
     CACHE --sharing shared "$GOCACHE"
     CACHE --sharing shared "$GOMODCACHE"
@@ -45,9 +45,9 @@ go-test-race:
 
     RUN go test -race "$package"
 
-# go-test-integration runs 'go test -tags integration'.
-go-test-integration:
-    FROM +go-test-base
+# test-integration runs 'go test -tags integration'.
+test-integration:
+    FROM +test-base
 
     CACHE --sharing shared "$GOCACHE"
     CACHE --sharing shared "$GOMODCACHE"
@@ -57,29 +57,29 @@ go-test-integration:
 
     RUN go test -tags integration "$package"
 
-# go-test runs all go test targets
-go-test:
-    BUILD +go-test-race
-    BUILD +go-test-integration
+# test runs all go test targets
+test:
+    BUILD +test-race
+    BUILD +test-integration
 
-go-proj-base:
-    FROM +go-deps
+proj-base:
+    FROM +deps
 
     # This copies the whole project. If you want better caching, try
     # limiting this to _just_ files required by your go project.
     COPY . .
 
-# go-mod-tidy runs 'go mod tidy', saving go.mod and go.sum locally.
-go-mod-tidy:
-    FROM +go-proj-base
+# mod-tidy runs 'go mod tidy', saving go.mod and go.sum locally.
+mod-tidy:
+    FROM +proj-base
 
     RUN go mod tidy
     SAVE ARTIFACT go.mod AS LOCAL go.mod
     SAVE ARTIFACT --if-exists go.sum AS LOCAL go.sum
 
-# go-build runs 'go build ./...', saving artifacts locally.
-go-build:
-    FROM +go-proj-base
+# build runs 'go build ./...', saving artifacts locally.
+build:
+    FROM +proj-base
 
     CACHE --sharing shared "$GOCACHE"
     CACHE --sharing shared "$GOMODCACHE"


### PR DESCRIPTION
This allows 'earthly init' to initialize a single-type project without the type-specific prefix. So no more '+go-build' in go-only projects, it's just '+build'.