### PR TITLE
Support changing platform in satellite update command

### DIFF
--- a/cloud/satellite.go
+++ b/cloud/satellite.go
@@ -313,6 +313,7 @@ type UpdateSatelliteOpt struct {
 	OrgName                 string
 	PinnedVersion           string
 	Size                    string
+	Platform                string
 	MaintenanceWindowStart  string
 	MaintenanceWeekendsOnly bool
 	DropCache               bool
@@ -334,6 +335,7 @@ func (c *Client) UpdateSatellite(ctx context.Context, opt UpdateSatelliteOpt) er
 		MaintenanceWindowStart:  opt.MaintenanceWindowStart,
 		MaintenanceWeekendsOnly: opt.MaintenanceWeekendsOnly,
 		Size:                    opt.Size,
+		Platform:                opt.Platform,
 	}
 	_, err = c.compute.UpdateSatellite(c.withAuth(ctx), req)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/docker/distribution v2.8.2+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/dustin/go-humanize v1.0.1
-	github.com/earthly/cloud-api v1.0.1-0.20230728191942-6d4979178ebd
+	github.com/earthly/cloud-api v1.0.1-0.20230802160321-f21bebf6053d
 	github.com/earthly/earthly/ast v0.0.0-00010101000000-000000000000
 	github.com/earthly/earthly/util/deltautil v0.0.0-00010101000000-000000000000
 	github.com/elastic/go-sysinfo v1.9.0

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/docker/distribution v2.8.2+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/dustin/go-humanize v1.0.1
-	github.com/earthly/cloud-api v1.0.1-0.20230718201745-618092fd204c
+	github.com/earthly/cloud-api v1.0.1-0.20230728191942-6d4979178ebd
 	github.com/earthly/earthly/ast v0.0.0-00010101000000-000000000000
 	github.com/earthly/earthly/util/deltautil v0.0.0-00010101000000-000000000000
 	github.com/elastic/go-sysinfo v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -171,8 +171,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/earthly/buildkit v0.0.0-20230727195742-97d5352c297d h1:YK/whHdP/m8EKpU+Ii0Wn28PUmKAtqq5z6OvJ04gtSY=
 github.com/earthly/buildkit v0.0.0-20230727195742-97d5352c297d/go.mod h1:P7bVT9bNSjRkPvWZwVvrCmXzP6bfqw2T9GB7iKMP34s=
-github.com/earthly/cloud-api v1.0.1-0.20230728191942-6d4979178ebd h1:9eHQh8RKm6LwcNnNNEW+9Tm8ZU2lJEAwkbaCYPY3jS8=
-github.com/earthly/cloud-api v1.0.1-0.20230728191942-6d4979178ebd/go.mod h1:rU/tYJ7GFBjdKAITV2heDbez++glpGSbtJaZcp73rNI=
+github.com/earthly/cloud-api v1.0.1-0.20230802160321-f21bebf6053d h1:NPIWdT1f/wzFfuN9rCfj4dcmQD1SPAva5/I5wBfBE2c=
+github.com/earthly/cloud-api v1.0.1-0.20230802160321-f21bebf6053d/go.mod h1:rU/tYJ7GFBjdKAITV2heDbez++glpGSbtJaZcp73rNI=
 github.com/earthly/fsutil v0.0.0-20230530182746-82567e6e2a92 h1:dy3w3B4OiDyQS+iHi/beUgMDJ1+fAAgbtr7OZ0d9ks0=
 github.com/earthly/fsutil v0.0.0-20230530182746-82567e6e2a92/go.mod h1:q1CxMSzcAbjUkVGHoZeQUcCaALnaE4XdWk+zJcgMYFw=
 github.com/elastic/go-sysinfo v1.9.0 h1:usICqY/Nw4Mpn9f4LdtpFrKxXroJDe81GaxxUlCckIo=

--- a/go.sum
+++ b/go.sum
@@ -171,8 +171,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/earthly/buildkit v0.0.0-20230727195742-97d5352c297d h1:YK/whHdP/m8EKpU+Ii0Wn28PUmKAtqq5z6OvJ04gtSY=
 github.com/earthly/buildkit v0.0.0-20230727195742-97d5352c297d/go.mod h1:P7bVT9bNSjRkPvWZwVvrCmXzP6bfqw2T9GB7iKMP34s=
-github.com/earthly/cloud-api v1.0.1-0.20230718201745-618092fd204c h1:hSfK+slM1jjAPLQJ12c6vsVoNPOvTgzHSW3NHMouu4E=
-github.com/earthly/cloud-api v1.0.1-0.20230718201745-618092fd204c/go.mod h1:rU/tYJ7GFBjdKAITV2heDbez++glpGSbtJaZcp73rNI=
+github.com/earthly/cloud-api v1.0.1-0.20230728191942-6d4979178ebd h1:9eHQh8RKm6LwcNnNNEW+9Tm8ZU2lJEAwkbaCYPY3jS8=
+github.com/earthly/cloud-api v1.0.1-0.20230728191942-6d4979178ebd/go.mod h1:rU/tYJ7GFBjdKAITV2heDbez++glpGSbtJaZcp73rNI=
 github.com/earthly/fsutil v0.0.0-20230530182746-82567e6e2a92 h1:dy3w3B4OiDyQS+iHi/beUgMDJ1+fAAgbtr7OZ0d9ks0=
 github.com/earthly/fsutil v0.0.0-20230530182746-82567e6e2a92/go.mod h1:q1CxMSzcAbjUkVGHoZeQUcCaALnaE4XdWk+zJcgMYFw=
 github.com/elastic/go-sysinfo v1.9.0 h1:usICqY/Nw4Mpn9f4LdtpFrKxXroJDe81GaxxUlCckIo=


### PR DESCRIPTION
Allows users to specify a new platform in the satellite update command. Note that this is currently the only way to change a runner in Earthly CI to ARM.