### PR TITLE
include dind base os version in tag

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -1,5 +1,5 @@
 # TODO: we must change the DOCKERHUB_USER_SECRET args to be project-based before we can change to 0.7
-VERSION --shell-out-anywhere --use-copy-link --no-network 0.6
+VERSION --shell-out-anywhere --use-copy-link --no-network --arg-scope-and-set 0.6
 
 FROM golang:1.20-alpine3.17
 
@@ -522,26 +522,25 @@ ci-release:
     SAVE IMAGE --push earthly/earthlybinaries:${EARTHLY_GIT_HASH}-${TAG_SUFFIX}
 
 dind:
-    BUILD +dind-alpine
-    BUILD +dind-ubuntu
-
-dind-alpine:
-    FROM docker:20.10.14-dind
+    ARG OS_IMAGE # e.g. alpine, ubuntu
+    ARG OS_VERSION # e.g. 3.18.0, 23.04
+    FROM $OS_IMAGE:$OS_VERSION
     COPY ./buildkitd/docker-auto-install.sh /usr/local/bin/docker-auto-install.sh
     RUN docker-auto-install.sh
-    ARG EARTHLY_TARGET_TAG_DOCKER
-    ARG DIND_ALPINE_TAG=alpine-$EARTHLY_TARGET_TAG_DOCKER
+    ARG INCLUDE_TARGET_TAG_DOCKER=true
+    IF [ "$INCLUDE_TARGET_TAG_DOCKER" = "true" ]
+      ARG EARTHLY_TARGET_TAG_DOCKER
+      LET TAG=$OS_IMAGE-$OS_VERSION-$EARTHLY_TARGET_TAG_DOCKER
+    ELSE
+      LET TAG=$OS_IMAGE-$OS_VERSION
+    END
     ARG DOCKERHUB_USER=earthly
-    SAVE IMAGE --push --cache-from=earthly/dind:main $DOCKERHUB_USER/dind:$DIND_ALPINE_TAG
-
-dind-ubuntu:
-    FROM ubuntu:20.04
-    COPY ./buildkitd/docker-auto-install.sh /usr/local/bin/docker-auto-install.sh
-    RUN docker-auto-install.sh
-    ARG EARTHLY_TARGET_TAG_DOCKER
-    ARG DIND_UBUNTU_TAG=ubuntu-$EARTHLY_TARGET_TAG_DOCKER
-    ARG DOCKERHUB_USER=earthly
-    SAVE IMAGE --push --cache-from=earthly/dind:ubuntu-main $DOCKERHUB_USER/dind:$DIND_UBUNTU_TAG
+    ARG LATEST
+    IF [ "$LATEST" = "true" ]
+      # latest means the version is ommitted (for historical reasons we initially just called it earthly/dind:alpine or earthly/dind:ubuntu)
+      SAVE IMAGE --push --cache-from=earthly/dind:$OS_IMAGE-main $DOCKERHUB_USER/dind:$OS_IMAGE
+    END
+    SAVE IMAGE --push --cache-from=earthly/dind:$OS_IMAGE-main $DOCKERHUB_USER/dind:$TAG
 
 # for-own builds earthly-buildkitd and the earthly CLI for the current system
 # and saves the final CLI binary locally.
@@ -592,11 +591,22 @@ all-buildkitd:
         --platform=linux/arm64 \
         ./buildkitd+buildkitd --BUILDKIT_PROJECT="$BUILDKIT_PROJECT"
 
+dind-alpine:
+    BUILD +dind --OS_IMAGE=alpine --OS_VERSION=3.18 --LATEST=true
+
+dind-ubuntu:
+    BUILD +dind --OS_IMAGE=ubuntu --OS_VERSION=20.04
+    BUILD +dind --OS_IMAGE=ubuntu --OS_VERSION=23.04 --LATEST=true
+
 all-dind:
     BUILD \
         --platform=linux/amd64 \
         --platform=linux/arm64 \
-        +dind
+        +dind-alpine
+    BUILD \
+        --platform=linux/amd64 \
+        --platform=linux/arm64 \
+        +dind-ubuntu
 
 all:
     BUILD +all-buildkitd

--- a/Earthfile
+++ b/Earthfile
@@ -120,7 +120,7 @@ lint-scripts:
 earthly-script-no-stdout:
     # This validates the ./earthly script doesn't print anything to stdout (it should print to stderr)
     # This is to ensure commands such as: MYSECRET="$(./earthly secrets get -n /user/my-secret)" work
-    FROM earthly/dind:alpine
+    FROM earthly/dind:alpine-3.18
     RUN apk add --no-cache --update bash
     COPY earthly .earthly_version_flag_overrides .
 
@@ -537,7 +537,7 @@ dind:
     ARG DOCKERHUB_USER=earthly
     ARG LATEST
     IF [ "$LATEST" = "true" ]
-      # latest means the version is ommitted (for historical reasons we initially just called it earthly/dind:alpine or earthly/dind:ubuntu)
+      # latest means the version is ommitted (for historical reasons we initially just called it earthly/dind:alpine-3.18 or earthly/dind:ubuntu)
       SAVE IMAGE --push --cache-from=earthly/dind:$OS_IMAGE-main $DOCKERHUB_USER/dind:$OS_IMAGE
     END
     SAVE IMAGE --push --cache-from=earthly/dind:$OS_IMAGE-main $DOCKERHUB_USER/dind:$TAG

--- a/ast/tests/with-docker.ast.json
+++ b/ast/tests/with-docker.ast.json
@@ -3,7 +3,7 @@
     {
       "command": {
         "args": [
-          "earthly/dind:alpine"
+          "earthly/dind:alpine-3.18"
         ],
         "name": "FROM"
       }
@@ -797,7 +797,7 @@
         {
           "command": {
             "args": [
-              "earthly/dind:alpine"
+              "earthly/dind:alpine-3.18"
             ],
             "name": "FROM"
           }
@@ -856,7 +856,7 @@
         {
           "command": {
             "args": [
-              "earthly/dind:alpine"
+              "earthly/dind:alpine-3.18"
             ],
             "name": "FROM"
           }

--- a/buildkitd/docker-auto-install.sh
+++ b/buildkitd/docker-auto-install.sh
@@ -6,7 +6,7 @@ distro=$(. /etc/os-release && echo "$ID")
 
 detect_dockerd() {
     set +e
-    command -v dockerd
+    command -v dockerd >/dev/null
     has_d="$?"
     set -e
     return "$has_d"
@@ -14,7 +14,7 @@ detect_dockerd() {
 
 detect_docker_compose() {
     set +e
-    command -v docker-compose
+    command -v docker-compose >/dev/null
     has_dc="$?"
     set -e
     return "$has_dc"
@@ -35,7 +35,7 @@ detect_docker_compose_cmd() {
 
 detect_jq() {
     set +e
-    command -v jq
+    command -v jq >/dev/null
     has_jq="$?"
     set -e
     return "$has_jq"

--- a/buildkitd/dockerd-wrapper.sh
+++ b/buildkitd/dockerd-wrapper.sh
@@ -31,6 +31,7 @@ docker_compose_cmd() {
     done
     export COMPOSE_HTTP_TIMEOUT=600
     docker_compose="$(detect_docker_compose_cmd)"
+    export COMPOSE_PROJECT_NAME="default" # newer versions of docker fail if this is not set; older versions used "default" when it was not set
     # shellcheck disable=SC2086
     $docker_compose $compose_file_flags "$@"
 }

--- a/buildkitd/dockerd-wrapper.sh
+++ b/buildkitd/dockerd-wrapper.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
-
 set -eu
+
+EARTHLY_DOCKER_WRAPPER_DEBUG=${EARTHLY_DOCKER_WRAPPER_DEBUG:-''}
+if [ "$EARTHLY_DOCKER_WRAPPER_DEBUG" = "1" ]; then
+    echo "enabling docker wrapper debug mode"
+    set -x
+fi
 
 # This host is used to pull images from the embedded BuildKit Docker registry.
 buildkit_docker_registry='172.30.0.1:8371'
@@ -135,6 +140,7 @@ EOF
     # Start with wiping the dir to make sure a previous interrupted build did not leave its state around.
     wipe_data_root "$data_root"
     mkdir -p "$data_root"
+    rm -f /var/run/docker.pid
     dockerd >/var/log/docker.log 2>&1 &
     dockerd_pid="$!"
     i=1
@@ -247,6 +253,14 @@ load_registry_images() {
         echo "...done"
     fi
 }
+
+EARTHLY_DOCKER_WRAPPER_DEBUG_CMD=${EARTHLY_DOCKER_WRAPPER_DEBUG_CMD:-''}
+if [ -n "$EARTHLY_DOCKER_WRAPPER_DEBUG_CMD" ]; then
+    echo "Running debug command: $EARTHLY_DOCKER_WRAPPER_DEBUG_CMD"
+    eval "$EARTHLY_DOCKER_WRAPPER_DEBUG_CMD"
+    echo "debug command exited with $?; forcing exit 1 to prevent saving RUN snapshot"
+    exit 1
+fi
 
 case "$1" in
     get-compose-config)

--- a/examples/grpc/Earthfile
+++ b/examples/grpc/Earthfile
@@ -35,7 +35,7 @@ WORKDIR /example-grpc
 #      the returned value is "salmon".
 
 test:
-    FROM earthly/dind:alpine
+    FROM earthly/dind:alpine-3.18
     WITH DOCKER \
         --load kvserver:latest=github.com/earthly/earthly-example-proto-server:main+kvserver-docker \
         --load kv-py-client:latest=github.com/earthly/earthly-example-proto-python-client:main+kvclient-docker \

--- a/examples/integration-test/Earthfile
+++ b/examples/integration-test/Earthfile
@@ -1,5 +1,5 @@
 VERSION 0.7
-FROM earthly/dind:alpine
+FROM earthly/dind:alpine-3.18
 WORKDIR /scala-example
 RUN apk add openjdk11 bash wget postgresql-client
 

--- a/examples/react/Earthfile
+++ b/examples/react/Earthfile
@@ -16,7 +16,7 @@ docker:
   SAVE IMAGE --push earthly/examples:react
   
 run:
-  FROM earthly/dind:alpine
+  FROM earthly/dind:alpine-3.18
   WITH DOCKER --load app:test=+docker
     RUN docker run --rm -p 3000:80 app:test
   END

--- a/examples/tutorial/go/part6/Earthfile
+++ b/examples/tutorial/go/part6/Earthfile
@@ -29,7 +29,7 @@ test-setup:
     SAVE IMAGE test:latest
 
 integration-tests:
-    FROM earthly/dind:alpine
+    FROM earthly/dind:alpine-3.18
     COPY docker-compose.yml ./
     WITH DOCKER --compose docker-compose.yml --load tests:latest=+test-setup
         RUN docker run --network=default_go/part6_default tests:latest | grep "ok"

--- a/examples/tutorial/java/part6/Earthfile
+++ b/examples/tutorial/java/part6/Earthfile
@@ -23,7 +23,7 @@ docker:
     SAVE IMAGE java-example:$tag
 
 integration-tests:
-    FROM earthly/dind:alpine
+    FROM earthly/dind:alpine-3.18
 	COPY ./docker-compose.yml .
 	RUN apk update
 	RUN apk add postgresql-client

--- a/examples/tutorial/js/part6/Earthfile
+++ b/examples/tutorial/js/part6/Earthfile
@@ -44,7 +44,7 @@ api-docker:
     SAVE IMAGE js-api:$tag
 
 integration-tests:
-    FROM earthly/dind:alpine
+    FROM earthly/dind:alpine-3.18
     RUN apk add curl
     WITH DOCKER \
         --load app:latest=+app-docker \

--- a/examples/tutorial/python/part6/Earthfile
+++ b/examples/tutorial/python/part6/Earthfile
@@ -12,7 +12,7 @@ build:
     SAVE ARTIFACT src /src
 
 integration-tests:
-	FROM earthly/dind:alpine
+	FROM earthly/dind:alpine-3.18
 	COPY ./docker-compose.yml .
 	COPY ./tests ./tests
 	RUN apk update

--- a/release/Earthfile
+++ b/release/Earthfile
@@ -21,14 +21,7 @@ release:
 release-dind:
     ARG DOCKERHUB_USER="earthly"
     BUILD ../+all-dind \
-        --DIND_ALPINE_TAG=alpine \
-        --DIND_UBUNTU_TAG=ubuntu \
-        --DOCKERHUB_USER="$DOCKERHUB_USER"
-    BUILD \
-        --platform=linux/amd64 \
-        --platform=linux/arm64 \
-        ../+dind-alpine \
-        --DIND_ALPINE_TAG=latest \
+        --INCLUDE_TARGET_TAG_DOCKER=false \
         --DOCKERHUB_USER="$DOCKERHUB_USER"
 
 release-dockerhub:

--- a/scripts/tests/interactive-debugger/docker-compose/Earthfile
+++ b/scripts/tests/interactive-debugger/docker-compose/Earthfile
@@ -1,5 +1,5 @@
 VERSION 0.7
-FROM earthly/dind:alpine
+FROM earthly/dind:alpine-3.18
 
 fail-with-docker-compose:
     WORKDIR /test

--- a/scripts/tests/interactive-debugger/docker-compose/docker-compose.yml
+++ b/scripts/tests/interactive-debugger/docker-compose/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3"
 
 services:
   rot13:
+    container_name: rot13
     image: earthly/rot13:latest
     ports:
       - 127.0.0.1:5432:5432

--- a/scripts/tests/interactive-debugger/docker-compose/test-docker-compose.py
+++ b/scripts/tests/interactive-debugger/docker-compose/test-docker-compose.py
@@ -27,7 +27,7 @@ def test_interactive(earthly_path, timeout):
             time.sleep(5)
 
             # test we can obtain decoded text from the rot13 echo server that is created via docker-compose
-            c.sendline('docker exec test_rot13_1 sh -c \'(echo guvf vf zl Frpe3g Z3ff4tr; sleep 1) | ncat localhost 5432\'')
+            c.sendline('docker exec rot13 sh -c \'(echo guvf vf zl Frpe3g Z3ff4tr; sleep 1) | ncat localhost 5432\'')
             try:
                 c.expect('this is my Secr3t M3ss4ge', timeout=timeout)
             except Exception as e:

--- a/tests/ssh.earth
+++ b/tests/ssh.earth
@@ -8,6 +8,7 @@ test:
 
 test-with-docker:
     FROM earthly/dind:alpine
+    RUN apk --update add openssh-client
     WITH DOCKER
         RUN --ssh test -n "$SSH_AUTH_SOCK" && ssh-add -l | grep 'rsa-key-from-earthly-tests'
     END

--- a/tests/wait-block/save-image/Earthfile
+++ b/tests/wait-block/save-image/Earthfile
@@ -26,7 +26,7 @@ check-tag-exists-locally:
     RUN docker images "$REGISTRY/myuser/myimg:$tag" | grep "$tag"
 
 check-with-docker-pull-works:
-    FROM earthly/dind:alpine
+    FROM earthly/dind:alpine-3.18
     ARG --required REGISTRY
     ARG --required tag
     WITH DOCKER --pull $REGISTRY/myuser/myimg:$tag
@@ -34,7 +34,7 @@ check-with-docker-pull-works:
     END
 
 check-with-docker-load-works:
-    FROM earthly/dind:alpine
+    FROM earthly/dind:alpine-3.18
     WITH DOCKER --load mytestimg=+myimg
         RUN docker run mytestimg /bin/sh -c 'cat /special-data' | grep NWMyMTQ2Y
     END

--- a/tests/wait-block/with-docker-run-load/Earthfile
+++ b/tests/wait-block/with-docker-run-load/Earthfile
@@ -26,7 +26,7 @@ a-test-image:
     SAVE IMAGE $REGISTRY/myuser/myimg:$tag
 
 test:
-    FROM earthly/dind:alpine
+    FROM earthly/dind:alpine-3.18
     ARG --required REGISTRY
     ARG --required tag
     WAIT

--- a/tests/with-docker-expose/Earthfile
+++ b/tests/with-docker-expose/Earthfile
@@ -1,5 +1,5 @@
 VERSION 0.7
-FROM earthly/dind:alpine
+FROM earthly/dind:alpine-3.18
 
 all:
     BUILD +test-single

--- a/tests/with-docker-registry/Earthfile
+++ b/tests/with-docker-registry/Earthfile
@@ -1,5 +1,5 @@
 VERSION 0.7
-FROM earthly/dind:alpine
+FROM earthly/dind:alpine-3.18
 
 all:
     BUILD +empty-test

--- a/tests/with-docker-via-command/Earthfile
+++ b/tests/with-docker-via-command/Earthfile
@@ -11,6 +11,6 @@ MY_COMMAND_WITH_DOCKER:
     END
 
 test:
-    FROM earthly/dind:alpine
+    FROM earthly/dind:alpine-3.18
     DO +MY_COMMAND_WITH_DOCKER --MY_ARG="myvalue"
     DO +MY_COMMAND_WITH_DOCKER

--- a/tests/with-docker/Earthfile
+++ b/tests/with-docker/Earthfile
@@ -1,5 +1,5 @@
 VERSION 0.7
-FROM earthly/dind:alpine
+FROM earthly/dind:alpine-3.18
 
 all:
     BUILD +empty-test
@@ -135,7 +135,7 @@ multi-from-two:
     FROM alpine:latest
 
 one-target-many-names:
-    FROM earthly/dind:alpine
+    FROM earthly/dind:alpine-3.18
     WITH DOCKER \
             --load a:latest=+multi-from-one \  # Test that there can be multiple names assigned to an image from a single target
             --load b:latest=+multi-from-one \
@@ -149,7 +149,7 @@ one-target-many-names:
     END
 
 if-after:
-    FROM earthly/dind:alpine
+    FROM earthly/dind:alpine-3.18
     WITH DOCKER --load a:latest=+multi-from-one
         RUN docker run a:latest
     END


### PR DESCRIPTION
New dind image tags are:

    earthly/dind:alpine-3.18 (which is also earthly/dind:alpine)
    earthly/dind:ubuntu-20.04
    earthly/dind:ubuntu-23.04 (which is also earthly/dind:ubuntu)