### PR TITLE
include docker version in dind tag

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -552,9 +552,12 @@ ci-release:
 
 # dind builds both the alpine and ubuntu dind containers for earthly
 dind:
-    ARG --required OS_IMAGE # e.g. alpine, ubuntu
-    ARG --required OS_VERSION # e.g. 3.18.0, 23.04
-    ARG --required DOCKER_VERSION # e.g. 20.10.14
+    # OS_IMAGE is the base image to use, e.g. alpine, ubuntu
+    ARG --required OS_IMAGE
+    # OS_VERSION is the version of the base OS to use, e.g. 3.18.0, 23.04
+    ARG --required OS_VERSION
+    # DOCKER_VERSION is the version of docker to use, e.g. 20.10.14
+    ARG --required DOCKER_VERSION
     FROM $OS_IMAGE:$OS_VERSION
     COPY ./buildkitd/docker-auto-install.sh /usr/local/bin/docker-auto-install.sh
     RUN docker-auto-install.sh

--- a/buildkitd/docker-auto-install.sh
+++ b/buildkitd/docker-auto-install.sh
@@ -3,6 +3,7 @@
 set -eu
 
 distro=$(. /etc/os-release && echo "$ID")
+DOCKER_VERSION="${DOCKER_VERSION:-}"
 
 detect_dockerd() {
     set +e
@@ -96,7 +97,11 @@ install_docker_compose() {
 install_dockerd() {
     case "$distro" in
         alpine)
-            apk add --update --no-cache docker
+            if [ -n "$DOCKER_VERSION" ]; then
+              apk add --update --no-cache docker="$DOCKER_VERSION"
+            else
+              apk add --update --no-cache docker
+            fi
             ;;
 
         amzn)
@@ -181,7 +186,12 @@ install_dockerd_debian_like() {
             ;;
     esac
     apt-get update # dont use apt_get_update since we must update the newly added apt repo
-    apt-get install -y docker-ce docker-ce-cli containerd.io
+    if [ -n "$DOCKER_VERSION" ]; then
+        apt-get install -y docker-ce="$DOCKER_VERSION"
+    else
+        apt-get install -y docker-ce
+    fi
+    apt-get install -y docker-ce-cli containerd.io
 }
 
 install_dockerd_amazon() {

--- a/docs/docker-images/dind.md
+++ b/docs/docker-images/dind.md
@@ -4,9 +4,9 @@ See the ["use-earthly-dind" best-practice](https://docs.earthly.dev/best-practic
 
 ## Tags
 
-* `alpine-3.18`
-* `ubuntu-23.04`
-* `ubuntu-20.04`
+* `alpine-3.18-docker-23.0.6-r4`
+* `ubuntu-20.04-docker-24.0.5-1`
+* `ubuntu-23.04-docker-24.0.5-1`
 
 ## Outdated Tags
 
@@ -15,7 +15,7 @@ See the ["use-earthly-dind" best-practice](https://docs.earthly.dev/best-practic
 
 ## Note
 
-The `alpine` and `ubuntu` images are incompatable with the earthly v0.7.14 onwards; newer versions of earthly should use the tags that contain an OS specific version in them.
+The `alpine` and `ubuntu` images are incompatible with the earthly v0.7.14 onwards; newer versions of earthly should use the tags that contain an OS specific version in them.
 
 To ease this transition, one can make use of an `IF` command that depends on the `EARTHLY_VERSION` builtin argument:
 
@@ -23,12 +23,12 @@ To ease this transition, one can make use of an `IF` command that depends on the
 VERSION 0.7
 
 dind:
-  FROM earthly/dind:alpine #alpine-3.18
+  FROM earthly/dind:alpine
   ARG EARTHLY_VERSION
   ARG SMALLEST_VERSION="$(echo -e "$EARTHLY_VERSION\nv0.7.14" | sort -V | head -n 1)"
   IF [ "$SMALLEST_VERSION" = "v0.7.14" ]
-    # earthly is at v0.7.14 or newer, and must use the more recent dind:alpine-3.18 image
-    FROM earthly/dind:alpine-3.18
+    # earthly is at v0.7.14 or newer, and must use the more recent dind:alpine-3.18-docker-23.0.6-r4 image
+    FROM earthly/dind:alpine-3.18-docker-23.0.6-r4
   END
 
 test:


### PR DESCRIPTION
earthly/dind images will now include the docker version in the tag.

For example:

    alpine-3.18-docker-23.0.6-r4
    ubuntu-23.04-docker-24.0.5-1

Additionally we will tag images to include when they were produced.

For example:

    alpine-3.18-docker-23.0.6-r4-20230808225455
    ubuntu-23.04-docker-24.0.5-1-20230808225455