### PR TITLE
limit docker hub readme paths

### DIFF
--- a/.github/workflows/update-docker-hub-readmes.yml
+++ b/.github/workflows/update-docker-hub-readmes.yml
@@ -1,9 +1,9 @@
-name: Docker CI Ubuntu
+name: Update Docker Hub READMEs
 
 on:
   push:
     branches: [ main ]
-    paths: [ docs/** ]
+    paths: [ docs/docker-images/*.md ]
 
 jobs:
   update-docker-hub-readmes:


### PR DESCRIPTION
Limit the paths to only reference the docker hub markdowns, the `docs/**` did not discover the docker-image markdowns.