### PR TITLE
update buildkit to include extra scheduler logs

### DIFF
--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -12,7 +12,7 @@ buildkitd:
             ARG BUILDKIT_BASE_IMAGE=$BUILDKIT_PROJECT+build
         END
     ELSE
-        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:97d5352c297dda803aca907eebd9e3041493eebb+build
+        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:6d9a29f49bc4238b668797d8f5e77783de695daf+build
     END
     ARG EARTHLY_TARGET_TAG_DOCKER
     ARG TAG="dev-$EARTHLY_TARGET_TAG_DOCKER"

--- a/go.mod
+++ b/go.mod
@@ -139,6 +139,6 @@ replace (
 	github.com/jdxcode/netrc => github.com/mikejholly/netrc v0.0.0-20221121193719-a154cb29ec2a
 	github.com/jessevdk/go-flags => github.com/alexcb/go-flags v0.0.0-20210722203016-f11d7ecb5ee5
 
-	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.0-20230727195742-97d5352c297d
+	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.0-20230810234114-6d9a29f49bc4
 	github.com/tonistiigi/fsutil => github.com/earthly/fsutil v0.0.0-20230530182746-82567e6e2a92
 )

--- a/go.sum
+++ b/go.sum
@@ -169,8 +169,8 @@ github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
-github.com/earthly/buildkit v0.0.0-20230727195742-97d5352c297d h1:YK/whHdP/m8EKpU+Ii0Wn28PUmKAtqq5z6OvJ04gtSY=
-github.com/earthly/buildkit v0.0.0-20230727195742-97d5352c297d/go.mod h1:P7bVT9bNSjRkPvWZwVvrCmXzP6bfqw2T9GB7iKMP34s=
+github.com/earthly/buildkit v0.0.0-20230810234114-6d9a29f49bc4 h1:amHaXMDsefjeB3tHCu3fwsqwHDiUplJSo/CFlmkzkgI=
+github.com/earthly/buildkit v0.0.0-20230810234114-6d9a29f49bc4/go.mod h1:P7bVT9bNSjRkPvWZwVvrCmXzP6bfqw2T9GB7iKMP34s=
 github.com/earthly/cloud-api v1.0.1-0.20230802160321-f21bebf6053d h1:NPIWdT1f/wzFfuN9rCfj4dcmQD1SPAva5/I5wBfBE2c=
 github.com/earthly/cloud-api v1.0.1-0.20230802160321-f21bebf6053d/go.mod h1:rU/tYJ7GFBjdKAITV2heDbez++glpGSbtJaZcp73rNI=
 github.com/earthly/fsutil v0.0.0-20230530182746-82567e6e2a92 h1:dy3w3B4OiDyQS+iHi/beUgMDJ1+fAAgbtr7OZ0d9ks0=


### PR DESCRIPTION
Updated buildkit will include additional

    return leaving incoming open help me: %s

logs.