### PR TITLE
Enable Logstream by default

### DIFF
--- a/.github/workflows/ci-docker-ubuntu-legacy-logs.yml
+++ b/.github/workflows/ci-docker-ubuntu-legacy-logs.yml
@@ -1,0 +1,203 @@
+name: Docker CI Ubuntu (Legacy Logs)
+
+on:
+  push:
+    branches: [ main ]
+    paths-ignore: [ docs/** ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  docker-tests-quick:
+    needs: build-earthly
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      TEST_TARGET: "+test-quick"
+      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
+      RUNS_ON: "ubuntu-latest"
+      BINARY: "docker"
+      SUDO: ""
+      LOGBUS: "--logstream false"
+    secrets: inherit
+
+  docker-tests-no-qemu-quick:
+    needs: build-earthly
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      TEST_TARGET: "+test-no-qemu-quick"
+      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
+      RUNS_ON: "ubuntu-latest"
+      BINARY: "docker"
+      SUDO: ""
+      LOGBUS: "--logstream false"
+    secrets: inherit
+
+  docker-tests-no-qemu-normal:
+    needs: build-earthly
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      TEST_TARGET: "+test-no-qemu-normal"
+      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
+      RUNS_ON: "ubuntu-latest"
+      BINARY: "docker"
+      SUDO: ""
+      LOGBUS: "--logstream false"
+    secrets: inherit
+
+  docker-tests-no-qemu-slow:
+    needs: build-earthly
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      TEST_TARGET: "+test-no-qemu-slow"
+      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
+      RUNS_ON: "ubuntu-latest"
+      BINARY: "docker"
+      SUDO: ""
+      LOGBUS: "--logstream false"
+    secrets: inherit
+
+  docker-tests-require-account-access:
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    needs: build-earthly
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      TEST_TARGET: "./tests+tests-that-require-earthly-technologies-account-access"
+      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
+      RUNS_ON: "ubuntu-latest"
+      BINARY: "docker"
+      SUDO: ""
+      LOGBUS: "--logstream false"
+    secrets: inherit
+
+  docker-tests-qemu:
+    needs: build-earthly
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      TEST_TARGET: "+test-qemu"
+      USE_QEMU: true
+      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
+      RUNS_ON: "ubuntu-latest"
+      BINARY: "docker"
+      SUDO: ""
+      LOGBUS: "--logstream false"
+    secrets: inherit
+
+  docker-examples-1:
+    needs: build-earthly
+    uses: ./.github/workflows/reusable-example.yml
+    with:
+      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
+      RUNS_ON: "ubuntu-latest"
+      BINARY: "docker"
+      SUDO: ""
+      EXAMPLE_NAME: "+examples1"
+      LOGBUS: "--logstream false"
+    secrets: inherit
+
+  docker-examples-2:
+    needs: build-earthly
+    uses: ./.github/workflows/reusable-example.yml
+    with:
+      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
+      RUNS_ON: "ubuntu-latest"
+      BINARY: "docker"
+      SUDO: ""
+      EXAMPLE_NAME: "+examples2"
+      LOGBUS: "--logstream false"
+    secrets: inherit
+
+  docker-test-local:
+    needs: build-earthly
+    uses: ./.github/workflows/reusable-test-local.yml
+    with:
+      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
+      RUNS_ON: "ubuntu-latest"
+      BINARY: "docker"
+      BINARY_COMPOSE: "\"docker compose\""
+      SUDO: ""
+      LOGBUS: "--logstream false"
+    secrets: inherit
+
+  docker-push-integrations:
+    needs: build-earthly
+    uses: ./.github/workflows/reusable-push-integrations.yml
+    with:
+      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
+      RUNS_ON: "ubuntu-latest"
+      BINARY: "docker"
+      SUDO: ""
+      LOGBUS: "--logstream false"
+    secrets: inherit
+
+  docker-earthly-image-test:
+    needs: build-earthly
+    uses: ./.github/workflows/reusable-earthly-image-tests.yml
+    with:
+      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
+      RUNS_ON: "ubuntu-latest"
+      BINARY: "docker"
+      SUDO: ""
+      LOGBUS: "--logstream false"
+    secrets: inherit
+
+  docker-misc-test-2:
+    needs: build-earthly
+    uses: ./.github/workflows/reusable-misc-tests-2.yml
+    with:
+      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
+      RUNS_ON: "ubuntu-latest"
+      BINARY: "docker"
+      SUDO: ""
+      LOGBUS: "--logstream false"
+    secrets: inherit
+
+  docker-git-metadata-test:
+    needs: build-earthly
+    uses: ./.github/workflows/reusable-git-metadata-test.yml
+    with:
+      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
+      RUNS_ON: "ubuntu-latest"
+      BINARY: "docker"
+      SUDO: ""
+      LOGBUS: "--logstream false"
+    secrets: inherit
+
+  race-tests-quick:
+    needs: build-earthly
+    uses: ./.github/workflows/reusable-race-test.yml
+    with:
+      TEST_TARGET: "+test-quick"
+      RUNS_ON: "ubuntu-latest"
+      USE_QEMU: false
+      LOGBUS: "--logstream false"
+    secrets: inherit
+
+  race-tests-no-qemu-quick:
+    needs: build-earthly
+    uses: ./.github/workflows/reusable-race-test.yml
+    with:
+      TEST_TARGET: "+test-no-qemu-quick"
+      RUNS_ON: "ubuntu-latest"
+      USE_QEMU: false
+      LOGBUS: "--logstream false"
+    secrets: inherit
+
+  race-tests-no-qemu-normal:
+    needs: build-earthly
+    uses: ./.github/workflows/reusable-race-test.yml
+    with:
+      TEST_TARGET: "+test-no-qemu-normal"
+      RUNS_ON: "ubuntu-latest"
+      USE_QEMU: false
+      LOGBUS: "--logstream false"
+    secrets: inherit
+
+  race-tests-no-qemu-slow:
+    needs: build-earthly
+    uses: ./.github/workflows/reusable-race-test.yml
+    with:
+      TEST_TARGET: "+test-no-qemu-slow"
+      RUNS_ON: "ubuntu-latest"
+      USE_QEMU: false
+      LOGBUS: "--logstream false"
+    secrets: inherit

--- a/.github/workflows/reusable-earthly-image-tests.yml
+++ b/.github/workflows/reusable-earthly-image-tests.yml
@@ -15,7 +15,10 @@ on:
       RUNS_ON:
         required: true
         type: string
-
+      LOGBUS:
+        required: false
+        type: string
+        default: ""
 
 jobs:
   earthly-image-tests:
@@ -75,7 +78,7 @@ jobs:
             EARTHLY_VERSION_FLAG_OVERRIDES="$(tr -d '\n' < .earthly_version_flag_overrides)"
             echo "EARTHLY_VERSION_FLAG_OVERRIDES=$EARTHLY_VERSION_FLAG_OVERRIDES" >> "$GITHUB_ENV"
       - name: Build the earthly docker image
-        run: ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} +earthly-docker --TAG=image-test
+        run: ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} ${{inputs.LOGBUS}} +earthly-docker --TAG=image-test
       - name: "Run the earthly image tests (Earthly only)"
         run: FRONTEND=${{inputs.BINARY}} EARTHLY_IMAGE=earthly/earthly:image-test DOCKERHUB_MIRROR_USERNAME="${{ secrets.DOCKERHUB_MIRROR_USERNAME }}" DOCKERHUB_MIRROR_PASSWORD="${{ secrets.DOCKERHUB_MIRROR_PASSWORD }}" DOCKERHUB_USERNAME="${{ secrets.DOCKERHUB_USERNAME }}" DOCKERHUB_PASSWORD="${{ secrets.DOCKERHUB_PASSWORD }}" ./scripts/tests/earthly-image.sh
         if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/reusable-example.yml
+++ b/.github/workflows/reusable-example.yml
@@ -28,7 +28,10 @@ on:
       EARTHLY_ORG:
         required: false
         type: string
-
+      LOGBUS:
+        required: false
+        type: string
+        default: ""
 
 jobs:
   example:
@@ -98,14 +101,14 @@ jobs:
           EARTHLY_VERSION_FLAG_OVERRIDES="$(tr -d '\n' < .earthly_version_flag_overrides)"
           echo "EARTHLY_VERSION_FLAG_OVERRIDES=$EARTHLY_VERSION_FLAG_OVERRIDES" >> "$GITHUB_ENV"
       - name: Build ${{inputs.EXAMPLE_NAME}} (PR build)
-        run: ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} --ci -P ${{inputs.EXAMPLE_NAME}}
+        run: ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} ${{ inputs.LOGBUS }} --ci -P ${{inputs.EXAMPLE_NAME}}
         if: github.event_name != 'push'
       - name: Build ${{inputs.EXAMPLE_NAME}} (main build)
-        run: ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} --ci --push -P ${{inputs.EXAMPLE_NAME}}
+        run: ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} ${{ inputs.LOGBUS }} --ci --push -P ${{inputs.EXAMPLE_NAME}}
         if: github.event_name == 'push'
       - name: Build and test multi-platform example
         run: |
-          ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} ./examples/multiplatform+all
+          ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} ${{ inputs.LOGBUS }} ./examples/multiplatform+all
           ${{inputs.SUDO}} ${{inputs.BINARY}} run --rm earthly/examples:multiplatform_linux_arm64 | grep aarch64
       - name: Buildkit logs (runs on failure)
         run: ${{inputs.SUDO}} ${{inputs.BINARY}} logs earthly-buildkitd

--- a/.github/workflows/reusable-git-metadata-test.yml
+++ b/.github/workflows/reusable-git-metadata-test.yml
@@ -25,7 +25,10 @@ on:
       EARTHLY_ORG:
         required: false
         type: string
-
+      LOGBUS:
+        required: true
+        type: string
+        default: ""
 
 jobs:
   test:
@@ -86,7 +89,7 @@ jobs:
           echo "EARTHLY_VERSION_FLAG_OVERRIDES=$EARTHLY_VERSION_FLAG_OVERRIDES" >> "$GITHUB_ENV"
       - name: Execute git-metadata-test
         run: |-
-          ${{inputs.SUDO}} ${{ inputs.BUILT_EARTHLY_PATH }} --ci -P \
+          ${{inputs.SUDO}} ${{ inputs.BUILT_EARTHLY_PATH }} ${{ inputs.LOGBUS }} --ci -P \
             --build-arg DOCKERHUB_AUTH=true \
             --build-arg DOCKERHUB_USER_SECRET=+secrets/earthly-technologies/dockerhub-mirror/user \
             --build-arg DOCKERHUB_TOKEN_SECRET=+secrets/earthly-technologies/dockerhub-mirror/pass \

--- a/.github/workflows/reusable-misc-tests-2.yml
+++ b/.github/workflows/reusable-misc-tests-2.yml
@@ -15,7 +15,10 @@ on:
       RUNS_ON:
         required: true
         type: string
-
+      LOGBUS:
+        required: true
+        type: string
+        default: ""
 
 jobs:
   misc-tests-2:
@@ -78,7 +81,7 @@ jobs:
         run: default_install_name=earthly ./tests/remote-buildkit/remote-buildkit-test.sh
       - name: Run linux-amd64 specific tests (Earthly Only)
         run: |-
-          ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} --ci -P \
+          ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} ${{inputs.LOGBUS}} --ci -P \
               --build-arg DOCKERHUB_AUTH=true \
               --build-arg DOCKERHUB_USER_SECRET=+secrets/earthly-technologies/dockerhub-mirror/user \
               --build-arg DOCKERHUB_TOKEN_SECRET=+secrets/earthly-technologies/dockerhub-mirror/pass \
@@ -91,7 +94,7 @@ jobs:
         run: (cd tests/docker && ${{inputs.SUDO}} ../../${{inputs.BUILT_EARTHLY_PATH}} docker-build --tag examples-test-docker:latest . && diff <(docker run --rm examples-test-docker:latest) <(echo "hello dockerfile") )
       - name: Execute private image test (Earthly Only)
         run: |-
-          ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} --ci \
+          ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} ${{inputs.LOGBUS}} --ci \
             --build-arg DOCKERHUB_AUTH=true \
             --build-arg DOCKERHUB_USER_SECRET=+secrets/earthly-technologies/dockerhub-mirror/user \
             --build-arg DOCKERHUB_TOKEN_SECRET=+secrets/earthly-technologies/dockerhub-mirror/pass \
@@ -102,7 +105,7 @@ jobs:
         run: frontend=${{inputs.BINARY}} ./tests/save-images/test.sh
       - name: Experimental tests (Earthly Only)
         run: |-
-          ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} --ci -P \
+          ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} ${{inputs.LOGBUS}} --ci -P \
               --build-arg DOCKERHUB_AUTH=true \
               --build-arg DOCKERHUB_USER_SECRET=+secrets/earthly-technologies/dockerhub-mirror/user \
               --build-arg DOCKERHUB_TOKEN_SECRET=+secrets/earthly-technologies/dockerhub-mirror/pass \
@@ -111,7 +114,7 @@ jobs:
         if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
       - name: Experimental tests (Fork Only)
         run: |-
-          ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} --ci -P \
+          ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} ${{inputs.LOGBUS}} --ci -P \
               --build-arg DOCKERHUB_AUTH=false \
           ./tests+experimental
         if: github.event_name != 'push' && github.event.pull_request.head.repo.full_name != github.repository
@@ -119,7 +122,7 @@ jobs:
         run: ${{inputs.SUDO}} ${{inputs.BINARY}} logs earthly-buildkitd 2>&1 | grep 'running server on'
       - name: Test for uncommitted generated code
         run: |-
-          ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} --ci -P \
+          ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} ${{inputs.LOGBUS}} --ci -P \
               --build-arg DOCKERHUB_AUTH=true \
               --build-arg DOCKERHUB_USER_SECRET=+secrets/earthly-technologies/dockerhub-mirror/user \
               --build-arg DOCKERHUB_TOKEN_SECRET=+secrets/earthly-technologies/dockerhub-mirror/pass \

--- a/.github/workflows/reusable-push-integrations.yml
+++ b/.github/workflows/reusable-push-integrations.yml
@@ -15,7 +15,10 @@ on:
       RUNS_ON:
         required: true
         type: string
-
+      LOGBUS:
+        required: false
+        type: string
+        default: ""
 
 jobs:
   push-integrations:
@@ -58,7 +61,7 @@ jobs:
           echo "EARTHLY_VERSION_FLAG_OVERRIDES=$EARTHLY_VERSION_FLAG_OVERRIDES" >> "$GITHUB_ENV"
       - name: Push and Pull Cloud Images
         run: |-
-          ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} --ci -P  \
+          ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} ${{inputs.LOGBUS}} --ci -P  \
            --build-arg DOCKERHUB_AUTH=true \
            --build-arg DOCKERHUB_USER_SECRET=+secrets/earthly-technologies/dockerhub-mirror/user \
            --build-arg DOCKERHUB_TOKEN_SECRET=+secrets/earthly-technologies/dockerhub-mirror/pass \

--- a/.github/workflows/reusable-race-test.yml
+++ b/.github/workflows/reusable-race-test.yml
@@ -12,6 +12,10 @@ on:
       USE_QEMU:
         required: false
         type: boolean
+      LOGBUS:
+        required: false
+        type: string
+        default: ""
 
 jobs:
   test-race:
@@ -53,7 +57,7 @@ jobs:
         run: ./build/earthly --use-inline-cache ./buildkitd+buildkitd --TAG=race-test
       - name: Execute tests (Earthly Only)
         run: |-
-          GORACE="halt_on_error=1" go run -race ./cmd/earthly/*.go --buildkit-image earthly/buildkitd:race-test -P --no-output \
+          GORACE="halt_on_error=1" go run -race ./cmd/earthly/*.go --buildkit-image earthly/buildkitd:race-test ${{inputs.LOGBUS}} -P --no-output \
             --build-arg DOCKERHUB_AUTH=true \
             --build-arg DOCKERHUB_USER_SECRET=+secrets/earthly-technologies/dockerhub-mirror/user \
             --build-arg DOCKERHUB_TOKEN_SECRET=+secrets/earthly-technologies/dockerhub-mirror/pass \
@@ -62,7 +66,7 @@ jobs:
         if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
       - name: Execute tests (Fork Only)
         run: |-
-          GORACE="halt_on_error=1" go run -race ./cmd/earthly/*.go --buildkit-image earthly/buildkitd:race-test -P --no-output \
+          GORACE="halt_on_error=1" go run -race ./cmd/earthly/*.go --buildkit-image earthly/buildkitd:race-test ${{inputs.LOGBUS}} -P --no-output \
             --build-arg DOCKERHUB_AUTH=false \
             ${{inputs.TEST_TARGET}}
         if: github.event_name != 'push' && github.event.pull_request.head.repo.full_name != github.repository

--- a/.github/workflows/reusable-test-local.yml
+++ b/.github/workflows/reusable-test-local.yml
@@ -32,6 +32,10 @@ on:
       EARTHLY_ORG:
         required: false
         type: string
+      LOGBUS:
+        required: false
+        type: string
+        default: ""
 
 
 jobs:
@@ -80,11 +84,11 @@ jobs:
             EARTHLY_VERSION_FLAG_OVERRIDES="$(tr -d '\n' < .earthly_version_flag_overrides)"
             echo "EARTHLY_VERSION_FLAG_OVERRIDES=$EARTHLY_VERSION_FLAG_OVERRIDES" >> "$GITHUB_ENV"
       - name: Execute test-local
-        run: "${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} ${{inputs.RUN_EARTHLY_TEST_ARGS}} ./tests/local+test-local --FRONTEND=${{inputs.BINARY}}"
+        run: "${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} ${{inputs.LOGBUS}} ${{inputs.RUN_EARTHLY_TEST_ARGS}} ./tests/local+test-local --FRONTEND=${{inputs.BINARY}}"
       - name: Execute test-local --push
-        run: "${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} ${{inputs.RUN_EARTHLY_TEST_ARGS}} --push ./tests/local+test-local --FRONTEND=${{inputs.BINARY}}"
+        run: "${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} ${{inputs.LOGBUS}} ${{inputs.RUN_EARTHLY_TEST_ARGS}} --push ./tests/local+test-local --FRONTEND=${{inputs.BINARY}}"
       - name: Run general local tests (TODO this is re-testing the +test-local target)
-        run: "${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} ${{inputs.RUN_EARTHLY_TEST_ARGS}} ./tests/local+all --FRONTEND=${{inputs.BINARY}} --FRONTEND_COMPOSE=${{inputs.BINARY_COMPOSE}}"
+        run: "${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} ${{inputs.LOGBUS}} ${{inputs.RUN_EARTHLY_TEST_ARGS}} ./tests/local+all --FRONTEND=${{inputs.BINARY}} --FRONTEND_COMPOSE=${{inputs.BINARY_COMPOSE}}"
       - name: Buildkit logs (runs on failure)
         run: ${{inputs.SUDO}} ${{inputs.BINARY}} logs earthly-buildkitd 2>&1
         if: ${{ failure() }}

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -31,7 +31,10 @@ on:
       EARTHLY_ORG:
         required: false
         type: string
-
+      LOGBUS:
+        required: false
+        type: string
+        default: ""
 
 jobs:
   test:
@@ -104,7 +107,7 @@ jobs:
         if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
       - name: Execute ${{ inputs.TEST_TARGET }} (Fork)
         run: |-
-          ${{inputs.SUDO}} ${{ inputs.BUILT_EARTHLY_PATH }} --ci -P \
+          ${{inputs.SUDO}} ${{ inputs.BUILT_EARTHLY_PATH }} ${{ inputs.LOGBUS }} --ci -P \
             --build-arg DOCKERHUB_AUTH=false \
             ${{inputs.TEST_TARGET}}
         if: github.event_name != 'push' && github.event.pull_request.head.repo.full_name != github.repository

--- a/cmd/earthly/flag/global.go
+++ b/cmd/earthly/flag/global.go
@@ -26,6 +26,7 @@ const (
 	DefaultSecretFile = ".secret"
 	SecretFileFlag    = "secret-file-path"
 
+	DefaultLogstream       = true
 	DefaultLogstreamUpload = true
 )
 
@@ -272,6 +273,7 @@ func (global *Global) RootFlags(installName string, bkImage string) []cli.Flag {
 			Usage:       "Enable log streaming only locally",
 			Destination: &global.Logstream,
 			Hidden:      true, // Internal.
+			Value:       DefaultLogstream,
 		},
 		&cli.BoolFlag{
 			Name:        "logstream-upload",

--- a/cmd/earthly/flag/global.go
+++ b/cmd/earthly/flag/global.go
@@ -25,6 +25,8 @@ const (
 
 	DefaultSecretFile = ".secret"
 	SecretFileFlag    = "secret-file-path"
+
+	DefaultLogstreamUpload = true
 )
 
 // Put flags on Flags instead as there are other things in the CLI that are being called + set
@@ -277,6 +279,7 @@ func (global *Global) RootFlags(installName string, bkImage string) []cli.Flag {
 			Usage:       "Enable log stream uploading",
 			Destination: &global.LogstreamUpload,
 			Hidden:      true, // Internal.
+			Value:       DefaultLogstreamUpload,
 		},
 		&cli.StringFlag{
 			Name:        "logstream-debug-file",

--- a/logbus/solvermon/solvermon.go
+++ b/logbus/solvermon/solvermon.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/earthly/cloud-api/logstream"
 	"github.com/earthly/earthly/logbus"
+	"github.com/earthly/earthly/util/stringutil"
 	"github.com/earthly/earthly/util/vertexmeta"
 	"github.com/earthly/earthly/util/xcontext"
 	"github.com/moby/buildkit/client"
@@ -116,7 +117,7 @@ func (sm *SolverMonitor) handleBuildkitStatus(ctx context.Context, status *clien
 				// Run this at the end so that we capture any additional log lines.
 				defer bp.SetFatalError(
 					*vertex.Completed, vm.meta.TargetID, vm.vertex.Digest.String(),
-					vm.fatalErrorType, vm.errorStr)
+					vm.fatalErrorType, stringutil.ScrubCredentialsAll(vm.errorStr))
 			}
 		}
 	}
@@ -139,6 +140,7 @@ func (sm *SolverMonitor) handleBuildkitStatus(ctx context.Context, status *clien
 		if !exists {
 			continue
 		}
+		logLine.Data = []byte(stringutil.ScrubCredentialsAll((string(logLine.Data))))
 		_, err := vm.Write(logLine.Data, logLine.Timestamp, logLine.Stream)
 		if err != nil {
 			return err

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -579,13 +579,13 @@ fail-test:
     RUN cat output.txt
     # The output of the failed command should have been printed twice.
     RUN cat output.txt | grep 'ZmFpbCA3YjcyZTAyNC01ZTIxLTRlMWItOTZlNC02NTVjMzk4NzYxMDcK' | test "$(wc -l)" -eq 2
-    RUN cat output.txt | grep 'Repeating the output of the command that caused the failure'
+    RUN cat output.txt | grep 'Repeating the failure error...'
     RUN cat output.txt | grep 'ERROR Earthfile line 10:4'
     RUN cat output.txt | grep 'RUN echo "fail 7b72e024-5e21-4e1b-96e4-655c39876107" | base64; false'
     RUN cat output.txt | grep 'did not complete successfully. Exit code 1'
     DO +RUN_EARTHLY --earthfile=fail.earth --should_fail=true --verbose=0 --target=+test-copy --post_command="2>output.txt"
     RUN cat output.txt
-    RUN cat output.txt | grep 'Repeating the output of the command that caused the failure'
+    RUN cat output.txt | grep 'Repeating the failure error...'
     RUN cat output.txt | grep 'ERROR Earthfile line 14:4'
     RUN cat output.txt | grep 'COPY ./does-not-exist ./'
     RUN cat output.txt | grep 'failed: "/does-not-exist": not found'

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -93,7 +93,7 @@ ga-no-qemu-quick:
     BUILD +env-test
     BUILD +env-home-test
     BUILD +stack-failure-test
-    #BUILD +multi-stack-failure-test
+    BUILD +multi-stack-failure-test
     BUILD +no-cache-local-artifact-test
     BUILD +empty-git-test
     BUILD +escape-test
@@ -725,7 +725,8 @@ stack-failure-test:
 
 multi-stack-failure-test:
     RUN echo "FOO=foo" >.arg
-    RUN echo "THIS_IS_SECRET=dont-display-this" >>.arg
+    RUN echo "THIS_IS_SECRET=dont-display-this" >>.secret
+    RUN echo "THIS_IS_ALSO_A_SECRET=dont-display-this-either" >>.env # test for user accidentally putting a secret in .env (carried over from a v0.6.0 .env file)
 
     DO +RUN_EARTHLY --earthfile=multi-stack-failure.earth --extra_args="--no-output --build-arg BAR=bar" --output_contains="unknown flag .cause-interpreter-failure." --should_fail="true" --target=+fail
     RUN if grep dont-display-this earthly.output; then echo "secret was leaked!"; exit 1; fi

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -93,7 +93,7 @@ ga-no-qemu-quick:
     BUILD +env-test
     BUILD +env-home-test
     BUILD +stack-failure-test
-    BUILD +multi-stack-failure-test
+    #BUILD +multi-stack-failure-test
     BUILD +no-cache-local-artifact-test
     BUILD +empty-git-test
     BUILD +escape-test

--- a/tests/scrub-https-credentials/Earthfile
+++ b/tests/scrub-https-credentials/Earthfile
@@ -47,7 +47,7 @@ earthly --config \$earthly_config --verbose --debug +gitclone >output.txt 2>&1
         else \
             echo "OK: password was not leaked"; \
         fi
-    RUN grep 'https://testuser:\*\*\*@selfsigned.example.com' output.txt >/dev/null
+    RUN grep 'https://testuser:xxxxx@selfsigned.example.com' output.txt >/dev/null
 
 scrub-remote-credentials:
     FROM ../git-webserver+server \
@@ -79,7 +79,7 @@ earthly --config \$earthly_config --verbose --debug selfsigned.example.com/repo:
             echo "OK: password was not leaked"; \
         fi
     # make sure the scrubbed URL appears somewhere (usually under llb.customname under the debug-level gwclientlogger)
-    RUN grep 'https://testuser:\*\*\*@selfsigned.example.com' output.txt >/dev/null
+    RUN grep 'https://testuser:xxxxx@selfsigned.example.com' output.txt >/dev/null
     # echo -n 98e15fb5-197c-43bf-886e-3291e65d646e | base64
     RUN grep 'OThlMTVmYjUtMTk3Yy00M2JmLTg4NmUtMzI5MWU2NWQ2NDZl' output.txt >/dev/null
 
@@ -104,7 +104,7 @@ fi
 
     RUN grep 'failed to fetch remote' output.txt
     # test the failure message correctly scrubs the credentials
-    RUN grep 'https://kallaxtheshelf:\*\*\*@github.com' output.txt >/dev/null
+    RUN grep 'https://kallaxtheshelf:xxxxx@github.com' output.txt >/dev/null
 
     # make sure the password doesn't appear anywhere
     RUN cat output.txt && \

--- a/util/stringutil/scrub.go
+++ b/util/stringutil/scrub.go
@@ -1,10 +1,27 @@
 package stringutil
 
-import "regexp"
+import (
+	"regexp"
+	"strings"
+)
 
 var scrubRegexp = regexp.MustCompile(`^(([a-zA-Z]+://)?([^:]+)):([^@]+)@`)
 
 // ScrubCredentials removes credentials from a string
 func ScrubCredentials(s string) string {
-	return string(scrubRegexp.ReplaceAll([]byte(s), []byte("$1:***@")))
+	return string(scrubRegexp.ReplaceAll([]byte(s), []byte("$1:xxxxx@")))
+}
+
+// ScrubCredentialsAll scrubs all credentials from a longer piece of text.
+func ScrubCredentialsAll(s string) string {
+	parts := strings.Split(s, " ")
+	ret := []string{}
+	for _, part := range parts {
+		if strings.Contains(part, "@") {
+			ret = append(ret, (ScrubCredentials(part)))
+		} else {
+			ret = append(ret, part)
+		}
+	}
+	return strings.Join(ret, " ")
 }

--- a/util/stringutil/scrub.go
+++ b/util/stringutil/scrub.go
@@ -14,11 +14,15 @@ func ScrubCredentials(s string) string {
 
 // ScrubCredentialsAll scrubs all credentials from a longer piece of text.
 func ScrubCredentialsAll(s string) string {
+	// Short circuit when no basic auth credentials present.
+	if !strings.Contains(s, "@") {
+		return s
+	}
 	parts := strings.Split(s, " ")
 	ret := []string{}
 	for _, part := range parts {
 		if strings.Contains(part, "@") {
-			ret = append(ret, (ScrubCredentials(part)))
+			ret = append(ret, ScrubCredentials(part))
 		} else {
 			ret = append(ret, part)
 		}

--- a/util/stringutil/scrub_test.go
+++ b/util/stringutil/scrub_test.go
@@ -6,10 +6,15 @@ import (
 
 func TestScrub(t *testing.T) {
 	s := ScrubCredentials("https://user:password@github.com/org/repo.git")
-	Equal(t, "https://user:***@github.com/org/repo.git", s)
+	Equal(t, "https://user:xxxxx@github.com/org/repo.git", s)
 }
 
 func TestScrubMissingProtocol(t *testing.T) {
 	s := ScrubCredentials("user:password@github.com/org/repo.git")
-	Equal(t, "user:***@github.com/org/repo.git", s)
+	Equal(t, "user:xxxxx@github.com/org/repo.git", s)
+}
+
+func TestScrubInline(t *testing.T) {
+	s := ScrubCredentialsAll("Here is a URL: https://user:password@github.com/org/repo.git")
+	Equal(t, "Here is a URL: https://user:xxxxx@github.com/org/repo.git", s)
 }


### PR DESCRIPTION
This PR enables the Logstream integration by default. It includes a few test fixes where there were some differences in how logging was handled. Before we merged, I'd like to do some basic load testing of the new Logstream database sharding to make sure we can support the rollout.