### PR TITLE
prompt for secret value when missing

### DIFF
--- a/.github/workflows/reusable-secrets-integrations.yml
+++ b/.github/workflows/reusable-secrets-integrations.yml
@@ -32,6 +32,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+      - name: install expect
+        run: sudo apt-get install -y expect
       - name: remove docker
         run: ${{inputs.SUDO}} apt-get purge docker-engine docker docker.io docker-ce docker-ce-cli ; ${{inputs.SUDO}} rm -rf /usr/bin/docker
         if: inputs.BINARY == 'podman'

--- a/cmd/earthly/subcmd/account_cmds.go
+++ b/cmd/earthly/subcmd/account_cmds.go
@@ -341,8 +341,10 @@ func (a *Account) actionRegister(cliCtx *cli.Context) error {
 	return nil
 }
 
-func promptPassword() (string, error) {
-	fmt.Printf("password: ")
+// promptHiddenText prompts the user to enter a value without echoing it to stdout
+// the hiddenTextPrompt is displayed to the user followed by a colon, as an interactive prompt.
+func promptHiddenText(hiddenTextPrompt string) (string, error) {
+	fmt.Printf("%s: ", hiddenTextPrompt)
 	password, err := term.ReadPassword(int(syscall.Stdin))
 	if err != nil {
 		return "", err
@@ -350,16 +352,16 @@ func promptPassword() (string, error) {
 	fmt.Println("")
 	return string(password), nil
 }
+func promptPassword() (string, error) {
+	return promptHiddenText("password")
+}
 
 func promptNewPassword() (string, error) {
-	fmt.Printf("New password: ")
-	enteredPassword, err := term.ReadPassword(int(syscall.Stdin))
+	enteredPassword, err := promptHiddenText("New password")
 	if err != nil {
 		return "", err
 	}
-	fmt.Println("")
-	fmt.Printf("Confirm password: ")
-	enteredPassword2, err := term.ReadPassword(int(syscall.Stdin))
+	enteredPassword2, err := promptHiddenText("Confirm password")
 	if err != nil {
 		return "", err
 	}

--- a/util/termutil/is_tty.go
+++ b/util/termutil/is_tty.go
@@ -4,7 +4,11 @@ import "os"
 
 // IsTTY returns true if a terminal is detected
 func IsTTY() bool {
-	if fileInfo, _ := os.Stdout.Stat(); (fileInfo.Mode() & os.ModeCharDevice) != 0 {
+	return isFileDescriptorTTY(os.Stdin) && isFileDescriptorTTY(os.Stdout)
+}
+
+func isFileDescriptorTTY(fd *os.File) bool {
+	if fileInfo, _ := fd.Stat(); (fileInfo.Mode() & os.ModeCharDevice) != 0 {
 		return true
 	}
 	return false


### PR DESCRIPTION
When running `earthly secret set <path>`, rather than exiting with an error, we will prompt the user for a single-line secret value.

This allows a user to type in a single line followed by hitting the <enter> key.

Additionally, if `-stdin` is used from an interactive tty, earthly will now display a message saying it is waiting for an EOF (ctrl-d).

This additionally fixes a bug with isTTY, which was only checking stdout but could not detect if a command was being piped to stdin or not.