### PR TITLE
Fix redundant output

### DIFF
--- a/earthfile2llb/with_docker_run_base.go
+++ b/earthfile2llb/with_docker_run_base.go
@@ -72,7 +72,7 @@ func (w *withDockerRunBase) installDeps(ctx context.Context, opt WithDockerOpt) 
 		llb.AddMount(
 			dockerAutoInstallScriptPath, llb.Scratch(), llb.HostBind(), llb.SourcePath(dockerAutoInstallScriptPath)),
 		llb.Args(args),
-		llb.WithCustomNamef("%sWITH DOCKER (install deps)", w.c.vertexPrefix(ctx, false, false, false, opt.Secrets)),
+		llb.WithCustomNamef("%sWITH DOCKER (install deps)", w.c.vertexPrefix(ctx, w.c.newCmdID(), false, false, false, opt.Secrets)),
 	}
 	w.c.mts.Final.MainState = w.c.mts.Final.MainState.Run(runOpts...).Root()
 	return nil
@@ -153,7 +153,7 @@ func (w *withDockerRunBase) getComposeConfig(ctx context.Context, opt WithDocker
 		llb.AddMount(
 			dockerdWrapperPath, llb.Scratch(), llb.HostBind(), llb.SourcePath(dockerdWrapperPath)),
 		llb.Args(args),
-		llb.WithCustomNamef("%sWITH DOCKER (docker-compose config)", w.c.vertexPrefix(ctx, false, false, false, opt.Secrets)),
+		llb.WithCustomNamef("%sWITH DOCKER (docker-compose config)", w.c.vertexPrefix(ctx, w.c.newCmdID(), false, false, false, opt.Secrets)),
 	}
 	state := w.c.mts.Final.MainState.Run(runOpts...).Root()
 	ref, err := llbutil.StateToRef(

--- a/earthfile2llb/with_docker_run_tar.go
+++ b/earthfile2llb/with_docker_run_tar.go
@@ -344,7 +344,7 @@ func (w *withDockerRunTar) solveImage(ctx context.Context, mts *states.MultiTarg
 			string(solveID),
 			llb.SessionID(sessionID),
 			llb.Platform(w.c.platr.LLBNative()),
-			llb.WithCustomNamef("%sdocker tar context %s %s", w.c.vertexPrefix(ctx, false, false, true, nil), opName, sessionID),
+			llb.WithCustomNamef("%sdocker tar context %s %s", w.c.vertexPrefix(ctx, w.c.newCmdID(), false, false, true, nil), opName, sessionID),
 		)
 		// Add directly to build context so that if a later statement forces execution, the images are available.
 		w.c.opt.BuildContextProvider.AddDir(string(solveID), outDir)

--- a/logbus/formatter/formatter.go
+++ b/logbus/formatter/formatter.go
@@ -311,11 +311,6 @@ func (f *Formatter) printHeader(targetID string, commandID string, tm *logstream
 	if verboseOnly && !f.verbose {
 		return
 	}
-	if cm.GetCategory() == "context" && !f.verbose {
-		// These tend to be pretty noisy. Don't print their header unless
-		// verbose is enabled.
-		return
-	}
 	if failure {
 		c = c.WithFailed(true)
 	}
@@ -441,6 +436,11 @@ func (f *Formatter) targetConsole(targetID string, commandID string) (consloggin
 	case strings.HasPrefix(commandID, "_generic:"):
 		targetName = strings.TrimPrefix(commandID, "_generic:")
 		writerTargetID = commandID
+		switch targetName {
+		case "context":
+			verboseOnly = true
+		default:
+		}
 	case commandID != "":
 		cm, ok := f.manifest.GetCommands()[commandID]
 		if ok {
@@ -454,6 +454,8 @@ func (f *Formatter) targetConsole(targetID string, commandID string) (consloggin
 			verboseOnly = true
 			targetName = strings.TrimPrefix(targetName, "internal ")
 		case targetName == "internal":
+			verboseOnly = true
+		case targetName == "context":
 			verboseOnly = true
 		case targetName == "":
 			verboseOnly = true

--- a/util/vertexmeta/vertexmeta.go
+++ b/util/vertexmeta/vertexmeta.go
@@ -19,6 +19,7 @@ type VertexMeta struct {
 	RepoGitURL          string               `json:"rgu,omitempty"`
 	RepoGitHash         string               `json:"rgh,omitempty"`
 	RepoFileRelToRepo   string               `json:"rfr,omitempty"`
+	CommandID           string               `json:"cid,omitempty"`
 	TargetID            string               `json:"tid,omitempty"`
 	TargetName          string               `json:"tnm,omitempty"`
 	CanonicalTargetName string               `json:"ctnm,omitempty"`


### PR DESCRIPTION
It seems that buildkit now creates a lot of duplicate vertices when parts of a build are re-used. This PR deduplicates these by tracking via a CommandID that is set in the converter, instead of relying on buildkit's vertex digest.

Additionally, this PR removes all `context` output (unless verbose is enabled) as it is extremely noisy.