### PR TITLE
--pass-args flag

### DIFF
--- a/ast/commandflag/flags.go
+++ b/ast/commandflag/flags.go
@@ -37,6 +37,7 @@ type RunOpts struct {
 
 type FromOpts struct {
 	AllowPrivileged bool     `long:"allow-privileged" description:"Allow commands under remote targets to enable privileged mode"`
+	PassArgs        bool     `long:"pass-args" description:"Pass arguments to external targets"`
 	BuildArgs       []string `long:"build-arg" description:"A build arg override passed on to a referenced Earthly target"`
 	Platform        string   `long:"platform" description:"The platform to use"`
 }
@@ -58,6 +59,7 @@ type CopyOpts struct {
 	IfExists        bool     `long:"if-exists" description:"Do not fail if the artifact does not exist"`
 	SymlinkNoFollow bool     `long:"symlink-no-follow" description:"Do not follow symlinks"`
 	AllowPrivileged bool     `long:"allow-privileged" description:"Allow targets to assume privileged mode"`
+	PassArgs        bool     `long:"pass-args" description:"Pass arguments to external targets"`
 	Platform        string   `long:"platform" description:"The platform to use"`
 	BuildArgs       []string `long:"build-arg" description:"A build arg override passed on to a referenced Earthly target"`
 }
@@ -82,6 +84,7 @@ type BuildOpts struct {
 	Platforms       []string `long:"platform" description:"The platform to use"`
 	BuildArgs       []string `long:"build-arg" description:"A build arg override passed on to a referenced Earthly target"`
 	AllowPrivileged bool     `long:"allow-privileged" description:"Allow targets to assume privileged mode"`
+	PassArgs        bool     `long:"pass-args" description:"Pass arguments to external targets"`
 }
 
 type GitCloneOpts struct {
@@ -104,14 +107,17 @@ type WithDockerOpts struct {
 	BuildArgs       []string `long:"build-arg" description:"A build arg override passed on to a referenced Earthly target"`
 	Pulls           []string `long:"pull" description:"An image which is pulled and made available in the docker cache"`
 	AllowPrivileged bool     `long:"allow-privileged" description:"Allow targets referenced by load to assume privileged mode"`
+	PassArgs        bool     `long:"pass-args" description:"Pass arguments to external targets"`
 }
 
 type DoOpts struct {
 	AllowPrivileged bool `long:"allow-privileged" description:"Allow targets to assume privileged mode"`
+	PassArgs        bool `long:"pass-args" description:"Pass arguments to external targets"`
 }
 
 type ImportOpts struct {
 	AllowPrivileged bool `long:"allow-privileged" description:"Allow targets to assume privileged mode"`
+	PassArgs        bool `long:"pass-args" description:"Pass arguments to external targets"`
 }
 
 type ArgOpts struct {

--- a/earthfile2llb/with_docker_run_base.go
+++ b/earthfile2llb/with_docker_run_base.go
@@ -29,6 +29,7 @@ type DockerLoadOpt struct {
 	Platform        platutil.Platform
 	BuildArgs       []string
 	AllowPrivileged bool
+	PassArgs        bool
 }
 
 // DockerPullOpt holds parameters for the WITH DOCKER --pull parameter.

--- a/earthfile2llb/with_docker_run_local_reg.go
+++ b/earthfile2llb/with_docker_run_local_reg.go
@@ -148,12 +148,12 @@ func (w *withDockerRunLocalReg) load(ctx context.Context, opt DockerLoadOpt) (ch
 	}
 
 	if w.enableParallel {
-		err = w.c.BuildAsync(ctx, depTarget.String(), opt.Platform, opt.AllowPrivileged, opt.BuildArgs, loadCmd, afterFun, w.sem)
+		err = w.c.BuildAsync(ctx, depTarget.String(), opt.Platform, opt.AllowPrivileged, opt.PassArgs, opt.BuildArgs, loadCmd, afterFun, w.sem)
 		if err != nil {
 			return nil, err
 		}
 	} else {
-		mts, err := w.c.buildTarget(ctx, depTarget.String(), opt.Platform, opt.AllowPrivileged, opt.BuildArgs, false, loadCmd)
+		mts, err := w.c.buildTarget(ctx, depTarget.String(), opt.Platform, opt.AllowPrivileged, opt.PassArgs, opt.BuildArgs, false, loadCmd)
 		if err != nil {
 			return nil, err
 		}

--- a/earthfile2llb/with_docker_run_local_tar.go
+++ b/earthfile2llb/with_docker_run_local_tar.go
@@ -131,12 +131,12 @@ func (wdrl *withDockerRunLocalTar) load(ctx context.Context, opt DockerLoadOpt) 
 		return nil
 	}
 	if wdrl.enableParallel {
-		err = wdrl.c.BuildAsync(ctx, depTarget.String(), opt.Platform, opt.AllowPrivileged, opt.BuildArgs, loadCmd, afterFun, wdrl.sem)
+		err = wdrl.c.BuildAsync(ctx, depTarget.String(), opt.Platform, opt.AllowPrivileged, opt.PassArgs, opt.BuildArgs, loadCmd, afterFun, wdrl.sem)
 		if err != nil {
 			return nil, err
 		}
 	} else {
-		mts, err := wdrl.c.buildTarget(ctx, depTarget.String(), opt.Platform, opt.AllowPrivileged, opt.BuildArgs, false, loadCmd)
+		mts, err := wdrl.c.buildTarget(ctx, depTarget.String(), opt.Platform, opt.AllowPrivileged, opt.PassArgs, opt.BuildArgs, false, loadCmd)
 		if err != nil {
 			return nil, err
 		}

--- a/earthfile2llb/with_docker_run_reg.go
+++ b/earthfile2llb/with_docker_run_reg.go
@@ -304,12 +304,12 @@ func (w *withDockerRunRegistry) load(ctx context.Context, opt DockerLoadOpt) (ch
 	}
 
 	if w.enableParallel {
-		err = w.c.BuildAsync(ctx, depTarget.String(), opt.Platform, opt.AllowPrivileged, opt.BuildArgs, loadCmd, afterFn, w.sem)
+		err = w.c.BuildAsync(ctx, depTarget.String(), opt.Platform, opt.AllowPrivileged, opt.PassArgs, opt.BuildArgs, loadCmd, afterFn, w.sem)
 		if err != nil {
 			return nil, err
 		}
 	} else {
-		mts, err := w.c.buildTarget(ctx, depTarget.String(), opt.Platform, opt.AllowPrivileged, opt.BuildArgs, false, loadCmd)
+		mts, err := w.c.buildTarget(ctx, depTarget.String(), opt.Platform, opt.AllowPrivileged, opt.PassArgs, opt.BuildArgs, false, loadCmd)
 		if err != nil {
 			return nil, err
 		}

--- a/earthfile2llb/with_docker_run_tar.go
+++ b/earthfile2llb/with_docker_run_tar.go
@@ -289,12 +289,12 @@ func (w *withDockerRunTar) load(ctx context.Context, opt DockerLoadOpt) (chan Do
 		return nil
 	}
 	if w.enableParallel {
-		err = w.c.BuildAsync(ctx, depTarget.String(), opt.Platform, opt.AllowPrivileged, opt.BuildArgs, loadCmd, afterFun, w.sem)
+		err = w.c.BuildAsync(ctx, depTarget.String(), opt.Platform, opt.AllowPrivileged, opt.PassArgs, opt.BuildArgs, loadCmd, afterFun, w.sem)
 		if err != nil {
 			return nil, err
 		}
 	} else {
-		mts, err := w.c.buildTarget(ctx, depTarget.String(), opt.Platform, opt.AllowPrivileged, opt.BuildArgs, false, loadCmd)
+		mts, err := w.c.buildTarget(ctx, depTarget.String(), opt.Platform, opt.AllowPrivileged, opt.PassArgs, opt.BuildArgs, false, loadCmd)
 		if err != nil {
 			return nil, err
 		}

--- a/features/features.go
+++ b/features/features.go
@@ -59,6 +59,7 @@ type Features struct {
 	ArgScopeSet                bool `long:"arg-scope-and-set" description:"enable SET to reassign ARGs and prevent ARGs from being redeclared in the same scope"`
 	EarthlyCIRunnerArg         bool `long:"earthly-ci-runner-arg" description:"includes EARTHLY_CI_RUNNER ARG"`
 	UseDockerIgnore            bool `long:"use-docker-ignore" description:"fallback to .dockerignore incase .earthlyignore or .earthignore do not exist in a local \"FROM DOCKERFILE\" target"`
+	PassArgs                   bool `long:"pass-args" description:"Allow the use of the --pass-arg flag in FROM, BUILD, COPY, WITH DOCKER, and DO commands"`
 
 	Major int
 	Minor int

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -149,6 +149,7 @@ ga-no-qemu-quick:
     BUILD +test-works-without-earthly-server
     BUILD +test-init-unsupported
     BUILD +test-init-golang
+    BUILD +pass-args-test
 
     # Forcing the implicit global wait/end block, causes some tests, which rely
     # on the ability to have two different targets issue the same SAVE IMAGE tag name
@@ -618,6 +619,11 @@ subdirprivileged:
 reject-privileged-import-test:
     DO +RUN_EARTHLY --earthfile=reject-privileged-import.earth --should_fail=true --extra_args="--allow-privileged" --target=+test-reject-copy
     DO +RUN_EARTHLY --earthfile=reject-privileged-import.earth --should_fail=true --extra_args="--allow-privileged" --target=+test-reject-cmd
+
+pass-args-test:
+    COPY pass-args-sub-dir.earth subdir/Earthfile
+    COPY pass-args-root.earth Earthfile
+    DO +RUN_EARTHLY --target=./subdir+test-all --extra_args="--build-arg foo=bar"
 
 required-arg-test:
     # test that build arg is required

--- a/tests/command-nested-global.earth
+++ b/tests/command-nested-global.earth
@@ -11,7 +11,7 @@ ARG --global foo=default
 SHARED:
     COMMAND
     # Note that foo has not yet been declared in the command, therefore we reference the globally declared arg
-    RUN test "$foo" == "expected" 
+    RUN test "$foo" == "expected"
 
     # foo should be passed in as "baz" when DO +SHARED is called for the
     # purposes of this test. This ensures that DO args do not impact globals but

--- a/tests/pass-args-root.earth
+++ b/tests/pass-args-root.earth
@@ -1,0 +1,20 @@
+VERSION --pass-args 0.7
+
+parent-target-wants-bar:
+    FROM alpine:3.18
+    ARG foo
+    RUN test "$foo" = "bar"
+    RUN echo "foo=$foo" > data
+    SAVE ARTIFACT data
+
+parent-target-wants-empty:
+    FROM alpine:3.18
+    ARG foo
+    RUN test -z "$foo"
+    RUN echo "foo=$foo" > data
+    SAVE ARTIFACT data
+
+PARENTCMD:
+    COMMAND
+    ARG foo
+    RUN echo "foo=$foo" > data

--- a/tests/pass-args-sub-dir.earth
+++ b/tests/pass-args-sub-dir.earth
@@ -1,0 +1,44 @@
+VERSION --pass-args 0.7
+
+test-all:
+  BUILD +test-empty-via-from
+  BUILD +test-pass-args-via-from
+  BUILD +test-empty-via-copy
+  BUILD +test-pass-args-via-copy
+  BUILD +test-empty-via-build
+  BUILD +test-pass-args-via-build
+  BUILD +test-empty-command
+  BUILD +test-pass-args-command
+
+test-empty-via-from:
+  FROM ..+parent-target-wants-empty
+
+test-pass-args-via-from:
+  FROM --pass-args ..+parent-target-wants-bar
+
+test-empty-via-copy:
+  FROM alpine:3.18
+  COPY ..+parent-target-wants-empty/data .
+
+test-pass-args-via-copy:
+  FROM alpine:3.18
+  COPY --pass-args ..+parent-target-wants-bar/data .
+
+test-empty-via-build:
+  BUILD ..+parent-target-wants-empty
+
+test-pass-args-via-build:
+  FROM alpine:3.18
+  BUILD --pass-args ..+parent-target-wants-bar
+
+test-empty-command:
+  FROM alpine:3.18
+  DO ..+PARENTCMD
+  RUN cat data
+  RUN grep '^foo=$' data
+
+test-pass-args-command:
+  FROM alpine:3.18
+  DO --pass-args ..+PARENTCMD
+  RUN cat data
+  RUN grep '^foo=bar$' data


### PR DESCRIPTION
Introduces a new `--pass-args` flag to BUILD, FROM, COPY, WITH DOCKER, and DO commands, which allows users to propigate args between targets that exist outside of the scope of a single Earthfile.

This implements https://github.com/earthly/earthly/issues/1891