### PR TITLE
Modifying buildkit print statement

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -550,6 +550,7 @@ for-own:
     # the documentaation on +earthly for extra detail about this option.
     ARG GO_GCFLAGS
     BUILD ./buildkitd+buildkitd --BUILDKIT_PROJECT="$BUILDKIT_PROJECT"
+    BUILD ./ast/parser+parser
     COPY (+earthly/earthly --GO_GCFLAGS="${GO_GCFLAGS}") ./
     SAVE ARTIFACT ./earthly AS LOCAL ./build/own/earthly
 

--- a/outmon/solvermon.go
+++ b/outmon/solvermon.go
@@ -317,6 +317,7 @@ func (sm *SolverMonitor) printProgress(vm *vertexMonitor, id string, progress in
 		if !vm.headerPrinted {
 			sm.printHeader(vm)
 		}
+		id = sm.modifyId(id)
 		vm.printProgress(id, progress, sm.verbose, sm.lastOutputWasProgress)
 		sm.lastOutputWasProgress = (progress != 100)
 		sm.lastOutputWasNoOutputUpdate = false
@@ -412,4 +413,15 @@ func (sm *SolverMonitor) reprintFailure(errVertex *vertexMonitor, phaseText stri
 		errVertex.console.Printf("[no output]\n")
 	}
 	errVertex.printError()
+}
+
+
+func (sm *SolverMonitor) modifyId(id string) string {
+	modifiedId := id
+	for old, new := range map[string]string{
+		"transferring docker.io/library":  "transferring locally to docker.io/library",
+	} {
+		modifiedId = strings.ReplaceAll(modifiedId, old, new)
+	}
+	return modifiedId
 }


### PR DESCRIPTION
Added a function to modify the print statement that originates from the buildkit. This allows us to replace or even reformat certain texts that may not be the clearest.