### PR TITLE
use acbgrep to get a more clear error message

### DIFF
--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -229,7 +229,7 @@ earthly --config \$earthly_config --verbose +copy 2>&1 | tee output2.txt;
     DO +RUN_EARTHLY --earthfile=copy-verbose.earth --exec_cmd=/tmp/multiple-earthly-script
 
     # test that the first run sends a.txt and doesn't send any non-referenced files
-    RUN cat output.txt | grep 'sent data for a.txt (1 B)'
+    RUN cat output.txt | acbgrep 'sent data for a.txt (1 B)'
     RUN if grep "sent data for alpha.txt" output.txt >/dev/null; then echo "alpha.txt should not have been sent"; exit 1; fi
     RUN if grep "sent data for .*beta.txt" output.txt >/dev/null; then echo "beta.txt should not have been sent"; exit 1; fi
 
@@ -257,7 +257,7 @@ cache-test:
     DO +RUN_EARTHLY --earthfile=cache1.earth --target=+test-no-bust-on-change --use_tmpfs=false \
         --post_command=">output.txt 2>&1" # check that all is still cached if re-running the prev version
     RUN cat output.txt
-    RUN cat output.txt | grep '\*cached\* --> RUN echo hey'
+    RUN cat output.txt | acbgrep '\*cached\* --> RUN echo hey'
 
 git-clone-test:
     DO +RUN_EARTHLY --earthfile=git-clone.earth --target=+test
@@ -408,15 +408,15 @@ transitive-args-test:
     RUN test -f ./abc
     RUN test -f ./xyz
     RUN test ! -f ./default
-    RUN cat ./abc | grep abc
-    RUN cat ./xyz | grep xyz
+    RUN cat ./abc | acbgrep abc
+    RUN cat ./xyz | acbgrep xyz
 
 transitive-args-test2:
     DO +RUN_EARTHLY --earthfile=transitive-args.earth --target=+test
     RUN ls
     RUN test -f ./abc && test -f ./default
-    RUN cat ./abc | grep abc
-    RUN cat ./default | grep default
+    RUN cat ./abc | acbgrep abc
+    RUN cat ./default | acbgrep default
 
 non-transitive-args-test:
     COPY non-transitive-args1.earth ./Earthfile
@@ -760,46 +760,46 @@ save-artifact-dont-overwrite:
 
     DO +RUN_EARTHLY --should_fail=true --earthfile=save-artifact-dont-overwrite.earth --extra_args="--version-flag-overrides=require-force-for-unsafe-saves" \
         --target=+dont-overwrite-abs-ref --post_command="> /tmp/output 2>&1"
-    RUN cat /tmp/output | grep 'Error.*path must be located under'
+    RUN cat /tmp/output | acbgrep 'Error.*path must be located under'
 
     DO +RUN_EARTHLY --should_fail=true --earthfile=save-artifact-dont-overwrite.earth --extra_args="--version-flag-overrides=require-force-for-unsafe-saves" \
         --target=+dont-overwrite-rel-ref --post_command="> /tmp/output 2>&1"
-    RUN cat /tmp/output | grep 'Error.*path must be located under'
+    RUN cat /tmp/output | acbgrep 'Error.*path must be located under'
 
     DO +RUN_EARTHLY --should_fail=true --earthfile=save-artifact-dont-overwrite.earth --extra_args="--version-flag-overrides=require-force-for-unsafe-saves" \
         --target=+dont-overwrite-rel-other-ref --post_command="> /tmp/output 2>&1"
-    RUN cat /tmp/output | grep 'Error.*path must be located under'
+    RUN cat /tmp/output | acbgrep 'Error.*path must be located under'
 
     DO +RUN_EARTHLY --should_fail=true --earthfile=save-artifact-dont-overwrite.earth --extra_args="--version-flag-overrides=require-force-for-unsafe-saves" \
         --target=+dont-overwrite-root --post_command="> /tmp/output 2>&1"
-    RUN cat /tmp/output | grep 'Error.*path must be located under'
+    RUN cat /tmp/output | acbgrep 'Error.*path must be located under'
 
     DO +RUN_EARTHLY --should_fail=true --earthfile=save-artifact-dont-overwrite.earth --extra_args="--version-flag-overrides=require-force-for-unsafe-saves" \
         --target=+dont-overwrite-root2 --post_command="> /tmp/output 2>&1"
-    RUN cat /tmp/output | grep 'Error.*path must be located under'
+    RUN cat /tmp/output | acbgrep 'Error.*path must be located under'
 
     DO +RUN_EARTHLY --should_fail=true --earthfile=save-artifact-dont-overwrite.earth --extra_args="--version-flag-overrides=require-force-for-unsafe-saves" \
         --target=+dont-overwrite-root3 --post_command="> /tmp/output 2>&1"
-    RUN cat /tmp/output | grep 'Error.*path must be located under'
+    RUN cat /tmp/output | acbgrep 'Error.*path must be located under'
 
     RUN ls important-data
 
 save-artifact-force-overwrite:
     RUN --no-cache echo hello > /root/important-data
     DO +RUN_EARTHLY --earthfile=save-artifact-overwrite.earth --extra_args="--version-flag-overrides=require-force-for-unsafe-saves" --target=+overwrite-root
-    RUN cat /root/base | grep 88716877-039f-4dea-8ec3-84eb64f326c5
-    RUN cat /root/sub/data1 | grep ff42c40d-034a-4855-8db7-febfa7322576
-    RUN cat /root/sub/data2 | grep 2b4a653d-cdf6-4574-ac5e-f02bb6993365
+    RUN cat /root/base | acbgrep 88716877-039f-4dea-8ec3-84eb64f326c5
+    RUN cat /root/sub/data1 | acbgrep ff42c40d-034a-4855-8db7-febfa7322576
+    RUN cat /root/sub/data2 | acbgrep 2b4a653d-cdf6-4574-ac5e-f02bb6993365
     RUN ! ls /root/important-data
 
 save-artifact-file-as-dot:
     DO +RUN_EARTHLY --earthfile=save-artifact-dot.earth --target=+save-local-file-as-dot
-    RUN cat uuid | grep eeee5a95-1506-428f-8ef0-94bbad5bd22b
+    RUN cat uuid | acbgrep eeee5a95-1506-428f-8ef0-94bbad5bd22b
 
 save-artifact-dir-as-dot:
     DO +RUN_EARTHLY --earthfile=save-artifact-dot.earth --target=+save-local-dir-as-dot
-    RUN cat the-data/file1 | grep 7be91098-1823-41df-911b-2a8907fe5da7
-    RUN cat the-data/file2 | grep b0359c17-d08b-411c-9db7-1333ef3673d0
+    RUN cat the-data/file1 | acbgrep 7be91098-1823-41df-911b-2a8907fe5da7
+    RUN cat the-data/file2 | acbgrep b0359c17-d08b-411c-9db7-1333ef3673d0
 
 run-no-cache:
     # Run twice to allow the second one to attempt to cache things


### PR DESCRIPTION
In paticular, `./tests+save-artifact-dont-overwrite` is failing under buildkite (but not locally), and it's not clear why.