### PR TITLE
exit if earthly secret get fails

### DIFF
--- a/.buildkite/tests.sh
+++ b/.buildkite/tests.sh
@@ -80,8 +80,8 @@ done
 
 # setup secrets
 set +x # dont echo secrets
-echo "DOCKERHUB_MIRROR_USER=$($earthly secret --org earthly-technologies --project core get -n dockerhub-mirror/user)" > .secret
-echo "DOCKERHUB_MIRROR_PASS=$($earthly secret --org earthly-technologies --project core get -n dockerhub-mirror/pass)" >> .secret
+echo "DOCKERHUB_MIRROR_USER=$($earthly secret --org earthly-technologies --project core get -n dockerhub-mirror/user || kill $$)" > .secret
+echo "DOCKERHUB_MIRROR_PASS=$($earthly secret --org earthly-technologies --project core get -n dockerhub-mirror/pass || kill $$)" >> .secret
 # setup args
 echo "DOCKERHUB_MIRROR_AUTH=true" > .arg
 echo "DOCKERHUB_MIRROR=registry-1.docker.io.mirror.corp.earthly.dev" >> .arg

--- a/.github/actions/stage2-setup/action.yml
+++ b/.github/actions/stage2-setup/action.yml
@@ -78,8 +78,8 @@ runs:
         echo "Setting up mirror credentials in .arg and .secret"
         export earthly=${{inputs.BUILT_EARTHLY_PATH}}
         # setup secrets
-        echo "DOCKERHUB_MIRROR_USER=$($earthly secret --org earthly-technologies --project core get -n dockerhub-mirror/user)" > .secret
-        echo "DOCKERHUB_MIRROR_PASS=$($earthly secret --org earthly-technologies --project core get -n dockerhub-mirror/pass)" >> .secret
+        echo "DOCKERHUB_MIRROR_USER=$($earthly secret --org earthly-technologies --project core get -n dockerhub-mirror/user || kill $$)" > .secret
+        echo "DOCKERHUB_MIRROR_PASS=$($earthly secret --org earthly-technologies --project core get -n dockerhub-mirror/pass || kill $$)" >> .secret
         # setup args
         echo "DOCKERHUB_MIRROR_AUTH=true" > .arg
         echo "DOCKERHUB_MIRROR=registry-1.docker.io.mirror.corp.earthly.dev" >> .arg


### PR DESCRIPTION
If the `earthly secret get ...` command substitution fails, propigate the failure to the calling script (since a `set -e` or `-o pipefail` doesn't catch this case)