### PR TITLE
fix mirror setup in tests

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -462,7 +462,7 @@ earthly-docker:
 # Otherwise, it will attempt to login to the docker hub mirror using the provided username and password
 earthly-integration-test-base:
     FROM +earthly-docker
-    RUN apk update && apk add pcre-tools curl python3 bash perl findutils expect
+    RUN apk update && apk add pcre-tools curl python3 bash perl findutils expect yq
     COPY scripts/acbtest/acbtest scripts/acbtest/acbgrep /bin/
     ENV NO_DOCKER=1
     ENV NETWORK_MODE=host # Note that this breaks access to embedded registry in WITH DOCKER.
@@ -490,6 +490,10 @@ earthly-integration-test-base:
     ELSE
         RUN ./setup-registry.sh
     END
+
+    # pull out buildkit_additional_config from the earthly config, for the special case of earthly-in-earthly testing
+    # which runs earthly-entrypoint.sh, which calls buildkitd/entrypoint, which requires EARTHLY_VERSION_FLAG_OVERRIDES to be set
+    ENV EARTHLY_ADDITIONAL_BUILDKIT_CONFIG="$(cat /etc/.earthly/config.yml  | yq .global.buildkit_additional_config)"
 
 # prerelease builds and pushes the prerelease version of earthly.
 # Tagged as prerelease

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -179,9 +179,10 @@ ga-no-qemu:
     BUILD +ga-no-qemu-slow
 
 tests-that-require-earthly-technologies-account-access:
-    BUILD --pass-args ./web+test
-    BUILD --pass-args ./registry-command+test
+    BUILD --pass-args +test-earthly-mirror-was-setup
     BUILD --pass-args ./account+test
+    BUILD --pass-args ./registry-command+test
+    BUILD --pass-args ./web+test
 
 # tests that only run on linux amd64
 # Note: this target is used to validate the USERPLATFORM user arg,
@@ -946,6 +947,10 @@ push-build:
     RUN cat output | perl -pe 'BEGIN {$status=1} END {exit $status} $status=0 if /\+test \| 0\n/;'
     RUN cat output | perl -pe 'BEGIN {$status=1} END {exit $status} $status=0 if /\+run1 \| 1\n/;'
     RUN cat output | perl -pe 'BEGIN {$status=1} END {exit $status} $status=0 if /\+run2 \| 2\n/;'
+
+test-earthly-mirror-was-setup:
+    DO +RUN_EARTHLY --verbose=false --earthfile=true.earth --target=+true --post_command="> /tmp/output 2>&1"
+    RUN acbgrep registry-1.docker.io.mirror.corp.earthly.dev /etc/buildkitd.toml
 
 build-arg-repeat:
     DO +RUN_EARTHLY --earthfile=build-arg-repeat.earth --target=+build-all-1


### PR DESCRIPTION
The dockerhub mirror was not correctly setup when running earthly-in-earthly tests, due to the refactor in d875bf0883cb61b717f90e0fd613dbf84b7ef3c7