### PR TITLE
display name of secret that is not found

### DIFF
--- a/scripts/tests/secrets-integration.sh
+++ b/scripts/tests/secrets-integration.sh
@@ -129,4 +129,14 @@ echo "=== test 2 ==="
 # test RUN --mount can reference a secret from the server that is only specified in the Earthfile
 "$earthly" --no-cache /tmp/earthtest+test-server-secret
 
+echo "=== test 3 ==="
+# Test earthly will display a message containing the name of the secret that was not found
+set +e
+"$earthly" --no-cache /tmp/earthtest+test-local-secret > output 2>&1
+exit_code="$?"
+set -e
+cat output
+test "$exit_code" != "0"
+acbgrep 'unable to lookup secret my_secret: not found' output
+
 echo "=== All tests have passed ==="

--- a/util/llbutil/secretprovider/secrets.go
+++ b/util/llbutil/secretprovider/secrets.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/url"
 
+	"github.com/earthly/earthly/cloud"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/secrets"
 	"github.com/pkg/errors"
@@ -33,7 +34,7 @@ func (sp *secretProvider) GetSecret(ctx context.Context, req *secrets.GetSecretR
 	for _, store := range sp.stores {
 		data, err := store.GetSecret(ctx, req.ID)
 		if err != nil {
-			if errors.Is(err, secrets.ErrNotFound) {
+			if errors.Is(err, secrets.ErrNotFound) || errors.Is(err, cloud.ErrNotFound) {
 				continue
 			}
 			return nil, err


### PR DESCRIPTION
When project-based secrets were introduced, the ErrNotFound type was changed, which prevented the secret lookup method from returning the correct error message which would contain **which** secret was not found.

Rather than displaying

    RUN ./some-command failed: not found

We will now show:

    RUN ./some-command failed: unable to lookup secret my_secret: not found