### PR TITLE
dont display buildkit logs on sat tests

### DIFF
--- a/.github/workflows/reusable-bootstrap-integrations.yml
+++ b/.github/workflows/reusable-bootstrap-integrations.yml
@@ -58,4 +58,4 @@ jobs:
         run: frontend=${{inputs.BINARY}} default_install_name=earthly ./tests/bootstrap/test-bootstrap.sh
       - name: Buildkit logs (runs on failure)
         run: ${{inputs.SUDO}} ${{inputs.BINARY}} logs earthly-buildkitd
-        if: ${{ failure() }}
+        if: ${{ failure() && ! inputs.USE_SATELLITE }}

--- a/.github/workflows/reusable-docker-build-integrations.yml
+++ b/.github/workflows/reusable-docker-build-integrations.yml
@@ -62,4 +62,4 @@ jobs:
         run: ${{inputs.SUDO}} env earthly=${{inputs.BUILT_EARTHLY_PATH}} scripts/tests/docker-build/integration.sh
       - name: Buildkit logs (runs on failure)
         run: ${{inputs.SUDO}} docker logs earthly-buildkitd
-        if: ${{ failure() }}
+        if: ${{ failure() && ! inputs.USE_SATELLITE }}

--- a/.github/workflows/reusable-earthly-image-tests.yml
+++ b/.github/workflows/reusable-earthly-image-tests.yml
@@ -52,4 +52,4 @@ jobs:
         if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
       - name: Buildkit logs (runs on failure)
         run: ${{inputs.SUDO}} ${{inputs.BINARY}} logs earthly-buildkitd
-        if: ${{ failure() }}
+        if: ${{ failure() && ! inputs.USE_SATELLITE }}

--- a/.github/workflows/reusable-example.yml
+++ b/.github/workflows/reusable-example.yml
@@ -80,4 +80,4 @@ jobs:
           ${{inputs.SUDO}} ${{inputs.BINARY}} run --rm earthly/examples:multiplatform_linux_arm64 | grep aarch64
       - name: Buildkit logs (runs on failure)
         run: ${{inputs.SUDO}} ${{inputs.BINARY}} logs earthly-buildkitd
-        if: ${{ failure() }}
+        if: ${{ failure() && ! inputs.USE_SATELLITE }}

--- a/.github/workflows/reusable-git-metadata-test.yml
+++ b/.github/workflows/reusable-git-metadata-test.yml
@@ -65,4 +65,4 @@ jobs:
           ./tests/git-metadata+test
       - name: Buildkit logs (runs on failure)
         run: ${{inputs.SUDO}} ${{inputs.BINARY}} logs earthly-buildkitd
-        if: ${{ failure() }}
+        if: ${{ failure() && ! inputs.USE_SATELLITE }}

--- a/.github/workflows/reusable-test-local.yml
+++ b/.github/workflows/reusable-test-local.yml
@@ -74,4 +74,4 @@ jobs:
         run: "${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} ${{inputs.RUN_EARTHLY_TEST_ARGS}} ./tests/local+all --FRONTEND=${{inputs.BINARY}} --FRONTEND_COMPOSE=${{inputs.BINARY_COMPOSE}}"
       - name: Buildkit logs (runs on failure)
         run: ${{inputs.SUDO}} ${{inputs.BINARY}} logs earthly-buildkitd 2>&1
-        if: ${{ failure() }}
+        if: ${{ failure() && ! inputs.USE_SATELLITE }}

--- a/.github/workflows/reusable-wait-block-override.yml
+++ b/.github/workflows/reusable-wait-block-override.yml
@@ -53,4 +53,4 @@ jobs:
            +test --GLOBAL_WAIT_END=true
       - name: Buildkit logs (runs on failure)
         run: ${{inputs.SUDO}} ${{inputs.BINARY}} logs earthly-buildkitd
-        if: ${{ failure() }}
+        if: ${{ failure() && ! inputs.USE_SATELLITE }}


### PR DESCRIPTION
The satellite tests don't have a local instance of buildkit -- it's not possible to show logs.