### PR TITLE
tests: fix random satellite selection

### DIFF
--- a/.github/actions/stage2-setup/action.yml
+++ b/.github/actions/stage2-setup/action.yml
@@ -96,10 +96,11 @@ runs:
       run: |-
         SATELLITE_NAME=${{inputs.SATELLITE_NAME}}
         if [ "$SATELLITE_NAME" = "core-test" ]; then
-          SATELLITE_NAME="$SATELLITE_NAME-$(expr $RANDOM % 4)"
+          SATELLITE_NAME="$SATELLITE_NAME-$(( $RANDOM % 4 ))"
           echo "Using core-test satellite: $SATELLITE_NAME"
         fi
-        ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} sat ls && ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} satellite select $SATELLITE_NAME
+        ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} sat ls
+        ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} satellite select $SATELLITE_NAME
       shell: bash
     - run: echo "stage2-setup action complete"
       shell: bash


### PR DESCRIPTION
Running `$(expr $RANDOM % 4)` returns an exit code of 1 when
0 is returned.

This was causing the random satellite shard selection to fail 25% of the
time.