### PR TITLE
split up sat tests from earthly-image tests

### DIFF
--- a/.github/workflows/reusable-earthly-image-tests.yml
+++ b/.github/workflows/reusable-earthly-image-tests.yml
@@ -49,9 +49,44 @@ jobs:
           echo "EARTHLY_VERSION_FLAG_OVERRIDES=$EARTHLY_VERSION_FLAG_OVERRIDES" >> "$GITHUB_ENV"
       - name: Build the earthly docker image
         run: ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} +earthly-docker --TAG=image-test
-      - name: "Run the earthly image tests (Earthly only)"
+      - name: "Run the earthly image tests"
         run: FRONTEND=${{inputs.BINARY}} EARTHLY_IMAGE=earthly/earthly:image-test DOCKERHUB_MIRROR_USERNAME="${{ secrets.DOCKERHUB_MIRROR_USERNAME }}" DOCKERHUB_MIRROR_PASSWORD="${{ secrets.DOCKERHUB_MIRROR_PASSWORD }}" DOCKERHUB_USERNAME="${{ secrets.DOCKERHUB_USERNAME }}" DOCKERHUB_PASSWORD="${{ secrets.DOCKERHUB_PASSWORD }}" ./scripts/tests/earthly-image.sh
-        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+      - name: Buildkit logs (runs on failure)
+        run: ${{inputs.SUDO}} ${{inputs.BINARY}} logs earthly-buildkitd
+        if: ${{ failure() && ! inputs.USE_SATELLITE }}
+  earthly-image-sat-tests:
+    runs-on: ${{inputs.RUNS_ON}}
+    env:
+      FORCE_COLOR: 1
+      EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"
+      EARTHLY_INSTALL_ID: "earthly-githubactions"
+      # Used in our github action as the token - TODO: look to change it into an input
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: ./.github/actions/stage2-setup
+        with:
+          DOCKERHUB_MIRROR_USERNAME: "${{ secrets.DOCKERHUB_MIRROR_USERNAME }}"
+          DOCKERHUB_MIRROR_PASSWORD: "${{ secrets.DOCKERHUB_MIRROR_PASSWORD }}"
+          DOCKERHUB_USERNAME: "${{ secrets.DOCKERHUB_USERNAME }}"
+          DOCKERHUB_PASSWORD: "${{ secrets.DOCKERHUB_TOKEN }}"
+          EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"
+          BUILT_EARTHLY_PATH: "${{ inputs.BUILT_EARTHLY_PATH }}"
+          BINARY: "${{ inputs.BINARY }}"
+          SUDO: "${{ inputs.SUDO }}"
+          USE_SATELLITE: "${{ inputs.USE_SATELLITE }}"
+          SATELLITE_NAME: "${{ inputs.SATELLITE_NAME }}"
+      - name: Set EARTHLY_VERSION_FLAG_OVERRIDES env
+        run: |-
+          set -euo pipefail
+          EARTHLY_VERSION_FLAG_OVERRIDES="$(tr -d '\n' < .earthly_version_flag_overrides)"
+          echo "EARTHLY_VERSION_FLAG_OVERRIDES=$EARTHLY_VERSION_FLAG_OVERRIDES" >> "$GITHUB_ENV"
+      - name: Build the earthly docker image
+        run: ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} +earthly-docker --TAG=image-test
+      - name: "Run the earthly image sat tests"
+        run: FRONTEND=${{inputs.BINARY}} EARTHLY_IMAGE=earthly/earthly:image-test DOCKERHUB_MIRROR_USERNAME="${{ secrets.DOCKERHUB_MIRROR_USERNAME }}" DOCKERHUB_MIRROR_PASSWORD="${{ secrets.DOCKERHUB_MIRROR_PASSWORD }}" DOCKERHUB_USERNAME="${{ secrets.DOCKERHUB_USERNAME }}" DOCKERHUB_PASSWORD="${{ secrets.DOCKERHUB_PASSWORD }}" ./scripts/tests/earthly-image-sat.sh
       - name: Buildkit logs (runs on failure)
         run: ${{inputs.SUDO}} ${{inputs.BINARY}} logs earthly-buildkitd
         if: ${{ failure() && ! inputs.USE_SATELLITE }}

--- a/scripts/tests/earthly-image-sat.sh
+++ b/scripts/tests/earthly-image-sat.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+set -euo pipefail # don't use -x as it will leak the mirror credentials
+
+# to run this locally; in the root of the repo:
+#   ./earthly +earthly-docker && EARTHLY_IMAGE="earthly/earthly:dev-$(git rev-parse --abbrev-ref HEAD | sed 's/\//_/g')" scripts/tests/earthly-image-sat.sh
+
+FRONTEND=${FRONTEND:-docker}
+EARTHLY_IMAGE=${EARTHLY_IMAGE:-earthly/earthly:dev-main}
+PATH="$(realpath "$(dirname "$0")/../acbtest"):$PATH"
+
+if [ -z "${DOCKERHUB_MIRROR_USERNAME:-}" ] && [ -z "${DOCKERHUB_MIRROR_PASSWORD:-}" ]; then
+  echo "using dockerhub credentials from earthly secrets"
+  DOCKERHUB_MIRROR_USERNAME="$(earthly secrets --org earthly-technologies --project core get dockerhub-mirror/user)"
+  export DOCKERHUB_MIRROR_USERNAME
+  DOCKERHUB_MIRROR_PASSWORD="$(earthly secrets --org earthly-technologies --project core get dockerhub-mirror/pass)"
+  export DOCKERHUB_MIRROR_PASSWORD
+fi
+test -n "$DOCKERHUB_MIRROR_USERNAME" || (echo "error: DOCKERHUB_MIRROR_USERNAME is not set" && exit 1)
+test -n "$DOCKERHUB_MIRROR_PASSWORD" || (echo "error: DOCKERHUB_MIRROR_PASSWORD is not set" && exit 1)
+
+if [ -z "${EARTHLY_TOKEN:-}" ]; then
+  echo "using EARTHLY_TOKEN from earthly secrets"
+  EARTHLY_TOKEN="$(earthly secrets --org earthly-technologies --project core get earthly-token-for-satellite-tests)"
+  export EARTHLY_TOKEN
+fi
+test -n "$EARTHLY_TOKEN" || (echo "error: EARTHLY_TOKEN is not set" && exit 1)
+
+function finish {
+  status="$?"
+  if [ "$status" = "0" ]; then
+    echo "earthly-image-sat.sh test passed"
+  else
+    echo "earthly-image-sat.sh failed with $status"
+  fi
+}
+trap finish EXIT
+
+echo "Test earthly sat inspect."
+"$FRONTEND" run --rm --privileged -e EARTHLY_TOKEN="${EARTHLY_TOKEN}" "${EARTHLY_IMAGE}" sat --org earthly-technologies inspect core-test 2>&1 | tee output.txt
+acbgrep "core-test" output.txt
+"$FRONTEND" run --rm -e EARTHLY_TOKEN="${EARTHLY_TOKEN}" -e NO_BUILDKIT=1 "${EARTHLY_IMAGE}" sat --org earthly-technologies inspect core-test 2>&1 | tee output.txt
+acbgrep "core-test" output.txt
+
+echo "Test satellite (not privileged, no buildkit)."
+satconfig="$(mktemp /tmp/earthly-image-test-satellite-config.XXXXXX)"
+chmod 600 "$satconfig"
+if [ -n "${DOCKERHUB_USERNAME:-}" ] && [ -n "${DOCKERHUB_PASSWORD:-}" ]; then
+    ENCODED_SAT_AUTH="$(echo -n "$DOCKERHUB_USERNAME:$DOCKERHUB_PASSWORD" | base64 -w 0)"
+
+    cat > "$satconfig" <<EOF
+{
+	"auths": {
+		"docker.io": {
+			"auth": "$ENCODED_SAT_AUTH"
+		}
+	}
+}
+EOF
+fi
+
+# TODO FIXME test that the above credentials are actually used by the satellite
+
+"$FRONTEND" run --rm -e EARTHLY_TOKEN="${EARTHLY_TOKEN}" -v "$satconfig:/root/.docker/config.json" -e NO_BUILDKIT=1 "${EARTHLY_IMAGE}" --org earthly-technologies --sat core-test --no-cache github.com/earthly/hello-world:4d466d524f768a379374c785fdef30470e87721d+hello 2>&1 | tee output.txt
+acbgrep "Hello World" output.txt
+acbgrep "Earthly installation is working correctly" output.txt
+
+rm output.txt
+echo "=== All tests have passed ==="

--- a/scripts/tests/earthly-image.sh
+++ b/scripts/tests/earthly-image.sh
@@ -18,13 +18,6 @@ fi
 test -n "$DOCKERHUB_MIRROR_USERNAME" || (echo "error: DOCKERHUB_MIRROR_USERNAME is not set" && exit 1)
 test -n "$DOCKERHUB_MIRROR_PASSWORD" || (echo "error: DOCKERHUB_MIRROR_PASSWORD is not set" && exit 1)
 
-if [ -z "${EARTHLY_TOKEN:-}" ]; then
-  echo "using EARTHLY_TOKEN from earthly secrets"
-  EARTHLY_TOKEN="$(earthly secrets --org earthly-technologies --project core get earthly-token-for-satellite-tests)"
-  export EARTHLY_TOKEN
-fi
-test -n "$EARTHLY_TOKEN" || (echo "error: EARTHLY_TOKEN is not set" && exit 1)
-
 ENCODED_AUTH="$(echo -n "$DOCKERHUB_MIRROR_USERNAME:$DOCKERHUB_MIRROR_PASSWORD" | base64 -w 0)"
 
 dockerconfig="$(mktemp /tmp/earthly-image-test-docker-config.XXXXXX)"
@@ -87,14 +80,6 @@ acbgrep "Executes Earthly builds" output.txt # Display help
 "$FRONTEND" run --rm -e NO_BUILDKIT=1 "${EARTHLY_IMAGE}" --help 2>&1 | tee output.txt
 acbgrep "Executes Earthly builds" output.txt # Display help
 
-# TODO move satellite tests into a separate test (since they are flakey)
-
-echo "Test earthly sat inspect."
-"$FRONTEND" run --rm --privileged -e EARTHLY_TOKEN="${EARTHLY_TOKEN}" "${EARTHLY_IMAGE}" sat --org earthly-technologies inspect core-test 2>&1 | tee output.txt
-acbgrep "core-test" output.txt
-"$FRONTEND" run --rm -e EARTHLY_TOKEN="${EARTHLY_TOKEN}" -e NO_BUILDKIT=1 "${EARTHLY_IMAGE}" sat --org earthly-technologies inspect core-test 2>&1 | tee output.txt
-acbgrep "core-test" output.txt
-
 echo "Test hello world with embedded buildkit."
 "$FRONTEND" run --rm --privileged -e EARTHLY_ADDITIONAL_BUILDKIT_CONFIG -v "$dockerconfig:/root/.docker/config.json" "${EARTHLY_IMAGE}" --no-cache github.com/earthly/hello-world:4d466d524f768a379374c785fdef30470e87721d+hello 2>&1 | tee output.txt
 acbgrep "Hello World" output.txt
@@ -106,30 +91,6 @@ if [ "$FRONTEND" = "docker" ]; then
     acbgrep "Hello World" output.txt
     acbgrep "Earthly installation is working correctly" output.txt
 fi
-
-echo "Test satellite (not privileged, no buildkit)."
-
-satconfig="$(mktemp /tmp/earthly-image-test-satellite-config.XXXXXX)"
-chmod 600 "$satconfig"
-if [ -n "${DOCKERHUB_USERNAME:-}" ] && [ -n "${DOCKERHUB_PASSWORD:-}" ]; then
-    ENCODED_SAT_AUTH="$(echo -n "$DOCKERHUB_USERNAME:$DOCKERHUB_PASSWORD" | base64 -w 0)"
-
-    cat > "$satconfig" <<EOF
-{
-	"auths": {
-		"docker.io": {
-			"auth": "$ENCODED_SAT_AUTH"
-		}
-	}
-}
-EOF
-fi
-
-# TODO FIXME test that the above credentials are actually used by the satellite
-
-"$FRONTEND" run --rm -e EARTHLY_TOKEN="${EARTHLY_TOKEN}" -v "$satconfig:/root/.docker/config.json" -e NO_BUILDKIT=1 "${EARTHLY_IMAGE}" --org earthly-technologies --sat core-test --no-cache github.com/earthly/hello-world:4d466d524f768a379374c785fdef30470e87721d+hello 2>&1 | tee output.txt
-acbgrep "Hello World" output.txt
-acbgrep "Earthly installation is working correctly" output.txt
 
 rm output.txt
 echo "=== All tests have passed ==="


### PR DESCRIPTION
Move the satellite related tests from earthly-image.sh into a separate earthly-image-sat.sh test, to make it make it more clear which tests depend on satellites or not.