### PR TITLE
add mode support to mount cache

### DIFF
--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -120,6 +120,7 @@ ga-no-qemu-quick:
     BUILD +test-init-golang
     BUILD +pass-args-test
     BUILD +test-reserved-label
+    BUILD +test-cache-mount-mode
 
     # Forcing the implicit global wait/end block, causes some tests, which rely
     # on the ability to have two different targets issue the same SAVE IMAGE tag name
@@ -1421,6 +1422,21 @@ test-reserved-label:
        --target=+test1 \
        --should_fail=true \
        --output_contains="LABEL keys starting with .dev.earthly.. are reserved"
+
+test-cache-mount-mode:
+  DO +RUN_EARTHLY \
+      --earthfile=cache-mount-mode.earth \
+      --target=+test \
+      --post_command="--mode=0004 "\
+      --should_fail=false \
+      --output_contains="d------r-- /cache-folder"
+
+  DO +RUN_EARTHLY \
+      --earthfile=cache-mount-mode.earth \
+      --target=+test \
+      --post_command="--mode=0777 "\
+      --should_fail=false \
+      --output_contains="drwxrwxrwx /cache-folder"
 
 RUN_EARTHLY:
     COMMAND

--- a/tests/cache-mount-mode.earth
+++ b/tests/cache-mount-mode.earth
@@ -1,0 +1,8 @@
+VERSION 0.7
+
+test:
+    FROM ubuntu:22.10
+    ARG mode
+    RUN --mount=type=cache,sharing=shared,mode=$mode,target=/cache-folder \
+    stat -c '%A %n' /cache-folder
+


### PR DESCRIPTION
fixes #3278 

```
$ build/linux/amd64/earthly  +build
 Init 🚀
————————————————————————————————————————————————————————————————————————————————

           buildkitd | Found buildkit daemon as docker container (earthly-dev-buildkitd)

Streaming logs to https://cloud.earthly.dev/builds/28574cd4-d086-4ca2-8132-31e0e7974b97

 Build 🔧
————————————————————————————————————————————————————————————————————————————————

        ubuntu:22.10 | --> Load metadata ubuntu:22.10 linux/amd64
              +build | --> FROM ubuntu:22.10
              +build | [----------] 100% FROM ubuntu:22.10
              +build | --> RUN stat -c '%A %n' /cache-folder
              +build | d------rwx /cache-folder
              output | --> exporting outputs

```