### PR TITLE
Move some error messages at end of execution to verbose mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 
 ## Unreleased
 
+### Changed
+- Some error messages at the end of an execution will only be displayed in verbose mode (`earthly -V ...`), e.g. `Error: build target: build main: failed to solve:`... [#3200](https://github.com/earthly/earthly/issues/3200)
+
 ## v0.7.19 - 2023-09-20
 
 ### Added

--- a/cmd/earthly/app/run.go
+++ b/cmd/earthly/app/run.go
@@ -31,8 +31,9 @@ import (
 var (
 	runExitCodeRegex  = regexp.MustCompile(`did not complete successfully: exit code: [^0][0-9]*($|[\n\t]+in\s+.*?\+.+)`)
 	notFoundRegex     = regexp.MustCompile(`("[^"]*"): not found`)
-  	qemuExitCodeRegex = regexp.MustCompile(`process "/dev/.buildkit_qemu_emulator.*?did not complete successfully: exit code: 255$`)
+	qemuExitCodeRegex = regexp.MustCompile(`process "/dev/.buildkit_qemu_emulator.*?did not complete successfully: exit code: 255$`)
 )
+
 func (app *EarthlyApp) Run(ctx context.Context, console conslogging.ConsoleLogger, startTime time.Time, lastSignal os.Signal) int {
 	err := app.unhideFlags(ctx)
 	if err != nil {
@@ -308,11 +309,12 @@ func (app *EarthlyApp) run(ctx context.Context, args []string) int {
 			return 1
 		default:
 			if app.BaseCLI.CommandName() == "build" {
+				app.BaseCLI.Console().VerboseWarnf("Error: %v\n", err)
 				app.BaseCLI.Logbus().Run().SetFatalError(time.Now(), "", "", logstream.FailureType_FAILURE_TYPE_OTHER, err.Error())
 			} else {
 				app.BaseCLI.Logbus().Run().SkipFatalError()
+				app.BaseCLI.Console().Warnf("Error: %v\n", err)
 			}
-			app.BaseCLI.Console().VerboseWarnf("Error: %v\n", err)
 			return 1
 		}
 	}

--- a/cmd/earthly/app/run.go
+++ b/cmd/earthly/app/run.go
@@ -31,8 +31,7 @@ import (
 var (
 	runExitCodeRegex  = regexp.MustCompile(`did not complete successfully: exit code: [^0][0-9]*($|[\n\t]+in\s+.*?\+.+)`)
 	notFoundRegex     = regexp.MustCompile(`("[^"]*"): not found`)
-	rpcRegex          = regexp.MustCompile(`(?U)rpc error: code = .+ desc = `)
-  qemuExitCodeRegex = regexp.MustCompile(`process "/dev/.buildkit_qemu_emulator.*?did not complete successfully: exit code: 255$`)
+  	qemuExitCodeRegex = regexp.MustCompile(`process "/dev/.buildkit_qemu_emulator.*?did not complete successfully: exit code: 255$`)
 )
 func (app *EarthlyApp) Run(ctx context.Context, console conslogging.ConsoleLogger, startTime time.Time, lastSignal os.Signal) int {
 	err := app.unhideFlags(ctx)

--- a/conslogging/conslogging.go
+++ b/conslogging/conslogging.go
@@ -305,6 +305,14 @@ func (cl ConsoleLogger) Warnf(format string, args ...interface{}) {
 	cl.colorPrintf(Warn, c, format, args...)
 }
 
+// VerboseWarnf prints a warning message in red to errWriter when verbose flag is set.
+func (cl ConsoleLogger) VerboseWarnf(format string, args ...interface{}) {
+	if cl.logLevel < Verbose {
+		return
+	}
+	cl.Warnf(format, args...)
+}
+
 // Printf prints formatted text to the console.
 func (cl ConsoleLogger) Printf(format string, args ...interface{}) {
 	c := cl.color(noColor)

--- a/scripts/tests/earthly-image.sh
+++ b/scripts/tests/earthly-image.sh
@@ -62,13 +62,13 @@ if "$FRONTEND" run --rm --privileged "${EARTHLY_IMAGE}" 2>&1 | tee output.txt; t
     exit 1
 fi
 acbgrep "Executes Earthly builds" output.txt # Display help
-acbgrep "Error: no target reference provided" output.txt # Show error
+acbgrep "| no target reference provided" output.txt # Show error
 if "$FRONTEND" run --rm -e NO_BUILDKIT=1 "${EARTHLY_IMAGE}" 2>&1 | tee output.txt; then
     echo "expected failure"
     exit 1
 fi
 acbgrep "Executes Earthly builds" output.txt # Display help
-acbgrep "Error: no target reference provided" output.txt # Show error
+acbgrep "| no target reference provided" output.txt # Show error
 
 echo "Test --version (smoke test)."
 "$FRONTEND" run --rm --privileged "${EARTHLY_IMAGE}" --version 2>&1


### PR DESCRIPTION
This pr partially addresses issue #3200 .
It suppresses some error messages from being displayed at the end of the execution
and allows to show them in verbose mode.