### PR TITLE
Print proper hint if qemu is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 
 ### Fixed
 - Fix a regression where URLs will not always get shorter when used as a prefix. Partially addresses [#3200](https://github.com/earthly/earthly/issues/3200).
-- If a build fails because of `qemu` missing, earthly will display a proper hint to install qemu [#3200](https://github.com/earthly/earthly/issues/3200).
+- If a build fails because of `qemu` missing, earthly will display a proper hint to install it [#3200](https://github.com/earthly/earthly/issues/3200).
 
 ### Changed
 - `GIT CLONE` URLs will only be printed once as part of a prefix, e.g. `+my-clone-target(https://g/e/earthly) | --> GIT CLONE (--branch ) https://github.com/earthly/earthly`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 
 ### Fixed
 - Fix a regression where URLs will not always get shorter when used as a prefix. Partially addresses [#3200](https://github.com/earthly/earthly/issues/3200).
+- If a build fails because of a qemu missing, earthly will display a proper hint to install qemu [#3200](https://github.com/earthly/earthly/issues/3200).
 
 ### Changed
 - `GIT CLONE` URLs will only be printed once as part of a prefix, e.g. `+my-clone-target(https://g/e/earthly) | --> GIT CLONE (--branch ) https://github.com/earthly/earthly`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 
 ### Fixed
 - Fix a regression where URLs will not always get shorter when used as a prefix. Partially addresses [#3200](https://github.com/earthly/earthly/issues/3200).
-- If a build fails because of a qemu missing, earthly will display a proper hint to install qemu [#3200](https://github.com/earthly/earthly/issues/3200).
+- If a build fails because of `qemu` missing, earthly will display a proper hint to install qemu [#3200](https://github.com/earthly/earthly/issues/3200).
 
 ### Changed
 - `GIT CLONE` URLs will only be printed once as part of a prefix, e.g. `+my-clone-target(https://g/e/earthly) | --> GIT CLONE (--branch ) https://github.com/earthly/earthly`


### PR DESCRIPTION
partially addresses #3200 
With this change we will ensure a non satellite build that fails due to missing qemu, will be display a message to tell the user what to do.

In case it's in a satellite, debug message will remind the user `--disable-emulation` flag is set in the satellite.