### PR TITLE
Add CACHE mode support

### DIFF
--- a/ast/commandflag/flags.go
+++ b/ast/commandflag/flags.go
@@ -138,5 +138,5 @@ type PipelineOpts struct {
 
 type CacheOpts struct {
 	Sharing string `long:"sharing" description:"The cache sharing mode: locked (default), shared, private"`
-	Mode    string `long:"mode" description:"Apply a mode to the cache folder" default:"0644"`
+	Mode    string `long:"chmod" description:"Apply a mode to the cache folder" default:"0644"`
 }

--- a/ast/commandflag/flags.go
+++ b/ast/commandflag/flags.go
@@ -138,4 +138,5 @@ type PipelineOpts struct {
 
 type CacheOpts struct {
 	Sharing string `long:"sharing" description:"The cache sharing mode: locked (default), shared, private"`
+	Mode    string `long:"mode" description:"Apply a mode to the cache folder" default:"0644"`
 }

--- a/docs/earthfile/earthfile.md
+++ b/docs/earthfile/earthfile.md
@@ -274,7 +274,7 @@ The `<mount-spec>` is defined as a series of comma-separated list of key-values.
 |-----------| --- | --- |
 | `type`    | The type of the mount. Currently only `cache`, `tmpfs`, and `secret` are allowed. | `type=cache` |
 | `target`  | The target path for the mount. | `target=/var/lib/data` |
-| `chmod`   | The permission of the mounted file, in octal format (the same format the chmod unix command line expects). | `chmod=0400` |
+| `mode`, `chmod`   | The permission of the mounted file, in octal format (the same format the chmod unix command line expects). | `chmod=0400` |
 | `id`      | The secret ID for the contents of the `target` file, only applicable for `type=secret`. | `id=my-password` |
 | `sharing` | The sharing mode (`locked`, `shared`, `private`) for the cache mount, only applicable for `type=cache`. | `sharing=shared` |
 

--- a/docs/earthfile/earthfile.md
+++ b/docs/earthfile/earthfile.md
@@ -242,7 +242,7 @@ earthly +release --SECRET_ID=""
 earthly +release-short --SECRET_ID=""
 ```
 
-It is also possible to mount a secret as a file with `RUN --mount type=secret,id=secret-id,target=/path/of/secret,mode=0400`. See `--mount` below.
+It is also possible to mount a secret as a file with `RUN --mount type=secret,id=secret-id,target=/path/of/secret,chmod=0400`. See `--mount` below.
 
 For more information on how to use secrets see the [build arguments and secrets guide](../guides/build-args.md). See also the [Cloud secrets guide](../cloud/cloud-secrets.md).
 
@@ -270,12 +270,12 @@ Mounts a file or directory in the context of the build environment.
 
 The `<mount-spec>` is defined as a series of comma-separated list of key-values. The following keys are allowed
 
-| Key | Description | Example |
-| --- | --- | --- |
-| `type` | The type of the mount. Currently only `cache`, `tmpfs`, and `secret` are allowed. | `type=cache` |
-| `target` | The target path for the mount. | `target=/var/lib/data` |
-| `mode` | The permission of the mounted file, in octal format (the same format the chmod unix command line expects). | `mode=0400` |
-| `id` | The secret ID for the contents of the `target` file, only applicable for `type=secret`. | `id=my-password` |
+| Key       | Description | Example |
+|-----------| --- | --- |
+| `type`    | The type of the mount. Currently only `cache`, `tmpfs`, and `secret` are allowed. | `type=cache` |
+| `target`  | The target path for the mount. | `target=/var/lib/data` |
+| `chmod`   | The permission of the mounted file, in octal format (the same format the chmod unix command line expects). | `chmod=0400` |
+| `id`      | The secret ID for the contents of the `target` file, only applicable for `type=secret`. | `id=my-password` |
 | `sharing` | The sharing mode (`locked`, `shared`, `private`) for the cache mount, only applicable for `type=cache`. | `sharing=shared` |
 
 For cache mounts, the sharing mode can be one of the following:
@@ -407,9 +407,9 @@ Instructs Earthly to not overwrite the file creation timestamps with a constant.
 
 Instructs Earthly to keep file ownership information. This applies only to the *artifact form* and has no effect otherwise.
 
-##### `--chmod <mode>`
+##### `--chmod <octal-format>`
 
-Instructs Earthly to change the file permissions of the copied files. The `<mode>` needs to be in octal format, e.g. `--chmod 0755` or `--chmod 755`.
+Instructs Earthly to change the file permissions of the copied files. The `<chmod>` needs to be in octal format, e.g. `--chmod 0755` or `--chmod 755`.
 
 {% hint style='info' %}
 Note that you must include the flag in the corresponding `SAVE ARTIFACT --keep-own ...` command, if using *artifact form*.
@@ -1371,7 +1371,7 @@ example:
 #### Synopsis
 
 * ```
-  CACHE [--sharing <sharing-mode>] [--mode <chmod>] <mountpoint>
+  CACHE [--sharing <sharing-mode>] [--chmod <octal-format>] <mountpoint>
   ```
 
 #### Description
@@ -1390,7 +1390,7 @@ The sharing mode for the cache mount, from one of the following:
 * `shared` - the cache mount is shared between all concurrent builds.
 * `private` - if another concurrent build attempts to use the cache, a new (empty) cache will be created for the concurrent build.
 
-##### `--mode <chmod>`
+##### `--chmod <octal-format>`
 
 The permission of the mounted folder, in octal format (the same format the chmod unix command line expects). 
 Default `--chmod 0644`

--- a/docs/earthfile/earthfile.md
+++ b/docs/earthfile/earthfile.md
@@ -1371,7 +1371,7 @@ example:
 #### Synopsis
 
 * ```
-  CACHE [--sharing <sharing-mode>] <mountpoint>
+  CACHE [--sharing <sharing-mode>] [--mode <chmod>] <mountpoint>
   ```
 
 #### Description
@@ -1389,6 +1389,11 @@ The sharing mode for the cache mount, from one of the following:
 * `locked` (default) - the cache mount is locked for the duration of the execution, other concurrent builds will wait for the lock to be released.
 * `shared` - the cache mount is shared between all concurrent builds.
 * `private` - if another concurrent build attempts to use the cache, a new (empty) cache will be created for the concurrent build.
+
+##### `--mode <chmod>`
+
+The permission of the mounted folder, in octal format (the same format the chmod unix command line expects). 
+Default `--chmod 0644`
 
 ## LOCALLY
 

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -1533,7 +1533,7 @@ func (c *Converter) Cache(ctx context.Context, mountTarget string, opts commandf
 		mountOpts = append(mountOpts, llb.SourcePath("/cache"))
 		var mountMode int
 		if opts.Mode == "" {
-			mountMode = 0644
+			opts.Mode = "0644"
 		}
 		mountMode, err = ParseMode(opts.Mode)
 		if err != nil {

--- a/earthfile2llb/interpreter.go
+++ b/earthfile2llb/interpreter.go
@@ -1960,7 +1960,7 @@ func (i *Interpreter) handleCache(ctx context.Context, cmd spec.Command) error {
 	opts := commandflag.CacheOpts{}
 	args, err := parseArgs("CACHE", &opts, getArgsCopy(cmd))
 	if err != nil {
-		return i.wrapError(err, cmd.SourceLocation, "invalid IMPORT arguments %v", cmd.Args)
+		return i.wrapError(err, cmd.SourceLocation, "invalid CACHE arguments %v", cmd.Args)
 	}
 	if len(args) != 1 {
 		return i.errorf(cmd.SourceLocation, "invalid number of arguments for CACHE: %s", args)
@@ -1970,12 +1970,18 @@ func (i *Interpreter) handleCache(ctx context.Context, cmd spec.Command) error {
 	}
 	dir, err := i.expandArgs(ctx, args[0], false, false)
 	if err != nil {
-		return i.wrapError(err, cmd.SourceLocation, "failed to expand CACHE %s", args[0])
+		return i.wrapError(err, cmd.SourceLocation, "failed to expand CACHE directory %s", args[0])
+	}
+	expandedMode, err := i.expandArgs(ctx, opts.Mode, false, false)
+	if err != nil {
+		return i.wrapError(err, cmd.SourceLocation, "failed to expand CACHE mode %s", opts.Mode)
+	} else {
+		opts.Mode = expandedMode
 	}
 	if !path.IsAbs(dir) {
 		dir = path.Clean(path.Join("/", i.converter.mts.Final.MainImage.Config.WorkingDir, dir))
 	}
-	if err := i.converter.Cache(ctx, dir, opts.Sharing); err != nil {
+	if err := i.converter.Cache(ctx, dir, opts); err != nil {
 		return i.wrapError(err, cmd.SourceLocation, "apply CACHE")
 	}
 	return nil

--- a/earthfile2llb/runmount.go
+++ b/earthfile2llb/runmount.go
@@ -85,14 +85,14 @@ func (c *Converter) parseMount(mount string) ([]llb.RunOption, error) {
 			// if err != nil {
 			// 	return nil, errors.Errorf("invalid mount arg %s", kvPair)
 			// }
-		case "mode":
+		case "mode", "chmod":
 			if len(kvSplit) != 2 {
 				return nil, errors.Errorf("invalid mount arg %s", kvPair)
 			}
 			var err error
 			mountMode, err = ParseMode(kvSplit[1])
 			if err != nil {
-				return nil, errors.Errorf("failed to parse mount mode %s", kvSplit[1])
+				return nil, errors.Errorf("failed to parse mount %s %s", kvSplit[0], kvSplit[1])
 			}
 		case "sharing":
 			if len(kvSplit) != 2 {

--- a/earthfile2llb/runmount.go
+++ b/earthfile2llb/runmount.go
@@ -90,7 +90,7 @@ func (c *Converter) parseMount(mount string) ([]llb.RunOption, error) {
 				return nil, errors.Errorf("invalid mount arg %s", kvPair)
 			}
 			var err error
-			mountMode, err = parseMode(kvSplit[1])
+			mountMode, err = ParseMode(kvSplit[1])
 			if err != nil {
 				return nil, errors.Errorf("failed to parse mount mode %s", kvSplit[1])
 			}
@@ -142,6 +142,9 @@ func (c *Converter) parseMount(mount string) ([]llb.RunOption, error) {
 		if err != nil {
 			return nil, err
 		}
+		if mountMode == 0 {
+			mountMode = 0644
+		}
 		cachePath := path.Join("/run/cache", key, mountID)
 		mountOpts = append(mountOpts, llb.AsPersistentCacheDir(cachePath, sharingMode))
 		state = c.cacheContext
@@ -189,7 +192,7 @@ func (c *Converter) parseMount(mount string) ([]llb.RunOption, error) {
 
 var errInvalidOctal = errors.New("invalid octal")
 
-func parseMode(s string) (int, error) {
+func ParseMode(s string) (int, error) {
 	if len(s) == 0 || s[0] != '0' {
 		return 0, errInvalidOctal
 	}

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -1427,14 +1427,21 @@ test-reserved-label:
 test-cache-mount-mode:
   DO +RUN_EARTHLY \
       --earthfile=cache-mount-mode.earth \
-      --target=+test \
+      --target=+test-chmod \
       --post_command="--mode=0004 " \
       --should_fail=false \
       --output_contains="d------r-- /cache-folder"
 
   DO +RUN_EARTHLY \
       --earthfile=cache-mount-mode.earth \
-      --target=+test \
+      --target=+test-chmod \
+      --post_command="--mode=0777 " \
+      --should_fail=false \
+      --output_contains="drwxrwxrwx /cache-folder"
+
+  DO +RUN_EARTHLY \
+      --earthfile=cache-mount-mode.earth \
+      --target=+test-mode \
       --post_command="--mode=0777 " \
       --should_fail=false \
       --output_contains="drwxrwxrwx /cache-folder"

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -121,10 +121,11 @@ ga-no-qemu-quick:
     BUILD +pass-args-test
     BUILD +test-reserved-label
     BUILD +test-cache-mount-mode
+    BUILD +test-cache-mode
 
     # Forcing the implicit global wait/end block, causes some tests, which rely
     # on the ability to have two different targets issue the same SAVE IMAGE tag name
-    # (with the last SAVE IMAGE command taking presidence)
+    # (with the last SAVE IMAGE command taking precedence)
     # Earthly, when using the wait-end feature, will return an error for such cases.
     # As a result, the following tests are incompatible with WAIT/END block.
     # Once version 0.7 is released AND support for 0.6 has been dropped,
@@ -1427,16 +1428,43 @@ test-cache-mount-mode:
   DO +RUN_EARTHLY \
       --earthfile=cache-mount-mode.earth \
       --target=+test \
-      --post_command="--mode=0004 "\
+      --post_command="--mode=0004 " \
       --should_fail=false \
       --output_contains="d------r-- /cache-folder"
 
   DO +RUN_EARTHLY \
       --earthfile=cache-mount-mode.earth \
       --target=+test \
-      --post_command="--mode=0777 "\
+      --post_command="--mode=0777 " \
       --should_fail=false \
       --output_contains="drwxrwxrwx /cache-folder"
+
+  DO +RUN_EARTHLY \
+      --earthfile=cache-mount-mode.earth \
+      --target=+test-default \
+      --should_fail=false \
+      --output_contains="drw-r--r-- /cache-folder"
+
+test-cache-mode:
+  DO +RUN_EARTHLY \
+      --earthfile=cache-mode.earth \
+      --target=+test \
+      --post_command="--mode=0004 " \
+      --should_fail=false \
+      --output_contains="d------r-- /cache-folder"
+
+  DO +RUN_EARTHLY \
+      --earthfile=cache-mode.earth \
+      --target=+test \
+      --post_command="--mode=0777 " \
+      --should_fail=false \
+      --output_contains="drwxrwxrwx /cache-folder"
+
+  DO +RUN_EARTHLY \
+      --earthfile=cache-mode.earth \
+      --target=+test-default \
+      --should_fail=false \
+      --output_contains="drw-r--r-- /cache-folder"
 
 RUN_EARTHLY:
     COMMAND

--- a/tests/cache-mode.earth
+++ b/tests/cache-mode.earth
@@ -8,5 +8,5 @@ test-default:
 test:
     FROM ubuntu:22.10
     ARG mode
-    CACHE --mode=$mode /cache-folder
+    CACHE --chmod=$mode /cache-folder
     RUN stat -c '%A %n' /cache-folder

--- a/tests/cache-mode.earth
+++ b/tests/cache-mode.earth
@@ -1,0 +1,13 @@
+VERSION 0.7
+
+test-default:
+    FROM ubuntu:22.10
+    ARG mode
+    CACHE /cache-folder
+    RUN stat -c '%A %n' /cache-folder
+
+test:
+    FROM ubuntu:22.10
+    ARG mode
+    CACHE --mode=$mode /cache-folder
+    RUN stat -c '%A %n' /cache-folder

--- a/tests/cache-mode.earth
+++ b/tests/cache-mode.earth
@@ -2,7 +2,6 @@ VERSION 0.7
 
 test-default:
     FROM ubuntu:22.10
-    ARG mode
     CACHE /cache-folder
     RUN stat -c '%A %n' /cache-folder
 

--- a/tests/cache-mount-mode.earth
+++ b/tests/cache-mount-mode.earth
@@ -1,8 +1,13 @@
 VERSION 0.7
 
+test-default:
+    FROM ubuntu:22.10
+    ARG mode
+    RUN --mount=type=cache,sharing=shared,target=/cache-folder \
+    stat -c '%A %n' /cache-folder
+
 test:
     FROM ubuntu:22.10
     ARG mode
     RUN --mount=type=cache,sharing=shared,mode=$mode,target=/cache-folder \
     stat -c '%A %n' /cache-folder
-

--- a/tests/cache-mount-mode.earth
+++ b/tests/cache-mount-mode.earth
@@ -5,7 +5,13 @@ test-default:
     RUN --mount=type=cache,sharing=shared,target=/cache-folder \
     stat -c '%A %n' /cache-folder
 
-test:
+test-chmod:
+    FROM ubuntu:22.10
+    ARG mode
+    RUN --mount=type=cache,sharing=shared,chmod=$mode,target=/cache-folder \
+    stat -c '%A %n' /cache-folder
+
+test-mode:
     FROM ubuntu:22.10
     ARG mode
     RUN --mount=type=cache,sharing=shared,mode=$mode,target=/cache-folder \

--- a/tests/cache-mount-mode.earth
+++ b/tests/cache-mount-mode.earth
@@ -2,7 +2,6 @@ VERSION 0.7
 
 test-default:
     FROM ubuntu:22.10
-    ARG mode
     RUN --mount=type=cache,sharing=shared,target=/cache-folder \
     stat -c '%A %n' /cache-folder
 


### PR DESCRIPTION
Right now, we cannot set the permissions for a `CACHE` directory. This PR fixes that.
_(Also, realized that we were using `0` as the default value for cache mount mode, so changing that to the `0644` standard in this same PR)_

I've noticed that we are using "mode" and "chmod" across different commands. I can take this opportunity to do some clean-up and unify into a single term. Personally I think "chmod" is more expressive. Thoughts?