### PR TITLE
CHANGELOG linter: enforce buildkit change info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 - Satellite reserve calls will now retry on error [#3255](https://github.com/earthly/earthly/issues/3255).
 - Display warning when TLS is disabled.
 
+### Additional Info
+- This release has no changes to buildkit
+
 ## v0.7.18 - 2023-09-18 (aborted release/not recommended)
 <!--changelog-parser-ignore-start-->
 Note: This release was aborted due to a regression in the log sharing functionality

--- a/Earthfile
+++ b/Earthfile
@@ -300,6 +300,7 @@ changelog:
 
 lint-changelog:
     FROM python:3
+    RUN pip install packaging
     COPY release/changelogparser.py /usr/bin/changelogparser
     COPY CHANGELOG.md .
     RUN changelogparser --changelog CHANGELOG.md

--- a/release/changelogparser.py
+++ b/release/changelogparser.py
@@ -2,6 +2,7 @@
 import argparse
 import re
 import sys
+import packaging.version
 from collections import OrderedDict
 
 class ChangeLogParseError(Exception):
@@ -25,6 +26,15 @@ class MalformedUnorderedItemError(ChangeLogParseError):
     pass
 
 class DuplicateVersionError(ChangeLogParseError):
+    pass
+
+class MissingIsBuildkitUpdateRequired(ChangeLogParseError):
+    pass
+
+class MalformedAdditionalInfoLint(ChangeLogParseError):
+    pass
+
+class DuplicateBuildkitUpdateRequired(ChangeLogParseError):
     pass
 
 
@@ -56,11 +66,16 @@ def parse_line(line, line_num):
 
 version_line_re = re.compile(r'^(v[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?) - ([0-9]{4}-[0-9]{2}-[0-9]{2})( \(aborted release/not recommended\))?$')
 
+def is_buildkit_change_additional_info_required(version):
+    return version != "Unreleased" and packaging.version.parse(version) >= packaging.version.parse('v0.7.19')
+
 def parse_changelog(changelog_data):
     versions = OrderedDict()
     def save_version(version, release_date, body):
         if version in versions:
             raise DuplicateVersionError(version, line_num)
+        if is_buildkit_change_additional_info_required(version) and is_buildkit_change_found is False:
+            raise MissingIsBuildkitUpdateRequired(f'Version {version} did not mention if release contains any buildkit changes', line_num)
         versions[version] = {
             'date': release_date,
             'body': '\n'.join(body),
@@ -69,6 +84,8 @@ def parse_changelog(changelog_data):
     line_num = 1
     version = None
     is_title_body = False
+    is_addition_info = False
+    is_buildkit_change_found = False
     dash_found = False
     body = []
     ignore = False
@@ -94,6 +111,16 @@ def parse_changelog(changelog_data):
             if line == '<!--changelog-parser-ignore-end-->':
                 ignore = False
                 continue
+            if is_addition_info:
+                allowed_additional_info_lines = ('- This release has no changes to buildkit', '- This release includes changes to buildkit')
+                if line == '':
+                    continue
+                if is_buildkit_change_found:
+                    raise DuplicateBuildkitUpdateRequired('buildkit update string already exists', line_num)
+                if line not in allowed_additional_info_lines:
+                    raise MalformedAdditionalInfoLint(f'expected line of either {allowed_additional_info_lines}, but got "{line}" instead', line_num)
+                is_buildkit_change_found = True
+                continue
             if ignore:
                 pass
             elif is_title_body:
@@ -116,6 +143,7 @@ def parse_changelog(changelog_data):
         elif num_headers == 2:
             is_intro = True
             ignore = False
+            is_addition_info = False
             if is_title_body:
                 if title != 'Unreleased':
                     raise MissingTitleError(f'expected `## Unreleased` title; got {line}', line_num)
@@ -132,9 +160,14 @@ def parse_changelog(changelog_data):
                 version = m.group(1)
                 release_date = m.group(3)
             body = []
+            is_buildkit_change_found = False
         elif num_headers == 3:
             ignore = False
             is_intro = False
+            is_addition_info = False
+            if title == 'Additional Info':
+                is_addition_info = True
+                continue
             allowed_titles = ('Added', 'Changed', 'Removed', 'Fixed')
             if title not in allowed_titles:
                 raise UnexpectedHeaderError(f'expected header of {allowed_titles}; but got "{title}"', line_num)


### PR DESCRIPTION
New releases will require the CHANGELOG to mention if a the release contains any buildkit changes, by enforcing the existance of a new section:

    ### Additional Info
    - This release includes changes to buildkit

or

    ### Additional Info
    - This release has no changes to buildkit

depending on if the release includes changes to buildkit or not.