### PR TITLE
improve secret errors

### DIFF
--- a/util/llbutil/secretprovider/secrets.go
+++ b/util/llbutil/secretprovider/secrets.go
@@ -37,14 +37,14 @@ func (sp *secretProvider) GetSecret(ctx context.Context, req *secrets.GetSecretR
 			if errors.Is(err, secrets.ErrNotFound) || errors.Is(err, cloud.ErrNotFound) {
 				continue
 			}
-			return nil, err
+			return nil, errors.WithStack(errors.Wrapf(err, "unable to lookup secret %s (id=%s)", v.Get("name"), req.ID))
 		}
 		return &secrets.GetSecretResponse{
 			Data: data,
 		}, nil
 	}
 
-	return nil, errors.WithStack(errors.Wrapf(secrets.ErrNotFound, "unable to lookup secret %s", v.Get("name")))
+	return nil, errors.WithStack(errors.Wrapf(secrets.ErrNotFound, "unable to lookup secret %s (id=%s)", v.Get("name"), req.ID))
 }
 
 // New returns a new secrets provider which looks up secrets


### PR DESCRIPTION
Previously one would see:

    Error: build target: build main: failed to solve: Earthfile line 245:12 with docker run: unlazy force execution: unauthorized

Now one will see:

    Error: build target: build main: failed to solve: Earthfile line 245:12 with docker run: unlazy force execution: unable to lookup secret dockerhub-mirror/user (id=name=dockerhub-mirror%2Fuser&org=earthly-technologies&project=core&v=1): unauthorized

This could use some further improvements, but without this change, it was not clear that I was logged into a different earthly account that did not have access to the earthly-technologies org.