### PR TITLE
Update docs with reference to previous docker images tags + release process

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -26,7 +26,7 @@
         "'earthly/earthly:(?<currentValue>.+?)'",
         'github.com/earthly/earthly:(?<currentValue>.+?)(\\+|`)',
         '(:|\\s+)earthly/earthly:(?<currentValue>.+?)[\\s\\n/]+',
-        '\\* `(?<currentValue>.+?)`, `latest`',
+        'the `latest` tag is :(?<currentValue>.+?)[\\s\\n]+',
       ],
       depNameTemplate: 'earthly/earthly',
       datasourceTemplate: 'github-releases',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -26,7 +26,7 @@
         "'earthly/earthly:(?<currentValue>.+?)'",
         'github.com/earthly/earthly:(?<currentValue>.+?)(\\+|`)',
         '(:|\\s+)earthly/earthly:(?<currentValue>.+?)[\\s\\n/]+',
-        'the `latest` tag is :(?<currentValue>.+?)[\\s\\n]+',
+        'the `latest` tag is `(?<currentValue>.+?)`',
       ],
       depNameTemplate: 'earthly/earthly',
       datasourceTemplate: 'github-releases',

--- a/docs/docker-images/all-in-one.md
+++ b/docs/docker-images/all-in-one.md
@@ -2,7 +2,7 @@ This image contains `earthly`, `buildkit`, and some extra configuration to enabl
 
 ## Tags
 
-Currently, the `latest` tag is :`v0.7.19`
+Currently, the `latest` tag is `v0.7.19`.
 For other available tags, please check out https://hub.docker.com/r/earthly/earthly/tags
 
 ## Quickstart

--- a/docs/docker-images/all-in-one.md
+++ b/docs/docker-images/all-in-one.md
@@ -2,7 +2,7 @@ This image contains `earthly`, `buildkit`, and some extra configuration to enabl
 
 ## Tags
 
-Currently, the `latest` tag is `v0.7.19`.
+Currently, the `latest` tag is `v0.7.19`.  
 For other available tags, please check out https://hub.docker.com/r/earthly/earthly/tags
 
 ## Quickstart

--- a/docs/docker-images/all-in-one.md
+++ b/docs/docker-images/all-in-one.md
@@ -2,9 +2,8 @@ This image contains `earthly`, `buildkit`, and some extra configuration to enabl
 
 ## Tags
 
-* `v0.7.19`, `latest`
-* `v0.7.17`
-* `v0.7.16`
+Currently, the `latest` tag is :`v0.7.19`
+For other available tags, please check out https://hub.docker.com/r/earthly/earthly/tags
 
 ## Quickstart
 

--- a/docs/docker-images/buildkit-standalone.md
+++ b/docs/docker-images/buildkit-standalone.md
@@ -4,7 +4,7 @@ This image contains `buildkit` with some Earthly-specific setup. This is what Ea
 
 ## Tags
 
-Currently, the `latest` tag is :`v0.7.19`
+Currently, the `latest` tag is `v0.7.19`.
 For other available tags, please check out https://hub.docker.com/r/earthly/buildkitd/tags
 
 ## Quickstart

--- a/docs/docker-images/buildkit-standalone.md
+++ b/docs/docker-images/buildkit-standalone.md
@@ -4,7 +4,7 @@ This image contains `buildkit` with some Earthly-specific setup. This is what Ea
 
 ## Tags
 
-Currently, the `latest` tag is `v0.7.19`.
+Currently, the `latest` tag is `v0.7.19`.  
 For other available tags, please check out https://hub.docker.com/r/earthly/buildkitd/tags
 
 ## Quickstart

--- a/docs/docker-images/buildkit-standalone.md
+++ b/docs/docker-images/buildkit-standalone.md
@@ -4,9 +4,8 @@ This image contains `buildkit` with some Earthly-specific setup. This is what Ea
 
 ## Tags
 
-* `v0.7.19`, `latest`
-* `v0.7.17`
-* `v0.7.16`
+Currently, the `latest` tag is :`v0.7.19`
+For other available tags, please check out https://hub.docker.com/r/earthly/buildkitd/tags
 
 ## Quickstart
 

--- a/release/README.md
+++ b/release/README.md
@@ -35,33 +35,27 @@
     ```shell
       git checkout docs-0.7 && git pull && git merge main && git push
     ```
+* Updating the Earthly version in our docs:  
+  [Renovate](https://www.mend.io/renovate/) will open a PR to update all docs as soon as a new release is available in this repo,  
+  which you should then review & merge (An example PR can be found [here](https://github.com/earthly/earthly/pull/3285/files)).
 
-* Update the version for the installation command in the following places:
+  * If for whatever reason you need/want to do this manually, please do the following:
+    * Update the version in the following places:
 <!-- vale HouseStyle.Spelling = NO -->
   * [circle-integration.md](../docs/ci-integration/guides/circle-integration.md)
   * [gh-actions-integration.md](../docs/ci-integration/guides/gh-actions-integration.md)
   * [codebuild-integration.md](../docs/ci-integration/guides/codebuild-integration.md)
   * [gitlab-integration.md](../docs/ci-integration/guides/gitlab-integration.md)
   * [build-an-earthly-ci-image.md](../docs/ci-integration/build-an-earthly-ci-image.md)
-<!-- vale HouseStyle.Spelling = YES -->
-  * you can try doing that with:
-    ```
-    REGEX='\(earthly\/releases\/download\/\)v[0-9]\+\.[0-9]\+\.[0-9]\+\(\/\)'; grep -Ril './docs/' -e $REGEX | xargs -n1 sed -i 's/'$REGEX'/\1'$RELEASE_TAG'\2/g'
-    ```
-* Update the pinned image tags used in the following places:
-<!-- vale HouseStyle.Spelling = NO -->
   * [all-in-one.md](../docs/docker-images/all-in-one.md)
   * [buildkit-standalone.md](../docs/docker-images/buildkit-standalone.md)
-  * [build-an-earthly-ci-image.md](../docs/ci-integration/build-an-earthly-ci-image.md)
 <!-- vale HouseStyle.Spelling = YES -->
   * you can try doing that with:
     ```shell
+    REGEX='\(earthly\/releases\/download\/\)v[0-9]\+\.[0-9]\+\.[0-9]\+\(\/\)'; grep -Ril './docs/' -e $REGEX | xargs -n1 sed -i 's/'$REGEX'/\1'$RELEASE_TAG'\2/g'
     REGEX='\(\searthly\/\(buildkitd\|earthly\):\)v[0-9]\+\.[0-9]\+\.[0-9]\+'; grep -Ril './docs/' -e $REGEX | xargs -n1 sed -i 's/'$REGEX'/\1'$RELEASE_TAG'/g'
     ```
-* Update the Docker image documentation's tags with the new version, plus the prior two image versions under:
-<!-- vale HouseStyle.Spelling = NO -->
-  * [all-in-one.md](../docs/docker-images/all-in-one.md)
-  * [buildkit-standalone.md](../docs/docker-images/buildkit-standalone.md)
+
 * Commit updated version changes to `docs-0.7`.
 * Merge `docs-0.7` into `main`.
   ```shell


### PR DESCRIPTION
Addresses https://github.com/earthly/earthly/issues/3006.

Some documents were referring to older tags which we then had to maintain as we release newer versions of earthly.
With this PR, the docs will link to all available tags in dockerhub.

In addition, making sure Renovate config is up to date to update the latest version of earthly/buildkitd mentioned in those docs.

Finally, the release readme was updated as well to acknowledge Renovate is responsible for updating the earthly version in our docs. 

