### PR TITLE
Fixes issue with incorrect error count report

### DIFF
--- a/logbus/setup/setup.go
+++ b/logbus/setup/setup.go
@@ -152,7 +152,9 @@ func (bs *BusSetup) Close() error {
 					multi = multierror.Append(multi, err)
 				}
 			}
-			ret = multierror.Append(ret, errors.Wrap(multi, "log streamer"))
+			if len(multi.Errors) > 0 {
+				ret = multierror.Append(ret, errors.Wrap(multi, "log streamer"))
+			}
 		}
 	}
 


### PR DESCRIPTION
An empty `multierror.Error` value ought not to be added to the list.