### PR TITLE
with this change, GH actions will only be able to run once for each branch/pr

### DIFF
--- a/.github/workflows/ci-docker-satellites.yml
+++ b/.github/workflows/ci-docker-satellites.yml
@@ -8,6 +8,10 @@ on:
     branches: [ main ]
     paths-ignore: [ docs/** ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-earthly:
     uses: ./.github/workflows/build-earthly.yml

--- a/.github/workflows/ci-docker-ubuntu.yml
+++ b/.github/workflows/ci-docker-ubuntu.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-earthly:
     uses: ./.github/workflows/build-earthly.yml

--- a/.github/workflows/ci-lint-docs.yml
+++ b/.github/workflows/ci-lint-docs.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main, next ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: +lint-docs

--- a/.github/workflows/ci-podman-ubuntu.yml
+++ b/.github/workflows/ci-podman-ubuntu.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-earthly:
     uses: ./.github/workflows/build-earthly.yml

--- a/.github/workflows/ci-scheduled-codeql-analysis.yml
+++ b/.github/workflows/ci-scheduled-codeql-analysis.yml
@@ -20,6 +20,10 @@ on:
   schedule:
     - cron: '28 18 * * 0'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze


### PR DESCRIPTION
A common case is when a new commit is pushed to the branch - 
With this added configuration any running jobs for the previous commit will be stopped and the jobs will start again for the newest commit (same as they do today).

Note, the configuration is added only in workflow files that are triggered by a pull request.

[docs reference](https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-concurrency-to-cancel-any-in-progress-job-or-run)