### PR TITLE
interactive debugger ignore errors if command exits correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 ### Fixed
 - Fix a regression where URLs will not always get shorter when used as a prefix. Partially addresses [#3200](https://github.com/earthly/earthly/issues/3200).
 - If a build fails because of `qemu` missing, earthly will display a proper hint to install it [#3200](https://github.com/earthly/earthly/issues/3200).
+- A Race condition when exiting interactive debugger mode resulting in confusing errors [#3200](https://github.com/earthly/earthly/issues/3200).
 
 ### Changed
 - Some error messages at the end of an execution will only be displayed in verbose mode (`earthly -V ...`), e.g. `Error: build target: build main: failed to solve:`... [#3200](https://github.com/earthly/earthly/issues/3200)
 - `GIT CLONE` URLs will only be printed once as part of a prefix, e.g. `+my-clone-target(https://g/e/earthly) | --> GIT CLONE (--branch ) https://github.com/earthly/earthly`
+- Clarify errors in interactive debugger so that they won't be confused with the build errors [#3200](https://github.com/earthly/earthly/issues/3200).  
 
 ## v0.7.19 - 2023-09-20
 

--- a/cmd/debugger/main.go
+++ b/cmd/debugger/main.go
@@ -188,7 +188,7 @@ func interactiveMode(ctx context.Context, remoteConsoleAddr string, cmdBuilder f
 
 	ptmx, err := pty.Start(c)
 	if err != nil {
-		conslogger.VerboseWarnf("failed to start pty\n")
+		conslogger.Warnf("%v\n", errors.Wrap(err, "failed to start pty"))
 		return err
 	}
 	defer func() { _ = ptmx.Close() }() // Best effort.

--- a/cmd/debugger/main.go
+++ b/cmd/debugger/main.go
@@ -10,7 +10,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
-	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/earthly/earthly/conslogging"
@@ -37,6 +37,18 @@ var (
 
 	errInteractiveModeWaitFailed = errors.New("interactive mode wait failed")
 )
+
+type waitError struct {
+	set bool
+	err error
+}
+
+func newWaitError(err error, set bool) *waitError {
+	return &waitError{
+		set: set,
+		err: err,
+	}
+}
 
 func getShellPath() (string, bool) {
 	for _, sh := range []string{
@@ -165,18 +177,15 @@ func interactiveMode(ctx context.Context, remoteConsoleAddr string, cmdBuilder f
 		return err
 	}
 
-	// once the command completes, waitErrSet will be set to true, indicating the command finished (or failed)
-	// if is is not set, then that means the interactive debugger has exited before the wrapped command has finished.
-	var waitErrMu sync.Mutex
-	var waitErr error
-	var waitErrSet bool
+	// once the command completes, waitErr will be set to true, indicating the command finished (or failed)
+	// if it is not set, then that means the interactive debugger has exited before the wrapped command has finished.
+	waitErr := atomic.Pointer[waitError]{}
+	waitErr.Store(newWaitError(nil, false))
 
 	hasCommandFinished := func() bool {
 		// give c.Wait() time to acquire the lock first, to detect if the command closed as expected
 		time.Sleep(time.Millisecond * 10)
-		waitErrMu.Lock()
-		defer waitErrMu.Unlock()
-		return waitErrSet
+		return waitErr.Load().set
 	}
 
 	logErrorIfNonCleanExit := func(err error) {
@@ -245,10 +254,7 @@ func interactiveMode(ctx context.Context, remoteConsoleAddr string, cmdBuilder f
 
 	go func() {
 		err := c.Wait()
-		waitErrMu.Lock()
-		waitErr = err
-		waitErrSet = true
-		waitErrMu.Unlock()
+		waitErr.Store(newWaitError(err, true))
 		cancel()
 	}()
 
@@ -259,12 +265,10 @@ func interactiveMode(ctx context.Context, remoteConsoleAddr string, cmdBuilder f
 		return errors.Wrap(err, "failed to send end shell session")
 	}
 
-	waitErrMu.Lock()
-	defer waitErrMu.Unlock()
-	if !waitErrSet {
+	if !waitErr.Load().set {
 		return errInteractiveModeWaitFailed
 	}
-	return waitErr
+	return waitErr.Load().err
 }
 
 func getSettings(path string) (*common.DebuggerSettings, error) {

--- a/debugger/terminal/terminal_other.go
+++ b/debugger/terminal/terminal_other.go
@@ -55,7 +55,9 @@ func ConnectTerm(ctx context.Context, conn io.ReadWriteCloser, console consloggi
 		for {
 			connDataType, data, err := common.ReadDataPacket(conn)
 			if err != nil {
-				console.VerbosePrintf("ReadDataPacket failed: %s\n", err.Error())
+				if err != io.EOF {
+					console.VerbosePrintf("ReadDataPacket failed: %s\n", err.Error())
+				}
 				break
 			}
 			switch connDataType {


### PR DESCRIPTION
Partially addresses #3200  (example 5)
 - Avoid printing log errors that occur due to debugger exiting
 - Make other log messages clearer that they are coming from the debugger, use console instead of Logger


Credit to @alexcb for solution.