### PR TITLE
Registry proxy: Use lower-level TCP streaming

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -818,8 +818,3 @@ npm-update-all:
         RUN cd $nodepath && npm update
         SAVE ARTIFACT --if-exists $nodepath/package-lock.json AS LOCAL $nodepath/package-lock.json
     END
-
-image-test:
-    FROM alpine
-    RUN echo "hello"
-    SAVE IMAGE foo

--- a/Earthfile
+++ b/Earthfile
@@ -818,3 +818,8 @@ npm-update-all:
         RUN cd $nodepath && npm update
         SAVE ARTIFACT --if-exists $nodepath/package-lock.json AS LOCAL $nodepath/package-lock.json
     END
+
+image-test:
+    FROM alpine
+    RUN echo "hello"
+    SAVE IMAGE foo

--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -12,7 +12,7 @@ buildkitd:
             ARG BUILDKIT_BASE_IMAGE=$BUILDKIT_PROJECT+build
         END
     ELSE
-        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:24896269e83a079ba5a5b677ed1c6e82949d6324+build
+        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:3431ead5d97972e7222b937ffd862a83967cd537+build
     END
     ARG EARTHLY_TARGET_TAG_DOCKER
     ARG TAG="dev-$EARTHLY_TARGET_TAG_DOCKER"

--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -12,7 +12,7 @@ buildkitd:
             ARG BUILDKIT_BASE_IMAGE=$BUILDKIT_PROJECT+build
         END
     ELSE
-        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:3431ead5d97972e7222b937ffd862a83967cd537+build
+        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:2da455824fc5bcb572c02ade315c16ed32ce9c1e+build
     END
     ARG EARTHLY_TARGET_TAG_DOCKER
     ARG TAG="dev-$EARTHLY_TARGET_TAG_DOCKER"

--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -12,7 +12,7 @@ buildkitd:
             ARG BUILDKIT_BASE_IMAGE=$BUILDKIT_PROJECT+build
         END
     ELSE
-        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:2da455824fc5bcb572c02ade315c16ed32ce9c1e+build
+        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:f3b4f010e26e8f2a66f988a025ffb0396da2b1a1+build
     END
     ARG EARTHLY_TARGET_TAG_DOCKER
     ARG TAG="dev-$EARTHLY_TARGET_TAG_DOCKER"

--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -12,7 +12,7 @@ buildkitd:
             ARG BUILDKIT_BASE_IMAGE=$BUILDKIT_PROJECT+build
         END
     ELSE
-        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:af796f0cb8ff6cf53fdebd543ff1e7cd173c00a1+build
+        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:24896269e83a079ba5a5b677ed1c6e82949d6324+build
     END
     ARG EARTHLY_TARGET_TAG_DOCKER
     ARG TAG="dev-$EARTHLY_TARGET_TAG_DOCKER"

--- a/cmd/earthly/subcmd/build_cmd.go
+++ b/cmd/earthly/subcmd/build_cmd.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/http"
 	"net/url"
 	"os"
 	"path"

--- a/cmd/earthly/subcmd/build_cmd.go
+++ b/cmd/earthly/subcmd/build_cmd.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/containerd/containerd/platforms"
 	"github.com/docker/cli/cli/config"
-	"github.com/docker/distribution/registry/listener"
 	"github.com/fatih/color"
 	"github.com/joho/godotenv"
 	"github.com/moby/buildkit/client"
@@ -728,8 +727,9 @@ func (a *Build) ActionBuildImp(cliCtx *cli.Context, flagArgs, nonFlagArgs []stri
 
 func (a *Build) startRegistryProxy(ctx context.Context, client *client.Client) (string, func(), error) {
 	addr := "localhost:0" // Have the OS select a port
-	ln, err := listener.NewListener("tcp", addr)
 
+	lnCfg := net.ListenConfig{}
+	ln, err := lnCfg.Listen(ctx, "tcp", addr)
 	if err != nil {
 		return "", nil, errors.Wrapf(err, "failed to listen on %q", addr)
 	}

--- a/cmd/earthly/subcmd/build_cmd.go
+++ b/cmd/earthly/subcmd/build_cmd.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"net/http"
 	"net/url"
 	"os"
 	"path"

--- a/go.mod
+++ b/go.mod
@@ -139,6 +139,6 @@ replace (
 	github.com/jdxcode/netrc => github.com/mikejholly/netrc v0.0.0-20221121193719-a154cb29ec2a
 	github.com/jessevdk/go-flags => github.com/alexcb/go-flags v0.0.0-20210722203016-f11d7ecb5ee5
 
-	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.0-20230929024137-24896269e83a
+	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.0-20230929041409-3431ead5d979
 	github.com/tonistiigi/fsutil => github.com/earthly/fsutil v0.0.0-20230530182746-82567e6e2a92
 )

--- a/go.mod
+++ b/go.mod
@@ -139,6 +139,6 @@ replace (
 	github.com/jdxcode/netrc => github.com/mikejholly/netrc v0.0.0-20221121193719-a154cb29ec2a
 	github.com/jessevdk/go-flags => github.com/alexcb/go-flags v0.0.0-20210722203016-f11d7ecb5ee5
 
-	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.0-20230928032329-af796f0cb8ff
+	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.0-20230929024137-24896269e83a
 	github.com/tonistiigi/fsutil => github.com/earthly/fsutil v0.0.0-20230530182746-82567e6e2a92
 )

--- a/go.mod
+++ b/go.mod
@@ -139,6 +139,6 @@ replace (
 	github.com/jdxcode/netrc => github.com/mikejholly/netrc v0.0.0-20221121193719-a154cb29ec2a
 	github.com/jessevdk/go-flags => github.com/alexcb/go-flags v0.0.0-20210722203016-f11d7ecb5ee5
 
-	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.0-20230929041409-3431ead5d979
+	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.0-20231001030407-2da455824fc5
 	github.com/tonistiigi/fsutil => github.com/earthly/fsutil v0.0.0-20230530182746-82567e6e2a92
 )

--- a/go.mod
+++ b/go.mod
@@ -139,6 +139,6 @@ replace (
 	github.com/jdxcode/netrc => github.com/mikejholly/netrc v0.0.0-20221121193719-a154cb29ec2a
 	github.com/jessevdk/go-flags => github.com/alexcb/go-flags v0.0.0-20210722203016-f11d7ecb5ee5
 
-	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.0-20231001030407-2da455824fc5
+	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.0-20231003205225-f3b4f010e26e
 	github.com/tonistiigi/fsutil => github.com/earthly/fsutil v0.0.0-20230530182746-82567e6e2a92
 )

--- a/go.sum
+++ b/go.sum
@@ -179,8 +179,8 @@ github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
-github.com/earthly/buildkit v0.0.0-20230928032329-af796f0cb8ff h1:GWFbzqZGwYZ9uKBnPb7FIccsW8JVlvaDgvgLynRRA/k=
-github.com/earthly/buildkit v0.0.0-20230928032329-af796f0cb8ff/go.mod h1:P7bVT9bNSjRkPvWZwVvrCmXzP6bfqw2T9GB7iKMP34s=
+github.com/earthly/buildkit v0.0.0-20230929024137-24896269e83a h1:y2RNzDWBwTySvF1wMEP9ERc2e61QLKV/lZOeMzQbSi0=
+github.com/earthly/buildkit v0.0.0-20230929024137-24896269e83a/go.mod h1:P7bVT9bNSjRkPvWZwVvrCmXzP6bfqw2T9GB7iKMP34s=
 github.com/earthly/cloud-api v1.0.1-0.20230914190823-c58662fdabd8 h1:8EW/AMPNtzOcExSV7Dk1weQGK/XqbAuhvLs062xlBH4=
 github.com/earthly/cloud-api v1.0.1-0.20230914190823-c58662fdabd8/go.mod h1:rU/tYJ7GFBjdKAITV2heDbez++glpGSbtJaZcp73rNI=
 github.com/earthly/fsutil v0.0.0-20230530182746-82567e6e2a92 h1:dy3w3B4OiDyQS+iHi/beUgMDJ1+fAAgbtr7OZ0d9ks0=

--- a/go.sum
+++ b/go.sum
@@ -179,8 +179,8 @@ github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
-github.com/earthly/buildkit v0.0.0-20230929041409-3431ead5d979 h1:Tz4a1ansuYIqDt6URHebOZindI5n7uQG8aU0Kx/+SRQ=
-github.com/earthly/buildkit v0.0.0-20230929041409-3431ead5d979/go.mod h1:P7bVT9bNSjRkPvWZwVvrCmXzP6bfqw2T9GB7iKMP34s=
+github.com/earthly/buildkit v0.0.0-20231001030407-2da455824fc5 h1:Gz4P8T+CRPvKle2c2U2a61Zv8qL+2CgE7QzVxZQAcbI=
+github.com/earthly/buildkit v0.0.0-20231001030407-2da455824fc5/go.mod h1:P7bVT9bNSjRkPvWZwVvrCmXzP6bfqw2T9GB7iKMP34s=
 github.com/earthly/cloud-api v1.0.1-0.20230914190823-c58662fdabd8 h1:8EW/AMPNtzOcExSV7Dk1weQGK/XqbAuhvLs062xlBH4=
 github.com/earthly/cloud-api v1.0.1-0.20230914190823-c58662fdabd8/go.mod h1:rU/tYJ7GFBjdKAITV2heDbez++glpGSbtJaZcp73rNI=
 github.com/earthly/fsutil v0.0.0-20230530182746-82567e6e2a92 h1:dy3w3B4OiDyQS+iHi/beUgMDJ1+fAAgbtr7OZ0d9ks0=

--- a/go.sum
+++ b/go.sum
@@ -179,8 +179,8 @@ github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
-github.com/earthly/buildkit v0.0.0-20231001030407-2da455824fc5 h1:Gz4P8T+CRPvKle2c2U2a61Zv8qL+2CgE7QzVxZQAcbI=
-github.com/earthly/buildkit v0.0.0-20231001030407-2da455824fc5/go.mod h1:P7bVT9bNSjRkPvWZwVvrCmXzP6bfqw2T9GB7iKMP34s=
+github.com/earthly/buildkit v0.0.0-20231003205225-f3b4f010e26e h1:QeAcISuMDUD9dILbFrxW6Hy6GlBGoxyJCQ+MkvqqKEY=
+github.com/earthly/buildkit v0.0.0-20231003205225-f3b4f010e26e/go.mod h1:P7bVT9bNSjRkPvWZwVvrCmXzP6bfqw2T9GB7iKMP34s=
 github.com/earthly/cloud-api v1.0.1-0.20230914190823-c58662fdabd8 h1:8EW/AMPNtzOcExSV7Dk1weQGK/XqbAuhvLs062xlBH4=
 github.com/earthly/cloud-api v1.0.1-0.20230914190823-c58662fdabd8/go.mod h1:rU/tYJ7GFBjdKAITV2heDbez++glpGSbtJaZcp73rNI=
 github.com/earthly/fsutil v0.0.0-20230530182746-82567e6e2a92 h1:dy3w3B4OiDyQS+iHi/beUgMDJ1+fAAgbtr7OZ0d9ks0=

--- a/go.sum
+++ b/go.sum
@@ -179,8 +179,8 @@ github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
-github.com/earthly/buildkit v0.0.0-20230929024137-24896269e83a h1:y2RNzDWBwTySvF1wMEP9ERc2e61QLKV/lZOeMzQbSi0=
-github.com/earthly/buildkit v0.0.0-20230929024137-24896269e83a/go.mod h1:P7bVT9bNSjRkPvWZwVvrCmXzP6bfqw2T9GB7iKMP34s=
+github.com/earthly/buildkit v0.0.0-20230929041409-3431ead5d979 h1:Tz4a1ansuYIqDt6URHebOZindI5n7uQG8aU0Kx/+SRQ=
+github.com/earthly/buildkit v0.0.0-20230929041409-3431ead5d979/go.mod h1:P7bVT9bNSjRkPvWZwVvrCmXzP6bfqw2T9GB7iKMP34s=
 github.com/earthly/cloud-api v1.0.1-0.20230914190823-c58662fdabd8 h1:8EW/AMPNtzOcExSV7Dk1weQGK/XqbAuhvLs062xlBH4=
 github.com/earthly/cloud-api v1.0.1-0.20230914190823-c58662fdabd8/go.mod h1:rU/tYJ7GFBjdKAITV2heDbez++glpGSbtJaZcp73rNI=
 github.com/earthly/fsutil v0.0.0-20230530182746-82567e6e2a92 h1:dy3w3B4OiDyQS+iHi/beUgMDJ1+fAAgbtr7OZ0d9ks0=

--- a/regproxy/proxy.go
+++ b/regproxy/proxy.go
@@ -2,7 +2,6 @@ package regproxy
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"net"
 	"sync"

--- a/regproxy/proxy.go
+++ b/regproxy/proxy.go
@@ -53,11 +53,9 @@ func (r *RegistryProxy) Serve(ctx context.Context) {
 				}
 				return
 			}
+			wg.Add(1)
 			go func() {
-				wg.Add(1)
-				defer func() {
-					wg.Done()
-				}()
+				defer wg.Done()
 				r.errCh <- r.handle(ctx, conn)
 			}()
 		}
@@ -82,7 +80,7 @@ func (r *RegistryProxy) handle(ctx context.Context, conn net.Conn) error {
 	}
 
 	rw := registry.NewStreamRW(stream)
-	eg, ctx := errgroup.WithContext(ctx)
+	eg, _ := errgroup.WithContext(ctx)
 
 	eg.Go(func() error {
 		_, err = copyWithDeadline(conn, rw)

--- a/regproxy/proxy.go
+++ b/regproxy/proxy.go
@@ -117,7 +117,7 @@ func copyWithDeadline(conn net.Conn, w io.Writer) (int64, error) {
 		if err != nil {
 			return 0, err
 		}
-		buf := make([]byte, 1024)
+		buf := make([]byte, 32*1024)
 		n, err := conn.Read(buf)
 		if err != nil {
 			if errors.Is(err, io.EOF) || isNetTimeout(err) {


### PR DESCRIPTION
Removes the HTTP-level code in favor of a lower-level TCP proxy approach. 

The tricky part here was that Docker (and most HTTP clients) leaves the TCP connection open. Hence, there's no way for the code to detect when to stop reading the initial request aside from a timeout. Apparently, the recommended approach is to set [`SetReadDeadline`](https://cs.opensource.google/go/go/+/refs/tags/go1.21.1:src/net/net.go;l=156) ahead of each read and appropriately handle any timeout errors. 

Overall, I think this is preferable to the original code as the HTTP code & header parsing is a bit brittle.

Works with: https://github.com/earthly/buildkit/pull/26