### PR TITLE
Conditionally run GH actions jobs only if relevant files changed

### DIFF
--- a/.github/workflows/ci-docker-ubuntu.yml
+++ b/.github/workflows/ci-docker-ubuntu.yml
@@ -12,7 +12,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # this job will output a boolean value to check whether files that require these tests to run
+  # since all jobs depend on `build-earthly` job, conditionally running it will either cause all jobs to run or skip,
+  # depending on the output value of this job
+  check-essential-files:
+    uses: ./.github/workflows/reusable-find-pr-changes.yaml
+    permissions:
+      pull-requests: read
+    secrets: inherit
   build-earthly:
+    needs: check-essential-files
+    # using "!= 'false'" so that an empty string (in case of output problem) will evaluate to true
+    if: ${{ needs.check-essential-files.outputs.essential-files != 'false' }}
     uses: ./.github/workflows/build-earthly.yml
     with:
       BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"

--- a/.github/workflows/ci-podman-ubuntu.yml
+++ b/.github/workflows/ci-podman-ubuntu.yml
@@ -12,7 +12,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # this job will output a boolean value to check whether files that require these tests to run
+  # since all jobs depend on `build-earthly` job, conditionally running it will either cause all jobs to run or skip,
+  # depending on the output value of this job
+  check-essential-files:
+    uses: ./.github/workflows/reusable-find-pr-changes.yaml
+    permissions:
+      pull-requests: read
+    secrets: inherit
   build-earthly:
+    needs: check-essential-files
+    # using "!= 'false'" so that an empty string (in case of output problem) will evaluate to true
+    if: ${{ needs.check-essential-files.outputs.essential-files != 'false' }}
     uses: ./.github/workflows/build-earthly.yml
     with:
       BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"

--- a/.github/workflows/reusable-find-pr-changes.yaml
+++ b/.github/workflows/reusable-find-pr-changes.yaml
@@ -1,0 +1,27 @@
+name: find pr file changes
+
+on:
+  workflow_call:
+    outputs:
+      essential-files:
+        description: A boolean (as string) indicating whether essential files were changed in the PR"
+        value: ${{ jobs.file-changes.outputs.essential-files }}
+
+jobs:
+  file-changes:
+    runs-on: ubuntu-latest
+    # Set permissions to minimum required
+    permissions:
+      pull-requests: read
+    # Set job outputs to values from filter step
+    outputs:
+      essential-files: ${{ steps.filter.outputs.essential-files }}
+    steps:
+    - uses: dorny/paths-filter@v2
+      id: filter
+      with:
+        filters: |
+          essential-files:
+          # evaluate to true if at least one of the changed files is none of the following
+          # (separated by "|"):
+            - '!(docs/**/*|*.md|**/*.md|.github/renovate.json5)'


### PR DESCRIPTION
Adding a new reusable job that will detect whether "essential" files were changed.
Then other jobs will run conditionally only is essentials files (e.g. *.go files) are changed as part of a PR.

Note that according to documentation, skipped jobs that are used as required checks in Github do not block PRs
(see note [here](https://docs.github.com/en/actions/using-jobs/using-conditions-to-control-job-execution#overview)).

Since all the tests are dependent on `build-earthly` job, it was sufficient to conditionally execute the latter.
If it is skipped, all dependent jobs will be skipped as well. 

I tested these changes on my fork of earthly