### PR TITLE
Adds --global-cache feature flag

### DIFF
--- a/docs/earthfile/earthfile.md
+++ b/docs/earthfile/earthfile.md
@@ -270,13 +270,13 @@ Mounts a file or directory in the context of the build environment.
 
 The `<mount-spec>` is defined as a series of comma-separated list of key-values. The following keys are allowed
 
-| Key             | Description                                                                                                                                                                     | Example                                |
-|-----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------|
-| `type`          | The type of the mount. Currently only `cache`, `tmpfs`, and `secret` are allowed.                                                                                               | `type=cache`                           |
-| `target`        | The target path for the mount.                                                                                                                                                  | `target=/var/lib/data`                 |
-| `mode`, `chmod` | The permission of the mounted file, in octal format (the same format the chmod unix command line expects).                                                                      | `chmod=0400`                           |
-| `id`            | The cache ID for a shared cache mount to be used across other targets or Earthfiles, when `type=cache`. The secret ID for the contents of the `target` file, when `type=secret` | `id=my-shared-cache`, `id=my-password` |
-| `sharing`       | The sharing mode (`locked`, `shared`, `private`) for the cache mount, only applicable for `type=cache`.                                                                         | `sharing=shared`                       |
+| Key             | Description                                                                                                                                                                                                                 | Example                                 |
+|-----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------|
+| `type`          | The type of the mount. Currently only `cache`, `tmpfs`, and `secret` are allowed.                                                                                                                                           | `type=cache`                            |
+| `target`        | The target path for the mount.                                                                                                                                                                                              | `target=/var/lib/data`                  |
+| `mode`, `chmod` | The permission of the mounted file, in octal format (the same format the chmod unix command line expects).                                                                                                                  | `chmod=0400`                            |
+| `id`            | The cache ID for a global cache mount to be used across other targets or Earthfiles, when `type=cache`. The secret ID for the contents of the `target` file, when `type=secret`. Use `VERSION --global-cache 0.7` to enable | `id=my-shared-cache`, `id=my-password`  |
+| `sharing`       | The sharing mode (`locked`, `shared`, `private`) for the cache mount, only applicable for `type=cache`.                                                                                                                     | `sharing=shared`                        |
 
 For cache mounts, the sharing mode can be one of the following:
 
@@ -1398,7 +1398,7 @@ Default `--chmod 0644`
 
 ##### `--id <cache-id>`
 
-The cache ID for a shared cache volume to be used across other targets or Earthfiles.
+The cache ID for a global cache volume to be used across other targets or Earthfiles. Use `VERSION --global-cache 0.7` to enable
 
 ## LOCALLY
 

--- a/docs/earthfile/earthfile.md
+++ b/docs/earthfile/earthfile.md
@@ -270,13 +270,13 @@ Mounts a file or directory in the context of the build environment.
 
 The `<mount-spec>` is defined as a series of comma-separated list of key-values. The following keys are allowed
 
-| Key             | Description                                                                                                                                                                                                                 | Example                                 |
-|-----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------|
-| `type`          | The type of the mount. Currently only `cache`, `tmpfs`, and `secret` are allowed.                                                                                                                                           | `type=cache`                            |
-| `target`        | The target path for the mount.                                                                                                                                                                                              | `target=/var/lib/data`                  |
-| `mode`, `chmod` | The permission of the mounted file, in octal format (the same format the chmod unix command line expects).                                                                                                                  | `chmod=0400`                            |
-| `id`            | The cache ID for a global cache mount to be used across other targets or Earthfiles, when `type=cache`. The secret ID for the contents of the `target` file, when `type=secret`. Use `VERSION --global-cache 0.7` to enable | `id=my-shared-cache`, `id=my-password`  |
-| `sharing`       | The sharing mode (`locked`, `shared`, `private`) for the cache mount, only applicable for `type=cache`.                                                                                                                     | `sharing=shared`                        |
+| Key             | Description                                                                                                                                                                                                                  | Example                                 |
+|-----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------|
+| `type`          | The type of the mount. Currently only `cache`, `tmpfs`, and `secret` are allowed.                                                                                                                                            | `type=cache`                            |
+| `target`        | The target path for the mount.                                                                                                                                                                                               | `target=/var/lib/data`                  |
+| `mode`, `chmod` | The permission of the mounted file, in octal format (the same format the chmod unix command line expects).                                                                                                                   | `chmod=0400`                            |
+| `id`            | The cache ID for a global cache mount to be used across other targets or Earthfiles, when `type=cache`. The secret ID for the contents of the `target` file, when `type=secret`. Use `VERSION --global-cache 0.7` to enable. | `id=my-shared-cache`, `id=my-password`  |
+| `sharing`       | The sharing mode (`locked`, `shared`, `private`) for the cache mount, only applicable for `type=cache`.                                                                                                                      | `sharing=shared`                        |
 
 For cache mounts, the sharing mode can be one of the following:
 
@@ -1398,7 +1398,7 @@ Default `--chmod 0644`
 
 ##### `--id <cache-id>`
 
-The cache ID for a global cache volume to be used across other targets or Earthfiles. Use `VERSION --global-cache 0.7` to enable
+The cache ID for a global cache volume to be used across other targets or Earthfiles. Use `VERSION --global-cache 0.7` to enable.
 
 ## LOCALLY
 

--- a/docs/earthfile/features.md
+++ b/docs/earthfile/features.md
@@ -33,36 +33,38 @@ to require version `0.X` (or later), and could be rewritten as `VERSION 0.X`.
 
 ## Feature flags
 
-| Feature flag | status | description |
-| --- | --- | --- |
-| `--use-registry-for-with-docker` | 0.5 | Makes use of the embedded BuildKit Docker registry (instead of tar files) for `WITH DOCKER` loads and pulls |
-| `--use-copy-include-patterns` | 0.6 | Speeds up COPY transfers |
-| `--referenced-save-only` | 0.6 | Changes the behavior of SAVE commands in a significant way |
-| `--for-in` | 0.6 | Enables support for `FOR ... IN ...` commands |
-| `--require-force-for-unsafe-saves` | 0.6 | Requires `--force` for saving artifacts locally outside the Earthfile's directory  |
-| `--no-implicit-ignore` | 0.6 | Eliminates implicit `.earthlyignore` entries, such as `Earthfile` and `.tmp-earthly-out` |
-| `--earthly-version-arg` | 0.7 | Enables builtin ARGs: `EARTHLY_VERSION` and `EARTHLY_BUILD_SHA` |
-| `--shell-out-anywhere` | 0.7 | Allows shelling-out in any earthly command (including in the middle of `ARG`) |
-| `--explicit-global` | 0.7 | Base target args must have a `--global` flag in order to be considered global args |
-| `--check-duplicate-images` | 0.7 | Check for duplicate images during output |
-| `--use-cache-command` | 0.7 | Allow use of `CACHE` command in Earthfiles |
-| `--use-host-command` | 0.7 | Allow use of `HOST` command in Earthfiles |
-| `--use-copy-link` | 0.7 | Use the equivalent of `COPY --link` for all copy-like operations |
-| `--new-platform` | 0.7 | Enable new platform behavior |
-| `--no-tar-build-output` | 0.7 | Do not print output when creating a tarball to load into `WITH DOCKER` |
-| `--use-no-manifest-list` | 0.7 | Enable the `SAVE IMAGE --no-manifest-list` option |
-| `--use-chmod` | 0.7 | Enable the `COPY --chmod` option |
-| `--earthly-locally-arg` | 0.7 | Enable the `EARTHLY_LOCALLY` arg |
-| `--use-project-secrets` | 0.7 | Enable project-based secret resolution |
-| `--use-pipelines` | 0.7 | Enable the `PIPELINE` and `TRIGGER` commands |
-| `--earthly-git-author-args` | 0.7 | Enable the `EARTHLY_GIT_AUTHOR` and `EARTHLY_GIT_CO_AUTHORS` args |
-| `--wait-block` | 0.7 | Enable the `WAIT` / `END` block commands |
-| `--earthly-ci-runner-arg` | 0.7 | Enable the `EARTHLY_CI_RUNNER` builtin ARG |
-| `--use-docker-ignore` | 0.7 | Enable the use of `.dockerignore` files in `FROM DOCKERFILE` targets |
-| `--try` | Experimental | Enable the `TRY` / `FINALLY` / `END` block commands |
-| `--arg-scope-and-set` | Experimental | Enable the `LET` / `SET` commands and nested `ARG` scoping |
-| `--pass-args` | Experimental | Enable the optional `--pass-args` flag for the `BUILD`, `FROM`, `COPY`, `WITH DOCKER --load` commands |
-
+| Feature flag                        | status       | description                                                                                                   |
+|-------------------------------------|--------------|---------------------------------------------------------------------------------------------------------------|
+| `--use-registry-for-with-docker`    | 0.5          | Makes use of the embedded BuildKit Docker registry (instead of tar files) for `WITH DOCKER` loads and pulls   |
+| `--use-copy-include-patterns`       | 0.6          | Speeds up COPY transfers                                                                                      |
+| `--referenced-save-only`            | 0.6          | Changes the behavior of SAVE commands in a significant way                                                    |
+| `--for-in`                          | 0.6          | Enables support for `FOR ... IN ...` commands                                                                 |
+| `--require-force-for-unsafe-saves`  | 0.6          | Requires `--force` for saving artifacts locally outside the Earthfile's directory                             |
+| `--no-implicit-ignore`              | 0.6          | Eliminates implicit `.earthlyignore` entries, such as `Earthfile` and `.tmp-earthly-out`                      |
+| `--earthly-version-arg`             | 0.7          | Enables builtin ARGs: `EARTHLY_VERSION` and `EARTHLY_BUILD_SHA`                                               |
+| `--shell-out-anywhere`              | 0.7          | Allows shelling-out in any earthly command (including in the middle of `ARG`)                                 |
+| `--explicit-global`                 | 0.7          | Base target args must have a `--global` flag in order to be considered global args                            |
+| `--check-duplicate-images`          | 0.7          | Check for duplicate images during output                                                                      |
+| `--use-cache-command`               | 0.7          | Allow use of `CACHE` command in Earthfiles                                                                    |
+| `--use-host-command`                | 0.7          | Allow use of `HOST` command in Earthfiles                                                                     |
+| `--use-copy-link`                   | 0.7          | Use the equivalent of `COPY --link` for all copy-like operations                                              |
+| `--new-platform`                    | 0.7          | Enable new platform behavior                                                                                  |
+| `--no-tar-build-output`             | 0.7          | Do not print output when creating a tarball to load into `WITH DOCKER`                                        |
+| `--use-no-manifest-list`            | 0.7          | Enable the `SAVE IMAGE --no-manifest-list` option                                                             |
+| `--use-chmod`                       | 0.7          | Enable the `COPY --chmod` option                                                                              |
+| `--earthly-locally-arg`             | 0.7          | Enable the `EARTHLY_LOCALLY` arg                                                                              |
+| `--use-project-secrets`             | 0.7          | Enable project-based secret resolution                                                                        |
+| `--use-pipelines`                   | 0.7          | Enable the `PIPELINE` and `TRIGGER` commands                                                                  |
+| `--earthly-git-author-args`         | 0.7          | Enable the `EARTHLY_GIT_AUTHOR` and `EARTHLY_GIT_CO_AUTHORS` args                                             |
+| `--wait-block`                      | 0.7          | Enable the `WAIT` / `END` block commands                                                                      |
+| `--no-use-registry-for-with-docker` | Experimental | Disable `use-registry-for-with-docker`                                                                        |
+| `--try`                             | Experimental | Enable the `TRY` / `FINALLY` / `END` block commands                                                           |
+| `--no-network`                      | Experimental | Allow the use of `RUN --network=none` commands                                                                |
+| `--arg-scope-and-set`               | Experimental | Enable the `LET` / `SET` commands and nested `ARG` scoping                                                    |
+| `--earthly-ci-runner-arg`           | Experimental | Enable the `EARTHLY_CI_RUNNER` builtin ARG                                                                    |
+| `--use-docker-ignore`               | Experimental | Enable the use of `.dockerignore` files in `FROM DOCKERFILE` targets                                          |
+| `--pass-args`                       | Experimental | Enable the optional `--pass-args` flag for the `BUILD`, `FROM`, `COPY`, `WITH DOCKER --load` commands         |
+| `--global-cache`                    | Experimental | Enable global caches (shared across different Earthfiles), for cache mounts and `CACHE` commands having an ID |
 
 Note that the features flags are disabled by default in Earthly versions lower than the version listed in the "status" column above.
 

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -1508,14 +1508,15 @@ func (c *Converter) Cache(ctx context.Context, mountTarget string, opts commandf
 		return err
 	}
 	c.nonSaveCommand()
-	cacheId := opts.ID
-	if cacheId == "" {
-		key, err := cacheKeyTargetInput(c.targetInputActiveOnly())
-		if err != nil {
-			return err
-		}
-		cacheId = path.Join("/run/cache", key, path.Clean(mountTarget))
+	key, err := cacheKeyTargetInput(c.targetInputActiveOnly())
+	if err != nil {
+		return err
 	}
+	cacheID := path.Join("/run/cache", key, path.Clean(mountTarget))
+	if c.ftrs.GlobalCache && opts.ID != "" {
+		cacheID = opts.ID
+	}
+
 	var shareMode llb.CacheMountSharingMode
 	switch opts.Sharing {
 	case "shared":
@@ -1530,7 +1531,7 @@ func (c *Converter) Cache(ctx context.Context, mountTarget string, opts commandf
 
 	if _, exists := c.persistentCacheDirs[mountTarget]; !exists {
 		var mountOpts []llb.MountOption
-		mountOpts = append(mountOpts, llb.AsPersistentCacheDir(cacheId, shareMode))
+		mountOpts = append(mountOpts, llb.AsPersistentCacheDir(cacheID, shareMode))
 		mountOpts = append(mountOpts, llb.SourcePath("/cache"))
 		var mountMode int
 		if opts.Mode == "" {

--- a/earthfile2llb/runmount.go
+++ b/earthfile2llb/runmount.go
@@ -137,13 +137,13 @@ func (c *Converter) parseMount(mount string) ([]llb.RunOption, error) {
 		if mountMode == 0 {
 			mountMode = 0644
 		}
-		cacheID := mountID
-		if cacheID == "" {
-			key, err := cacheKeyTargetInput(c.targetInputActiveOnly())
-			if err != nil {
-				return nil, err
-			}
-			cacheID = path.Join("/run/cache", key, path.Clean(mountTarget))
+		key, err := cacheKeyTargetInput(c.targetInputActiveOnly())
+		if err != nil {
+			return nil, err
+		}
+		cacheID := path.Join("/run/cache", key, path.Clean(mountTarget))
+		if c.ftrs.GlobalCache && mountID != "" {
+			cacheID = mountID
 		}
 		mountOpts = append(mountOpts, llb.AsPersistentCacheDir(cacheID, sharingMode))
 		state = c.cacheContext

--- a/features/features.go
+++ b/features/features.go
@@ -60,6 +60,7 @@ type Features struct {
 	EarthlyCIRunnerArg         bool `long:"earthly-ci-runner-arg" description:"includes EARTHLY_CI_RUNNER ARG"`
 	UseDockerIgnore            bool `long:"use-docker-ignore" description:"fallback to .dockerignore incase .earthlyignore or .earthignore do not exist in a local \"FROM DOCKERFILE\" target"`
 	PassArgs                   bool `long:"pass-args" description:"Allow the use of the --pass-arg flag in FROM, BUILD, COPY, WITH DOCKER, and DO commands"`
+	GlobalCache                bool `long:"global-cache" description:"enable global caches (shared across different Earthfiles), for cache mounts and CACHEs having an ID"`
 
 	Major int
 	Minor int

--- a/tests/shared-cache/Earthfile
+++ b/tests/shared-cache/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION --global-cache 0.7
 FROM alpine:3.18
 
 test:

--- a/tests/shared-cache/lib1/Earthfile
+++ b/tests/shared-cache/lib1/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION --global-cache 0.7
 FROM alpine:3.18
 
 check:


### PR DESCRIPTION
Adds `--global-cache` feature flag for https://github.com/earthly/earthly/pull/3296

Also changes names from "shared" to "global", since this first one is too overloaded in our documentation