### PR TITLE
Logstream: Fix panic when logs are written after Close called

### DIFF
--- a/cmd/earthly/subcmd/build_cmd.go
+++ b/cmd/earthly/subcmd/build_cmd.go
@@ -594,11 +594,6 @@ func (a *Build) ActionBuildImp(cliCtx *cli.Context, flagArgs, nonFlagArgs []stri
 	}
 
 	if a.cli.Flags().UseRemoteRegistry {
-		doneCh := make(chan struct{})
-		defer func() {
-			<-doneCh // Wait for server shutdown before returning.
-		}()
-
 		tmpAddr := "localhost:0" // Have the OS select a port
 
 		ln, err := listener.NewListener("tcp", tmpAddr)
@@ -619,7 +614,6 @@ func (a *Build) ActionBuildImp(cliCtx *cli.Context, flagArgs, nonFlagArgs []stri
 			if err != nil && !errors.Is(err, http.ErrServerClosed) {
 				a.cli.Console().Warnf("Failed to serve registry proxy: %v", err)
 			}
-			doneCh <- struct{}{}
 		}()
 
 		defer func() {

--- a/cmd/earthly/subcmd/build_cmd.go
+++ b/cmd/earthly/subcmd/build_cmd.go
@@ -594,6 +594,11 @@ func (a *Build) ActionBuildImp(cliCtx *cli.Context, flagArgs, nonFlagArgs []stri
 	}
 
 	if a.cli.Flags().UseRemoteRegistry {
+		doneCh := make(chan struct{})
+		defer func() {
+			<-doneCh // Wait for server shutdown before returning.
+		}()
+
 		tmpAddr := "localhost:0" // Have the OS select a port
 
 		ln, err := listener.NewListener("tcp", tmpAddr)
@@ -614,6 +619,7 @@ func (a *Build) ActionBuildImp(cliCtx *cli.Context, flagArgs, nonFlagArgs []stri
 			if err != nil && !errors.Is(err, http.ErrServerClosed) {
 				a.cli.Console().Warnf("Failed to serve registry proxy: %v", err)
 			}
+			doneCh <- struct{}{}
 		}()
 
 		defer func() {

--- a/logbus/ship/ship.go
+++ b/logbus/ship/ship.go
@@ -2,6 +2,8 @@ package ship
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -41,6 +43,8 @@ func NewLogShipper(cl streamer, man *pb.RunManifest, verbose bool) *LogShipper {
 
 func (l *LogShipper) Write(delta *pb.Delta) {
 	if l.closed.Load() {
+		logMsg := string(delta.GetDeltaFormattedLog().GetData())
+		fmt.Fprintf(os.Stderr, "WARNING: Message sent to closed log stream: %s", logMsg)
 		return
 	}
 	l.ch <- delta


### PR DESCRIPTION
It appears that `Write` is being called after `Close` in very rare cases. I noticed this once last night but lost the CI URL. IN any case, it seems reasonable to discard log messages after `Close` is called.