### PR TITLE
Buildkit entrypoint kills externally provided pids

### DIFF
--- a/buildkitd/entrypoint.sh
+++ b/buildkitd/entrypoint.sh
@@ -268,6 +268,11 @@ execpid=$!
 
 stop_buildkit() {
   echo "Shutdown signal received. Stopping buildkit..."
+  for i in $(echo "$OOM_EXCLUDED_PIDS" | sed "s/,/ /g"); do
+    echo "killing externallly provided pid: $i"
+    kill -SIGTERM "$i"
+  done
+  echo "killing buildkit pid: $execpid"
   kill -SIGTERM "$execpid"
 }
 


### PR DESCRIPTION
The current `OOM_EXCLUDED_PIDS` variable allows one or more process IDs to be passed-in externally to buildkit, so that its oom adj script will not attempt to reap them. This is currently used by the runner service (i.e. satellites) so that the runner process can run alongside buildkit in a container.

This PR allows buildkit to also gracefully kill those pids as part of its own shutdown process, which in turn allows our runner service to gracefully shutdown as well.