### PR TITLE
changelog-parser: use a common base

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -295,14 +295,17 @@ submodule-decouple-check:
 # changelog saves the CHANGELOG.md as an artifact
 changelog:
     FROM scratch
-    COPY CHANGELOG.md .
     SAVE ARTIFACT CHANGELOG.md
 
-lint-changelog:
+changelog-parser:
     FROM python:3
     RUN pip install packaging
     COPY release/changelogparser.py /usr/bin/changelogparser
+    WORKDIR /changelog
     COPY CHANGELOG.md .
+
+lint-changelog:
+    FROM +changelog-parser
     RUN changelogparser --changelog CHANGELOG.md
 
 # debugger builds the earthly debugger and saves the artifact in build/earth_debugger

--- a/release/Earthfile
+++ b/release/Earthfile
@@ -60,10 +60,7 @@ perform-release-dockerhub:
         --DOCKERHUB_BUILDKIT_IMG="$DOCKERHUB_BUILDKIT_IMG"
 
 release-notes:
-    FROM python:3
-    WORKDIR /changelog
-    COPY changelogparser.py /usr/bin/changelogparser
-    COPY ..+changelog/CHANGELOG.md .
+    FROM ..+changelog-parser
     ARG --required RELEASE_TAG
     RUN changelogparser --changelog CHANGELOG.md --version "$RELEASE_TAG" > notes.txt
     ARG SKIP_CHANGELOG_DATE_TEST="false"


### PR DESCRIPTION
The changelog-parser was changed in
7e7bd7c92be740354b1bb4b266f8c44d477351e4 to make use of the packaging library; however it was only ever installed in the base linter, and not the ./release+release-notes target, which caused that target to break.

This refactors the targets to use the same common base (which includes the packaging library).