### PR TITLE
Change how PRs are skipped so that required checks won't get stuck in pending

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,51 @@
+# Github Actions
+
+Documentation for this repo Github actions configuration
+
+## Skipping PR Workflows
+### Motivation
+Some PR workflows (workflows triggered by PRs) in this repo might take substantial time to complete,  
+and it is not always necessary to run them all, especially in cases where the affected files are documents or any other file that don't affect our workflows or tests.  
+In addition, some of our tests use satellites and limiting the number of (concurrent) builds might help with their performance.
+
+### Github Builtin Support
+Github supports defining filters on workflows so that they won't get triggered, and there is a builtin filter that would do so according to affected files - [paths-ignore](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore).  
+The shortcoming of this filter is that when the workflow is marked as a `required check` and does not get triggered because of this filter,  
+the workflow will be stuck in `pending` and won't allow the PR to be merged.  
+Thus, using this filter is a good approach when handling workflows that are not required checks, but it's problematic otherwise.
+
+### Solution for required workflows
+An alternative to `paths-ignore` is examining the affected files at the `job` level instead.  
+Jobs allow you to set conditions on whether they should execute or not.  
+The advantage of using conditions on the job level is that if a job does not run due to a condition evaluation to false,
+Github will still mark the workflow as passing/successful instead of pending,  
+and will not block the PR even if the workflow is marked as a required check ([reference](https://docs.github.com/en/actions/using-jobs/using-conditions-to-control-job-execution#overview)).  
+
+To examine the files, [dorny/paths-filter](https://github.com/dorny/paths-filter) is used.
+Similarly to Github's `paths-ignore`, `dorny/paths-filter` supports setting rules that match against the affected files, which evaluates to a boolean value.
+We can then use that boolean value to determine whether subsequent jobs in the workflow should execute or not. 
+
+### Complexity due to reusable workflows
+
+#### Background
+A problem arises when the job we wish to conditionally run uses a reusable workflow.
+The problem is that Github treats such configuration as a parent-child relationship,
+and any job that is skipped, by default will also cause its children jobs to skip as well.
+In addition, when we set `required checks`, we cannot properly select the parent job, only the child job.  
+In this scenario, if a child job is skipped as a result of skipping its parent, the child job will get stuck in `pending` and the PR will be blocked from merging (just like in the original problem).
+
+#### Final Solution
+So, in order to work around the above-mentioned issue, we need to avoid
+skipping the parent job. Instead, we evaluate the boolean as before, and pass it as  
+an input argument to the child job. As a matter of standardization, we call this input arg `CONTINUE`.
+This argument is then used to conditionally run the _child_ job instead of the _parent_ job,  
+and so if the child job is skipped, even if it is marked as a required check, it won't get stuck in `pending`.
+
+Lastly, because most jobs are dependent on (`needs` directive) `build-earthly` job, if the latter is skipped, by default - so will the dependent jobs.  
+As described before, that is something we need to avoid. To change that default configuration, we change
+the default condition of each dependent job to `$ {{ !failure() }}` which will allow the dependent jobs to run whether the dependency job was successful or if it was skipped.
+
+
+
+
+

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -37,7 +37,7 @@ In this scenario, if a child job is skipped as a result of skipping its parent, 
 #### Final Solution
 So, in order to work around the above-mentioned issue, we need to avoid
 skipping the parent job. Instead, we evaluate the boolean as before, and pass it as  
-an input argument to the child job. As a matter of standardization, we call this input arg `CONTINUE`.
+an input argument to the child job. As a matter of standardization, we call this input arg `SKIP_JOB`.
 This argument is then used to conditionally run the _child_ job instead of the _parent_ job,  
 and so if the child job is skipped, even if it is marked as a required check, it won't get stuck in `pending`.
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -44,8 +44,3 @@ and so if the child job is skipped, even if it is marked as a required check, it
 Lastly, because most jobs are dependent on (`needs` directive) `build-earthly` job, if the latter is skipped, by default - so will the dependent jobs.  
 As described before, that is something we need to avoid. To change that default configuration, we change
 the default condition of each dependent job to `$ {{ !failure() }}` which will allow the dependent jobs to run whether the dependency job was successful or if it was skipped.
-
-
-
-
-

--- a/.github/workflows/build-earthly.yml
+++ b/.github/workflows/build-earthly.yml
@@ -18,7 +18,7 @@ on:
       SKIP_JOB:
         required: false
         type: boolean
-        default: true
+        default: false
 
 jobs:
 

--- a/.github/workflows/build-earthly.yml
+++ b/.github/workflows/build-earthly.yml
@@ -15,11 +15,16 @@ on:
       RUNS_ON:
         required: true
         type: string
+      CONTINUE:
+        required: false
+        type: boolean
+        default: true
 
 jobs:
 
   build-earthly:
     name: build (and push) earthly using ${{inputs.BINARY}}
+    if: ${{inputs.CONTINUE}}
     runs-on: ${{inputs.RUNS_ON}}
     env:
       FORCE_COLOR: 1

--- a/.github/workflows/build-earthly.yml
+++ b/.github/workflows/build-earthly.yml
@@ -15,7 +15,7 @@ on:
       RUNS_ON:
         required: true
         type: string
-      CONTINUE:
+      SKIP_JOB:
         required: false
         type: boolean
         default: true
@@ -24,7 +24,7 @@ jobs:
 
   build-earthly:
     name: build (and push) earthly using ${{inputs.BINARY}}
-    if: ${{inputs.CONTINUE}}
+    if: ${{!inputs.SKIP_JOB}}
     runs-on: ${{inputs.RUNS_ON}}
     env:
       FORCE_COLOR: 1

--- a/.github/workflows/ci-docker-satellites.yml
+++ b/.github/workflows/ci-docker-satellites.yml
@@ -3,10 +3,20 @@ name: Satellites Docker CI Ubuntu
 on:
   push:
     branches: [ main ]
-    paths-ignore: [ docs/** ]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+      - '.github/renovate.json5'
+      - '.github/CODEOWNERS'
+      - 'LICENSE'
   pull_request:
     branches: [ main ]
-    paths-ignore: [ docs/** ]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+      - '.github/renovate.json5'
+      - '.github/CODEOWNERS'
+      - 'LICENSE'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/ci-docker-ubuntu.yml
+++ b/.github/workflows/ci-docker-ubuntu.yml
@@ -21,12 +21,16 @@ jobs:
   # since all jobs depend on `build-earthly` job, conditionally running it will either cause all jobs to run or skip,
   # depending on the output value of this job
   check-essential-files:
+    # only run on pull request since push to main is already checking files with paths-ignore
+    if: ${{ github.event_name == 'pull_request' }}
     uses: ./.github/workflows/reusable-find-pr-changes.yaml
     permissions:
       pull-requests: read
     secrets: inherit
   build-earthly:
     needs: check-essential-files
+    # allow the job to execute even if check-essential-files is skipped
+    if: ${{ !failure() }}
     # using "!= 'false'" so that an empty string (in case of output problem) will evaluate to true
     uses: ./.github/workflows/build-earthly.yml
     with:

--- a/.github/workflows/ci-docker-ubuntu.yml
+++ b/.github/workflows/ci-docker-ubuntu.yml
@@ -3,7 +3,12 @@ name: Docker CI Ubuntu
 on:
   push:
     branches: [ main ]
-    paths-ignore: [ docs/** ]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+      - '.github/renovate.json5'
+      - '.github/CODEOWNERS'
+      - 'LICENSE'
   pull_request:
     branches: [ main ]
 
@@ -23,13 +28,13 @@ jobs:
   build-earthly:
     needs: check-essential-files
     # using "!= 'false'" so that an empty string (in case of output problem) will evaluate to true
-    if: ${{ needs.check-essential-files.outputs.essential-files != 'false' }}
     uses: ./.github/workflows/build-earthly.yml
     with:
       BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
       RUNS_ON: "ubuntu-latest"
       BINARY: "docker"
       SUDO: ""
+      CONTINUE: ${{ needs.check-essential-files.outputs.essential-files != 'false' }}
     secrets: inherit
 
   docker-lint:
@@ -41,10 +46,12 @@ jobs:
       RUNS_ON: "ubuntu-latest"
       BINARY: "docker"
       SUDO: ""
+      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
     secrets: inherit
 
   docker-tests-quick:
     needs: build-earthly
+    if: ${{ !failure() }}
     uses: ./.github/workflows/reusable-test.yml
     with:
       TEST_TARGET: "+test-quick"
@@ -52,10 +59,12 @@ jobs:
       RUNS_ON: "ubuntu-latest"
       BINARY: "docker"
       SUDO: ""
+      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
     secrets: inherit
 
   docker-tests-no-qemu-quick:
     needs: build-earthly
+    if: ${{ !failure() }}
     uses: ./.github/workflows/reusable-test.yml
     with:
       TEST_TARGET: "+test-no-qemu-quick"
@@ -63,10 +72,12 @@ jobs:
       RUNS_ON: "ubuntu-latest"
       BINARY: "docker"
       SUDO: ""
+      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
     secrets: inherit
 
   docker-tests-no-qemu-quick-no-logbus:
     needs: build-earthly
+    if: ${{ !failure() }}
     uses: ./.github/workflows/reusable-test.yml
     with:
       TEST_TARGET: "+test-no-qemu-quick"
@@ -75,10 +86,12 @@ jobs:
       BINARY: "docker"
       SUDO: ""
       EXTRA_ARGS: "--logstream=false --logstream-upload=false"
+      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
     secrets: inherit
 
   docker-tests-no-qemu-normal:
     needs: build-earthly
+    if: ${{ !failure() }}
     uses: ./.github/workflows/reusable-test.yml
     with:
       TEST_TARGET: "+test-no-qemu-normal"
@@ -86,10 +99,12 @@ jobs:
       RUNS_ON: "ubuntu-latest"
       BINARY: "docker"
       SUDO: ""
+      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
     secrets: inherit
 
   docker-tests-no-qemu-normal-no-logbus:
     needs: build-earthly
+    if: ${{ !failure() }}
     uses: ./.github/workflows/reusable-test.yml
     with:
       TEST_TARGET: "+test-no-qemu-normal"
@@ -98,10 +113,12 @@ jobs:
       BINARY: "docker"
       SUDO: ""
       EXTRA_ARGS: "--logstream=false --logstream-upload=false"
+      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
     secrets: inherit
 
   docker-tests-no-qemu-slow:
     needs: build-earthly
+    if: ${{ !failure() }}
     uses: ./.github/workflows/reusable-test.yml
     with:
       TEST_TARGET: "+test-no-qemu-slow"
@@ -109,10 +126,12 @@ jobs:
       RUNS_ON: "ubuntu-latest"
       BINARY: "docker"
       SUDO: ""
+      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
     secrets: inherit
 
   docker-tests-no-qemu-kind:
     needs: build-earthly
+    if: ${{ !failure() }}
     uses: ./.github/workflows/reusable-test.yml
     with:
       TEST_TARGET: "+test-no-qemu-kind"
@@ -120,10 +139,11 @@ jobs:
       RUNS_ON: "ubuntu-latest"
       BINARY: "docker"
       SUDO: ""
+      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
     secrets: inherit
 
   docker-tests-require-account-access:
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    if: ${{ !failure() && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
     needs: build-earthly
     uses: ./.github/workflows/reusable-test.yml
     with:
@@ -132,10 +152,12 @@ jobs:
       RUNS_ON: "ubuntu-latest"
       BINARY: "docker"
       SUDO: ""
+      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
     secrets: inherit
 
   docker-tests-qemu:
     needs: build-earthly
+    if: ${{ !failure() }}
     uses: ./.github/workflows/reusable-test.yml
     with:
       TEST_TARGET: "+test-qemu"
@@ -144,10 +166,12 @@ jobs:
       RUNS_ON: "ubuntu-latest"
       BINARY: "docker"
       SUDO: ""
+      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
     secrets: inherit
 
   docker-examples-1:
     needs: build-earthly
+    if: ${{ !failure() }}
     uses: ./.github/workflows/reusable-example.yml
     with:
       BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
@@ -155,10 +179,12 @@ jobs:
       BINARY: "docker"
       SUDO: ""
       EXAMPLE_NAME: "+examples1"
+      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
     secrets: inherit
 
   docker-examples-2:
     needs: build-earthly
+    if: ${{ !failure() }}
     uses: ./.github/workflows/reusable-example.yml
     with:
       BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
@@ -166,10 +192,12 @@ jobs:
       BINARY: "docker"
       SUDO: ""
       EXAMPLE_NAME: "+examples2"
+      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
     secrets: inherit
 
   docker-test-local:
     needs: build-earthly
+    if: ${{ !failure() }}
     uses: ./.github/workflows/reusable-test-local.yml
     with:
       BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
@@ -177,120 +205,144 @@ jobs:
       BINARY: "docker"
       BINARY_COMPOSE: "\"docker compose\""
       SUDO: ""
+      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
     secrets: inherit
 
   docker-push-integrations:
     needs: build-earthly
+    if: ${{ !failure() }}
     uses: ./.github/workflows/reusable-push-integrations.yml
     with:
       BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
       RUNS_ON: "ubuntu-latest"
       BINARY: "docker"
       SUDO: ""
+      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
     secrets: inherit
 
   docker-secret-integrations:
     needs: build-earthly
+    if: ${{ !failure() }}
     uses: ./.github/workflows/reusable-secrets-integrations.yml
     with:
       BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
       RUNS_ON: "ubuntu-latest"
       BINARY: "docker"
       SUDO: ""
+      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
     secrets: inherit
 
   docker-bootstrap-integrations:
     needs: build-earthly
+    if: ${{ !failure() }}
     uses: ./.github/workflows/reusable-bootstrap-integrations.yml
     with:
       BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
       RUNS_ON: "ubuntu-latest"
       BINARY: "docker"
       SUDO: ""
+      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
     secrets: inherit
 
   docker-repo-auth-tests:
     needs: build-earthly
+    if: ${{ !failure() }}
     uses: ./.github/workflows/reusable-repo-auth-tests.yml
     with:
       BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
       RUNS_ON: "ubuntu-latest"
       BINARY: "docker"
       SUDO: ""
+      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
     secrets: inherit
 
   docker-export-test:
     needs: build-earthly
+    if: ${{ !failure() }}
     uses: ./.github/workflows/reusable-export-test.yml
     with:
       BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
       RUNS_ON: "ubuntu-latest"
       BINARY: "docker"
       SUDO: ""
+      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
     secrets: inherit
 
   docker-docker-build-integrations:
     needs: build-earthly
+    if: ${{ !failure() }}
     uses: ./.github/workflows/reusable-docker-build-integrations.yml
     with:
       BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
       RUNS_ON: "ubuntu-latest"
       BINARY: "docker"
       SUDO: ""
+      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
     secrets: inherit
 
   docker-earthly-image-test:
     needs: build-earthly
+    if: ${{ !failure() }}
     uses: ./.github/workflows/reusable-earthly-image-tests.yml
     with:
       BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
       RUNS_ON: "ubuntu-latest"
       BINARY: "docker"
       SUDO: ""
+      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
     secrets: inherit
 
   docker-misc-test-1:
     needs: build-earthly
+    if: ${{ !failure() }}
     uses: ./.github/workflows/reusable-misc-tests-1.yml
     with:
       BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
       RUNS_ON: "ubuntu-latest"
       BINARY: "docker"
       SUDO: ""
+      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
     secrets: inherit
 
   docker-misc-test-2:
     needs: build-earthly
+    if: ${{ !failure() }}
     uses: ./.github/workflows/reusable-misc-tests-2.yml
     with:
       BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
       RUNS_ON: "ubuntu-latest"
       BINARY: "docker"
       SUDO: ""
+      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
     secrets: inherit
 
   docker-wait-block-override:
     needs: build-earthly
+    if: ${{ !failure() }}
     uses: ./.github/workflows/reusable-wait-block-override.yml
     with:
       BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
       RUNS_ON: "ubuntu-latest"
       BINARY: "docker"
       SUDO: ""
+      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
     secrets: inherit
 
   docker-git-metadata-test:
     needs: build-earthly
+    if: ${{ !failure() }}
     uses: ./.github/workflows/reusable-git-metadata-test.yml
     with:
       BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
       RUNS_ON: "ubuntu-latest"
       BINARY: "docker"
       SUDO: ""
+      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
     secrets: inherit
 
   race-tests-quick:
     needs: build-earthly
+    if: ${{ !failure() }}
     uses: ./.github/workflows/reusable-race-test.yml
     with:
       BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
@@ -299,10 +351,12 @@ jobs:
       USE_QEMU: false
       BINARY: "docker"
       SUDO: ""
+      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
     secrets: inherit
 
   race-tests-no-qemu-quick:
     needs: build-earthly
+    if: ${{ !failure() }}
     uses: ./.github/workflows/reusable-race-test.yml
     with:
       BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
@@ -311,10 +365,12 @@ jobs:
       USE_QEMU: false
       BINARY: "docker"
       SUDO: ""
+      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
     secrets: inherit
 
   race-tests-no-qemu-normal:
     needs: build-earthly
+    if: ${{ !failure() }}
     uses: ./.github/workflows/reusable-race-test.yml
     with:
       BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
@@ -323,10 +379,12 @@ jobs:
       USE_QEMU: false
       BINARY: "docker"
       SUDO: ""
+      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
     secrets: inherit
 
   race-tests-no-qemu-slow:
     needs: build-earthly
+    if: ${{ !failure() }}
     uses: ./.github/workflows/reusable-race-test.yml
     with:
       BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
@@ -335,6 +393,7 @@ jobs:
       USE_QEMU: false
       BINARY: "docker"
       SUDO: ""
+      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
     secrets: inherit
 
   tutorial:

--- a/.github/workflows/ci-docker-ubuntu.yml
+++ b/.github/workflows/ci-docker-ubuntu.yml
@@ -31,7 +31,6 @@ jobs:
     needs: check-essential-files
     # allow the job to execute even if check-essential-files is skipped
     if: ${{ !failure() }}
-    # using "!= 'false'" so that an empty string (in case of output problem) will evaluate to true
     uses: ./.github/workflows/build-earthly.yml
     with:
       BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"

--- a/.github/workflows/ci-docker-ubuntu.yml
+++ b/.github/workflows/ci-docker-ubuntu.yml
@@ -38,7 +38,7 @@ jobs:
       RUNS_ON: "ubuntu-latest"
       BINARY: "docker"
       SUDO: ""
-      CONTINUE: ${{ needs.check-essential-files.outputs.essential-files != 'false' }}
+      SKIP_JOB: ${{ needs.check-essential-files.outputs.essential-files == 'false' }}
     secrets: inherit
 
   docker-lint:
@@ -50,7 +50,7 @@ jobs:
       RUNS_ON: "ubuntu-latest"
       BINARY: "docker"
       SUDO: ""
-      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
 
   docker-tests-quick:
@@ -63,7 +63,7 @@ jobs:
       RUNS_ON: "ubuntu-latest"
       BINARY: "docker"
       SUDO: ""
-      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
 
   docker-tests-no-qemu-quick:
@@ -76,7 +76,7 @@ jobs:
       RUNS_ON: "ubuntu-latest"
       BINARY: "docker"
       SUDO: ""
-      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
 
   docker-tests-no-qemu-quick-no-logbus:
@@ -90,7 +90,7 @@ jobs:
       BINARY: "docker"
       SUDO: ""
       EXTRA_ARGS: "--logstream=false --logstream-upload=false"
-      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
 
   docker-tests-no-qemu-normal:
@@ -103,7 +103,7 @@ jobs:
       RUNS_ON: "ubuntu-latest"
       BINARY: "docker"
       SUDO: ""
-      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
 
   docker-tests-no-qemu-normal-no-logbus:
@@ -117,7 +117,7 @@ jobs:
       BINARY: "docker"
       SUDO: ""
       EXTRA_ARGS: "--logstream=false --logstream-upload=false"
-      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
 
   docker-tests-no-qemu-slow:
@@ -130,7 +130,7 @@ jobs:
       RUNS_ON: "ubuntu-latest"
       BINARY: "docker"
       SUDO: ""
-      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
 
   docker-tests-no-qemu-kind:
@@ -143,7 +143,7 @@ jobs:
       RUNS_ON: "ubuntu-latest"
       BINARY: "docker"
       SUDO: ""
-      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
 
   docker-tests-require-account-access:
@@ -156,7 +156,7 @@ jobs:
       RUNS_ON: "ubuntu-latest"
       BINARY: "docker"
       SUDO: ""
-      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
 
   docker-tests-qemu:
@@ -170,7 +170,7 @@ jobs:
       RUNS_ON: "ubuntu-latest"
       BINARY: "docker"
       SUDO: ""
-      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
 
   docker-examples-1:
@@ -183,7 +183,7 @@ jobs:
       BINARY: "docker"
       SUDO: ""
       EXAMPLE_NAME: "+examples1"
-      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
 
   docker-examples-2:
@@ -196,7 +196,7 @@ jobs:
       BINARY: "docker"
       SUDO: ""
       EXAMPLE_NAME: "+examples2"
-      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
 
   docker-test-local:
@@ -209,7 +209,7 @@ jobs:
       BINARY: "docker"
       BINARY_COMPOSE: "\"docker compose\""
       SUDO: ""
-      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
 
   docker-push-integrations:
@@ -221,7 +221,7 @@ jobs:
       RUNS_ON: "ubuntu-latest"
       BINARY: "docker"
       SUDO: ""
-      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
 
   docker-secret-integrations:
@@ -233,7 +233,7 @@ jobs:
       RUNS_ON: "ubuntu-latest"
       BINARY: "docker"
       SUDO: ""
-      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
 
   docker-bootstrap-integrations:
@@ -245,7 +245,7 @@ jobs:
       RUNS_ON: "ubuntu-latest"
       BINARY: "docker"
       SUDO: ""
-      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
 
   docker-repo-auth-tests:
@@ -257,7 +257,7 @@ jobs:
       RUNS_ON: "ubuntu-latest"
       BINARY: "docker"
       SUDO: ""
-      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
 
   docker-export-test:
@@ -269,7 +269,7 @@ jobs:
       RUNS_ON: "ubuntu-latest"
       BINARY: "docker"
       SUDO: ""
-      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
 
   docker-docker-build-integrations:
@@ -281,7 +281,7 @@ jobs:
       RUNS_ON: "ubuntu-latest"
       BINARY: "docker"
       SUDO: ""
-      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
 
   docker-earthly-image-test:
@@ -293,7 +293,7 @@ jobs:
       RUNS_ON: "ubuntu-latest"
       BINARY: "docker"
       SUDO: ""
-      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
 
   docker-misc-test-1:
@@ -305,7 +305,7 @@ jobs:
       RUNS_ON: "ubuntu-latest"
       BINARY: "docker"
       SUDO: ""
-      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
 
   docker-misc-test-2:
@@ -317,7 +317,7 @@ jobs:
       RUNS_ON: "ubuntu-latest"
       BINARY: "docker"
       SUDO: ""
-      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
 
   docker-wait-block-override:
@@ -329,7 +329,7 @@ jobs:
       RUNS_ON: "ubuntu-latest"
       BINARY: "docker"
       SUDO: ""
-      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
 
   docker-git-metadata-test:
@@ -341,7 +341,7 @@ jobs:
       RUNS_ON: "ubuntu-latest"
       BINARY: "docker"
       SUDO: ""
-      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
 
   race-tests-quick:
@@ -355,7 +355,7 @@ jobs:
       USE_QEMU: false
       BINARY: "docker"
       SUDO: ""
-      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
 
   race-tests-no-qemu-quick:
@@ -369,7 +369,7 @@ jobs:
       USE_QEMU: false
       BINARY: "docker"
       SUDO: ""
-      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
 
   race-tests-no-qemu-normal:
@@ -383,7 +383,7 @@ jobs:
       USE_QEMU: false
       BINARY: "docker"
       SUDO: ""
-      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
 
   race-tests-no-qemu-slow:
@@ -397,7 +397,7 @@ jobs:
       USE_QEMU: false
       BINARY: "docker"
       SUDO: ""
-      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
 
   tutorial:

--- a/.github/workflows/ci-podman-ubuntu.yml
+++ b/.github/workflows/ci-podman-ubuntu.yml
@@ -37,7 +37,7 @@ jobs:
       RUNS_ON: "ubuntu-latest"
       BINARY: "podman"
       SUDO: "sudo -E"
-      CONTINUE: ${{ needs.check-essential-files.outputs.essential-files != 'false' }}
+      SKIP_JOB: ${{ needs.check-essential-files.outputs.essential-files == 'false' }}
     secrets: inherit
 
   podman-lint:
@@ -50,7 +50,7 @@ jobs:
       RUNS_ON: "ubuntu-latest"
       BINARY: "podman"
       SUDO: "sudo -E"
-      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
 
   podman-tests-quick:
@@ -63,7 +63,7 @@ jobs:
       RUNS_ON: "ubuntu-latest"
       BINARY: "podman"
       SUDO: "sudo -E"
-      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
 
   podman-tests-no-qemu-quick:
@@ -76,7 +76,7 @@ jobs:
       RUNS_ON: "ubuntu-latest"
       BINARY: "podman"
       SUDO: "sudo -E"
-      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
 
   podman-tests-no-qemu-normal:
@@ -89,7 +89,7 @@ jobs:
       RUNS_ON: "ubuntu-latest"
       BINARY: "podman"
       SUDO: "sudo -E"
-      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
 
   podman-tests-no-qemu-slow:
@@ -102,7 +102,7 @@ jobs:
       RUNS_ON: "ubuntu-latest"
       BINARY: "podman"
       SUDO: "sudo -E"
-      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
 
   podman-tests-require-account-access:
@@ -115,7 +115,7 @@ jobs:
       RUNS_ON: "ubuntu-latest"
       BINARY: "podman"
       SUDO: "sudo -E"
-      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
 
   podman-tests-qemu:
@@ -129,7 +129,7 @@ jobs:
       RUNS_ON: "ubuntu-latest"
       BINARY: "podman"
       SUDO: "sudo -E"
-      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
 
   podman-examples-1:
@@ -144,7 +144,7 @@ jobs:
       USE_QEMU: true
       SUDO: "sudo -E"
       EXAMPLE_NAME: "+examples1"
-      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
 
   podman-examples-2:
@@ -159,7 +159,7 @@ jobs:
       USE_QEMU: true
       SUDO: "sudo -E"
       EXAMPLE_NAME: "+examples2"
-      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
 
 #  podman-test-local:
@@ -173,7 +173,7 @@ jobs:
 #      BINARY: "podman"
 #      BINARY_COMPOSE: "\"sudo -E podman-compose\""
 #      SUDO: "sudo -E"
-#      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
+#      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
 #    secrets: inherit
 #
 # TODO: Fix and bring back the below tests
@@ -187,7 +187,7 @@ jobs:
 #      RUNS_ON: "ubuntu-latest"
 #      BINARY: "podman"
 #      SUDO: "sudo -E"
-#      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
+#      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
 #    secrets: inherit
 #
 #  podman-secret-integrations:
@@ -200,7 +200,7 @@ jobs:
 #      RUNS_ON: "ubuntu-latest"
 #      BINARY: "podman"
 #      SUDO: "sudo -E"
-#      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
+#      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
 #    secrets: inherit
 #
 #  podman-bootstrap-integrations:
@@ -213,7 +213,7 @@ jobs:
 #      RUNS_ON: "ubuntu-latest"
 #      BINARY: "podman"
 #      SUDO: "sudo -E"
-#      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
+#      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
 #    secrets: inherit
 #
 #  podman-repo-auth-tests:
@@ -226,7 +226,7 @@ jobs:
 #      RUNS_ON: "ubuntu-latest"
 #      BINARY: "podman"
 #      SUDO: "sudo -E"
-#      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
+#      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
 #    secrets: inherit
 #
 #  podman-export-tests:
@@ -239,7 +239,7 @@ jobs:
 #      RUNS_ON: "ubuntu-latest"
 #      BINARY: "podman"
 #      SUDO: "sudo -E"
-#      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
+#      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
 #    secrets: inherit
 #
 #  podman-earthly-image-tests:
@@ -252,7 +252,7 @@ jobs:
 #      RUNS_ON: "ubuntu-latest"
 #      BINARY: "podman"
 #      SUDO: "sudo -E"
-#      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
+#      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
 #    secrets: inherit
 #
 #  podman-misc-tests-1:
@@ -265,7 +265,7 @@ jobs:
 #      RUNS_ON: "ubuntu-latest"
 #      BINARY: "podman"
 #      SUDO: "sudo -E"
-#      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
+#      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
 #    secrets: inherit
 #
 #  podman-misc-tests-2:
@@ -278,5 +278,5 @@ jobs:
 #      RUNS_ON: "ubuntu-latest"
 #      BINARY: "podman"
 #      SUDO: "sudo -E"
-#      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
+#      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
 #    secrets: inherit

--- a/.github/workflows/ci-podman-ubuntu.yml
+++ b/.github/workflows/ci-podman-ubuntu.yml
@@ -3,7 +3,12 @@ name: Podman CI Ubuntu
 on:
   push:
     branches: [ main ]
-    paths-ignore: [ docs/** ]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+      - '.github/renovate.json5'
+      - '.github/CODEOWNERS'
+      - 'LICENSE'
   pull_request:
     branches: [ main ]
 
@@ -22,18 +27,18 @@ jobs:
     secrets: inherit
   build-earthly:
     needs: check-essential-files
-    # using "!= 'false'" so that an empty string (in case of output problem) will evaluate to true
-    if: ${{ needs.check-essential-files.outputs.essential-files != 'false' }}
     uses: ./.github/workflows/build-earthly.yml
     with:
       BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
       RUNS_ON: "ubuntu-latest"
       BINARY: "podman"
       SUDO: "sudo -E"
+      CONTINUE: ${{ needs.check-essential-files.outputs.essential-files != 'false' }}
     secrets: inherit
 
   podman-lint:
     needs: build-earthly
+    if: ${{ !failure() }}
     uses: ./.github/workflows/reusable-test.yml
     with:
       TEST_TARGET: "+lint-all"
@@ -41,10 +46,12 @@ jobs:
       RUNS_ON: "ubuntu-latest"
       BINARY: "podman"
       SUDO: "sudo -E"
+      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
     secrets: inherit
 
   podman-tests-quick:
     needs: build-earthly
+    if: ${{ !failure() }}
     uses: ./.github/workflows/reusable-test.yml
     with:
       TEST_TARGET: "+test-quick"
@@ -52,10 +59,12 @@ jobs:
       RUNS_ON: "ubuntu-latest"
       BINARY: "podman"
       SUDO: "sudo -E"
+      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
     secrets: inherit
 
   podman-tests-no-qemu-quick:
     needs: build-earthly
+    if: ${{ !failure() }}
     uses: ./.github/workflows/reusable-test.yml
     with:
       TEST_TARGET: "+test-no-qemu-quick"
@@ -63,10 +72,12 @@ jobs:
       RUNS_ON: "ubuntu-latest"
       BINARY: "podman"
       SUDO: "sudo -E"
+      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
     secrets: inherit
 
   podman-tests-no-qemu-normal:
     needs: build-earthly
+    if: ${{ !failure() }}
     uses: ./.github/workflows/reusable-test.yml
     with:
       TEST_TARGET: "+test-no-qemu-normal"
@@ -74,10 +85,12 @@ jobs:
       RUNS_ON: "ubuntu-latest"
       BINARY: "podman"
       SUDO: "sudo -E"
+      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
     secrets: inherit
 
   podman-tests-no-qemu-slow:
     needs: build-earthly
+    if: ${{ !failure() }}
     uses: ./.github/workflows/reusable-test.yml
     with:
       TEST_TARGET: "+test-no-qemu-slow"
@@ -85,10 +98,11 @@ jobs:
       RUNS_ON: "ubuntu-latest"
       BINARY: "podman"
       SUDO: "sudo -E"
+      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
     secrets: inherit
 
   podman-tests-require-account-access:
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    if: ${{ !failure() && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
     needs: build-earthly
     uses: ./.github/workflows/reusable-test.yml
     with:
@@ -97,10 +111,12 @@ jobs:
       RUNS_ON: "ubuntu-latest"
       BINARY: "podman"
       SUDO: "sudo -E"
+      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
     secrets: inherit
 
   podman-tests-qemu:
     needs: build-earthly
+    if: ${{ !failure() }}
     uses: ./.github/workflows/reusable-test.yml
     with:
       TEST_TARGET: "+test-qemu"
@@ -109,12 +125,13 @@ jobs:
       RUNS_ON: "ubuntu-latest"
       BINARY: "podman"
       SUDO: "sudo -E"
+      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
     secrets: inherit
 
   podman-examples-1:
     # TODO: Figure out how to run multiple Podman instances in parallel with different ports for buildkitd
-    needs:
-    - build-earthly
+    needs: build-earthly
+    if: ${{ !failure() }}
     uses: ./.github/workflows/reusable-example.yml
     with:
       BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
@@ -123,12 +140,13 @@ jobs:
       USE_QEMU: true
       SUDO: "sudo -E"
       EXAMPLE_NAME: "+examples1"
+      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
     secrets: inherit
 
   podman-examples-2:
     # TODO: Figure out how to run multiple Podman instances in parallel with different ports for buildkitd
-    needs:
-    - build-earthly
+    needs: build-earthly
+    if: ${{ !failure() }}
     uses: ./.github/workflows/reusable-example.yml
     with:
       BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
@@ -137,12 +155,13 @@ jobs:
       USE_QEMU: true
       SUDO: "sudo -E"
       EXAMPLE_NAME: "+examples2"
+      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
     secrets: inherit
 
 #  podman-test-local:
 #    # TODO: Figure out how to run multiple Podman instances in parallel with different ports for buildkitd
-#    needs:
-#    - build-earthly
+#    needs: build-earthly
+#    if: ${{ !failure() }}
 #    uses: ./.github/workflows/reusable-test-local.yml
 #    with:
 #      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
@@ -150,100 +169,110 @@ jobs:
 #      BINARY: "podman"
 #      BINARY_COMPOSE: "\"sudo -E podman-compose\""
 #      SUDO: "sudo -E"
+#      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
 #    secrets: inherit
 #
 # TODO: Fix and bring back the below tests
 #  podman-push-integrations:
 #    # TODO: Figure out how to run multiple Podman instances in parallel with different ports for buildkitd
 #    needs: build-earthly
+#    if: ${{ !failure() }}
 #    uses: ./.github/workflows/reusable-push-integrations.yml
 #    with:
 #      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
 #      RUNS_ON: "ubuntu-latest"
 #      BINARY: "podman"
 #      SUDO: "sudo -E"
+#      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
 #    secrets: inherit
 #
 #  podman-secret-integrations:
 #    # TODO: Figure out how to run multiple Podman instances in parallel with different ports for buildkitd
-#    needs:
-#    - build-earthly
+#    needs: build-earthly
+#    if: ${{ !failure() }}
 #    uses: ./.github/workflows/reusable-secrets-integrations.yml
 #    with:
 #      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
 #      RUNS_ON: "ubuntu-latest"
 #      BINARY: "podman"
 #      SUDO: "sudo -E"
+#      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
 #    secrets: inherit
 #
 #  podman-bootstrap-integrations:
 #    # TODO: Figure out how to run multiple Podman instances in parallel with different ports for buildkitd
-#    needs:
-#    - build-earthly
+#    needs: build-earthly
+#    if: ${{ !failure() }}
 #    uses: ./.github/workflows/reusable-bootstrap-integrations.yml
 #    with:
 #      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
 #      RUNS_ON: "ubuntu-latest"
 #      BINARY: "podman"
 #      SUDO: "sudo -E"
+#      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
 #    secrets: inherit
 #
 #  podman-repo-auth-tests:
 #    # TODO: Figure out how to run multiple Podman instances in parallel with different ports for buildkitd
-#    needs:
-#    - build-earthly
+#    needs: build-earthly
+#    if: ${{ !failure() }}
 #    uses: ./.github/workflows/reusable-repo-auth-tests.yml
 #    with:
 #      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
 #      RUNS_ON: "ubuntu-latest"
 #      BINARY: "podman"
 #      SUDO: "sudo -E"
+#      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
 #    secrets: inherit
 #
 #  podman-export-tests:
 #    # TODO: Figure out how to run multiple Podman instances in parallel with different ports for buildkitd
-#    needs:
-#    - build-earthly
+#    needs: build-earthly
+#    if: ${{ !failure() }}
 #    uses: ./.github/workflows/reusable-export-test.yml
 #    with:
 #      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
 #      RUNS_ON: "ubuntu-latest"
 #      BINARY: "podman"
 #      SUDO: "sudo -E"
+#      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
 #    secrets: inherit
 #
 #  podman-earthly-image-tests:
 #    # TODO: Figure out how to run multiple Podman instances in parallel with different ports for buildkitd
-#    needs:
-#    - build-earthly
+#    needs: build-earthly
+#    if: ${{ !failure() }}
 #    uses: ./.github/workflows/reusable-earthly-image-tests.yml
 #    with:
 #      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
 #      RUNS_ON: "ubuntu-latest"
 #      BINARY: "podman"
 #      SUDO: "sudo -E"
+#      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
 #    secrets: inherit
 #
 #  podman-misc-tests-1:
 #    # TODO: Figure out how to run multiple Podman instances in parallel with different ports for buildkitd
-#    needs:
-#    - build-earthly
+#    needs: build-earthly
+#    if: ${{ !failure() }}
 #    uses: ./.github/workflows/reusable-misc-tests-1.yml
 #    with:
 #      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
 #      RUNS_ON: "ubuntu-latest"
 #      BINARY: "podman"
 #      SUDO: "sudo -E"
+#      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
 #    secrets: inherit
 #
 #  podman-misc-tests-2:
 #    # TODO: Figure out how to run multiple Podman instances in parallel with different ports for buildkitd
-#    needs:
-#    - build-earthly
+#    needs: build-earthly
+#    if: ${{ !failure() }}
 #    uses: ./.github/workflows/reusable-misc-tests-2.yml
 #    with:
 #      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
 #      RUNS_ON: "ubuntu-latest"
 #      BINARY: "podman"
 #      SUDO: "sudo -E"
+#      CONTINUE: ${{ needs.build-earthly.result == 'success' }}
 #    secrets: inherit

--- a/.github/workflows/ci-podman-ubuntu.yml
+++ b/.github/workflows/ci-podman-ubuntu.yml
@@ -21,12 +21,16 @@ jobs:
   # since all jobs depend on `build-earthly` job, conditionally running it will either cause all jobs to run or skip,
   # depending on the output value of this job
   check-essential-files:
+    # only run on pull request since push to main is already checking files with paths-ignore
+    if: ${{ github.event_name == 'pull_request' }}
     uses: ./.github/workflows/reusable-find-pr-changes.yaml
     permissions:
       pull-requests: read
     secrets: inherit
   build-earthly:
     needs: check-essential-files
+    # allow the job to execute even if check-essential-files is skipped
+    if: ${{ !failure() }}
     uses: ./.github/workflows/build-earthly.yml
     with:
       BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"

--- a/.github/workflows/ci-staging-deploy.yml
+++ b/.github/workflows/ci-staging-deploy.yml
@@ -7,6 +7,10 @@ on:
       - '**-staging-test'
     paths-ignore:
       - 'docs/**'
+      - '**.md'
+      - '.github/renovate.json5'
+      - '.github/CODEOWNERS'
+      - 'LICENSE'
 
 jobs:
   build-earthly:

--- a/.github/workflows/reusable-bootstrap-integrations.yml
+++ b/.github/workflows/reusable-bootstrap-integrations.yml
@@ -25,7 +25,7 @@ on:
       SKIP_JOB:
         required: false
         type: boolean
-        default: true
+        default: false
 
 jobs:
   secret-integration:

--- a/.github/workflows/reusable-bootstrap-integrations.yml
+++ b/.github/workflows/reusable-bootstrap-integrations.yml
@@ -22,7 +22,7 @@ on:
       SATELLITE_NAME:
         required: false
         type: string
-      CONTINUE:
+      SKIP_JOB:
         required: false
         type: boolean
         default: true
@@ -37,7 +37,7 @@ jobs:
       DOCKERHUB_MIRROR_PASSWORD: "${{ secrets.DOCKERHUB_MIRROR_PASSWORD }}"
       # Used in our github action as the token - TODO: look to change it into an input
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    if: ${{ inputs.CONTINUE && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    if: ${{ !inputs.SKIP_JOB && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ${{inputs.RUNS_ON}}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/reusable-bootstrap-integrations.yml
+++ b/.github/workflows/reusable-bootstrap-integrations.yml
@@ -22,6 +22,10 @@ on:
       SATELLITE_NAME:
         required: false
         type: string
+      CONTINUE:
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   secret-integration:
@@ -33,7 +37,7 @@ jobs:
       DOCKERHUB_MIRROR_PASSWORD: "${{ secrets.DOCKERHUB_MIRROR_PASSWORD }}"
       # Used in our github action as the token - TODO: look to change it into an input
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    if: ${{ inputs.CONTINUE && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ${{inputs.RUNS_ON}}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/reusable-docker-build-integrations.yml
+++ b/.github/workflows/reusable-docker-build-integrations.yml
@@ -28,7 +28,7 @@ on:
       SKIP_JOB:
         required: false
         type: boolean
-        default: true
+        default: false
 
 jobs:
   docker-build-integration:

--- a/.github/workflows/reusable-docker-build-integrations.yml
+++ b/.github/workflows/reusable-docker-build-integrations.yml
@@ -25,10 +25,14 @@ on:
       EARTHLY_ORG:
         required: false
         type: string
+      CONTINUE:
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   docker-build-integration:
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    if: ${{ inputs.CONTINUE && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ${{inputs.RUNS_ON}}
     env:
       FORCE_COLOR: 1

--- a/.github/workflows/reusable-docker-build-integrations.yml
+++ b/.github/workflows/reusable-docker-build-integrations.yml
@@ -25,14 +25,14 @@ on:
       EARTHLY_ORG:
         required: false
         type: string
-      CONTINUE:
+      SKIP_JOB:
         required: false
         type: boolean
         default: true
 
 jobs:
   docker-build-integration:
-    if: ${{ inputs.CONTINUE && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    if: ${{ !inputs.SKIP_JOB && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ${{inputs.RUNS_ON}}
     env:
       FORCE_COLOR: 1

--- a/.github/workflows/reusable-earthly-image-tests.yml
+++ b/.github/workflows/reusable-earthly-image-tests.yml
@@ -15,10 +15,15 @@ on:
       RUNS_ON:
         required: true
         type: string
+      CONTINUE:
+        required: false
+        type: boolean
+        default: true
 
 
 jobs:
   earthly-image-tests:
+    if: ${{inputs.CONTINUE}}
     runs-on: ${{inputs.RUNS_ON}}
     env:
       FORCE_COLOR: 1
@@ -55,6 +60,7 @@ jobs:
         run: ${{inputs.SUDO}} ${{inputs.BINARY}} logs earthly-buildkitd
         if: ${{ failure() && ! inputs.USE_SATELLITE }}
   earthly-image-sat-tests:
+    if: ${{inputs.CONTINUE}}
     runs-on: ${{inputs.RUNS_ON}}
     env:
       FORCE_COLOR: 1

--- a/.github/workflows/reusable-earthly-image-tests.yml
+++ b/.github/workflows/reusable-earthly-image-tests.yml
@@ -15,7 +15,7 @@ on:
       RUNS_ON:
         required: true
         type: string
-      CONTINUE:
+      SKIP_JOB:
         required: false
         type: boolean
         default: true
@@ -23,7 +23,7 @@ on:
 
 jobs:
   earthly-image-tests:
-    if: ${{inputs.CONTINUE}}
+    if: ${{!inputs.SKIP_JOB}}
     runs-on: ${{inputs.RUNS_ON}}
     env:
       FORCE_COLOR: 1
@@ -60,7 +60,7 @@ jobs:
         run: ${{inputs.SUDO}} ${{inputs.BINARY}} logs earthly-buildkitd
         if: ${{ failure() && ! inputs.USE_SATELLITE }}
   earthly-image-sat-tests:
-    if: ${{inputs.CONTINUE}}
+    if: ${{!inputs.SKIP_JOB}}
     runs-on: ${{inputs.RUNS_ON}}
     env:
       FORCE_COLOR: 1

--- a/.github/workflows/reusable-earthly-image-tests.yml
+++ b/.github/workflows/reusable-earthly-image-tests.yml
@@ -18,7 +18,7 @@ on:
       SKIP_JOB:
         required: false
         type: boolean
-        default: true
+        default: false
 
 
 jobs:

--- a/.github/workflows/reusable-example.yml
+++ b/.github/workflows/reusable-example.yml
@@ -31,11 +31,16 @@ on:
       EARTHLY_ORG:
         required: false
         type: string
+      CONTINUE:
+        required: false
+        type: boolean
+        default: true
 
 
 jobs:
   example:
     name: ${{inputs.EXAMPLE_NAME}}-${{inputs.RUNS_ON}}-${{inputs.BINARY}}
+    if: ${{inputs.CONTINUE}}
     runs-on: ${{inputs.RUNS_ON}}
     env:
       FORCE_COLOR: 1

--- a/.github/workflows/reusable-example.yml
+++ b/.github/workflows/reusable-example.yml
@@ -31,7 +31,7 @@ on:
       EARTHLY_ORG:
         required: false
         type: string
-      CONTINUE:
+      SKIP_JOB:
         required: false
         type: boolean
         default: true
@@ -40,7 +40,7 @@ on:
 jobs:
   example:
     name: ${{inputs.EXAMPLE_NAME}}-${{inputs.RUNS_ON}}-${{inputs.BINARY}}
-    if: ${{inputs.CONTINUE}}
+    if: ${{!inputs.SKIP_JOB}}
     runs-on: ${{inputs.RUNS_ON}}
     env:
       FORCE_COLOR: 1

--- a/.github/workflows/reusable-example.yml
+++ b/.github/workflows/reusable-example.yml
@@ -34,7 +34,7 @@ on:
       SKIP_JOB:
         required: false
         type: boolean
-        default: true
+        default: false
 
 
 jobs:

--- a/.github/workflows/reusable-export-test.yml
+++ b/.github/workflows/reusable-export-test.yml
@@ -25,7 +25,7 @@ on:
       SKIP_JOB:
         required: false
         type: boolean
-        default: true
+        default: false
 
 jobs:
   export-test:

--- a/.github/workflows/reusable-export-test.yml
+++ b/.github/workflows/reusable-export-test.yml
@@ -22,7 +22,7 @@ on:
       SATELLITE_NAME:
         required: false
         type: string
-      CONTINUE:
+      SKIP_JOB:
         required: false
         type: boolean
         default: true
@@ -31,7 +31,7 @@ jobs:
   export-test:
     name: Export tests
     runs-on: ${{inputs.RUNS_ON}}
-    if: ${{ inputs.CONTINUE && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    if: ${{ !inputs.SKIP_JOB && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
     env:
       FORCE_COLOR: 1
       EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"

--- a/.github/workflows/reusable-export-test.yml
+++ b/.github/workflows/reusable-export-test.yml
@@ -22,12 +22,16 @@ on:
       SATELLITE_NAME:
         required: false
         type: string
+      CONTINUE:
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   export-test:
     name: Export tests
     runs-on: ${{inputs.RUNS_ON}}
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    if: ${{ inputs.CONTINUE && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
     env:
       FORCE_COLOR: 1
       EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"

--- a/.github/workflows/reusable-git-metadata-test.yml
+++ b/.github/workflows/reusable-git-metadata-test.yml
@@ -25,11 +25,16 @@ on:
       EARTHLY_ORG:
         required: false
         type: string
+      CONTINUE:
+        required: false
+        type: boolean
+        default: true
 
 
 jobs:
   test:
     name: +testing-gha-${{inputs.RUNS_ON}}-${{inputs.BINARY}}
+    if: ${{inputs.CONTINUE}}
     runs-on: ${{inputs.RUNS_ON}}
     env:
       FORCE_COLOR: 1

--- a/.github/workflows/reusable-git-metadata-test.yml
+++ b/.github/workflows/reusable-git-metadata-test.yml
@@ -28,7 +28,7 @@ on:
       SKIP_JOB:
         required: false
         type: boolean
-        default: true
+        default: false
 
 
 jobs:

--- a/.github/workflows/reusable-git-metadata-test.yml
+++ b/.github/workflows/reusable-git-metadata-test.yml
@@ -25,7 +25,7 @@ on:
       EARTHLY_ORG:
         required: false
         type: string
-      CONTINUE:
+      SKIP_JOB:
         required: false
         type: boolean
         default: true
@@ -34,7 +34,7 @@ on:
 jobs:
   test:
     name: +testing-gha-${{inputs.RUNS_ON}}-${{inputs.BINARY}}
-    if: ${{inputs.CONTINUE}}
+    if: ${{!inputs.SKIP_JOB}}
     runs-on: ${{inputs.RUNS_ON}}
     env:
       FORCE_COLOR: 1

--- a/.github/workflows/reusable-misc-tests-1.yml
+++ b/.github/workflows/reusable-misc-tests-1.yml
@@ -15,10 +15,15 @@ on:
       RUNS_ON:
         required: true
         type: string
+      CONTINUE:
+        required: false
+        type: boolean
+        default: true
 
 
 jobs:
   misc-tests-1:
+    if: ${{inputs.CONTINUE}}
     runs-on: ${{inputs.RUNS_ON}}
     env:
       FORCE_COLOR: 1

--- a/.github/workflows/reusable-misc-tests-1.yml
+++ b/.github/workflows/reusable-misc-tests-1.yml
@@ -15,7 +15,7 @@ on:
       RUNS_ON:
         required: true
         type: string
-      CONTINUE:
+      SKIP_JOB:
         required: false
         type: boolean
         default: true
@@ -23,7 +23,7 @@ on:
 
 jobs:
   misc-tests-1:
-    if: ${{inputs.CONTINUE}}
+    if: ${{!inputs.SKIP_JOB}}
     runs-on: ${{inputs.RUNS_ON}}
     env:
       FORCE_COLOR: 1

--- a/.github/workflows/reusable-misc-tests-1.yml
+++ b/.github/workflows/reusable-misc-tests-1.yml
@@ -18,7 +18,7 @@ on:
       SKIP_JOB:
         required: false
         type: boolean
-        default: true
+        default: false
 
 
 jobs:

--- a/.github/workflows/reusable-misc-tests-2.yml
+++ b/.github/workflows/reusable-misc-tests-2.yml
@@ -15,10 +15,15 @@ on:
       RUNS_ON:
         required: true
         type: string
+      CONTINUE:
+        required: false
+        type: boolean
+        default: true
 
 
 jobs:
   misc-tests-2:
+    if: ${{inputs.CONTINUE}}
     runs-on: ${{inputs.RUNS_ON}}
     env:
       FORCE_COLOR: 1

--- a/.github/workflows/reusable-misc-tests-2.yml
+++ b/.github/workflows/reusable-misc-tests-2.yml
@@ -15,7 +15,7 @@ on:
       RUNS_ON:
         required: true
         type: string
-      CONTINUE:
+      SKIP_JOB:
         required: false
         type: boolean
         default: true
@@ -23,7 +23,7 @@ on:
 
 jobs:
   misc-tests-2:
-    if: ${{inputs.CONTINUE}}
+    if: ${{!inputs.SKIP_JOB}}
     runs-on: ${{inputs.RUNS_ON}}
     env:
       FORCE_COLOR: 1

--- a/.github/workflows/reusable-misc-tests-2.yml
+++ b/.github/workflows/reusable-misc-tests-2.yml
@@ -18,7 +18,7 @@ on:
       SKIP_JOB:
         required: false
         type: boolean
-        default: true
+        default: false
 
 
 jobs:

--- a/.github/workflows/reusable-push-integrations.yml
+++ b/.github/workflows/reusable-push-integrations.yml
@@ -18,7 +18,7 @@ on:
       SKIP_JOB:
         required: false
         type: boolean
-        default: true
+        default: false
 
 jobs:
   push-integrations:

--- a/.github/workflows/reusable-push-integrations.yml
+++ b/.github/workflows/reusable-push-integrations.yml
@@ -15,14 +15,14 @@ on:
       RUNS_ON:
         required: true
         type: string
-      CONTINUE:
+      SKIP_JOB:
         required: false
         type: boolean
         default: true
 
 jobs:
   push-integrations:
-    if: ${{ inputs.CONTINUE && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    if: ${{ !inputs.SKIP_JOB && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ${{inputs.RUNS_ON}}
     env:
       FORCE_COLOR: 1

--- a/.github/workflows/reusable-push-integrations.yml
+++ b/.github/workflows/reusable-push-integrations.yml
@@ -15,11 +15,14 @@ on:
       RUNS_ON:
         required: true
         type: string
-
+      CONTINUE:
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   push-integrations:
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    if: ${{ inputs.CONTINUE && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ${{inputs.RUNS_ON}}
     env:
       FORCE_COLOR: 1

--- a/.github/workflows/reusable-race-test.yml
+++ b/.github/workflows/reusable-race-test.yml
@@ -24,7 +24,7 @@ on:
       SKIP_JOB:
         required: false
         type: boolean
-        default: true
+        default: false
 
 jobs:
   test-race:

--- a/.github/workflows/reusable-race-test.yml
+++ b/.github/workflows/reusable-race-test.yml
@@ -21,10 +21,15 @@ on:
       USE_QEMU:
         required: false
         type: boolean
+      CONTINUE:
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   test-race:
     name: ${{inputs.TEST_TARGET}} (-race)
+    if: ${{inputs.CONTINUE}}
     runs-on: ${{inputs.RUNS_ON}}
     env:
       FORCE_COLOR: 1

--- a/.github/workflows/reusable-race-test.yml
+++ b/.github/workflows/reusable-race-test.yml
@@ -21,7 +21,7 @@ on:
       USE_QEMU:
         required: false
         type: boolean
-      CONTINUE:
+      SKIP_JOB:
         required: false
         type: boolean
         default: true
@@ -29,7 +29,7 @@ on:
 jobs:
   test-race:
     name: ${{inputs.TEST_TARGET}} (-race)
-    if: ${{inputs.CONTINUE}}
+    if: ${{!inputs.SKIP_JOB}}
     runs-on: ${{inputs.RUNS_ON}}
     env:
       FORCE_COLOR: 1

--- a/.github/workflows/reusable-repo-auth-tests.yml
+++ b/.github/workflows/reusable-repo-auth-tests.yml
@@ -15,11 +15,15 @@ on:
       RUNS_ON:
         required: true
         type: string
+      CONTINUE:
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   repo-auth-test:
     name: repo auth tests
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    if: ${{ inputs.CONTINUE && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ${{inputs.RUNS_ON}}
     services:
       sshd:

--- a/.github/workflows/reusable-repo-auth-tests.yml
+++ b/.github/workflows/reusable-repo-auth-tests.yml
@@ -18,7 +18,7 @@ on:
       SKIP_JOB:
         required: false
         type: boolean
-        default: true
+        default: false
 
 jobs:
   repo-auth-test:

--- a/.github/workflows/reusable-repo-auth-tests.yml
+++ b/.github/workflows/reusable-repo-auth-tests.yml
@@ -15,7 +15,7 @@ on:
       RUNS_ON:
         required: true
         type: string
-      CONTINUE:
+      SKIP_JOB:
         required: false
         type: boolean
         default: true
@@ -23,7 +23,7 @@ on:
 jobs:
   repo-auth-test:
     name: repo auth tests
-    if: ${{ inputs.CONTINUE && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    if: ${{ !inputs.SKIP_JOB && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ${{inputs.RUNS_ON}}
     services:
       sshd:

--- a/.github/workflows/reusable-secrets-integrations.yml
+++ b/.github/workflows/reusable-secrets-integrations.yml
@@ -15,14 +15,14 @@ on:
       RUNS_ON:
         required: true
         type: string
-      CONTINUE:
+      SKIP_JOB:
         required: false
         type: boolean
         default: true
 
 jobs:
   secret-integration:
-    if: ${{ inputs.CONTINUE && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    if: ${{ !inputs.SKIP_JOB && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ${{inputs.RUNS_ON}}
     env:
       FORCE_COLOR: 1

--- a/.github/workflows/reusable-secrets-integrations.yml
+++ b/.github/workflows/reusable-secrets-integrations.yml
@@ -18,7 +18,7 @@ on:
       SKIP_JOB:
         required: false
         type: boolean
-        default: true
+        default: false
 
 jobs:
   secret-integration:

--- a/.github/workflows/reusable-secrets-integrations.yml
+++ b/.github/workflows/reusable-secrets-integrations.yml
@@ -15,10 +15,14 @@ on:
       RUNS_ON:
         required: true
         type: string
+      CONTINUE:
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   secret-integration:
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    if: ${{ inputs.CONTINUE && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ${{inputs.RUNS_ON}}
     env:
       FORCE_COLOR: 1

--- a/.github/workflows/reusable-test-local.yml
+++ b/.github/workflows/reusable-test-local.yml
@@ -32,7 +32,7 @@ on:
       EARTHLY_ORG:
         required: false
         type: string
-      CONTINUE:
+      SKIP_JOB:
         required: false
         type: boolean
         default: true
@@ -41,7 +41,7 @@ on:
 jobs:
   test-local:
     name: test-local ${{inputs.BINARY}}
-    if: ${{inputs.CONTINUE}}
+    if: ${{!inputs.SKIP_JOB}}
     runs-on: ${{inputs.RUNS_ON}}
     env:
       FORCE_COLOR: 1

--- a/.github/workflows/reusable-test-local.yml
+++ b/.github/workflows/reusable-test-local.yml
@@ -35,7 +35,7 @@ on:
       SKIP_JOB:
         required: false
         type: boolean
-        default: true
+        default: false
 
 
 jobs:

--- a/.github/workflows/reusable-test-local.yml
+++ b/.github/workflows/reusable-test-local.yml
@@ -32,11 +32,16 @@ on:
       EARTHLY_ORG:
         required: false
         type: string
+      CONTINUE:
+        required: false
+        type: boolean
+        default: true
 
 
 jobs:
   test-local:
     name: test-local ${{inputs.BINARY}}
+    if: ${{inputs.CONTINUE}}
     runs-on: ${{inputs.RUNS_ON}}
     env:
       FORCE_COLOR: 1

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -34,7 +34,7 @@ on:
       EXTRA_ARGS:
         required: false
         type: string
-      CONTINUE:
+      SKIP_JOB:
         required: false
         type: boolean
         default: true
@@ -42,7 +42,7 @@ on:
 jobs:
   test:
     name: +testing-gha-${{inputs.RUNS_ON}}-${{inputs.BINARY}}
-    if: ${{inputs.CONTINUE}}
+    if: ${{!inputs.SKIP_JOB}}
     runs-on: ${{inputs.RUNS_ON}}
     env:
       FORCE_COLOR: 1

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -37,7 +37,7 @@ on:
       SKIP_JOB:
         required: false
         type: boolean
-        default: true
+        default: false
 
 jobs:
   test:

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -34,10 +34,15 @@ on:
       EXTRA_ARGS:
         required: false
         type: string
+      CONTINUE:
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   test:
     name: +testing-gha-${{inputs.RUNS_ON}}-${{inputs.BINARY}}
+    if: ${{inputs.CONTINUE}}
     runs-on: ${{inputs.RUNS_ON}}
     env:
       FORCE_COLOR: 1

--- a/.github/workflows/reusable-wait-block-override.yml
+++ b/.github/workflows/reusable-wait-block-override.yml
@@ -18,7 +18,7 @@ on:
       SKIP_JOB:
         required: false
         type: boolean
-        default: true
+        default: false
 
 jobs:
   wait-block-override:

--- a/.github/workflows/reusable-wait-block-override.yml
+++ b/.github/workflows/reusable-wait-block-override.yml
@@ -15,10 +15,14 @@ on:
       RUNS_ON:
         required: true
         type: string
-
+      CONTINUE:
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   wait-block-override:
+    if: ${{inputs.CONTINUE}}
     runs-on: ${{inputs.RUNS_ON}}
     env:
       FORCE_COLOR: 1

--- a/.github/workflows/reusable-wait-block-override.yml
+++ b/.github/workflows/reusable-wait-block-override.yml
@@ -15,14 +15,14 @@ on:
       RUNS_ON:
         required: true
         type: string
-      CONTINUE:
+      SKIP_JOB:
         required: false
         type: boolean
         default: true
 
 jobs:
   wait-block-override:
-    if: ${{inputs.CONTINUE}}
+    if: ${{!inputs.SKIP_JOB}}
     runs-on: ${{inputs.RUNS_ON}}
     env:
       FORCE_COLOR: 1

--- a/examples/tutorial/python/part3/requirements.txt
+++ b/examples/tutorial/python/part3/requirements.txt
@@ -1,1 +1,1 @@
-Markdown==3.2.2
+Markdown==3.4.4

--- a/examples/tutorial/python/part4/requirements.txt
+++ b/examples/tutorial/python/part4/requirements.txt
@@ -1,1 +1,1 @@
-Markdown==3.2.2
+Markdown==3.4.4

--- a/examples/tutorial/python/part5/services/service-one/requirements.txt
+++ b/examples/tutorial/python/part5/services/service-one/requirements.txt
@@ -1,1 +1,1 @@
-Markdown==3.2.2
+Markdown==3.4.4

--- a/examples/tutorial/python/part6/requirements.txt
+++ b/examples/tutorial/python/part6/requirements.txt
@@ -1,2 +1,2 @@
-Markdown==3.2.2
+Markdown==3.4.4
 psycopg2==2.9.3


### PR DESCRIPTION
The current configuration might causes jobs that are marked as required checks to get stuck in pending.
This PR aims to fix it.

See the readme added in this PR for more information.

Also fixing:
* workflows not running properly on push to main
* python tutorial tests