### PR TITLE
Implement registry capabilities check

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -18,6 +19,7 @@ import (
 	"github.com/earthly/earthly/logbus"
 	"github.com/earthly/earthly/logbus/solvermon"
 	"github.com/earthly/earthly/outmon"
+	"github.com/earthly/earthly/regproxy"
 	"github.com/earthly/earthly/states"
 	"github.com/earthly/earthly/util/containerutil"
 	"github.com/earthly/earthly/util/dockerutil"
@@ -34,6 +36,8 @@ import (
 	"github.com/moby/buildkit/client/llb"
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/moby/buildkit/session"
+	"github.com/moby/buildkit/solver/pb"
+	"github.com/moby/buildkit/util/apicaps"
 	"github.com/moby/buildkit/util/entitlements"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
@@ -155,6 +159,47 @@ func (b *Builder) BuildTarget(ctx context.Context, target domain.Target, opt Bui
 	return mts, nil
 }
 
+func (b *Builder) startRegistryProxy(ctx context.Context, caps apicaps.CapSet) (func(), bool) {
+
+	if err := caps.Supports(pb.CapEarthlyRegistryProxy); err != nil {
+		b.opt.Console.VerbosePrintf("Registry proxying not supported by BuildKit: %s", err)
+		return nil, false
+	}
+
+	addr := "localhost:0" // Have the OS select a port
+
+	lnCfg := net.ListenConfig{}
+	ln, err := lnCfg.Listen(ctx, "tcp", addr)
+	if err != nil {
+		b.opt.Console.Warnf("Failed to create proxy listener: %v", err)
+		return nil, false
+	}
+
+	p := regproxy.NewRegistryProxy(ln, b.s.bkClient.RegistryClient())
+	go p.Serve(ctx)
+
+	addr = fmt.Sprintf("localhost:%d", ln.Addr().(*net.TCPAddr).Port)
+	b.opt.Console.VerbosePrintf("Starting local registry proxy: %s", addr)
+
+	doneCh := make(chan struct{})
+
+	go func() {
+		for err := range p.Err() {
+			if err != nil && !errors.Is(err, context.Canceled) {
+				b.opt.Console.Warnf("Failed to serve registry proxy: %v", err)
+			}
+		}
+		doneCh <- struct{}{}
+	}()
+
+	b.opt.LocalRegistryAddr = addr
+
+	return func() {
+		p.Close()
+		<-doneCh
+	}, true
+}
+
 func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt BuildOpt) (*states.MultiTarget, error) {
 	var (
 		sharedLocalStateCache = earthfile2llb.NewSharedLocalStateCache()
@@ -174,12 +219,17 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 		dirIndex   = 0
 	)
 	var mts *states.MultiTarget
-	bf := func(childCtx context.Context, gwClient gwclient.Client) (*gwclient.Result, error) {
+	buildFn := func(childCtx context.Context, gwClient gwclient.Client) (*gwclient.Result, error) {
 		if opt.EnableGatewayClientLogging {
 			gwClient = gwclientlogger.New(gwClient)
 		}
 		var err error
 		caps := gwClient.BuildOpts().LLBCaps
+
+		if stopProxy, ok := b.startRegistryProxy(ctx, caps); ok {
+			defer stopProxy()
+		}
+
 		if !b.builtMain {
 			opt := earthfile2llb.ConvertOpt{
 				GwClient:                             gwClient,
@@ -523,7 +573,7 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 	if opt.PrintPhases {
 		b.opt.Console.PrintPhaseHeader(PhaseBuild, false, "")
 	}
-	err := b.s.buildMainMulti(ctx, bf, onImage, onArtifact, onFinalArtifact, onPull, PhaseBuild, b.opt.Console)
+	err := b.s.buildMainMulti(ctx, buildFn, onImage, onArtifact, onFinalArtifact, onPull, PhaseBuild, b.opt.Console)
 	if err != nil {
 		return nil, errors.Wrapf(err, "build main")
 	}
@@ -547,7 +597,7 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 			}
 		}
 		if hasRunPush {
-			err = b.s.buildMainMulti(ctx, bf, onImage, onArtifact, onFinalArtifact, onPull, PhasePush, b.opt.Console)
+			err = b.s.buildMainMulti(ctx, buildFn, onImage, onArtifact, onFinalArtifact, onPull, PhasePush, b.opt.Console)
 			if err != nil {
 				return nil, errors.Wrapf(err, "build push")
 			}

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -202,7 +202,10 @@ func (b *Builder) startRegistryProxy(ctx context.Context, caps apicaps.CapSet) (
 
 	return func() {
 		p.Close()
-		<-doneCh
+		select {
+		case <-ctx.Done():
+		case <-doneCh:
+		}
 	}, true
 }
 

--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -12,7 +12,7 @@ buildkitd:
             ARG BUILDKIT_BASE_IMAGE=$BUILDKIT_PROJECT+build
         END
     ELSE
-        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:e9fbad46a010e94afd2e20834844b89a45eee601+build
+        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:7dfd9c2450b308260942b3ed43c985c176c9716b+build
     END
     ARG EARTHLY_TARGET_TAG_DOCKER
     ARG TAG="dev-$EARTHLY_TARGET_TAG_DOCKER"

--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -12,7 +12,7 @@ buildkitd:
             ARG BUILDKIT_BASE_IMAGE=$BUILDKIT_PROJECT+build
         END
     ELSE
-        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:3bf8e1e625124d7dc20dc53b2c66e04c15286a6d+build
+        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:e9fbad46a010e94afd2e20834844b89a45eee601+build
     END
     ARG EARTHLY_TARGET_TAG_DOCKER
     ARG TAG="dev-$EARTHLY_TARGET_TAG_DOCKER"

--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -12,7 +12,7 @@ buildkitd:
             ARG BUILDKIT_BASE_IMAGE=$BUILDKIT_PROJECT+build
         END
     ELSE
-        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:f3b4f010e26e8f2a66f988a025ffb0396da2b1a1+build
+        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:3bf8e1e625124d7dc20dc53b2c66e04c15286a6d+build
     END
     ARG EARTHLY_TARGET_TAG_DOCKER
     ARG TAG="dev-$EARTHLY_TARGET_TAG_DOCKER"

--- a/cmd/earthly/subcmd/build_cmd.go
+++ b/cmd/earthly/subcmd/build_cmd.go
@@ -734,11 +734,12 @@ func (a *Build) remoteRegistryEnabled(ctx context.Context, client *client.Client
 	}
 	res, err := client.RegistryClient().Caps(ctx, &registry.CapsRequest{})
 	if err != nil {
-		if status.Code(err) == codes.Unimplemented {
+		if status.Code(err) == codes.Unimplemented || status.Code(err) == codes.Unavailable {
 			a.cli.Console().VerbosePrintf("Call not supported by remote BuildKit: %s", err)
 			return false
 		}
 		a.cli.Console().Warnf("Failed to check for registry proxy support: %s", err)
+		return false
 	}
 	for _, cap := range res.Caps {
 		if cap.ID == "earthly.registry" && cap.GetEnabled() {

--- a/cmd/earthly/subcmd/build_cmd.go
+++ b/cmd/earthly/subcmd/build_cmd.go
@@ -619,6 +619,7 @@ func (a *Build) ActionBuildImp(cliCtx *cli.Context, flagArgs, nonFlagArgs []stri
 		ParallelConversion:                    (a.cli.Cfg().Global.ConversionParallelism != 0),
 		Parallelism:                           parallelism,
 		LocalRegistryAddr:                     localRegistryAddr,
+		UseRemoteRegistry:                     a.cli.Flags().UseRemoteRegistry,
 		FeatureFlagOverrides:                  a.cli.Flags().FeatureFlagOverrides,
 		ContainerFrontend:                     a.cli.Flags().ContainerFrontend,
 		InternalSecretStore:                   internalSecretStore,

--- a/go.mod
+++ b/go.mod
@@ -139,6 +139,6 @@ replace (
 	github.com/jdxcode/netrc => github.com/mikejholly/netrc v0.0.0-20221121193719-a154cb29ec2a
 	github.com/jessevdk/go-flags => github.com/alexcb/go-flags v0.0.0-20210722203016-f11d7ecb5ee5
 
-	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.0-20231004171653-3bf8e1e62512
+	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.0-20231004185012-e9fbad46a010
 	github.com/tonistiigi/fsutil => github.com/earthly/fsutil v0.0.0-20230530182746-82567e6e2a92
 )

--- a/go.mod
+++ b/go.mod
@@ -139,6 +139,6 @@ replace (
 	github.com/jdxcode/netrc => github.com/mikejholly/netrc v0.0.0-20221121193719-a154cb29ec2a
 	github.com/jessevdk/go-flags => github.com/alexcb/go-flags v0.0.0-20210722203016-f11d7ecb5ee5
 
-	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.0-20231004185012-e9fbad46a010
+	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.0-20231005001609-7dfd9c2450b3
 	github.com/tonistiigi/fsutil => github.com/earthly/fsutil v0.0.0-20230530182746-82567e6e2a92
 )

--- a/go.mod
+++ b/go.mod
@@ -139,6 +139,6 @@ replace (
 	github.com/jdxcode/netrc => github.com/mikejholly/netrc v0.0.0-20221121193719-a154cb29ec2a
 	github.com/jessevdk/go-flags => github.com/alexcb/go-flags v0.0.0-20210722203016-f11d7ecb5ee5
 
-	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.0-20231003205225-f3b4f010e26e
+	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.0-20231004171653-3bf8e1e62512
 	github.com/tonistiigi/fsutil => github.com/earthly/fsutil v0.0.0-20230530182746-82567e6e2a92
 )

--- a/go.sum
+++ b/go.sum
@@ -179,8 +179,8 @@ github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
-github.com/earthly/buildkit v0.0.0-20231003205225-f3b4f010e26e h1:QeAcISuMDUD9dILbFrxW6Hy6GlBGoxyJCQ+MkvqqKEY=
-github.com/earthly/buildkit v0.0.0-20231003205225-f3b4f010e26e/go.mod h1:P7bVT9bNSjRkPvWZwVvrCmXzP6bfqw2T9GB7iKMP34s=
+github.com/earthly/buildkit v0.0.0-20231004171653-3bf8e1e62512 h1:Q4vloADcJynA3kix2zRw8H+L4Y5smTIlHP9lyx9Esk4=
+github.com/earthly/buildkit v0.0.0-20231004171653-3bf8e1e62512/go.mod h1:P7bVT9bNSjRkPvWZwVvrCmXzP6bfqw2T9GB7iKMP34s=
 github.com/earthly/cloud-api v1.0.1-0.20230914190823-c58662fdabd8 h1:8EW/AMPNtzOcExSV7Dk1weQGK/XqbAuhvLs062xlBH4=
 github.com/earthly/cloud-api v1.0.1-0.20230914190823-c58662fdabd8/go.mod h1:rU/tYJ7GFBjdKAITV2heDbez++glpGSbtJaZcp73rNI=
 github.com/earthly/fsutil v0.0.0-20230530182746-82567e6e2a92 h1:dy3w3B4OiDyQS+iHi/beUgMDJ1+fAAgbtr7OZ0d9ks0=

--- a/go.sum
+++ b/go.sum
@@ -179,8 +179,8 @@ github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
-github.com/earthly/buildkit v0.0.0-20231004171653-3bf8e1e62512 h1:Q4vloADcJynA3kix2zRw8H+L4Y5smTIlHP9lyx9Esk4=
-github.com/earthly/buildkit v0.0.0-20231004171653-3bf8e1e62512/go.mod h1:P7bVT9bNSjRkPvWZwVvrCmXzP6bfqw2T9GB7iKMP34s=
+github.com/earthly/buildkit v0.0.0-20231004185012-e9fbad46a010 h1:qb14u5whgwoAHMm/YD9lvO4ev9nzD1hBZ/nX904pNSM=
+github.com/earthly/buildkit v0.0.0-20231004185012-e9fbad46a010/go.mod h1:P7bVT9bNSjRkPvWZwVvrCmXzP6bfqw2T9GB7iKMP34s=
 github.com/earthly/cloud-api v1.0.1-0.20230914190823-c58662fdabd8 h1:8EW/AMPNtzOcExSV7Dk1weQGK/XqbAuhvLs062xlBH4=
 github.com/earthly/cloud-api v1.0.1-0.20230914190823-c58662fdabd8/go.mod h1:rU/tYJ7GFBjdKAITV2heDbez++glpGSbtJaZcp73rNI=
 github.com/earthly/fsutil v0.0.0-20230530182746-82567e6e2a92 h1:dy3w3B4OiDyQS+iHi/beUgMDJ1+fAAgbtr7OZ0d9ks0=

--- a/go.sum
+++ b/go.sum
@@ -179,8 +179,8 @@ github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
-github.com/earthly/buildkit v0.0.0-20231004185012-e9fbad46a010 h1:qb14u5whgwoAHMm/YD9lvO4ev9nzD1hBZ/nX904pNSM=
-github.com/earthly/buildkit v0.0.0-20231004185012-e9fbad46a010/go.mod h1:P7bVT9bNSjRkPvWZwVvrCmXzP6bfqw2T9GB7iKMP34s=
+github.com/earthly/buildkit v0.0.0-20231005001609-7dfd9c2450b3 h1:SRoe8He4WD1Ggk6uI5/Qk47eW+F+nnXIzH9I+870RPA=
+github.com/earthly/buildkit v0.0.0-20231005001609-7dfd9c2450b3/go.mod h1:P7bVT9bNSjRkPvWZwVvrCmXzP6bfqw2T9GB7iKMP34s=
 github.com/earthly/cloud-api v1.0.1-0.20230914190823-c58662fdabd8 h1:8EW/AMPNtzOcExSV7Dk1weQGK/XqbAuhvLs062xlBH4=
 github.com/earthly/cloud-api v1.0.1-0.20230914190823-c58662fdabd8/go.mod h1:rU/tYJ7GFBjdKAITV2heDbez++glpGSbtJaZcp73rNI=
 github.com/earthly/fsutil v0.0.0-20230530182746-82567e6e2a92 h1:dy3w3B4OiDyQS+iHi/beUgMDJ1+fAAgbtr7OZ0d9ks0=


### PR DESCRIPTION
This PR moves the registry proxy start-up code into `Builder` and gates the feature using the new cap added here: https://github.com/earthly/buildkit/pull/27