### PR TITLE
staging-release: add Additional Info to CHANGELOG

### DIFF
--- a/.github/workflows/ci-staging-deploy.yml
+++ b/.github/workflows/ci-staging-deploy.yml
@@ -80,6 +80,7 @@ jobs:
             git remote add staging git@github.com:earthly/earthly-staging.git
             git push staging HEAD:pre-release-$RELEASE_TAG
             echo -e "# Earthly Changelog\n\nAll notable changes to [Earthly](https://github.com/earthly/earthly) will be documented in this file.\n\n## Unreleased\n\n## $RELEASE_TAG - $(date +%Y-%m-%d)\n\nThis pre-release was built from $(git rev-parse HEAD)" > CHANGELOG.md
+            echo -e "\n### Additional Info\n- This release includes changes to buildkit" >> CHANGELOG.md
             ./release/release.sh
       - name: Buildkit logs (runs on failure)
         if: ${{ failure() }}


### PR DESCRIPTION
The CHANGELOG linter was changed to enforce each release contains a new "Additional Info" section in 7e7bd7c92be740354b1bb4b266f8c44d477351e4; however, the ci-staging-deploy script was never changed to emit the newly required text.

In this case we will always append a "This release includes changes to buildkit" message, even if there isn't actually a change.