### PR TITLE
Address v0.7.20 release process retro

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -10,6 +10,7 @@
   includePaths: [
     'docs/**',
     '.github/',
+    'release/**',
   ],
   enabledManagers: [
     'regex',
@@ -27,6 +28,7 @@
         'github.com/earthly/earthly:(?<currentValue>.+?)(\\+|`)',
         '(:|\\s+)earthly/earthly:(?<currentValue>.+?)[\\s\\n/]+',
         'the `latest` tag is `(?<currentValue>.+?)`',
+        'earthly/compare/(?<currentValue>.+?)\\.\\.\\.main',
       ],
       depNameTemplate: 'earthly/earthly',
       datasourceTemplate: 'github-releases',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,6 +14,7 @@
   ],
   enabledManagers: [
     'regex',
+    'github-actions',
   ],
   customManagers: [
     {

--- a/.github/workflows/docs-checks-links.yml
+++ b/.github/workflows/docs-checks-links.yml
@@ -19,7 +19,12 @@ jobs:
       EARTHLY_INSTALL_ID: "earthly-githubactions"
       DOCKERHUB_MIRROR_USERNAME: "${{ secrets.DOCKERHUB_MIRROR_USERNAME }}"
       DOCKERHUB_MIRROR_PASSWORD: "${{ secrets.DOCKERHUB_MIRROR_PASSWORD }}"
+      # Used in our github action as the token - TODO: look to change it into an input
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: earthly/actions-setup@main
       - name: Check Broken Links
         run: earthly --ci +check-broken-links --VERBOSE=true

--- a/.github/workflows/docs-checks-links.yml
+++ b/.github/workflows/docs-checks-links.yml
@@ -5,6 +5,10 @@ on:
     branches: [ docs-0.7 ]
   pull_request:
     branches: [ main ]
+  workflow_run:
+    workflows: ['GitBook']
+    types:
+      - completed
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/docs-checks-links.yml
+++ b/.github/workflows/docs-checks-links.yml
@@ -3,8 +3,6 @@ name: check docs broken links
 on:
   push:
     branches: [ docs-0.7 ]
-  pull_request:
-    branches: [ main ]
   workflow_run:
     workflows: ['GitBook']
     types:

--- a/.github/workflows/docs-checks-links.yml
+++ b/.github/workflows/docs-checks-links.yml
@@ -1,0 +1,25 @@
+name: check docs broken links
+
+on:
+  push:
+    branches: [ docs-0.7 ]
+  pull_request:
+    branches: [ main ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-broken-links:
+    runs-on: "ubuntu-latest"
+    env:
+      FORCE_COLOR: 1
+      EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"
+      EARTHLY_INSTALL_ID: "earthly-githubactions"
+      DOCKERHUB_MIRROR_USERNAME: "${{ secrets.DOCKERHUB_MIRROR_USERNAME }}"
+      DOCKERHUB_MIRROR_PASSWORD: "${{ secrets.DOCKERHUB_MIRROR_PASSWORD }}"
+    steps:
+      - uses: earthly/actions-setup@main
+      - name: Check Broken Links
+        run: earthly --ci +check-broken-links --VERBOSE=true

--- a/.github/workflows/docs-checks-links.yml
+++ b/.github/workflows/docs-checks-links.yml
@@ -1,12 +1,12 @@
 name: check docs broken links
 
 on:
-  push:
-    branches: [ docs-0.7 ]
+  push: # this can be removed if we noticed the workflow_run trigger is working as expected (after the gitbook workflow completes)
+    branches: [docs-0.7]
   workflow_run:
     workflows: ['GitBook']
-    types:
-      - completed
+    types: [completed]
+    branches: [docs-0.7]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -14,6 +14,7 @@ concurrency:
 
 jobs:
   check-broken-links:
+    if: ${{ github.event_name == 'push' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: "ubuntu-latest"
     env:
       FORCE_COLOR: 1

--- a/Earthfile
+++ b/Earthfile
@@ -847,3 +847,29 @@ merge-main-to-docs:
         git checkout $to_branch && \
         git merge $from_branch && \
         git push
+
+# check-broken-links checks for broken links in our docs website
+check-broken-links:
+    FROM node:20-alpine3.18
+    RUN npm install broken-link-checker -g
+    WORKDIR /report
+    ARG ADDRESS=https://docs.earthly.dev
+    ARG VERBOSE=false
+    LET REPORT_FILE_NAME=report.txt
+    LET BLC_COMMAND="blc $ADDRESS -rog --exclude https://twitter.com/E1arthlyTech --exclude http://localhost:8080/"
+    IF [ $VERBOSE = "true" ]
+        RUN --no-cache $BLC_COMMAND |tee $REPORT_FILE_NAME
+    ELSE
+        RUN --no-cache $BLC_COMMAND &> $REPORT_FILE_NAME || true
+    END
+    LET RESULT=$(grep -qE '^├─BROKEN─' $REPORT_FILE_NAME; echo $?)
+    LET NOCOLOR='\033[0m'
+    LET RED='\033[0;31m'
+    LET GREEN='\033[0;32m'
+    IF [ $RESULT = "0" ]
+        RUN --no-cache echo -e "${RED}Final Broken Links Report:${NOCOLOR}"
+        RUN --no-cache grep --color=always -E '^(Getting links from|├─BROKEN─|Finished!|Elapsed)' $REPORT_FILE_NAME
+        RUN exit 1
+    ELSE
+        RUN --no-cache echo -e "${GREEN}No Broken Links were found${NOCOLOR}"
+    END

--- a/Earthfile
+++ b/Earthfile
@@ -856,7 +856,7 @@ check-broken-links:
     ARG ADDRESS=https://docs.earthly.dev
     ARG VERBOSE=false
     LET REPORT_FILE_NAME=report.txt
-    LET BLC_COMMAND="blc $ADDRESS -rog --exclude https://twitter.com/E1arthlyTech --exclude http://localhost:8080/"
+    LET BLC_COMMAND="blc $ADDRESS -rog --exclude https://twitter.com/EarthlyTech --exclude http://localhost:8080/"
     IF [ $VERBOSE = "true" ]
         RUN --no-cache $BLC_COMMAND |tee $REPORT_FILE_NAME
     ELSE

--- a/docs/earthfile/earthlyignore.md
+++ b/docs/earthfile/earthlyignore.md
@@ -4,7 +4,7 @@ When a build takes place, the `earthly` command sends any necessary local build 
 
 The `.earthlyignore` file must be present in the same directory as the target being built.
 
-The syntax of the `.earthlyignore` file is the same as the syntax of a [`.dockerignore` file](https://docs.docker.com/engine/reference/builder/#dockerignore-file). Behind the scenes, the matching is performed using the Go [`filepath.Match`](https://golang.org/pkg/path/filepath/#Match) function.
+The syntax of the `.earthlyignore` file is the same as the syntax of a [`.dockerignore` file](https://docs.docker.com/engine/reference/builder/#dockerignore-file). Behind the scenes, the matching is performed using the Go [`filepath.Match`](https://pkg.go.dev/path/filepath#Match) function.
 
 Patterns of files to exclude from the build context are specified as one pattern per line, with empty lines or lines starting with `#` being ignored. Each pattern has the following syntax:
 

--- a/release/README.md
+++ b/release/README.md
@@ -50,7 +50,7 @@
     `git checkout main && git push`
   
 <!-- vale HouseStyle.Spelling = YES -->
-* After GitBook has processed the [docs-0.7](https://github.com/earthly/earthly/tree/docs-0.7) branch (you can see the gitbook check/job in Github), run a broken link checker over https://docs.earthly.dev. This one is fast and easy: https://www.deadlinkchecker.com/.
+* After GitBook has processed the [docs-0.7](https://github.com/earthly/earthly/tree/docs-0.7), a GH action will run to check for broken links in https://docs.earthly.dev. [This](https://github.com/earthly/earthly/actions/runs/6434655743/job/17474292828) is an example of such workflow.
 * Verify the [Homebrew release job](https://github.com/earthly/homebrew-earthly) has successfully run and has merged the new `release-v...` branch into `main`.
 * Copy the release notes you have written before and paste them in the Earthly Community slack channel `#announcements`, together with a link to the release's GitHub page. If you have Slack markdown editing activated, you can copy the markdown version of the text.
 

--- a/release/README.md
+++ b/release/README.md
@@ -20,7 +20,7 @@
 * Update the CHANGELOG.md with the corresponding release notes and open a PR
   * Use a comparison such as https://github.com/earthly/earthly/compare/v0.7.19...main (replace the versions in the URL with the previously released version) or a tool such as `gitk` (aka `git-gui`) to see which PRs will go into this release.
 * Make sure that main build is green for all platforms (check build status for the latest commit on GitHub).
-* Make sure nightly BuildKite builds are green for most recent build
+* Make sure the following build status are green:
   | Platform      | Status        |
   | ------------- | ------------- |
   | MacOS (x86)   | [![Build status](https://badge.buildkite.com/cc0627732806ab3b76cf13b02c498658b851056242ec28f62d.svg)](https://buildkite.com/earthly-technologies/earthly-mac-scheduled)
@@ -38,24 +38,6 @@
 * Updating the Earthly version in our docs:  
   [Renovate](https://www.mend.io/renovate/) will open a PR to update all docs as soon as a new release is available in this repo,  
   which you should then review & merge (An example PR can be found [here](https://github.com/earthly/earthly/pull/3285/files)).
-
-  * If for whatever reason you need/want to do this manually, please do the following:
-    * Update the version in the following places:
-<!-- vale HouseStyle.Spelling = NO -->
-  * [circle-integration.md](../docs/ci-integration/guides/circle-integration.md)
-  * [gh-actions-integration.md](../docs/ci-integration/guides/gh-actions-integration.md)
-  * [codebuild-integration.md](../docs/ci-integration/guides/codebuild-integration.md)
-  * [gitlab-integration.md](../docs/ci-integration/guides/gitlab-integration.md)
-  * [build-an-earthly-ci-image.md](../docs/ci-integration/build-an-earthly-ci-image.md)
-  * [all-in-one.md](../docs/docker-images/all-in-one.md)
-  * [buildkit-standalone.md](../docs/docker-images/buildkit-standalone.md)
-<!-- vale HouseStyle.Spelling = YES -->
-  * you can try doing that with:
-    ```shell
-    REGEX='\(earthly\/releases\/download\/\)v[0-9]\+\.[0-9]\+\.[0-9]\+\(\/\)'; grep -Ril './docs/' -e $REGEX | xargs -n1 sed -i 's/'$REGEX'/\1'$RELEASE_TAG'\2/g'
-    REGEX='\(\searthly\/\(buildkitd\|earthly\):\)v[0-9]\+\.[0-9]\+\.[0-9]\+'; grep -Ril './docs/' -e $REGEX | xargs -n1 sed -i 's/'$REGEX'/\1'$RELEASE_TAG'/g'
-    ```
-
 * Commit updated version changes to `docs-0.7`.
 * Merge `docs-0.7` into `main`.
   ```shell
@@ -68,10 +50,9 @@
     `git checkout main && git push`
   
 <!-- vale HouseStyle.Spelling = YES -->
-* After GitBook has processed the `main` branch (you can see the gitbook check/job in Github), run a broken link checker over https://docs.earthly.dev. This one is fast and easy: https://www.deadlinkchecker.com/.
+* After GitBook has processed the [docs-0.7](https://github.com/earthly/earthly/tree/docs-0.7) branch (you can see the gitbook check/job in Github), run a broken link checker over https://docs.earthly.dev. This one is fast and easy: https://www.deadlinkchecker.com/.
 * Verify the [Homebrew release job](https://github.com/earthly/homebrew-earthly) has successfully run and has merged the new `release-v...` branch into `main`.
 * Copy the release notes you have written before and paste them in the Earthly Community slack channel `#announcements`, together with a link to the release's GitHub page. If you have Slack markdown editing activated, you can copy the markdown version of the text.
-* Ask Adam to tweet about the release.
 
 ### One-Time (clear this section when done during release)
 


### PR DESCRIPTION
 - Clarify/Update release/README.md
 - Update Renovate to update referenced earthly version in release/README.md
 - Add GH workflow to find broken links
 - Enable Renovate for Github actions (Renovate will start updating dependencies of referenced gh actions, e.g. 
 `uses: actions/checkout@v3` => `uses: actions/checkout@v4`