### PR TITLE
Split examples target for disk use issue

### DIFF
--- a/.github/workflows/ci-docker-satellites.yml
+++ b/.github/workflows/ci-docker-satellites.yml
@@ -140,7 +140,7 @@ jobs:
       RUNS_ON: "ubuntu-latest"
       BINARY: "docker"
       SUDO: ""
-      EXAMPLE_NAME: "+examples1"
+      EXAMPLE_NAME: "+examples-1"
       USE_SATELLITE: true
       SATELLITE_NAME: "core-examples"
       EARTHLY_ORG: "earthly-technologies"
@@ -154,7 +154,21 @@ jobs:
       RUNS_ON: "ubuntu-latest"
       BINARY: "docker"
       SUDO: ""
-      EXAMPLE_NAME: "+examples2"
+      EXAMPLE_NAME: "+examples-2"
+      USE_SATELLITE: true
+      SATELLITE_NAME: "core-examples"
+      EARTHLY_ORG: "earthly-technologies"
+    secrets: inherit
+
+  docker-satellites-examples-3:
+    needs: build-earthly
+    uses: ./.github/workflows/reusable-example.yml
+    with:
+      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
+      RUNS_ON: "ubuntu-latest"
+      BINARY: "docker"
+      SUDO: ""
+      EXAMPLE_NAME: "+examples-3"
       USE_SATELLITE: true
       SATELLITE_NAME: "core-examples"
       EARTHLY_ORG: "earthly-technologies"
@@ -187,4 +201,3 @@ jobs:
       SATELLITE_NAME: "core-test"
       EARTHLY_ORG: "earthly-technologies"
     secrets: inherit
-

--- a/.github/workflows/ci-docker-ubuntu.yml
+++ b/.github/workflows/ci-docker-ubuntu.yml
@@ -182,7 +182,7 @@ jobs:
       RUNS_ON: "ubuntu-latest"
       BINARY: "docker"
       SUDO: ""
-      EXAMPLE_NAME: "+examples1"
+      EXAMPLE_NAME: "+examples-1"
       SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
 
@@ -195,7 +195,20 @@ jobs:
       RUNS_ON: "ubuntu-latest"
       BINARY: "docker"
       SUDO: ""
-      EXAMPLE_NAME: "+examples2"
+      EXAMPLE_NAME: "+examples-2"
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
+    secrets: inherit
+
+  docker-examples-3:
+    needs: build-earthly
+    if: ${{ !failure() }}
+    uses: ./.github/workflows/reusable-example.yml
+    with:
+      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
+      RUNS_ON: "ubuntu-latest"
+      BINARY: "docker"
+      SUDO: ""
+      EXAMPLE_NAME: "+examples-3"
       SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
 

--- a/.github/workflows/ci-podman-ubuntu.yml
+++ b/.github/workflows/ci-podman-ubuntu.yml
@@ -143,7 +143,7 @@ jobs:
       BINARY: "podman"
       USE_QEMU: true
       SUDO: "sudo -E"
-      EXAMPLE_NAME: "+examples1"
+      EXAMPLE_NAME: "+examples-1"
       SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
 
@@ -158,7 +158,22 @@ jobs:
       BINARY: "podman"
       USE_QEMU: true
       SUDO: "sudo -E"
-      EXAMPLE_NAME: "+examples2"
+      EXAMPLE_NAME: "+examples-2"
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
+    secrets: inherit
+
+  podman-examples-3:
+    # TODO: Figure out how to run multiple Podman instances in parallel with different ports for buildkitd
+    needs: build-earthly
+    if: ${{ !failure() }}
+    uses: ./.github/workflows/reusable-example.yml
+    with:
+      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
+      RUNS_ON: "ubuntu-latest"
+      BINARY: "podman"
+      USE_QEMU: true
+      SUDO: "sudo -E"
+      EXAMPLE_NAME: "+examples-3"
       SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
 

--- a/Earthfile
+++ b/Earthfile
@@ -737,13 +737,12 @@ test-all:
     BUILD --pass-args +test-qemu
     BUILD --pass-args ./tests+experimental
 
-# examples runs both sets of examples
 examples:
-    BUILD +examples1
-    BUILD +examples2
+    BUILD +examples-1
+    BUILD +examples-2
+    BUILD +examples-3
 
-# examples1 runs set 1 of examples
-examples1:
+examples-1:
     ARG TARGETARCH
     BUILD ./examples/c+docker
     BUILD ./examples/cpp+docker
@@ -769,8 +768,7 @@ examples1:
     BUILD ./examples/secrets+base
     BUILD ./examples/cloud-secrets+base
 
-# examples2 runs set 2 of examples
-examples2:
+examples-2:
     BUILD ./examples/readme/go1+all
     BUILD ./examples/readme/go2+build
     BUILD ./examples/readme/proto+docker
@@ -790,6 +788,8 @@ examples2:
     BUILD github.com/earthly/hello-world:main+hello
     BUILD ./examples/cache-command/npm+docker
     BUILD ./examples/cache-command/mvn+docker
+
+examples-3:
     BUILD ./examples/typescript-node+docker
     BUILD ./examples/bazel+run
     BUILD ./examples/bazel+image


### PR DESCRIPTION
Existing `examples2` target seems to be using all available GHA runner disk.