### PR TITLE
bootstrap: --force-certification-generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 ### Added
 
 - The new ARG `EARTHLY_GIT_REFS` will contain the references to the current git commit, this ARG must be enabled with the `VERSION --git-refs` feature flag. [#3341](https://github.com/earthly/earthly/pull/3341)
+- A new `--force-certificate-generation` flag for bootstrapping, which will force the generation of self signed TLS certificates even when the `--no-buildkit` flag is set.
 
 ## v0.7.20 - 2023-10-03
 

--- a/earthly-entrypoint.sh
+++ b/earthly-entrypoint.sh
@@ -39,7 +39,7 @@ if [ -z "$NO_BUILDKIT" ]; then
     fi
 
     # generate certificates
-    earthly --config "$earthly_config" --buildkit-host=tcp://127.0.0.1:8372 bootstrap --certs-hostname="$(hostname)"
+    earthly --config "$earthly_config" --buildkit-host=tcp://127.0.0.1:8372 bootstrap --certs-hostname="$(hostname)" --no-buildkit --force-certificate-generation
 
     if [ ! -f /etc/ca.pem ]; then
       ln -s /root/.earthly/certs/ca_cert.pem /etc/ca.pem


### PR DESCRIPTION
The earthly/earthly image entrypoint script performs a bootstrap in order to generate self-signed TLS certificates (which is good), but continues to attempt to start a buildkit instance (which is bad), since the script continues to run buildkitd directly in the same container.

This leads to confusing warning messages such as

           buildkitd | Starting buildkit daemon as a docker container (earthly-buildkitd)...
           bootstrap | Warning: Bootstrapping buildkit failed: maybe start buildkitd: start: could not start buildkit: 1 error occurred:
           bootstrap | 	* command failed: docker run --privileged --env BUILDKIT_DEBUG=false --env BUILDKIT_TCP_TRANSPORT_ENABLED=true --env BUILDKIT_TLS_ENABLED=true --env BUILDKIT_MAX_PARALLELISM=20 --label dev.earthly.settingshash=53bb7043424f0e87 --mount type=volume,source=earthly-cache,dst=/tmp/earthly --mount type=bind,source=/root/.earthly/certs/ca_cert.pem,dst=/etc/ca.pem,ro=true --mount type=bind,source=/root/.earthly/certs/buildkit_cert.pem,dst=/etc/cert.pem,ro=true --mount type=bind,source=/root/.earthly/certs/buildkit_key.pem,dst=/etc/key.pem,ro=true --publish 127.0.0.1:8371:8371/tcp --publish 127.0.0.1:8372:8372/tcp -d --pull missing --name earthly-buildkitd docker.io/earthly/buildkitd:v0.7.20: exit status 125: docker: Error response from daemon: invalid mount config for type "bind": bind source path does not exist: /root/.earthly/certs/ca_cert.pem.
           bootstrap | See 'docker run --help'.: exit status 125
           bootstrap |
           bootstrap | Bootstrapping successful.

This occurs when following our official gitlab integration docs.

This new flag will allow us to run:

    earthly bootstrap --force-certificate-generate --no-buildkit

which will prevent this warning from occuring.