### PR TITLE
internal-docs: list buildkit-fork features

### DIFF
--- a/docs-internals/README.md
+++ b/docs-internals/README.md
@@ -37,7 +37,8 @@ the [buildkit/docs/dev](https://github.com/moby/buildkit/tree/master/docs/dev) s
 
 ## Guides
 
-[build action lifecycle](build-steps.md)
+- [build action lifecycle](build-steps.md)
+- [Why do we have a fork of buildkit](buildkit-fork.md)
 
 ## Citations
 

--- a/docs-internals/buildkit-fork.md
+++ b/docs-internals/buildkit-fork.md
@@ -1,0 +1,13 @@
+# Why do we have a buildkit fork?
+
+Here's a very rough list on some of the features we have in our BuildKit fork, which are too-specific to earthly,
+and would not be a good fit to submit upstream.
+
+- ability to pass arbitrary sockets from the host to buildkitd container; used by the interactive debugger
+- to support `WITH DOCKER` via host-bind mounts
+- faster exports of images from remote buildkit instance to local host; used for "pull ping" registry
+- git LFS support
+- verbose debugging of which files are sent to buildkit (via fsutils fork)
+- `Export` method on gateway client, which is used to enable WAIT / END blocks
+- healthcheck overrides, which are required for maintaining stability of our satellite instances
+- modifications to the `llbsolver/ops/exec.go` in order to support `LOCALLY` mode

--- a/docs-internals/buildkit-fork.md
+++ b/docs-internals/buildkit-fork.md
@@ -5,7 +5,7 @@ and would not be a good fit to submit upstream.
 
 - ability to pass arbitrary sockets from the host to buildkitd container; used by the interactive debugger
 - to support `WITH DOCKER` via host-bind mounts
-- faster exports of images from remote buildkit instance to local host; used for "pull ping" registry
+- faster exports of images and artifacts from remote buildkit instance to local host. This includes the Earthly exporter, the pull-ping call, the embedded registry, and the storage driver to plug the registry into the buildkit cache
 - git LFS support
 - verbose debugging of which files are sent to buildkit (via fsutils fork)
 - `Export` method on gateway client, which is used to enable WAIT / END blocks

--- a/docs-internals/buildkit-fork.md
+++ b/docs-internals/buildkit-fork.md
@@ -11,3 +11,7 @@ and would not be a good fit to submit upstream.
 - `Export` method on gateway client, which is used to enable WAIT / END blocks
 - healthcheck overrides, which are required for maintaining stability of our satellite instances
 - modifications to the `llbsolver/ops/exec.go` in order to support `LOCALLY` mode
+- GCAnalytics for stats on garbage collection and disk space used
+- info call that includes the op load and the number of sessions currently executing
+- StopIfIdle - the ability to shut down buildkit while ensuring that no session is active and that no session is accepted while closing
+- session management capabilities, including the ability to sessions that run for too long


### PR DESCRIPTION
A rough list of our features in our buildkit fork, which are not appropriate for upstream submissions.