### PR TITLE
update buildkit with double-merged-edge fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 
 ### Fixed
 - `prune --age` did not support `d` (for days) suffix, even thought `earthly --help` said it did [#3401](https://github.com/earthly/earthly/issues/3401)  
+- `buildkit scheduler error: return leaving incoming open` which occured during deduplication of opperations within buildkit; cherry-picked 100d3cb6b6903be50f7a3e5dba193515aa9530fa from upstream buildkit repo. [#2957](https://github.com/earthly/earthly/issues/2957)
 
 ## v0.7.20 - 2023-10-03
 

--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -12,7 +12,7 @@ buildkitd:
             ARG BUILDKIT_BASE_IMAGE=$BUILDKIT_PROJECT+build
         END
     ELSE
-        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:6cce2996a65c28b48c4ace7c51249558263893ba+build
+        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:0b107b045b571b4f3184d6d975e567bd46d213bd+build
     END
     ARG EARTHLY_TARGET_TAG_DOCKER
     ARG TAG="dev-$EARTHLY_TARGET_TAG_DOCKER"

--- a/go.mod
+++ b/go.mod
@@ -141,6 +141,6 @@ replace (
 	github.com/jdxcode/netrc => github.com/mikejholly/netrc v0.0.0-20221121193719-a154cb29ec2a
 	github.com/jessevdk/go-flags => github.com/alexcb/go-flags v0.0.0-20210722203016-f11d7ecb5ee5
 
-	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.0-20231013180450-6cce2996a65c
+	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.0-20231019213109-0b107b045b57
 	github.com/tonistiigi/fsutil => github.com/earthly/fsutil v0.0.0-20230530182746-82567e6e2a92
 )

--- a/go.sum
+++ b/go.sum
@@ -181,8 +181,8 @@ github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
-github.com/earthly/buildkit v0.0.0-20231013180450-6cce2996a65c h1:l2Od0jVSd9Pe+/ffB+34eell1JvcwRl1SxpY2vAgb2I=
-github.com/earthly/buildkit v0.0.0-20231013180450-6cce2996a65c/go.mod h1:AJ3nMleWpsh6L06n2sFkT70+zGjnD9+rtsdmyw5YHLU=
+github.com/earthly/buildkit v0.0.0-20231019213109-0b107b045b57 h1:4yzg1k6cuPyuMSUF/Erl52Nf1j4MPdvhwsCbo5ITG7A=
+github.com/earthly/buildkit v0.0.0-20231019213109-0b107b045b57/go.mod h1:AJ3nMleWpsh6L06n2sFkT70+zGjnD9+rtsdmyw5YHLU=
 github.com/earthly/cloud-api v1.0.1-0.20230914190823-c58662fdabd8 h1:8EW/AMPNtzOcExSV7Dk1weQGK/XqbAuhvLs062xlBH4=
 github.com/earthly/cloud-api v1.0.1-0.20230914190823-c58662fdabd8/go.mod h1:rU/tYJ7GFBjdKAITV2heDbez++glpGSbtJaZcp73rNI=
 github.com/earthly/fsutil v0.0.0-20230530182746-82567e6e2a92 h1:dy3w3B4OiDyQS+iHi/beUgMDJ1+fAAgbtr7OZ0d9ks0=


### PR DESCRIPTION
cherry-picked 100d3cb6b6903be50f7a3e5dba193515aa9530fa from https://github.com/moby/buildkit/pull/4285

fixes https://github.com/earthly/earthly/issues/2957