### PR TITLE
fix wait/end test name to include TARGET_NAME

### DIFF
--- a/.github/workflows/reusable-wait-block-target.yml
+++ b/.github/workflows/reusable-wait-block-target.yml
@@ -55,7 +55,7 @@ jobs:
           set -euo pipefail
           EARTHLY_VERSION_FLAG_OVERRIDES="$(tr -d '\n' < .earthly_version_flag_overrides)"
           echo "EARTHLY_VERSION_FLAG_OVERRIDES=$EARTHLY_VERSION_FLAG_OVERRIDES" >> "$GITHUB_ENV"
-      - name: Execute +test using wait-block override (Earthly Only)
+      - name: Execute ${{inputs.TARGET_NAME}} using wait-block override
         run: |-
           ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} --ci -P --global-wait-end \
            ${{inputs.TARGET_NAME}} --GLOBAL_WAIT_END=true


### PR DESCRIPTION
the wait-block-target test used to run all of +test, but was split up in 02a2749b8b1d35ce893c54c34dbffc2e79fb6110 however the test name was never updated.