### PR TITLE
Patch: Eliminates deprecated ioutil

### DIFF
--- a/examples/go-monorepo/services/one/main_test.go
+++ b/examples/go-monorepo/services/one/main_test.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -15,7 +15,7 @@ func TestService(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 	expected := "Hello, World!"
-	actual, _ := ioutil.ReadAll(resp.Body)
+	actual, _ := io.ReadAll(resp.Body)
 	if expected != string(actual) {
 		t.Fail()
 	}

--- a/examples/go-monorepo/services/two/main_test.go
+++ b/examples/go-monorepo/services/two/main_test.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -15,7 +15,7 @@ func TestService(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 	expected := "Hello, Friend!"
-	actual, _ := ioutil.ReadAll(resp.Body)
+	actual, _ := io.ReadAll(resp.Body)
 	if expected != string(actual) {
 		t.Fail()
 	}


### PR DESCRIPTION
io/ioutil has been deprecated in favor of 'io' and 'os' which are drop-in replacements for io/ioutil.

In this case, we are replacing ioutil's ReadAll with io's ReadAll.

Happy Hacktoberfest :) Thank you for considering my PR!