### PR TITLE
Registry proxy: support container for Mac

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -873,7 +873,3 @@ check-broken-links:
     ELSE
         RUN --no-cache echo -e "${GREEN}No Broken Links were found${NOCOLOR}"
     END
-
-image-test:
-    FROM alpine
-    SAVE IMAGE alpine

--- a/Earthfile
+++ b/Earthfile
@@ -873,3 +873,7 @@ check-broken-links:
     ELSE
         RUN --no-cache echo -e "${GREEN}No Broken Links were found${NOCOLOR}"
     END
+
+image-test:
+    FROM alpine
+    SAVE IMAGE alpine

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -217,7 +217,7 @@ func (b *Builder) startRegistryProxy(ctx context.Context, caps apicaps.CapSet) (
 			return nil, false
 		}
 		b.opt.Console.VerbosePrintf("Started support container for registry proxy on port %d", darwinProxyPort)
-		addr = fmt.Sprintf("host.docker.internal:%d", darwinProxyPort)
+		addr = fmt.Sprintf("127.0.0.1:%d", darwinProxyPort)
 	}
 
 	b.opt.LocalRegistryAddr = addr

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -223,7 +223,6 @@ func (b *Builder) startRegistryProxy(ctx context.Context, caps apicaps.CapSet) (
 	b.opt.LocalRegistryAddr = addr
 
 	closeFn := func() {
-		fmt.Println("Closing registry proxy")
 		if isDarwin {
 			err := b.stopDarwinProxyHelper(ctx)
 			if err != nil {

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -209,7 +209,7 @@ func (b *Builder) startRegistryProxy(ctx context.Context, caps apicaps.CapSet) (
 	if isDarwin {
 		darwinProxyPort, err := b.startDarwinProxyHelper(ctx, registryPort)
 		if err != nil {
-			b.opt.Console.Warnf("Darwin registry container: %v", err)
+			b.opt.Console.Warnf("Failed to start registry proxy support container: %v", err)
 			err := b.stopDarwinProxyHelper(ctx) // Clean up dangling container on failure.
 			if err != nil {
 				b.opt.Console.Warnf("Failed to stop registry proxy support container: %v", err)

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -184,7 +184,7 @@ func (b *Builder) startRegistryProxy(ctx context.Context, caps apicaps.CapSet) (
 		isDarwin,
 		b.opt.DarwinProxyImage,
 		b.opt.DarwinProxyWait,
-		b.opt.Console,
+		b.opt.Console.WithPrefix("registry-proxy"),
 	)
 	addr, closeFn, err := controller.Start(ctx)
 	if err != nil {

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/earthly/earthly/buildcontext"
 	"github.com/earthly/earthly/buildcontext/provider"
@@ -83,6 +84,7 @@ type Opt struct {
 	Parallelism                           semutil.Semaphore
 	UseRemoteRegistry                     bool
 	DarwinProxyImageTag                   string
+	DarwinProxyWait                       time.Duration
 	LocalRegistryAddr                     string
 	FeatureFlagOverrides                  string
 	ContainerFrontend                     containerutil.ContainerFrontend
@@ -181,6 +183,7 @@ func (b *Builder) startRegistryProxy(ctx context.Context, caps apicaps.CapSet) (
 		b.opt.ContainerFrontend,
 		isDarwin,
 		b.opt.DarwinProxyImageTag,
+		b.opt.DarwinProxyWait,
 		b.opt.Console,
 	)
 	addr, closeFn, err := controller.Start(ctx)

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -177,7 +177,7 @@ func (b *Builder) startRegistryProxy(ctx context.Context, caps apicaps.CapSet) (
 		return nil, false
 	}
 
-	addr := "127.0.0.1:0" // Have the OS select a port
+	addr := ":0" // Have the OS select a port
 
 	lnCfg := net.ListenConfig{}
 	ln, err := lnCfg.Listen(ctx, "tcp", addr)
@@ -217,7 +217,7 @@ func (b *Builder) startRegistryProxy(ctx context.Context, caps apicaps.CapSet) (
 			return nil, false
 		}
 		b.opt.Console.VerbosePrintf("Started support container for registry proxy on port %d", darwinProxyPort)
-		addr = fmt.Sprintf("127.0.0.1:%d", darwinProxyPort)
+		addr = fmt.Sprintf("localhost:%d", darwinProxyPort)
 	}
 
 	b.opt.LocalRegistryAddr = addr

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -83,7 +83,7 @@ type Opt struct {
 	ParallelConversion                    bool
 	Parallelism                           semutil.Semaphore
 	UseRemoteRegistry                     bool
-	DarwinProxyImageTag                   string
+	DarwinProxyImage                      string
 	DarwinProxyWait                       time.Duration
 	LocalRegistryAddr                     string
 	FeatureFlagOverrides                  string
@@ -182,7 +182,7 @@ func (b *Builder) startRegistryProxy(ctx context.Context, caps apicaps.CapSet) (
 		b.s.bkClient.RegistryClient(),
 		b.opt.ContainerFrontend,
 		isDarwin,
-		b.opt.DarwinProxyImageTag,
+		b.opt.DarwinProxyImage,
 		b.opt.DarwinProxyWait,
 		b.opt.Console,
 	)

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -173,16 +173,17 @@ func (b *Builder) startRegistryProxy(ctx context.Context, caps apicaps.CapSet) (
 	}
 
 	if err := caps.Supports(pb.CapEarthlyRegistryProxy); err != nil {
-		cons.Warnf(err.Error())
+		cons.Printf(err.Error())
+		return nil, false
+	}
+
+	// Podman does not support the insecure localhost
+	if b.opt.ContainerFrontend.Scheme() == "podman-container" {
+		cons.Printf("Registry proxy not supported on Podman. Falling back to tar-based outputs.")
 		return nil, false
 	}
 
 	isDarwin := runtime.GOOS == "darwin"
-
-	if isDarwin && b.opt.ContainerFrontend.Scheme() == "podman-container" {
-		cons.Warnf("Registry proxy not supported on Podman. Falling back to tar-based outputs.")
-		return nil, false
-	}
 
 	controller := regproxy.NewController(
 		b.s.bkClient.RegistryClient(),

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -314,6 +314,8 @@ func (b *Builder) startDarwinProxyHelper(ctx context.Context, registryPort int) 
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
+	// Wait for the proxy chain to resolve to the BK registry. The /v2/ path
+	// will return a 200 when ready.
 	for {
 		res, err := http.Get(fmt.Sprintf("http://localhost:%d/v2/", assignedPort))
 		if res != nil && res.Body != nil {

--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -12,7 +12,7 @@ buildkitd:
             ARG BUILDKIT_BASE_IMAGE=$BUILDKIT_PROJECT+build
         END
     ELSE
-        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:0b107b045b571b4f3184d6d975e567bd46d213bd+build
+        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:50a633c1a3d4641d2c2f3b74f9ce80cdfb5b0d2c+build
     END
     ARG EARTHLY_TARGET_TAG_DOCKER
     ARG TAG="dev-$EARTHLY_TARGET_TAG_DOCKER"

--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -12,7 +12,7 @@ buildkitd:
             ARG BUILDKIT_BASE_IMAGE=$BUILDKIT_PROJECT+build
         END
     ELSE
-        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:50a633c1a3d4641d2c2f3b74f9ce80cdfb5b0d2c+build
+        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:d5e9d257c3981eb60454fea598510566e3972e33+build
     END
     ARG EARTHLY_TARGET_TAG_DOCKER
     ARG TAG="dev-$EARTHLY_TARGET_TAG_DOCKER"

--- a/cmd/earthly/subcmd/build_cmd.go
+++ b/cmd/earthly/subcmd/build_cmd.go
@@ -556,6 +556,7 @@ func (a *Build) ActionBuildImp(cliCtx *cli.Context, flagArgs, nonFlagArgs []stri
 	if a.cli.Flags().Logstream {
 		logbusSM = a.cli.LogbusSetup().SolverMonitor
 	}
+
 	builderOpts := builder.Opt{
 		BkClient:                              bkClient,
 		LogBusSolverMonitor:                   logbusSM,

--- a/cmd/earthly/subcmd/build_cmd.go
+++ b/cmd/earthly/subcmd/build_cmd.go
@@ -584,6 +584,7 @@ func (a *Build) ActionBuildImp(cliCtx *cli.Context, flagArgs, nonFlagArgs []stri
 		Parallelism:                           parallelism,
 		LocalRegistryAddr:                     localRegistryAddr,
 		UseRemoteRegistry:                     a.cli.Flags().UseRemoteRegistry,
+		DarwinProxyImageTag:                   a.cli.Cfg().Global.DarwinProxyImageTag,
 		FeatureFlagOverrides:                  a.cli.Flags().FeatureFlagOverrides,
 		ContainerFrontend:                     a.cli.Flags().ContainerFrontend,
 		InternalSecretStore:                   internalSecretStore,

--- a/cmd/earthly/subcmd/build_cmd.go
+++ b/cmd/earthly/subcmd/build_cmd.go
@@ -584,7 +584,7 @@ func (a *Build) ActionBuildImp(cliCtx *cli.Context, flagArgs, nonFlagArgs []stri
 		Parallelism:                           parallelism,
 		LocalRegistryAddr:                     localRegistryAddr,
 		UseRemoteRegistry:                     a.cli.Flags().UseRemoteRegistry,
-		DarwinProxyImageTag:                   a.cli.Cfg().Global.DarwinProxyImageTag,
+		DarwinProxyImage:                      a.cli.Cfg().Global.DarwinProxyImage,
 		DarwinProxyWait:                       a.cli.Cfg().Global.DarwinProxyWait,
 		FeatureFlagOverrides:                  a.cli.Flags().FeatureFlagOverrides,
 		ContainerFrontend:                     a.cli.Flags().ContainerFrontend,

--- a/cmd/earthly/subcmd/build_cmd.go
+++ b/cmd/earthly/subcmd/build_cmd.go
@@ -585,6 +585,7 @@ func (a *Build) ActionBuildImp(cliCtx *cli.Context, flagArgs, nonFlagArgs []stri
 		LocalRegistryAddr:                     localRegistryAddr,
 		UseRemoteRegistry:                     a.cli.Flags().UseRemoteRegistry,
 		DarwinProxyImageTag:                   a.cli.Cfg().Global.DarwinProxyImageTag,
+		DarwinProxyWait:                       a.cli.Cfg().Global.DarwinProxyWait,
 		FeatureFlagOverrides:                  a.cli.Flags().FeatureFlagOverrides,
 		ContainerFrontend:                     a.cli.Flags().ContainerFrontend,
 		InternalSecretStore:                   internalSecretStore,

--- a/config/config.go
+++ b/config/config.go
@@ -19,8 +19,8 @@ const (
 	// DefaultLocalRegistryPort is the default user-facing port for the local registry used for exports.
 	DefaultLocalRegistryPort = 8371
 
-	// DefaultDarwinProxyImageTag is the alpine/socat tag used for the Docker Desktop registry proxy on Darwin.
-	DefaultDarwinProxyImageTag = "1.7.4.4"
+	// DefaultDarwinProxyImage is the image tag used for the Docker Desktop registry proxy on Darwin.
+	DefaultDarwinProxyImage = "alpine/socat:1.7.4.4"
 
 	// DefaultDarwinProxyWait is the maximum time to wait for the Darwin registry proxy support container to become available.
 	DefaultDarwinProxyWait = 10 * time.Second
@@ -79,7 +79,7 @@ type GlobalConfig struct {
 	CniMtu                     uint16        `yaml:"cni_mtu"                        help:"Override auto-detection of the default interface MTU, for all containers within buildkit"`
 	BuildkitHost               string        `yaml:"buildkit_host"                  help:"The URL of your buildkit, remote or local."`
 	LocalRegistryHost          string        `yaml:"local_registry_host"            help:"The URL of the local registry used for image exports to Docker."`
-	DarwinProxyImageTag        string        `yaml:"darwin_proxy_image_tag"         help:"The 'alpine/socat' image tag used for the Docker Desktop registry proxy."`
+	DarwinProxyImage           string        `yaml:"darwin_proxy_image"             help:"The container image & tag used for the Docker Desktop registry proxy."`
 	DarwinProxyWait            time.Duration `yaml:"darwin_proxy_wait"              help:"The maximum time to wait for the Darwin registry proxy support container to become available."`
 	TLSCACert                  string        `yaml:"tlsca"                          help:"The path to the CA cert for verification. Relative paths are interpreted as relative to the config path."`
 	TLSCAKey                   string        `yaml:"tlsca_key"                      help:"The path to the CA key for generating any missing certificates. Relative paths are interpreted as relative to the config path."`
@@ -146,7 +146,7 @@ func ParseYAML(yamlData []byte, installationName string) (Config, error) {
 			BuildkitCacheSizeMb:     0,
 			BuildkitCacheSizePct:    0,
 			LocalRegistryHost:       fmt.Sprintf("tcp://127.0.0.1:%d", defaultLocalRegistryPort),
-			DarwinProxyImageTag:     DefaultDarwinProxyImageTag,
+			DarwinProxyImage:        DefaultDarwinProxyImage,
 			DarwinProxyWait:         DefaultDarwinProxyWait,
 			BuildkitScheme:          DefaultBuildkitScheme,
 			BuildkitRestartTimeoutS: 60,

--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,9 @@ const (
 	// DefaultLocalRegistryPort is the default user-facing port for the local registry used for exports.
 	DefaultLocalRegistryPort = 8371
 
+	// DefaultDarwinProxyImageTag is the alpine/socat tag used for the Docker Desktop registry proxy on Darwin.
+	DefaultDarwinProxyImageTag = "1.7.4.4"
+
 	// DefaultBuildkitScheme is the default scheme earthly uses to connect to its buildkitd. tcp or docker-container.
 	DefaultBuildkitScheme = "docker-container"
 
@@ -72,6 +75,7 @@ type GlobalConfig struct {
 	CniMtu                     uint16   `yaml:"cni_mtu"                        help:"Override auto-detection of the default interface MTU, for all containers within buildkit"`
 	BuildkitHost               string   `yaml:"buildkit_host"                  help:"The URL of your buildkit, remote or local."`
 	LocalRegistryHost          string   `yaml:"local_registry_host"            help:"The URL of the local registry used for image exports to Docker."`
+	DarwinProxyImageTag        string   `yaml:"darwin_proxy_image_tag"         help:"The 'alpine/socat' image tag used for the Docker Desktop registry proxy."`
 	TLSCACert                  string   `yaml:"tlsca"                          help:"The path to the CA cert for verification. Relative paths are interpreted as relative to the config path."`
 	TLSCAKey                   string   `yaml:"tlsca_key"                      help:"The path to the CA key for generating any missing certificates. Relative paths are interpreted as relative to the config path."`
 	ClientTLSCert              string   `yaml:"tlscert"                        help:"The path to the client cert for verification. Relative paths are interpreted as relative to the config path."`
@@ -137,6 +141,7 @@ func ParseYAML(yamlData []byte, installationName string) (Config, error) {
 			BuildkitCacheSizeMb:     0,
 			BuildkitCacheSizePct:    0,
 			LocalRegistryHost:       fmt.Sprintf("tcp://127.0.0.1:%d", defaultLocalRegistryPort),
+			DarwinProxyImageTag:     DefaultDarwinProxyImageTag,
 			BuildkitScheme:          DefaultBuildkitScheme,
 			BuildkitRestartTimeoutS: 60,
 			ConversionParallelism:   DefaultConversionParallelism,

--- a/go.mod
+++ b/go.mod
@@ -141,6 +141,6 @@ replace (
 	github.com/jdxcode/netrc => github.com/mikejholly/netrc v0.0.0-20221121193719-a154cb29ec2a
 	github.com/jessevdk/go-flags => github.com/alexcb/go-flags v0.0.0-20210722203016-f11d7ecb5ee5
 
-	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.0-20231019213109-0b107b045b57
+	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.0-20231023204736-50a633c1a3d4
 	github.com/tonistiigi/fsutil => github.com/earthly/fsutil v0.0.0-20230530182746-82567e6e2a92
 )

--- a/go.mod
+++ b/go.mod
@@ -141,6 +141,6 @@ replace (
 	github.com/jdxcode/netrc => github.com/mikejholly/netrc v0.0.0-20221121193719-a154cb29ec2a
 	github.com/jessevdk/go-flags => github.com/alexcb/go-flags v0.0.0-20210722203016-f11d7ecb5ee5
 
-	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.0-20231023204736-50a633c1a3d4
+	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.0-20231025204852-d5e9d257c398
 	github.com/tonistiigi/fsutil => github.com/earthly/fsutil v0.0.0-20230530182746-82567e6e2a92
 )

--- a/go.sum
+++ b/go.sum
@@ -181,8 +181,8 @@ github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
-github.com/earthly/buildkit v0.0.0-20231019213109-0b107b045b57 h1:4yzg1k6cuPyuMSUF/Erl52Nf1j4MPdvhwsCbo5ITG7A=
-github.com/earthly/buildkit v0.0.0-20231019213109-0b107b045b57/go.mod h1:AJ3nMleWpsh6L06n2sFkT70+zGjnD9+rtsdmyw5YHLU=
+github.com/earthly/buildkit v0.0.0-20231023204736-50a633c1a3d4 h1:apMNJAYqAFT/x6Hz2k3umxDF6Hic2PMsYtspqSqkVAM=
+github.com/earthly/buildkit v0.0.0-20231023204736-50a633c1a3d4/go.mod h1:AJ3nMleWpsh6L06n2sFkT70+zGjnD9+rtsdmyw5YHLU=
 github.com/earthly/cloud-api v1.0.1-0.20230914190823-c58662fdabd8 h1:8EW/AMPNtzOcExSV7Dk1weQGK/XqbAuhvLs062xlBH4=
 github.com/earthly/cloud-api v1.0.1-0.20230914190823-c58662fdabd8/go.mod h1:rU/tYJ7GFBjdKAITV2heDbez++glpGSbtJaZcp73rNI=
 github.com/earthly/fsutil v0.0.0-20230530182746-82567e6e2a92 h1:dy3w3B4OiDyQS+iHi/beUgMDJ1+fAAgbtr7OZ0d9ks0=

--- a/go.sum
+++ b/go.sum
@@ -181,8 +181,8 @@ github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
-github.com/earthly/buildkit v0.0.0-20231023204736-50a633c1a3d4 h1:apMNJAYqAFT/x6Hz2k3umxDF6Hic2PMsYtspqSqkVAM=
-github.com/earthly/buildkit v0.0.0-20231023204736-50a633c1a3d4/go.mod h1:AJ3nMleWpsh6L06n2sFkT70+zGjnD9+rtsdmyw5YHLU=
+github.com/earthly/buildkit v0.0.0-20231025204852-d5e9d257c398 h1:Zco4CmxV7h1lds9enPRx7mebto0I8zj9EgucRCV1OxE=
+github.com/earthly/buildkit v0.0.0-20231025204852-d5e9d257c398/go.mod h1:AJ3nMleWpsh6L06n2sFkT70+zGjnD9+rtsdmyw5YHLU=
 github.com/earthly/cloud-api v1.0.1-0.20230914190823-c58662fdabd8 h1:8EW/AMPNtzOcExSV7Dk1weQGK/XqbAuhvLs062xlBH4=
 github.com/earthly/cloud-api v1.0.1-0.20230914190823-c58662fdabd8/go.mod h1:rU/tYJ7GFBjdKAITV2heDbez++glpGSbtJaZcp73rNI=
 github.com/earthly/fsutil v0.0.0-20230530182746-82567e6e2a92 h1:dy3w3B4OiDyQS+iHi/beUgMDJ1+fAAgbtr7OZ0d9ks0=

--- a/regproxy/controller.go
+++ b/regproxy/controller.go
@@ -133,7 +133,7 @@ func (c *Controller) startDarwinProxy(ctx context.Context, containerName string,
 
 	runCfg := containerutil.ContainerRun{
 		NameOrID: containerName,
-		ImageRef: fmt.Sprintf("alpine/socat:%s", c.darwinProxyImage),
+		ImageRef: c.darwinProxyImage,
 		Ports: []containerutil.Port{
 			{
 				IP:            "127.0.0.1",

--- a/regproxy/controller.go
+++ b/regproxy/controller.go
@@ -23,12 +23,12 @@ const (
 // Controller handles the management of the registry proxy. This may also
 // include the Darwin proxy used to enable Docker Desktop setups.
 type Controller struct {
-	registryClient      registry.RegistryClient
-	containerFrontend   containerutil.ContainerFrontend
-	darwinProxy         bool
-	darwinProxyImageTag string
-	darwinProxyWait     time.Duration
-	cons                conslog.ConsoleLogger
+	registryClient    registry.RegistryClient
+	containerFrontend containerutil.ContainerFrontend
+	darwinProxy       bool
+	darwinProxyImage  string
+	darwinProxyWait   time.Duration
+	cons              conslog.ConsoleLogger
 }
 
 // NewController creates and returns a new registry proxy controller.
@@ -36,16 +36,16 @@ func NewController(
 	registryClient registry.RegistryClient,
 	containerFrontend containerutil.ContainerFrontend,
 	darwinProxy bool,
-	darwinProxyImageTag string,
+	darwinProxyImage string,
 	darwinProxyWait time.Duration,
 	cons conslog.ConsoleLogger,
 ) *Controller {
 	return &Controller{
-		registryClient:      registryClient,
-		containerFrontend:   containerFrontend,
-		darwinProxy:         darwinProxy,
-		darwinProxyImageTag: darwinProxyImageTag,
-		cons:                cons,
+		registryClient:    registryClient,
+		containerFrontend: containerFrontend,
+		darwinProxy:       darwinProxy,
+		darwinProxyImage:  darwinProxyImage,
+		cons:              cons,
 	}
 }
 
@@ -133,7 +133,7 @@ func (c *Controller) startDarwinProxy(ctx context.Context, containerName string,
 
 	runCfg := containerutil.ContainerRun{
 		NameOrID: containerName,
-		ImageRef: fmt.Sprintf("alpine/socat:%s", c.darwinProxyImageTag),
+		ImageRef: fmt.Sprintf("alpine/socat:%s", c.darwinProxyImage),
 		Ports: []containerutil.Port{
 			{
 				IP:            "127.0.0.1",

--- a/regproxy/controller.go
+++ b/regproxy/controller.go
@@ -184,7 +184,7 @@ func (c *Controller) stopOldDarwinProxies(ctx context.Context) error {
 	}
 	for _, container := range containers {
 		if strings.HasPrefix(container.Name, darwinContainerPrefix) &&
-			time.Now().Sub(container.Created) > darwinContainerMaxAge {
+			time.Since(container.Created) > darwinContainerMaxAge {
 			err = c.stopDarwinProxy(ctx, container.Name, false)
 			if err != nil {
 				return err
@@ -194,9 +194,9 @@ func (c *Controller) stopOldDarwinProxies(ctx context.Context) error {
 	return nil
 }
 
-func (c *Controller) stopDarwinProxy(ctx context.Context, containerName string, checkExists bool) error {
+func (c *Controller) stopDarwinProxy(_ context.Context, containerName string, checkExists bool) error {
 	// Ignore parent context cancellations as to prevent orphaned containers.
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 	if checkExists {
 		infos, err := c.containerFrontend.ContainerInfo(ctx, containerName)

--- a/regproxy/controller.go
+++ b/regproxy/controller.go
@@ -72,7 +72,7 @@ func (c *Controller) Start(ctx context.Context) (string, func(), error) {
 	go func() {
 		for err := range p.err() {
 			if err != nil && !errors.Is(err, context.Canceled) {
-				c.cons.Warnf("Failed to serve registry proxy: %v", err)
+				c.cons.VerbosePrintf("Failed to serve registry proxy: %v", err)
 			}
 		}
 		doneCh <- struct{}{}
@@ -93,7 +93,7 @@ func (c *Controller) Start(ctx context.Context) (string, func(), error) {
 		stopFn := func(ctx context.Context) {
 			err := c.stopDarwinProxy(ctx, containerName, true)
 			if err != nil {
-				c.cons.Warnf("Failed to stop registry proxy support container: %v", err)
+				c.cons.VerbosePrintf("Failed to stop registry proxy support container: %v", err)
 			}
 		}
 		port, err := c.startDarwinProxy(ctx, containerName, registryPort)
@@ -122,7 +122,7 @@ func (c *Controller) startDarwinProxy(ctx context.Context, containerName string,
 	go func() {
 		err := c.stopOldDarwinProxies(ctx)
 		if err != nil {
-			c.cons.Warnf("Failed to stop old Darwin proxy support container: %s", err)
+			c.cons.VerbosePrintf("Failed to stop old Darwin proxy support container: %s", err)
 		}
 	}()
 

--- a/regproxy/proxy.go
+++ b/regproxy/proxy.go
@@ -6,14 +6,11 @@ import (
 	"net"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	registry "github.com/moby/buildkit/api/services/registry"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 )
-
-const readDeadline = 50 * time.Millisecond
 
 // newRegistryProxy creates and returns a new registry proxy that streams Docker
 // container image data from the BK embedded Docker registry.

--- a/util/containerutil/frontend.go
+++ b/util/containerutil/frontend.go
@@ -19,6 +19,7 @@ type ContainerFrontend interface {
 	Config() *CurrentFrontend
 	Information(ctx context.Context) (*FrontendInfo, error)
 
+	ContainerList(ctx context.Context) ([]*ContainerInfo, error)
 	ContainerInfo(ctx context.Context, namesOrIDs ...string) (map[string]*ContainerInfo, error)
 	ContainerRemove(ctx context.Context, force bool, namesOrIDs ...string) error
 	ContainerStop(ctx context.Context, timeoutSec uint, namesOrIDs ...string) error

--- a/util/containerutil/shell_shared.go
+++ b/util/containerutil/shell_shared.go
@@ -73,7 +73,6 @@ func (sf *shellFrontend) ContainerInfo(ctx context.Context, namesOrIDs ...string
 		}
 	}
 
-	// Anonymous struct to just pick out what we need
 	containers := []containerInfo{}
 	err := json.Unmarshal([]byte(output.stdout.String()), &containers)
 	if err != nil {

--- a/util/containerutil/shell_shared.go
+++ b/util/containerutil/shell_shared.go
@@ -77,7 +77,7 @@ func (sf *shellFrontend) ContainerList(ctx context.Context) ([]*ContainerInfo, e
 			return nil, errors.Wrap(err, "failed to parse command output")
 		}
 		if len(record) != 7 {
-			return nil, errors.Errorf("expected 7 fields, got %d", len(record))
+			return nil, errors.Errorf("unexpected format: %+v", record)
 		}
 		dur, err := parseDuration(record[3])
 		if err != nil {

--- a/util/containerutil/shell_shared.go
+++ b/util/containerutil/shell_shared.go
@@ -60,7 +60,7 @@ func (sf *shellFrontend) IsAvailable(ctx context.Context) bool {
 	return err == nil
 }
 
-var listRE = regexp.MustCompile("\\s{2,}")
+var listRE = regexp.MustCompile(`\s{2,}`)
 
 func (sf *shellFrontend) ContainerList(ctx context.Context) ([]*ContainerInfo, error) {
 	output, err := sf.commandContextOutput(ctx, "ps")

--- a/util/containerutil/stub.go
+++ b/util/containerutil/stub.go
@@ -46,6 +46,9 @@ func (sf *stubFrontend) Config() *CurrentFrontend {
 func (*stubFrontend) Information(ctx context.Context) (*FrontendInfo, error) {
 	return &FrontendInfo{}, nil
 }
+func (*stubFrontend) ContainerList(ctx context.Context) ([]*ContainerInfo, error) {
+	return nil, ErrFrontendNotInitialized
+}
 func (*stubFrontend) ContainerInfo(ctx context.Context, namesOrIDs ...string) (map[string]*ContainerInfo, error) {
 	return nil, ErrFrontendNotInitialized
 }

--- a/util/containerutil/types.go
+++ b/util/containerutil/types.go
@@ -2,6 +2,7 @@ package containerutil
 
 import (
 	"net/url"
+	"time"
 
 	"github.com/pkg/errors"
 )
@@ -10,6 +11,7 @@ import (
 type ContainerInfo struct {
 	ID      string
 	Name    string
+	Created time.Time
 	Status  string
 	IPs     map[string]string
 	Ports   []string

--- a/util/containerutil/types.go
+++ b/util/containerutil/types.go
@@ -12,6 +12,7 @@ type ContainerInfo struct {
 	Name    string
 	Status  string
 	IPs     map[string]string
+	Ports   []string
 	Image   string
 	ImageID string
 	Labels  map[string]string


### PR DESCRIPTION
Enables image registry proxy support for Mac via a side-car `socat` container. On Mac, `docker pull` (and friends) will make requests to `localhost`. These requests will be answered by the `socat` container and proxied through to the registry proxy server spawned by the CLI. That server then sends the request to BK (remote or local) via the gRPC tunnel. 

Depends on: https://github.com/earthly/buildkit/pull/30

https://github.com/earthly/earthly/issues/3412