### PR TITLE
Update to release process & docs

### DIFF
--- a/.github/workflows/release-merge-docs.yml
+++ b/.github/workflows/release-merge-docs.yml
@@ -29,4 +29,4 @@ jobs:
       - name: Execute merge
         # currently this is just in dry-run mode Add --push to the earthly command
         # to get it out of dry run mode
-        run: earthly --ci +merge-main-to-docs
+        run: earthly --push --ci +merge-main-to-docs

--- a/Earthfile
+++ b/Earthfile
@@ -837,12 +837,7 @@ merge-main-to-docs:
     WORKDIR earthly
     ARG git_hash=$(git rev-parse HEAD)
     RUN --mount=type=secret,id=littleredcorvette-id_rsa,mode=0400,target=/root/.ssh/id_rsa \
-        git fetch --unshallow && \
-        # dry run merge:
-        git checkout $to_branch && \
-        git merge --no-commit origin/$from_branch && \
-        git status && \
-        git merge --abort
+        git fetch --unshallow
     RUN --push --mount=type=secret,id=littleredcorvette-id_rsa,mode=0400,target=/root/.ssh/id_rsa \
         git checkout $to_branch && \
         git merge $from_branch && \

--- a/docs/ci-integration/pull-through-cache.md
+++ b/docs/ci-integration/pull-through-cache.md
@@ -18,9 +18,9 @@ A pull through cache is a registry mirror that contains no images. When your cli
 To run a cache, you'll need the ability to deploy a persistent service, somewhere. This could be a dedicated instance with Docker installed, or a container in your Kubernetes cluster.
 
 There are multiple ways to setup a registry -- Docker, for example, has a [guide for using the registry as a pull through cache](https://docs.docker.com/registry/recipes/mirror),
-as well as documentation for the [available options](https://docs.docker.com/registry/configuration/), and other details under the [registry image](https://hub.docker.com/_/registry).
+as well as documentation for the [available options](https://distribution.github.io/distribution/about/configuration/), and other details under the [registry image](https://hub.docker.com/_/registry).
 
-Documenting all the possible ways to setup a pull through cache is beyond the scope of this document; however, it does include a [quick getting-started section](#insecure-docker-hub-cache-example) for those who wish
+Documenting all the possible ways to set up a pull through cache is beyond the scope of this document; however, it does include a [quick getting-started section](#insecure-docker-hub-cache-example) for those who wish
 to run an insecure pull through cache.
 
 ### Configuration & Tips

--- a/release/README.md
+++ b/release/README.md
@@ -31,10 +31,9 @@
     cd release
     env -i HOME="$HOME" PATH="$PATH" SSH_AUTH_SOCK="$SSH_AUTH_SOCK" RELEASE_TAG="$RELEASE_TAG" USER="$USER" PRERELEASE="$PRERELEASE" ./release.sh
     ```
-  * Merge branch `main` into `docs-0.7` (via `git`):
-    ```shell
-      git checkout docs-0.7 && git pull && git merge main && git push
-    ```
+  * Make sure `main` branch is properly merged to `docs-0.7`:  
+    [![update docs](https://github.com/earthly/earthly/actions/workflows/release-merge-docs.yml/badge.svg)](https://github.com/earthly/earthly/actions/workflows/release-merge-docs.yml)
+
 * Updating the Earthly version in our docs:  
   [Renovate](https://www.mend.io/renovate/) will open a PR to update all docs as soon as a new release is available in this repo,  
   which you should then review & merge (An example PR can be found [here](https://github.com/earthly/earthly/pull/3285/files)).
@@ -50,7 +49,8 @@
     `git checkout main && git push`
   
 <!-- vale HouseStyle.Spelling = YES -->
-* After GitBook has processed the [docs-0.7](https://github.com/earthly/earthly/tree/docs-0.7), a GH action will run to check for broken links in https://docs.earthly.dev. [This](https://github.com/earthly/earthly/actions/runs/6434655743/job/17474292828) is an example of such workflow.
+* Make sure there are no broken links in https://docs.earthly.dev:  
+  [![check docs broken links](https://github.com/earthly/earthly/actions/workflows/docs-checks-links.yml/badge.svg)](https://github.com/earthly/earthly/actions/workflows/docs-checks-links.yml)
 * Verify the [Homebrew release job](https://github.com/earthly/homebrew-earthly) has successfully run and has merged the new `release-v...` branch into `main`.
 * Copy the release notes you have written before and paste them in the Earthly Community slack channel `#announcements`, together with a link to the release's GitHub page. If you have Slack markdown editing activated, you can copy the markdown version of the text.
 


### PR DESCRIPTION
* Get workflow to merge main to docs-0.7 out of dry run mode
* Update release/README to use badges of relevant workflows - the above mentioned worklow & find broken links
* Fix broken link in docs (the docker registry configuration page has moved)