### PR TITLE
fix: non-rsa public-key auth challeng signing

### DIFF
--- a/cloud/auth.go
+++ b/cloud/auth.go
@@ -15,6 +15,7 @@ import (
 	"github.com/earthly/earthly/util/cliutil"
 	"github.com/earthly/earthly/util/fileutil"
 	"github.com/pkg/errors"
+	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
 )
 
@@ -539,7 +540,11 @@ func (c *Client) getChallenge(ctx context.Context) (string, error) {
 }
 
 func (c *Client) signChallenge(challenge string, key *agent.Key) (string, string, error) {
-	sig, err := c.sshAgent.SignWithFlags(key, []byte(challenge), agent.SignatureFlagRsaSha512)
+	var sigFlags agent.SignatureFlags
+	if key.Type() == ssh.KeyAlgoRSA {
+		sigFlags = agent.SignatureFlagRsaSha512
+	}
+	sig, err := c.sshAgent.SignWithFlags(key, []byte(challenge), sigFlags)
 	if err != nil {
 		return "", "", err
 	}


### PR DESCRIPTION
Fixes a call to SignWithFlags which requested sha512 be used for all callenge signing requests; however this flag is only used by ssh-rsa keys.

Some ssh agents, like OpenSSH, will simply ignore this flag when a different key type is used; however other agents, like 1password's ssh agent, will raise an error if this flag is set.

Fixes #3366