### PR TITLE
dind docs: older versions work again

### DIFF
--- a/docs/docker-images/dind.md
+++ b/docs/docker-images/dind.md
@@ -15,7 +15,12 @@ See the ["use-earthly-dind" best-practice](https://docs.earthly.dev/best-practic
 
 ## Note
 
-The `alpine` and `ubuntu` images are incompatible with the earthly v0.7.14 onwards; newer versions of earthly should use the tags that contain an OS specific version in them.
+The outdated `ubuntu` image is incompatible with the earthly v0.7.14 (and fixed in v0.7.15).
+Correspondingly the `alpine` image at one point was also incompatible with v0.7.14, but was updated with
+a backwards-compatable fix.
+
+Users, however, are encouraged to pin to specific version tags moving forward. The unversioned tags will be left as-is
+to help backwards-breaking changes.
 
 To ease this transition, one can make use of an `IF` command that depends on the `EARTHLY_VERSION` builtin argument:
 


### PR DESCRIPTION
Fix the docs to mention that the legacy unversioned tags only broke earthly v0.7.14, and were fixed again in v0.7.15.