### PR TITLE
make it obvious when the confit test passes

### DIFF
--- a/tests/config/Earthfile
+++ b/tests/config/Earthfile
@@ -108,6 +108,9 @@ test:
     RUN ! earthly --verbose +hello > output.txt 2>&1
     RUN cat output.txt | grep 'Error: read config: failed to read from /home/testuser/.earthly/config.yml: open /home/testuser/.earthly/config.yml: permission denied'
 
+    # make it obvious that this test passed, due to the previous grep displaying "Error: ..." when it passes
+    RUN echo "config test passed"
+
 
 RUN_EARTHLY_ARGS:
     COMMAND


### PR DESCRIPTION
The final stage of the config-test is to check for an error case (via grep), this causes the last line to be output as:

    ./tests/config+test | --> RUN cat output.txt | grep 'Error: read config: failed to read from /home/testuser/.earthly/config.yml: open /home/testuser/.earthly/config.yml: permission denied'
    ./tests/config+test | Error: read config: failed to read from /home/testuser/.earthly/config.yml: open /home/testuser/.earthly/config.yml: permission denied

which is not obvious at a quick glance.

Now we will print a final "config test passed" line.