### PR TITLE
Display per-target CPU and memory stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 
 ## Unreleased
 
+### Added
+- A new experimental `earthly --exec-stats` flag, which displays per-target execution stats such as total CPU and memory usage.
+
 ### Fixed
 - Remove redundant verbose error messages that were not different from messages that were already being printed.
 

--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -12,7 +12,7 @@ buildkitd:
             ARG BUILDKIT_BASE_IMAGE=$BUILDKIT_PROJECT+build
         END
     ELSE
-        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:c7c1f7a1cff493d552a28dea36acdf1b3725e15f+build
+        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:b4cfdf184379a5398e207ef8a8e39c5f8bc0b486+build
     END
     ARG EARTHLY_TARGET_TAG_DOCKER
     ARG TAG="dev-$EARTHLY_TARGET_TAG_DOCKER"

--- a/buildkitd/runc-ps
+++ b/buildkitd/runc-ps
@@ -1,10 +1,20 @@
 #!/bin/sh
 set -e
 
+total_procs=0
 for bundle in $(ps auxw | grep 'runc.*bundle' | grep -v grep | awk '{print $11}'); do
+  id="$(basename "$bundle")"
   data="$(cat "$bundle/config.json")"
   if [ -n "$data" ]; then
     echo "=== $bundle ==="
     echo "$data" | jq .process.args
+    statsdata="$(/usr/bin/buildkit-runc events --stats "$id")"
+    memory="$(echo "$statsdata" | jq .data.memory.usage.usage)"
+    cpu="$(echo "$statsdata" | jq .data.cpu.usage.total)"
+    echo "total cpu usage: $cpu"
+    echo "total memory usage: $memory"
+    total_procs=$((total_procs + 1))
   fi
 done
+echo "=== summary ==="
+echo "runc-ps found $total_procs container(s)"

--- a/cmd/earthly/app/before.go
+++ b/cmd/earthly/app/before.go
@@ -55,7 +55,7 @@ func (app *EarthlyApp) before(cliCtx *cli.Context) error {
 		noColor := envutil.IsTrue("NO_COLOR")
 		var err error
 		newSetup, err := logbussetup.New(
-			cliCtx.Context, app.BaseCLI.Logbus(), app.BaseCLI.Flags().Debug, app.BaseCLI.Flags().Verbose, forceColor, noColor,
+			cliCtx.Context, app.BaseCLI.Logbus(), app.BaseCLI.Flags().Debug, app.BaseCLI.Flags().Verbose, app.BaseCLI.Flags().DisplayExecStats, forceColor, noColor,
 			disableOngoingUpdates, app.BaseCLI.Flags().LogstreamDebugFile, app.BaseCLI.Flags().BuildID)
 		app.BaseCLI.SetLogbusSetup(newSetup)
 		if err != nil {

--- a/cmd/earthly/flag/global.go
+++ b/cmd/earthly/flag/global.go
@@ -44,6 +44,7 @@ type Global struct {
 	SSHAuthSock                string
 	Verbose                    bool
 	Debug                      bool
+	DisplayExecStats           bool
 	CloudHTTPAddr              string
 	CloudGRPCAddr              string
 	CloudGRPCInsecure          bool
@@ -174,6 +175,13 @@ func (global *Global) RootFlags(installName string, bkImage string) []cli.Flag {
 			Usage:       "Enable debug mode. This flag also turns on the debug mode of buildkitd, which may cause it to restart",
 			Destination: &global.Debug,
 			Hidden:      true, // For development purposes only.
+		},
+		&cli.BoolFlag{
+			Name:        "exec-stats",
+			EnvVars:     []string{"EARTHLY_EXEC_STATS"},
+			Usage:       "Display container stats (e.g. cpu and memory usage)",
+			Destination: &global.DisplayExecStats,
+			Hidden:      true, // Experimental
 		},
 		&cli.BoolFlag{
 			Name:        "profiler",

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -1907,7 +1907,6 @@ func (c *Converter) internalRun(ctx context.Context, opts ConvertRunOpts) (pllb.
 	if err != nil {
 		return pllb.State{}, errors.Wrap(err, "parse mounts")
 	}
-
 	if opts.NoNetwork {
 		runOpts = append(runOpts, llb.Network(llb.NetModeNone))
 	}

--- a/earthfile2llb/earthfile2llb.go
+++ b/earthfile2llb/earthfile2llb.go
@@ -177,6 +177,7 @@ type ConvertOpt struct {
 	// * "sat:<org-name>/<sat-name>" - remote builds via satellite
 	Runner string
 
+	// ProjectAdder is a callback that is used to discover PROJECT <org>/<project> values
 	ProjectAdder ProjectAdder
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,14 +1,18 @@
 module github.com/earthly/earthly
 
-go 1.21
+go 1.21.0
+
+toolchain go1.21.4
 
 require (
 	git.sr.ht/~nelsam/hel v0.4.6
 	github.com/adrg/xdg v0.4.0
 	github.com/alessio/shellescape v1.4.1
+	github.com/alexcb/binarystream v0.0.0-20231107003751-3af02e542c26
 	github.com/aws/aws-sdk-go-v2 v1.17.6
 	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20230227212328-9f4511cd144a
 	github.com/containerd/containerd v1.7.7
+	github.com/containerd/go-runc v1.1.0
 	github.com/creack/pty v1.1.18
 	github.com/docker/cli v24.0.5+incompatible
 	github.com/docker/distribution v2.8.2+incompatible
@@ -108,6 +112,7 @@ require (
 	github.com/moby/sys/signal v0.7.0 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/opencontainers/runc v1.1.9 // indirect
+	github.com/opencontainers/runtime-spec v1.1.0-rc.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/procfs v0.9.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
@@ -142,6 +147,6 @@ replace (
 	github.com/jdxcode/netrc => github.com/mikejholly/netrc v0.0.0-20221121193719-a154cb29ec2a
 	github.com/jessevdk/go-flags => github.com/alexcb/go-flags v0.0.0-20210722203016-f11d7ecb5ee5
 
-	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.0-20231031185549-c7c1f7a1cff4
+	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.0-20231114180628-b4cfdf184379
 	github.com/tonistiigi/fsutil => github.com/earthly/fsutil v0.0.0-20231030221755-644b08355b65
 )

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,8 @@ github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7l
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=
 github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
+github.com/alexcb/binarystream v0.0.0-20231107003751-3af02e542c26 h1:yMErBTaBm/Aw59TfUuGlu7OiFGOwXg8g9jWKaj7oXQs=
+github.com/alexcb/binarystream v0.0.0-20231107003751-3af02e542c26/go.mod h1:zKsqqCtJopbsBYivUZGuK3Tc6fFxvNUrjUJzGtxksq4=
 github.com/alexcb/go-flags v0.0.0-20210722203016-f11d7ecb5ee5 h1:im0niQRZXdxO8F1rw4zwb5rJmOJ9XnNtlnMFyfLenYE=
 github.com/alexcb/go-flags v0.0.0-20210722203016-f11d7ecb5ee5/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
 github.com/anchore/go-struct-converter v0.0.0-20221118182256-c68fdcfa2092 h1:aM1rlcoLz8y5B2r4tTLMiVTrMtpfY0O8EScKJxaSaEc=
@@ -142,6 +144,8 @@ github.com/containerd/continuity v0.4.2 h1:v3y/4Yz5jwnvqPKJJ+7Wf93fyWoCB3F5EclWG
 github.com/containerd/continuity v0.4.2/go.mod h1:F6PTNCKepoxEaXLQp3wDAjygEnImnZ/7o4JzpodfroQ=
 github.com/containerd/fifo v1.1.0 h1:4I2mbh5stb1u6ycIABlBw9zgtlK8viPI9QkQNRQEEmY=
 github.com/containerd/fifo v1.1.0/go.mod h1:bmC4NWMbXlt2EZ0Hc7Fx7QzTFxgPID13eH0Qu+MAb2o=
+github.com/containerd/go-runc v1.1.0 h1:OX4f+/i2y5sUT7LhmcJH7GYrjjhHa1QI4e8yO0gGleA=
+github.com/containerd/go-runc v1.1.0/go.mod h1:xJv2hFF7GvHtTJd9JqTS2UVxMkULUYw4JN5XAUZqH5U=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
 github.com/containerd/nydus-snapshotter v0.8.2 h1:7SOrMU2YmLzfbsr5J7liMZJlNi5WT6vtIOxLGv+iz7E=
@@ -181,8 +185,8 @@ github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
-github.com/earthly/buildkit v0.0.0-20231031185549-c7c1f7a1cff4 h1:jWMKId/dXhFACepfzhgv+mBihP85CUMAjFt0IfI+gy8=
-github.com/earthly/buildkit v0.0.0-20231031185549-c7c1f7a1cff4/go.mod h1:GxrJYu39+sws431wtuvv3k2acwMGdSIXCSeGjJKZ97c=
+github.com/earthly/buildkit v0.0.0-20231114180628-b4cfdf184379 h1:tTDfPRq8D5TgKa/Fev0Kizs+0uBKv+DBE/S4BO5Hap8=
+github.com/earthly/buildkit v0.0.0-20231114180628-b4cfdf184379/go.mod h1:9YV/0upRPk36WbLrmr2bf2MZ0M27fvjxiBr5VD/ia80=
 github.com/earthly/cloud-api v1.0.1-0.20231104021724-b38162a550cb h1:a5u2YnTVZGScHBHo3qugai43RTXRYnt1x33lsKTOy2I=
 github.com/earthly/cloud-api v1.0.1-0.20231104021724-b38162a550cb/go.mod h1:rU/tYJ7GFBjdKAITV2heDbez++glpGSbtJaZcp73rNI=
 github.com/earthly/fsutil v0.0.0-20231030221755-644b08355b65 h1:6oyWHoxHXwcTt4EqmMw6361scIV87uEAB1N42+VpIwk=

--- a/logbus/command.go
+++ b/logbus/command.go
@@ -10,7 +10,12 @@ import (
 	"github.com/pkg/errors"
 )
 
-const tailErrorBufferSizeBytes = 80 * 1024 // About as much as 1024 lines of 80 chars each.
+const (
+	stdout = 1
+	stderr = 2
+
+	tailErrorBufferSizeBytes = 80 * 1024 // About as much as 1024 lines of 80 chars each.
+)
 
 // Command is a build log writer for a command.
 type Command struct {
@@ -40,8 +45,11 @@ func newCommand(b *Bus, commandID string, targetID string) *Command {
 
 // Write prints a byte slice with a timestamp.
 func (c *Command) Write(dt []byte, ts time.Time, stream int32) (int, error) {
+	var err error
 	c.mu.Lock()
-	_, err := c.tailOutput.Write(dt)
+	if stream == stdout || stream == stderr {
+		_, err = c.tailOutput.Write(dt)
+	}
 	c.mu.Unlock()
 	if err != nil {
 		return 0, errors.Wrap(err, "write to tail output")

--- a/logbus/setup/setup.go
+++ b/logbus/setup/setup.go
@@ -34,7 +34,7 @@ type BusSetup struct {
 }
 
 // New creates a new BusSetup.
-func New(ctx context.Context, bus *logbus.Bus, debug, verbose, forceColor, noColor, disableOngoingUpdates bool, busDebugFile string, buildID string) (*BusSetup, error) {
+func New(ctx context.Context, bus *logbus.Bus, debug, verbose, displayStats, forceColor, noColor, disableOngoingUpdates bool, busDebugFile string, buildID string) (*BusSetup, error) {
 	bs := &BusSetup{
 		Bus:           bus,
 		ConsoleWriter: writersub.New(os.Stderr, "_full"),
@@ -47,7 +47,7 @@ func New(ctx context.Context, bus *logbus.Bus, debug, verbose, forceColor, noCol
 		},
 		verbose: verbose,
 	}
-	bs.Formatter = formatter.New(ctx, bs.Bus, debug, verbose, forceColor, noColor, disableOngoingUpdates)
+	bs.Formatter = formatter.New(ctx, bs.Bus, debug, verbose, displayStats, forceColor, noColor, disableOngoingUpdates)
 	bs.Bus.AddRawSubscriber(bs.Formatter)
 	bs.Bus.AddFormattedSubscriber(bs.ConsoleWriter)
 	bs.SolverMonitor = solvermon.New(bs.Bus)

--- a/logbus/solvermon/solvermon.go
+++ b/logbus/solvermon/solvermon.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/earthly/cloud-api/logstream"
 	"github.com/earthly/earthly/logbus"
+	"github.com/earthly/earthly/util/statsstreamparser"
 	"github.com/earthly/earthly/util/stringutil"
 	"github.com/earthly/earthly/util/vertexmeta"
 	"github.com/earthly/earthly/util/xcontext"
@@ -102,6 +103,7 @@ func (sm *SolverMonitor) handleBuildkitStatus(ctx context.Context, status *clien
 				meta:      meta,
 				operation: operation,
 				cp:        cp,
+				ssp:       statsstreamparser.New(),
 			}
 			sm.vertices[cmdID] = vm
 			sm.digests[vertex.Digest] = cmdID

--- a/scripts/tests/interactive-debugger/test-interactive.py
+++ b/scripts/tests/interactive-debugger/test-interactive.py
@@ -39,6 +39,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('-e', '--earthly', help="earthly binary to run test against", default='earthly')
     parser.add_argument('-t', '--timeout', help="fail test if it takes longer than this many seconds", type=float, default=30.0)
+    parser.add_argument('--test', help="run specified test instead of all tests")
     args = parser.parse_args()
 
     earthly_path = os.path.realpath(get_earthly_binary(args.earthly))
@@ -55,6 +56,8 @@ if __name__ == '__main__':
     exit_code = 0
     summary_msgs = []
     for test_name, test in tests:
+        if args.test and test_name != args.test:
+            continue
         print_box(f'Running {test_name}')
         test_exit_code = test(earthly_path, args.timeout)
         if test_exit_code == 2:

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -125,6 +125,7 @@ ga-no-qemu-group2:
     BUILD +test-cache-mode
     BUILD +test-shared-cache
     BUILD +test-visited-upfront-hash-collection
+    BUILD +test-exec-stats
 
     # Forcing the implicit global wait/end block, causes some tests, which rely
     # on the ability to have two different targets issue the same SAVE IMAGE tag name
@@ -1457,6 +1458,13 @@ test-visited-upfront-hash-collection:
       else \
          echo "parallelization checked"; \
       fi
+
+test-exec-stats:
+  DO +RUN_EARTHLY \
+      --earthfile=stats.earth \
+      --target=+sleep \
+      --extra_args=" --exec-stats " \
+      --output_contains="total CPU:.*total memory:.*"
 
 RUN_EARTHLY:
     COMMAND

--- a/tests/stats.earth
+++ b/tests/stats.earth
@@ -1,0 +1,4 @@
+VERSION 0.7
+sleep:
+  FROM alpine
+  RUN sleep 3

--- a/util/statsstreamparser/parser.go
+++ b/util/statsstreamparser/parser.go
@@ -1,0 +1,63 @@
+package statsstreamparser
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+
+	"github.com/alexcb/binarystream"
+	"github.com/containerd/go-runc"
+)
+
+type Parser struct {
+	buf                 *bytes.Buffer
+	bsr                 *binarystream.BinaryStream
+	readProtocolVersion bool
+}
+
+func New() *Parser {
+	buf := bytes.NewBuffer(nil)
+	return &Parser{
+		buf: buf,
+		bsr: binarystream.NewReader(buf, binary.LittleEndian),
+	}
+}
+
+func (ssp *Parser) Parse(b []byte) ([]*runc.Stats, error) {
+	_, err := ssp.buf.Write(b)
+	if err != nil {
+		return nil, err
+	}
+	var stats []*runc.Stats
+	for {
+		if !ssp.readProtocolVersion {
+			protocolVersion, err := ssp.bsr.ReadUint8()
+			if err != nil {
+				if err == binarystream.ErrBufferUnderflow {
+					break
+				}
+				return nil, err
+			}
+			if protocolVersion != 1 {
+				return nil, fmt.Errorf("unexpected stats stream protocol version %d", protocolVersion)
+			}
+			ssp.readProtocolVersion = true
+		}
+		statsStreamJSON, err := ssp.bsr.ReadUint32PrefixedString()
+		if err != nil {
+			if err == binarystream.ErrBufferUnderflow {
+				break
+			}
+			return nil, err
+		}
+		var runcStat runc.Stats
+		err = json.Unmarshal([]byte(statsStreamJSON), &runcStat)
+		if err != nil {
+			return nil, err
+		}
+		stats = append(stats, &runcStat)
+		ssp.readProtocolVersion = false
+	}
+	return stats, nil
+}


### PR DESCRIPTION
Introduces a new `--exec--stats` flag that displays cpu and memory usage per
target.