### PR TITLE
Make it clearer to the docs readers how to install Earthly

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -2,7 +2,7 @@
 # Table of contents
 
 * [👋 Introduction](README.md)
-* [💻 Get started for free](https://cloud.earthly.dev/login)
+* [💻 Install Earthly](install/install.md)
 * [🎓 Learn the basics](basics/basics.md)
     * [Part 1: A simple Earthfile](basics/part-1-a-simple-earthfile.md)
     * [Part 2: Outputs](basics/part-2-outputs.md)

--- a/docs/alt-installation/alt-installation.md
+++ b/docs/alt-installation/alt-installation.md
@@ -1,6 +1,6 @@
 # Alternative Installation
 
-This page outlines alternative installation instructions for the `earthly` build tool. The main instructions that most users need are available on the [installation instructions page](https://earthly.dev/get-earthly).
+This page outlines alternative installation instructions for the `earthly` build tool. The main instructions that most users need are available in [Earthly Cloud](https://cloud.earthly.dev/login), or on the [installation instructions page](https://earthly.dev/get-earthly).
 
 ## Prerequisites
 

--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -1,0 +1,15 @@
+# Install
+
+## Log In and Install
+
+To install the Earthly CLI on your machine, [head over to Earthly Cloud and get started for free](https://cloud.earthly.dev/login).
+
+The logged-in experience gives you access to the following additional features:
+
+* Logs sharing
+* [Earthly Cloud Secrets](../cloud/cloud-secrets.md)
+* [Earthly Satellites](../cloud/satellites.md) (6,000 minutes/month free)
+
+## Install without Logging In
+
+If you prefer to install Earthly without logging in, head over to the [Get Earthly page](https://earthly.dev/get-earthly).


### PR DESCRIPTION
A new user reported that it wasn't clear how to install Earthly after going through the docs. They ended up Googling for a Docker image and used that instead, which was less than ideal.

Our docs TOC did not have a link to install Earthly. Added that now.