### PR TITLE
Support FOR..IN variable expansion

### DIFF
--- a/ast/commandflag/flags.go
+++ b/ast/commandflag/flags.go
@@ -141,3 +141,10 @@ type CacheOpts struct {
 	Mode    string `long:"chmod" description:"Apply a mode to the cache folder" default:"0644"`
 	ID      string `long:"id" description:"Cache ID, to reuse the same cache across different targets and Earthfiles"`
 }
+
+// NewForOpts creates and returns a ForOpts with default separators.
+func NewForOpts() ForOpts {
+	return ForOpts{
+		Separators: "\n\t ",
+	}
+}

--- a/earthfile2llb/interpreter.go
+++ b/earthfile2llb/interpreter.go
@@ -417,9 +417,7 @@ func (i *Interpreter) handleFor(ctx context.Context, forStmt spec.ForStatement) 
 }
 
 func (i *Interpreter) handleForArgs(ctx context.Context, forArgs []string, sl *spec.SourceLocation) (string, []string, error) {
-	opts := commandflag.ForOpts{
-		Separators: "\n\t ",
-	}
+	opts := commandflag.NewForOpts()
 	args, err := flagutil.ParseArgsCleaned("FOR", &opts, forArgs)
 	if err != nil {
 		return "", nil, i.wrapError(err, sl, "invalid FOR arguments %v", forArgs)

--- a/inputgraph/loader.go
+++ b/inputgraph/loader.go
@@ -365,9 +365,7 @@ func (l *loader) handleIf(ctx context.Context, ifStmt spec.IfStatement) error {
 func (l *loader) handleFor(ctx context.Context, forStmt spec.ForStatement) error {
 	l.hashForStatement(forStmt)
 
-	opts := commandflag.ForOpts{
-		Separators: "\n\t ",
-	}
+	opts := commandflag.NewForOpts()
 
 	args, err := flagutil.ParseArgsCleaned("FOR", &opts, forStmt.Args)
 	if err != nil {

--- a/tests/autoskip/Earthfile
+++ b/tests/autoskip/Earthfile
@@ -63,6 +63,14 @@ test-for-in:
     DO --pass-args +RUN_EARTHLY_ARGS --earthfile=for.earth --target=+test --output_contains="hello 3"
     DO --pass-args +RUN_EARTHLY_ARGS --earthfile=for.earth --target=+test --output_contains="target .* has already been run; exiting"
 
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=for.earth --target=+test-vars --output_contains="hello foo"
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=for.earth --target=+test-vars --output_contains="target .* has already been run; exiting"
+
+    RUN sed -i s/baz/boo/g Earthfile
+
+    DO --pass-args +RUN_EARTHLY_ARGS --target=+test-vars --output_contains="hello foo"
+    DO --pass-args +RUN_EARTHLY_ARGS --target=+test-vars --output_contains="target .* has already been run; exiting"
+
 test-copy-glob:
     DO --pass-args +RUN_EARTHLY_ARGS --earthfile=copy-glob.earth --should_fail=true --target=+globstar --output_contains="globstar (\*\*) not supported"
 

--- a/tests/autoskip/for.earth
+++ b/tests/autoskip/for.earth
@@ -8,3 +8,13 @@ test:
     FOR idx IN "1 2 3"
         RUN echo "hello $idx"
     END
+
+test-vars:
+    ARG vals = \
+        foo \
+        bar \
+        baz \
+        bim
+    FOR idx IN $vals
+        RUN echo "hello $idx"
+    END


### PR DESCRIPTION
This PR adds support for `FOR...IN` variable expansion (example below). Shell-out is not yet supported.  

```
test-vars:
    ARG vals = \
        foo \
        bar \
        baz \
        bim
    FOR idx IN $vals
        RUN echo "hello $idx"
    END
```