### PR TITLE
make error message for  `RUN` under  `LOCALLY` the same as `RUN` without `LOCALLY`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 
 ### Changed
 - Final error messages for executions without a known target will be displayed without `_unknown *failed* |` prefix. and instead use `Error: ` as prefix more consistently.
+- Failing `RUN` commands under `LOCALLY` will display the same format of error message for `RUN` without `LOCALLY` [#3356](https://github.com/earthly/earthly/issues/3356). 
 - Use dedicated logstream failure category for param related error.
 - An authentication attempt with an expired auth token will result in a `auth token expired` error instead of `unauthorized`.
 - A successful authentication with an auth token will display a warning with time left before token expires if it's 14 days or under.

--- a/logbus/formatter/formatter.go
+++ b/logbus/formatter/formatter.go
@@ -409,7 +409,9 @@ func (f *Formatter) printBuildFailure() {
 	}
 	c, _ := f.targetConsole(failure.GetTargetId(), failure.GetCommandId())
 	c = c.WithFailed(true)
+	msgPrefix := "Error: " // print this prefix only when the command id is set
 	if failure.GetCommandId() != "" && failure.GetCommandId() != logbus.GenericDefault {
+		msgPrefix = ""
 		c.PrintFailure("")
 		c.Printf("Repeating the failure error...\n")
 		f.printHeader(failure.GetTargetId(), failure.GetCommandId(), tm, cm, true)
@@ -419,7 +421,7 @@ func (f *Formatter) printBuildFailure() {
 			c.Printf("[no output]\n")
 		}
 	}
-	c.Printf("Error: %s\n", failure.GetErrorMessage())
+	c.Printf("%s%s\n", msgPrefix, failure.GetErrorMessage())
 	f.lastOutputWasOngoingUpdate = false
 	f.lastOutputWasProgress = false
 	f.lastCommandOutput = nil


### PR DESCRIPTION
Closed #3356 

Also fixing cases where `Error:` prefix is added to the message even though the message already starts with `ERROR` or `WARN`.

Earthfile:
```Earthfile
local:
    LOCALLY
    RUN false
```

Before:
```
/U/i/Documents+local | darwin/arm64
/U/i/Documents+local | --> RUN false
/U/i/Documents+local | WARN /Users/idodavid/Documents/Earthfile line 9:4: The command 'RUN false' failed: error calling LocalhostExec: exit code: 1
View logs at https://cloud.earthly.dev/builds/5ba6eca1-111e-4597-9c90-b7aeaba78488
Error: /Users/idodavid/Documents/Earthfile line 9:4 apply RUN: unlazy force execution: error calling LocalhostExec: exit code: 1
in              /Users/idodavid/Documents+local
```

After:
```
/U/i/Documents+local *failed* | Repeating the failure error...
/U/i/Documents+local *failed* | darwin/arm64
/U/i/Documents+local *failed* | --> RUN false
/U/i/Documents+local *failed* | [no output]
/U/i/Documents+local *failed* | ERROR /Users/idodavid/Documents/Earthfile line 9:4
/U/i/Documents+local *failed* |       The command
/U/i/Documents+local *failed* |           RUN false
/U/i/Documents+local *failed* |       did not complete successfully. Exit code 1
View logs at https://cloud.earthly.dev/builds/56dbdb73-f301-4295-89a6-022537b4c07a
```