### PR TITLE
Cache key is not intuitive

### DIFF
--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -1511,10 +1511,7 @@ func (c *Converter) Cache(ctx context.Context, mountTarget string, opts commandf
 		return err
 	}
 	c.nonSaveCommand()
-	key, err := cacheKeyTargetInput(c.targetInputActiveOnly())
-	if err != nil {
-		return err
-	}
+	key := cacheKey(c.target)
 	cacheID := path.Join("/run/cache", key, path.Clean(mountTarget))
 	if c.ftrs.GlobalCache && opts.ID != "" {
 		cacheID = opts.ID
@@ -2492,14 +2489,6 @@ func (c *Converter) checkAllowed(command cmdType) error {
 	}
 
 	return nil
-}
-
-func (c *Converter) targetInputActiveOnly() dedup.TargetInput {
-	activeBuildArgs := make(map[string]bool)
-	for _, k := range c.varCollection.SortedVariables(variables.WithActive()) {
-		activeBuildArgs[k] = true
-	}
-	return c.mts.Final.TargetInput().WithFilterBuildArgs(activeBuildArgs)
 }
 
 // persistCache makes temporary cache directories permanent by writing their contents

--- a/earthfile2llb/runmount.go
+++ b/earthfile2llb/runmount.go
@@ -1,6 +1,8 @@
 package earthfile2llb
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"os"
 	"path"
 	"strconv"
@@ -207,6 +209,7 @@ func ParseMode(s string) (int, error) {
 // cacheKey returns a key that can be used to uniquely identify the target.
 // Cache mounts use this key to ensure that the cache is unique to the target.
 func cacheKey(target domain.Target) string {
-	target.Tag = ""
-	return target.StringCanonical()
+	target.Tag = "" // Strip away tag info (e.g. git sha)
+	digest := sha256.Sum256([]byte(target.StringCanonical()))
+	return hex.EncodeToString(digest[:])
 }


### PR DESCRIPTION
We've been getting a ton of feedback lately that cache mounts are difficult to work with. A source of confusion is that the cache key by default is a digest of target + args. Everyone expects this to be just target.

This PR fixes the issue.