### PR TITLE
Move logstream link to be printed after build errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 
 ### Changed
 - Final error messages for executions without a known target will be displayed without `_unknown *failed* |` prefix. and instead use `Error: ` as prefix more consistently.
-- Failing `RUN` commands under `LOCALLY` will display the same format of error message for `RUN` without `LOCALLY` [#3356](https://github.com/earthly/earthly/issues/3356). 
+- Failing `RUN` commands under `LOCALLY` will display the same format of error message for `RUN` without `LOCALLY` [#3356](https://github.com/earthly/earthly/issues/3356).
+- Log sharing link will be printed last, even in case of a build error.
+- Help message after a build error will be printed in color.
 - Use dedicated logstream failure category for param related error.
 - An authentication attempt with an expired auth token will result in a `auth token expired` error instead of `unauthorized`.
 - A successful authentication with an auth token will display a warning with time left before token expires if it's 14 days or under.

--- a/cmd/earthly/app/run.go
+++ b/cmd/earthly/app/run.go
@@ -139,6 +139,7 @@ func (app *EarthlyApp) run(ctx context.Context, args []string) int {
 			}
 		}
 	}()
+	defer app.BaseCLI.ExecuteDeferredFuncs()
 	app.BaseCLI.Logbus().Run().SetStart(time.Now())
 	// Initialize log streaming early if we're passed the organization and
 	// project names as environmental variables. This will allow nearly all
@@ -206,7 +207,7 @@ func (app *EarthlyApp) run(ctx context.Context, args []string) int {
 			if app.BaseCLI.AnaMetaIsSat() {
 				app.BaseCLI.Console().DebugPrintf("Are you using --platform to target a different architecture? Please note that \"disable-emulation\" flag is set in your satellite.\n")
 			} else {
-				app.BaseCLI.Console().Printf(
+				app.BaseCLI.Console().HelpPrintf(
 					"Are you using --platform to target a different architecture? You may have to manually install QEMU.\n" +
 						"For more information see https://docs.earthly.dev/guides/multi-platform\n")
 			}
@@ -219,7 +220,7 @@ func (app *EarthlyApp) run(ctx context.Context, args []string) int {
 			return 1
 		case strings.Contains(err.Error(), "security.insecure is not allowed"):
 			app.BaseCLI.Logbus().Run().SetGenericFatalError(time.Now(), logstream.FailureType_FAILURE_TYPE_NEEDS_PRIVILEGED, err.Error())
-			app.BaseCLI.Console().Printf("earthly --allow-privileged (earthly -P) flag is required\n")
+			app.BaseCLI.Console().HelpPrintf("earthly --allow-privileged (earthly -P) flag is required\n")
 			return 9
 		case strings.Contains(err.Error(), errutil.EarthlyGitStdErrMagicString):
 			app.BaseCLI.Logbus().Run().SetGenericFatalError(time.Now(), logstream.FailureType_FAILURE_TYPE_GIT, err.Error())
@@ -229,7 +230,7 @@ func (app *EarthlyApp) run(ctx context.Context, args []string) int {
 			} else {
 				app.BaseCLI.Console().VerboseWarnf("Error: %v\n", err.Error())
 			}
-			app.BaseCLI.Console().Printf(
+			app.BaseCLI.Console().HelpPrintf(
 				"Check your git auth settings.\n" +
 					"Did you ssh-add today? Need to configure ~/.earthly/config.yml?\n" +
 					"For more information see https://docs.earthly.dev/guides/auth\n")
@@ -254,7 +255,7 @@ func (app *EarthlyApp) run(ctx context.Context, args []string) int {
 				registryName = "The remote registry"
 				registryHost = " <server>" // keep the leading space
 			}
-			app.BaseCLI.Console().Warnf("Error: %s responded with a rate limit error. This is usually because you are not logged in.\n"+
+			app.BaseCLI.Console().HelpPrintf("%s responded with a rate limit error. This is usually because you are not logged in.\n"+
 				"You can login using the command:\n"+
 				"  docker login%s", registryName, registryHost)
 			return 1

--- a/cmd/earthly/base/cli.go
+++ b/cmd/earthly/base/cli.go
@@ -27,6 +27,7 @@ type CLI struct {
 	defaultBuildkitdImage   string
 	defaultInstallationName string
 	flags                   flag.Global
+	deferredFuncs           []func()
 	analyticsMetadata
 }
 
@@ -212,6 +213,16 @@ func (c *CLI) SetAnaMetaUserPlatform(platform string) {
 }
 func (c *CLI) SetAnaMetaTarget(target domain.Target) {
 	c.analyticsMetadata.target = target
+}
+
+func (c *CLI) AddDeferredFunc(f func()) {
+	c.deferredFuncs = append([]func(){f}, c.deferredFuncs...)
+}
+
+func (c *CLI) ExecuteDeferredFuncs() {
+	for _, f := range c.deferredFuncs {
+		f()
+	}
 }
 
 // CIHost returns protocol://hostname

--- a/cmd/earthly/subcmd/build_cmd.go
+++ b/cmd/earthly/subcmd/build_cmd.go
@@ -258,7 +258,7 @@ func (a *Build) ActionBuildImp(cliCtx *cli.Context, flagArgs, nonFlagArgs []stri
 
 	// Determine if Logstream is enabled and create log sharing link in either case.
 	logstreamURL, doLogstreamUpload, printLinkFn := a.logShareLink(cliCtx.Context, cloudClient, target, cleanCollection)
-	defer printLinkFn() // Output log sharing link after build.
+	a.cli.AddDeferredFunc(printLinkFn) // Output log sharing link after build and other possible messages
 
 	a.cli.Console().PrintPhaseHeader(builder.PhaseInit, false, "")
 	a.warnIfArgContainsBuildArg(flagArgs)

--- a/cmd/earthly/subcmd/cli.go
+++ b/cmd/earthly/subcmd/cli.go
@@ -41,4 +41,6 @@ type CLI interface {
 	CIHost() string
 	LogbusSetup() *setup.BusSetup
 	Logbus() *logbus.Bus
+
+	AddDeferredFunc(f func())
 }

--- a/conslogging/color.go
+++ b/conslogging/color.go
@@ -12,6 +12,7 @@ var (
 	successColor       = makeColor(color.FgGreen)
 	warnColor          = makeColor(color.FgHiRed)
 	localColor         = makeColor(color.FgHiBlue)
+	helpColor          = makeColor(color.FgMagenta)
 )
 
 var availablePrefixColors = []*color.Color{

--- a/conslogging/conslogging.go
+++ b/conslogging/conslogging.go
@@ -312,6 +312,11 @@ func (cl ConsoleLogger) VerboseWarnf(format string, args ...interface{}) {
 	cl.Warnf(format, args...)
 }
 
+// HelpPrintf prints formatted text to the console with `Help:` prefix in a specific color
+func (cl ConsoleLogger) HelpPrintf(format string, args ...interface{}) {
+	cl.ColorPrintf(cl.color(helpColor), fmt.Sprintf("\nHelp: %s\n", format), args...)
+}
+
 // Printf prints formatted text to the console.
 func (cl ConsoleLogger) Printf(format string, args ...interface{}) {
 	c := cl.color(noColor)


### PR DESCRIPTION
Also printing help messages after build errors in color, adding `Help: ` as a prefix to these messages.