### PR TITLE
Auto-skip: handle --no-cache & --push on command line

### DIFF
--- a/cmd/earthly/subcmd/build_cmd.go
+++ b/cmd/earthly/subcmd/build_cmd.go
@@ -830,6 +830,11 @@ func (a *Build) initAutoSkip(ctx context.Context, target domain.Target, overridi
 		return nil, nil, false, nil
 	}
 
+	if a.cli.Flags().NoCache {
+		console.Warnf("--no-cache is not supported")
+		return nil, nil, false, nil
+	}
+
 	var (
 		skipDB      bk.BuildkitSkipper
 		targetHash  []byte

--- a/inputgraph/hash.go
+++ b/inputgraph/hash.go
@@ -2,7 +2,6 @@ package inputgraph
 
 import (
 	"context"
-	"errors"
 
 	"github.com/earthly/earthly/conslogging"
 	"github.com/earthly/earthly/domain"
@@ -14,7 +13,6 @@ type HashOpt struct {
 	Target          domain.Target
 	Console         conslogging.ConsoleLogger
 	CI              bool
-	Push            bool
 	BuiltinArgs     variables.DefaultArgs
 	OverridingVars  *variables.Scope
 	EarthlyCIRunner bool
@@ -31,7 +29,7 @@ func HashTarget(ctx context.Context, opt HashOpt) (org, project string, hash []b
 
 	err = l.load(ctx)
 	if err != nil {
-		return "", "", nil, errors.Join(ErrUnableToDetermineHash, err)
+		return "", "", nil, err
 	}
 
 	return org, project, l.hasher.GetHash(), nil

--- a/inputgraph/loader.go
+++ b/inputgraph/loader.go
@@ -53,20 +53,6 @@ func newLoader(ctx context.Context, opt HashOpt) *loader {
 	}
 }
 
-func (l *loader) handleRun(ctx context.Context, cmd spec.Command) error {
-	opts := commandflag.RunOpts{}
-	_, err := flagutil.ParseArgsCleaned(command.From, &opts, flagutil.GetArgsCopy(cmd))
-	if err != nil {
-		return err
-	}
-
-	if opts.NoCache {
-		return errors.New("--no-cache not supported")
-	}
-
-	return nil
-}
-
 func (l *loader) handleFrom(ctx context.Context, cmd spec.Command) error {
 	opts := commandflag.FromOpts{}
 	args, err := flagutil.ParseArgsCleaned(command.From, &opts, flagutil.GetArgsCopy(cmd))
@@ -284,8 +270,6 @@ func (l *loader) handleCommand(ctx context.Context, cmd spec.Command) error {
 		return l.handleCopy(ctx, cmd)
 	case command.Arg:
 		return l.handleArg(ctx, cmd)
-	case command.Run:
-		return l.handleRun(ctx, cmd)
 	default:
 		return nil
 	}

--- a/tests/autoskip/Earthfile
+++ b/tests/autoskip/Earthfile
@@ -140,12 +140,12 @@ test-try-catch:
     DO --pass-args +RUN_EARTHLY_ARGS --earthfile=try-catch.earth --target=+basic --output_contains="target .* has already been run; exiting"
 
 test-no-cache:
-    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=simple.earth --target=+no-cache --output_contains="no-cache not supported"
-    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=simple.earth --target=+no-cache --output_does_not_contain="target .* has already been run; exiting"
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=simple.earth --target=+no-cache --should_fail=true --extra_args="--no-cache" --output_contains="no-cache cannot be used"
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=simple.earth --target=+no-cache --should_fail=true --extra_args="--no-cache" --output_does_not_contain="target .* has already been run; exiting"
 
 test-push:
-    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=simple.earth --target=+simple --extra_args="--push" --output_contains="push is not supported"
-    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=simple.earth --target=+simple --extra_args="--push" --output_does_not_contain="target .* has already been run; exiting"
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=simple.earth --target=+simple --should_fail=true --extra_args="--push" --output_contains="push cannot be used"
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=simple.earth --target=+simple --should_fail=true --extra_args="--push" --output_does_not_contain="target .* has already been run; exiting"
 
 RUN_EARTHLY_ARGS:
     COMMAND

--- a/tests/autoskip/Earthfile
+++ b/tests/autoskip/Earthfile
@@ -20,6 +20,8 @@ test-all:
     BUILD +test-copy-target-args
     BUILD +test-arg-matrix
     BUILD +test-try-catch
+    BUILD +test-push
+    BUILD +test-no-cache
 
 test-files:
     RUN echo hello > my-file
@@ -137,6 +139,14 @@ test-try-catch:
     DO --pass-args +RUN_EARTHLY_ARGS --earthfile=try-catch.earth --target=+basic --output_contains="Artifact +basic/hello.txt output as hello.txt"
     DO --pass-args +RUN_EARTHLY_ARGS --earthfile=try-catch.earth --target=+basic --output_contains="target .* has already been run; exiting"
 
+test-no-cache:
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=simple.earth --target=+no-cache --output_contains="no-cache not supported"
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=simple.earth --target=+no-cache --output_does_not_contain="target .* has already been run; exiting"
+
+test-push:
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=simple.earth --target=+simple --extra_args="--push" --output_contains="push is not supported"
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=simple.earth --target=+simple --extra_args="--push" --output_does_not_contain="target .* has already been run; exiting"
+
 RUN_EARTHLY_ARGS:
     COMMAND
     ARG earthfile
@@ -145,6 +155,7 @@ RUN_EARTHLY_ARGS:
     ARG output_contains
     ARG output_does_not_contain
     ARG post_command
+    ARG extra_args
     DO --pass-args tests+RUN_EARTHLY \
         --earthfile=$earthfile \
         --target=$target \

--- a/tests/autoskip/simple.earth
+++ b/tests/autoskip/simple.earth
@@ -12,3 +12,11 @@ mytarget:
 mypipeline:
   PIPELINE
   BUILD +mytarget
+
+no-cache:
+  FROM alpine
+  RUN --no-cache echo "hello"
+
+simple:
+  FROM alpine
+  RUN echo "hello"

--- a/tests/autoskip/subdir/test.earth
+++ b/tests/autoskip/subdir/test.earth
@@ -9,4 +9,4 @@ filetarget:
 test:
   FROM ..+deps
   COPY +filetarget/hash .
-  RUN cat hash
+  RUN --no-cache cat hash

--- a/tests/autoskip/subdir/test.earth
+++ b/tests/autoskip/subdir/test.earth
@@ -9,4 +9,4 @@ filetarget:
 test:
   FROM ..+deps
   COPY +filetarget/hash .
-  RUN --no-cache cat hash
+  RUN cat hash


### PR DESCRIPTION
Includes the following auto-skip changes:
* Fail with messages when `--no-cache` and `--push` are passed to the CLI with `--auto-skip`
* ~Abort when `--no-cache` is used in a visited `RUN` command~
* Don't add log-sharing link when build is skipped
* Added back prefix for some auto-skip messages (only when build continues)
