### PR TITLE
Auto-skip: further support for shell-out

### DIFF
--- a/inputgraph/loader.go
+++ b/inputgraph/loader.go
@@ -222,18 +222,16 @@ func (l *loader) expandDirs(dirs ...string) ([]string, error) {
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to read dir")
 			}
+			children := []string{}
 			for _, entry := range entries {
-				next := filepath.Join(dir, entry.Name())
-				if entry.IsDir() {
-					found, err := l.expandDirs(next)
-					if err != nil {
-						return nil, err
-					}
-					ret = append(ret, found...)
-				} else {
-					ret = append(ret, next)
-				}
+				child := filepath.Join(dir, entry.Name())
+				children = append(children, child)
 			}
+			found, err := l.expandDirs(children...)
+			if err != nil {
+				return nil, err
+			}
+			ret = append(ret, found...)
 		} else {
 			ret = append(ret, dir)
 		}

--- a/inputgraph/loader.go
+++ b/inputgraph/loader.go
@@ -501,7 +501,7 @@ func (l *loader) loadTargetFromString(ctx context.Context, targetName string, ar
 	// If the target name contains a variable that hasn't been expanded, we
 	// won't be able to explore the rest of the graph and generate a valid hash.
 	if strings.Contains(targetName, "$") {
-		return errors.Errorf("target name %q is the result of a shell expression", targetName)
+		return errors.Errorf("dynamic target %q cannot be resolved", targetName)
 	}
 
 	relTarget, err := domain.ParseTarget(targetName)

--- a/inputgraph/loader.go
+++ b/inputgraph/loader.go
@@ -121,6 +121,10 @@ func (l *loader) handleCopy(ctx context.Context, cmd spec.Command) error {
 
 func (l *loader) handleCopySrc(ctx context.Context, src string, isDir bool) error {
 
+	if strings.Contains(src, "$") {
+		return errors.Errorf("dynamic COPY source %q cannot be resolved", src)
+	}
+
 	var (
 		classical   bool
 		artifactSrc domain.Artifact

--- a/inputgraph/loader.go
+++ b/inputgraph/loader.go
@@ -119,9 +119,13 @@ func (l *loader) handleCopy(ctx context.Context, cmd spec.Command) error {
 	return nil
 }
 
+func hasShellExpr(s string) bool {
+	return strings.Contains(s, "$(") && strings.Contains(s, ")")
+}
+
 func (l *loader) handleCopySrc(ctx context.Context, src string, isDir bool) error {
 
-	if strings.Contains(src, "$") {
+	if hasShellExpr(src) {
 		return errors.Errorf("dynamic COPY source %q cannot be resolved", src)
 	}
 
@@ -502,7 +506,7 @@ func (l *loader) forTarget(ctx context.Context, target domain.Target, args []str
 func (l *loader) loadTargetFromString(ctx context.Context, targetName string, args []string, passArgs bool) error {
 	// If the target name contains a variable that hasn't been expanded, we
 	// won't be able to explore the rest of the graph and generate a valid hash.
-	if strings.Contains(targetName, "$") {
+	if hasShellExpr(targetName) {
 		return errors.Errorf("dynamic target %q cannot be resolved", targetName)
 	}
 

--- a/tests/autoskip/Earthfile
+++ b/tests/autoskip/Earthfile
@@ -152,10 +152,10 @@ test-shell-out:
     DO --pass-args +RUN_EARTHLY_ARGS --earthfile=shell-out.earth --target=+shell-out --should_fail=false
     DO --pass-args +RUN_EARTHLY_ARGS --earthfile=shell-out.earth --target=+shell-out --output_contains="target .* has already been run; exiting"
 
-    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=shell-out.earth --target=+shell-out-target --output_contains="result of a shell expression"
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=shell-out.earth --target=+shell-out-target --output_contains="dynamic target"
     DO --pass-args +RUN_EARTHLY_ARGS --earthfile=shell-out.earth --target=+shell-out-target --output_does_not_contain="target .* has already been run; exiting"
 
-    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=shell-out.earth --target=+shell-out-target-2 --output_contains="result of a shell expression"
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=shell-out.earth --target=+shell-out-target-2 --output_contains="dynamic target"
     DO --pass-args +RUN_EARTHLY_ARGS --earthfile=shell-out.earth --target=+shell-out-target-2 --output_does_not_contain="target .* has already been run; exiting"
 
 RUN_EARTHLY_ARGS:

--- a/tests/autoskip/Earthfile
+++ b/tests/autoskip/Earthfile
@@ -22,6 +22,7 @@ test-all:
     BUILD +test-try-catch
     BUILD +test-push
     BUILD +test-no-cache
+    BUILD +test-shell-out
 
 test-files:
     RUN echo hello > my-file
@@ -146,6 +147,16 @@ test-no-cache:
 test-push:
     DO --pass-args +RUN_EARTHLY_ARGS --earthfile=simple.earth --target=+simple --should_fail=true --extra_args="--push" --output_contains="push cannot be used"
     DO --pass-args +RUN_EARTHLY_ARGS --earthfile=simple.earth --target=+simple --should_fail=true --extra_args="--push" --output_does_not_contain="target .* has already been run; exiting"
+
+test-shell-out:
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=shell-out.earth --target=+shell-out --should_fail=false
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=shell-out.earth --target=+shell-out --output_contains="target .* has already been run; exiting"
+
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=shell-out.earth --target=+shell-out-target --output_contains="result of a shell expression"
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=shell-out.earth --target=+shell-out-target --output_does_not_contain="target .* has already been run; exiting"
+
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=shell-out.earth --target=+shell-out-target-2 --output_contains="result of a shell expression"
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=shell-out.earth --target=+shell-out-target-2 --output_does_not_contain="target .* has already been run; exiting"
 
 RUN_EARTHLY_ARGS:
     COMMAND

--- a/tests/autoskip/Earthfile
+++ b/tests/autoskip/Earthfile
@@ -158,6 +158,11 @@ test-shell-out:
     DO --pass-args +RUN_EARTHLY_ARGS --earthfile=shell-out.earth --target=+shell-out-target-2 --output_contains="dynamic target"
     DO --pass-args +RUN_EARTHLY_ARGS --earthfile=shell-out.earth --target=+shell-out-target-2 --output_does_not_contain="target .* has already been run; exiting"
 
+    RUN echo "foo" > my-file
+
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=shell-out.earth --target=+shell-out-copy --output_contains="dynamic COPY source"
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=shell-out.earth --target=+shell-out-copy --output_does_not_contain="target .* has already been run; exiting"
+
 RUN_EARTHLY_ARGS:
     COMMAND
     ARG earthfile

--- a/tests/autoskip/Earthfile
+++ b/tests/autoskip/Earthfile
@@ -149,7 +149,7 @@ test-push:
     DO --pass-args +RUN_EARTHLY_ARGS --earthfile=simple.earth --target=+simple --should_fail=true --extra_args="--push" --output_does_not_contain="target .* has already been run; exiting"
 
 test-shell-out:
-    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=shell-out.earth --target=+shell-out --should_fail=false
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=shell-out.earth --target=+shell-out
     DO --pass-args +RUN_EARTHLY_ARGS --earthfile=shell-out.earth --target=+shell-out --output_contains="target .* has already been run; exiting"
 
     DO --pass-args +RUN_EARTHLY_ARGS --earthfile=shell-out.earth --target=+shell-out-target --output_contains="dynamic target"

--- a/tests/autoskip/shell-out.earth
+++ b/tests/autoskip/shell-out.earth
@@ -22,4 +22,4 @@ shell-out-target-2:
 
 shell-out-copy:
   ARG file=$(echo "my-file")
-  COPY $file /
+  COPY $file .

--- a/tests/autoskip/shell-out.earth
+++ b/tests/autoskip/shell-out.earth
@@ -1,0 +1,21 @@
+VERSION 0.7
+
+PROJECT testorg/testproj
+
+FROM alpine:3.18
+
+shell-out:
+  ARG result=$(echo "hi")
+  RUN echo $result
+
+foo:
+  RUN echo "hello from foo"
+
+shell-out-target:
+  ARG target=$(echo "+foo")
+  BUILD $target
+
+shell-out-target-2:
+  ARG name="+foo"
+  ARG target=$(echo $name)
+  BUILD $target

--- a/tests/autoskip/shell-out.earth
+++ b/tests/autoskip/shell-out.earth
@@ -19,3 +19,7 @@ shell-out-target-2:
   ARG name="+foo"
   ARG target=$(echo $name)
   BUILD $target
+
+shell-out-copy:
+  ARG file=$(echo "my-file")
+  COPY $file /


### PR DESCRIPTION
Allows targets that use shell-out features to be auto-skipped unless the target name is to be dynamically resolved using the result of a shell-out command.