### PR TITLE
make sure selected org is used in all applicable commands when org is not explicitly set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 - Use dedicated logstream failure category for param related error.
 - An authentication attempt with an expired auth token will result in a `auth token expired` error instead of `unauthorized`.
 - A successful authentication with an auth token will display a warning with time left before token expires if it's 14 days or under.
+- The command `earthly registry` will attempt to use the selected org if no org is specified.
  
 
 ## v0.7.21 - 2023-10-24

--- a/cmd/earthly/base/buildkit.go
+++ b/cmd/earthly/base/buildkit.go
@@ -43,9 +43,6 @@ func (cli *CLI) ConfigureSatellite(cliCtx *cli.Context, cloudClient *cloud.Clien
 	if cli.Flags().SatelliteName == "" {
 		cli.Flags().SatelliteName = cli.Cfg().Satellite.Name
 	}
-	if cli.Flags().OrgName == "" {
-		cli.Flags().OrgName = cli.Cfg().Satellite.Org
-	}
 
 	cli.Flags().BuildkitdSettings.UseTCP = true
 	if cli.Cfg().Global.TLSEnabled {
@@ -109,6 +106,13 @@ func (c *CLI) IsUsingSatellite(cliCtx *cli.Context) bool {
 		return false
 	}
 	return c.Cfg().Satellite.Name != "" || c.Flags().SatelliteName != ""
+}
+
+func (c *CLI) OrgName() string {
+	if c.Flags().OrgName != "" {
+		return c.Flags().OrgName
+	}
+	return c.Cfg().Global.Org
 }
 
 func (c *CLI) GetSatelliteOrg(ctx context.Context, cloudClient *cloud.Client) (orgName, orgID string, err error) {

--- a/cmd/earthly/subcmd/build_cmd.go
+++ b/cmd/earthly/subcmd/build_cmd.go
@@ -590,15 +590,6 @@ func (a *Build) ActionBuildImp(cliCtx *cli.Context, flagArgs, nonFlagArgs []stri
 	// information to logbusSetup. This function will be called right at the
 	// beginning of the build within earthfile2llb.
 	buildOpts.MainTargetDetailsFunc = func(d earthfile2llb.TargetDetails) error {
-		if a.cli.LogbusSetup().LogStreamerStarted() {
-			// If the org & project have been provided by envs, let's verify
-			// that they're correct once we've parsed them from the Earthfile.
-			if a.cli.Flags().OrgName != d.EarthlyOrgName || a.cli.Flags().ProjectName != d.EarthlyProjectName {
-				return fmt.Errorf("organization or project do not match PROJECT statement")
-			}
-			a.cli.Console().VerbosePrintf("Organization and project already set via environmental")
-			return nil
-		}
 		a.cli.Console().VerbosePrintf("Logbus: setting organization %q and project %q at %s", d.EarthlyOrgName, d.EarthlyProjectName, time.Now().Format(time.RFC3339Nano))
 		analytics.AddEarthfileProject(d.EarthlyOrgName, d.EarthlyProjectName)
 		if a.cli.Flags().Logstream {
@@ -774,7 +765,7 @@ func (a *Build) runnerName(ctx context.Context) (string, bool, error) {
 		runnerName = fmt.Sprintf("local:%s", hostname)
 	} else {
 		if a.cli.Flags().SatelliteName != "" {
-			runnerName = fmt.Sprintf("sat:%s/%s", a.cli.Flags().OrgName, a.cli.Flags().SatelliteName)
+			runnerName = fmt.Sprintf("sat:%s/%s", a.cli.OrgName(), a.cli.Flags().SatelliteName)
 		} else {
 			runnerName = fmt.Sprintf("bk:%s", a.cli.Flags().BuildkitdSettings.BuildkitAddress)
 		}

--- a/cmd/earthly/subcmd/cli.go
+++ b/cmd/earthly/subcmd/cli.go
@@ -33,6 +33,7 @@ type CLI interface {
 	SetAnaMetaBKPlatform(string)
 	SetAnaMetaUserPlatform(string)
 	IsUsingSatellite(*cli.Context) bool
+	OrgName() string
 
 	GetBuildkitClient(*cli.Context, *cloud.Client) (*client.Client, error)
 	GetSatelliteOrg(context.Context, *cloud.Client) (string, string, error)

--- a/cmd/earthly/subcmd/common.go
+++ b/cmd/earthly/subcmd/common.go
@@ -10,7 +10,7 @@ import (
 // projectOrgName returns the specified org or retrieves the default org from the API.
 func projectOrgName(cli CLI, ctx context.Context, cloudClient *cloud.Client) (string, error) {
 
-	if configuredOrg := verifyOrg(cli); configuredOrg != "" {
+	if configuredOrg := cli.OrgName(); configuredOrg != "" {
 		return configuredOrg, nil
 	}
 
@@ -26,14 +26,6 @@ func projectOrgName(cli CLI, ctx context.Context, cloudClient *cloud.Client) (st
 	}
 
 	return userOrgs[0].Name, nil
-}
-
-// verifyOrg returns orgName from cli Flags if set, else from config
-func verifyOrg(cli CLI) string {
-	if cli.Flags().OrgName != "" {
-		return cli.Flags().OrgName
-	}
-	return cli.Cfg().Global.Org
 }
 
 func concatCmds(slices [][]*cli.Command) []*cli.Command {
@@ -55,7 +47,7 @@ func concatCmds(slices [][]*cli.Command) []*cli.Command {
 }
 
 func getOrgAndProject(cli CLI, ctx context.Context, client *cloud.Client) (org, project string, isPersonal bool, err error) {
-	org = verifyOrg(cli)
+	org = cli.OrgName()
 	if org == "" {
 		return org, project, isPersonal, errors.Errorf("provide an org using the --org flag or `org select` command")
 	}

--- a/cmd/earthly/subcmd/registry_cmds.go
+++ b/cmd/earthly/subcmd/registry_cmds.go
@@ -180,10 +180,10 @@ func (a *Registry) Cmds() []*cli.Command {
 }
 
 func (a *Registry) isUserRegistryLocation() (bool, error) {
-	if a.cli.Flags().OrgName == "" && a.cli.Flags().ProjectName == "" {
+	if a.cli.OrgName() == "" && a.cli.Flags().ProjectName == "" {
 		return true, nil
 	}
-	if a.cli.Flags().OrgName == "" {
+	if a.cli.OrgName() == "" {
 		return false, fmt.Errorf("--project was specified without an --org value")
 	}
 	if a.cli.Flags().ProjectName == "" {


### PR DESCRIPTION
When using the selected org instead of explicitly setting the org in the command (or via an env var),
the org was not properly sent to analytics server.

This PR adds a new function that reads the org name from the command flag and falls back to the selected org if the former is not set.

In addition this also changes the `earthly registry` command to fall back to the selected org which it did not do before.
