### PR TITLE
Auto-skip: support for COPY --if-exists & FOR IN fix

### DIFF
--- a/tests/autoskip/Earthfile
+++ b/tests/autoskip/Earthfile
@@ -23,6 +23,7 @@ test-all:
     BUILD +test-push
     BUILD +test-no-cache
     BUILD +test-shell-out
+    BUILD +test-copy-if-exists
 
 test-files:
     RUN echo hello > my-file
@@ -162,6 +163,14 @@ test-shell-out:
 
     DO --pass-args +RUN_EARTHLY_ARGS --earthfile=shell-out.earth --target=+shell-out-copy --output_contains="dynamic COPY source"
     DO --pass-args +RUN_EARTHLY_ARGS --earthfile=shell-out.earth --target=+shell-out-copy --output_does_not_contain="target .* has already been run; exiting"
+
+test-copy-if-exists:
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=simple.earth --target=+copy-if-exists
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=simple.earth --target=+copy-if-exists --output_contains="target .* has already been run; exiting"
+
+    RUN echo "foo" > my-file
+
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=simple.earth --target=+copy-if-exists --output_does_not_contain="target .* has already been run; exiting"
 
 RUN_EARTHLY_ARGS:
     COMMAND

--- a/tests/autoskip/simple.earth
+++ b/tests/autoskip/simple.earth
@@ -20,3 +20,7 @@ no-cache:
 simple:
   FROM alpine
   RUN echo "hello"
+
+copy-if-exists:
+  FROM alpine
+  COPY --if-exists my-file .


### PR DESCRIPTION
This PR adds auto-skip support for `COPY --if-exists` & fixes a bug with `FOR...IN` incorrectly including the index var & `IN`. 