### PR TITLE
Auto-skip: support for some remote targets

### DIFF
--- a/inputgraph/loader.go
+++ b/inputgraph/loader.go
@@ -70,11 +70,7 @@ func (l *loader) handleFrom(ctx context.Context, cmd spec.Command) error {
 	}
 
 	target, err := domain.ParseTarget(fromTarget)
-	if err != nil {
-		return errors.Wrap(err, "failed to parse target")
-	}
-
-	if target.IsRemote() {
+	if err == nil && target.IsRemote() {
 		if supportedRemoteTarget(target) {
 			l.hasher.HashString(target.StringCanonical())
 			return nil
@@ -104,11 +100,7 @@ func (l *loader) handleBuild(ctx context.Context, cmd spec.Command) error {
 	}
 
 	target, err := domain.ParseTarget(targetName)
-	if err != nil {
-		return errors.Wrap(err, "failed to parse target")
-	}
-
-	if target.IsRemote() {
+	if err == nil && target.IsRemote() {
 		if supportedRemoteTarget(target) {
 			l.hasher.HashString(target.StringCanonical())
 			return nil

--- a/inputgraph/loader.go
+++ b/inputgraph/loader.go
@@ -24,8 +24,8 @@ import (
 )
 
 var (
-	errCannotLoadRemoteTarget  = errors.New("remote targets not supported")
-	errUnsupportedRemoteTarget = errors.New("only remote targets referenced by a complete git SHA or tag are supported")
+	errUnsupportedRemoteTarget = errors.New("only remote targets referenced by a complete Git SHA or tag (e.g. tags/my-tag) are supported")
+	errCannotLoadRemoteTarget  = errors.New("cannot load remote target")
 )
 
 type loader struct {

--- a/inputgraph/loader.go
+++ b/inputgraph/loader.go
@@ -25,7 +25,7 @@ import (
 
 var (
 	errCannotLoadRemoteTarget  = errors.New("remote targets not supported")
-	errUnsupportedRemoteTarget = errors.New("only remote targets with full SHAs or tags are supported")
+	errUnsupportedRemoteTarget = errors.New("only remote targets referenced by a complete git SHA or tag are supported")
 )
 
 type loader struct {

--- a/inputgraph/loader_hashing.go
+++ b/inputgraph/loader_hashing.go
@@ -1,6 +1,8 @@
 package inputgraph
 
-import "github.com/earthly/earthly/ast/spec"
+import (
+	"github.com/earthly/earthly/ast/spec"
+)
 
 func (l *loader) hashIfStatement(s spec.IfStatement) {
 	l.hasher.HashString("IF")

--- a/tests/autoskip/Earthfile
+++ b/tests/autoskip/Earthfile
@@ -172,6 +172,26 @@ test-copy-if-exists:
 
     DO --pass-args +RUN_EARTHLY_ARGS --earthfile=simple.earth --target=+copy-if-exists --output_does_not_contain="target .* has already been run; exiting"
 
+test-remote:
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=remote-target.earth --target=+valid-copy
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=remote-target.earth --target=+valid-copy --output_contains="target .* has already been run; exiting"
+
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=remote-target.earth --target=+valid-copy-sha
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=remote-target.earth --target=+valid-copy-sha --output_contains="target .* has already been run; exiting"
+
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=remote-target.earth --target=+valid-from
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=remote-target.earth --target=+valid-from --output_contains="target .* has already been run; exiting"
+
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=remote-target.earth --target=+valid-from-sha
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=remote-target.earth --target=+valid-from-sha --output_contains="target .* has already been run; exiting"
+
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=remote-target.earth --target=+invalid-copy-branch --output_contains="targets with full SHAs or tags"
+
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=remote-target.earth --target=+valid-build
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=remote-target.earth --target=+valid-build --output_contains="target .* has already been run; exiting"
+
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=remote-target.earth --target=+invalid-build --output_contains="targets with full SHAs or tags"
+
 RUN_EARTHLY_ARGS:
     COMMAND
     ARG earthfile

--- a/tests/autoskip/Earthfile
+++ b/tests/autoskip/Earthfile
@@ -24,6 +24,7 @@ test-all:
     BUILD +test-no-cache
     BUILD +test-shell-out
     BUILD +test-copy-if-exists
+    BUILD +test-remote-targets
 
 test-files:
     RUN echo hello > my-file
@@ -172,7 +173,7 @@ test-copy-if-exists:
 
     DO --pass-args +RUN_EARTHLY_ARGS --earthfile=simple.earth --target=+copy-if-exists --output_does_not_contain="target .* has already been run; exiting"
 
-test-remote:
+test-remote-targets:
     DO --pass-args +RUN_EARTHLY_ARGS --earthfile=remote-target.earth --target=+valid-copy
     DO --pass-args +RUN_EARTHLY_ARGS --earthfile=remote-target.earth --target=+valid-copy --output_contains="target .* has already been run; exiting"
 

--- a/tests/autoskip/Earthfile
+++ b/tests/autoskip/Earthfile
@@ -186,12 +186,12 @@ test-remote-targets:
     DO --pass-args +RUN_EARTHLY_ARGS --earthfile=remote-target.earth --target=+valid-from-sha
     DO --pass-args +RUN_EARTHLY_ARGS --earthfile=remote-target.earth --target=+valid-from-sha --output_contains="target .* has already been run; exiting"
 
-    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=remote-target.earth --target=+invalid-copy-branch --output_contains="targets with full SHAs or tags"
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=remote-target.earth --target=+invalid-copy-branch --output_contains="complete Git SHA or tag"
 
     DO --pass-args +RUN_EARTHLY_ARGS --earthfile=remote-target.earth --target=+valid-build
     DO --pass-args +RUN_EARTHLY_ARGS --earthfile=remote-target.earth --target=+valid-build --output_contains="target .* has already been run; exiting"
 
-    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=remote-target.earth --target=+invalid-build --output_contains="targets with full SHAs or tags"
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=remote-target.earth --target=+invalid-build --output_contains="complete Git SHA or tag"
 
 RUN_EARTHLY_ARGS:
     COMMAND

--- a/tests/autoskip/remote-target.earth
+++ b/tests/autoskip/remote-target.earth
@@ -1,0 +1,29 @@
+VERSION 0.7
+PROJECT testorg/testproj
+
+valid-copy:
+    FROM alpine
+    COPY github.com/earthly/earthly:tags/v0.7.21+license/LICENSE .
+
+valid-copy-sha:
+    FROM alpine
+    COPY github.com/earthly/earthly:6610b73131f94cbe594dba3b90665748f21a9b8d+license/LICENSE .
+
+valid-from:
+    FROM github.com/earthly/earthly:tags/v0.7.21+license
+    RUN echo "hello"
+
+valid-from-sha:
+    FROM github.com/earthly/earthly:6610b73131f94cbe594dba3b90665748f21a9b8d+license
+    RUN echo "hello"
+
+invalid-copy-branch:
+    FROM alpine
+    COPY github.com/earthly/earthly:main+license/LICENSE .
+
+valid-build:
+    BUILD github.com/earthly/earthly:6610b73131f94cbe594dba3b90665748f21a9b8d+license
+    BUILD github.com/earthly/earthly:tags/v0.7.21+license
+
+invalid-build:
+    BUILD github.com/earthly/earthly:main+license


### PR DESCRIPTION
Adds `BUILD`, `COPY`, `FROM` support for remote targets that use explicit SHAs or tags. 