### PR TITLE
Allow not persisting CACHE mount

### DIFF
--- a/ast/commandflag/flags.go
+++ b/ast/commandflag/flags.go
@@ -137,9 +137,10 @@ type PipelineOpts struct {
 }
 
 type CacheOpts struct {
-	Sharing string `long:"sharing" description:"The cache sharing mode: locked (default), shared, private"`
-	Mode    string `long:"chmod" description:"Apply a mode to the cache folder" default:"0644"`
-	ID      string `long:"id" description:"Cache ID, to reuse the same cache across different targets and Earthfiles"`
+	Sharing   string `long:"sharing" description:"The cache sharing mode: locked (default), shared, private"`
+	Mode      string `long:"chmod" description:"Apply a mode to the cache folder" default:"0644"`
+	ID        string `long:"id" description:"Cache ID, to reuse the same cache across different targets and Earthfiles"`
+	Persisted bool   `long:"persisted" description:"If should persist cache state in image"`
 }
 
 // NewForOpts creates and returns a ForOpts with default separators.

--- a/ast/commandflag/flags.go
+++ b/ast/commandflag/flags.go
@@ -137,10 +137,10 @@ type PipelineOpts struct {
 }
 
 type CacheOpts struct {
-	Sharing   string `long:"sharing" description:"The cache sharing mode: locked (default), shared, private"`
-	Mode      string `long:"chmod" description:"Apply a mode to the cache folder" default:"0644"`
-	ID        string `long:"id" description:"Cache ID, to reuse the same cache across different targets and Earthfiles"`
-	Persisted bool   `long:"persisted" description:"If should persist cache state in image"`
+	Sharing string `long:"sharing" description:"The cache sharing mode: locked (default), shared, private"`
+	Mode    string `long:"chmod" description:"Apply a mode to the cache folder" default:"0644"`
+	ID      string `long:"id" description:"Cache ID, to reuse the same cache across different targets and Earthfiles"`
+	Persist bool   `long:"persist" description:"If should persist cache state in image"`
 }
 
 // NewForOpts creates and returns a ForOpts with default separators.

--- a/docs/earthfile/features.md
+++ b/docs/earthfile/features.md
@@ -33,38 +33,39 @@ to require version `0.X` (or later), and could be rewritten as `VERSION 0.X`.
 
 ## Feature flags
 
-| Feature flag                        | status       | description                                                                                                   |
-|-------------------------------------|--------------|---------------------------------------------------------------------------------------------------------------|
-| `--use-registry-for-with-docker`    | 0.5          | Makes use of the embedded BuildKit Docker registry (instead of tar files) for `WITH DOCKER` loads and pulls   |
-| `--use-copy-include-patterns`       | 0.6          | Speeds up COPY transfers                                                                                      |
-| `--referenced-save-only`            | 0.6          | Changes the behavior of SAVE commands in a significant way                                                    |
-| `--for-in`                          | 0.6          | Enables support for `FOR ... IN ...` commands                                                                 |
-| `--require-force-for-unsafe-saves`  | 0.6          | Requires `--force` for saving artifacts locally outside the Earthfile's directory                             |
-| `--no-implicit-ignore`              | 0.6          | Eliminates implicit `.earthlyignore` entries, such as `Earthfile` and `.tmp-earthly-out`                      |
-| `--earthly-version-arg`             | 0.7          | Enables builtin ARGs: `EARTHLY_VERSION` and `EARTHLY_BUILD_SHA`                                               |
-| `--shell-out-anywhere`              | 0.7          | Allows shelling-out in any earthly command (including in the middle of `ARG`)                                 |
-| `--explicit-global`                 | 0.7          | Base target args must have a `--global` flag in order to be considered global args                            |
-| `--check-duplicate-images`          | 0.7          | Check for duplicate images during output                                                                      |
-| `--use-cache-command`               | 0.7          | Allow use of `CACHE` command in Earthfiles                                                                    |
-| `--use-host-command`                | 0.7          | Allow use of `HOST` command in Earthfiles                                                                     |
-| `--use-copy-link`                   | 0.7          | Use the equivalent of `COPY --link` for all copy-like operations                                              |
-| `--new-platform`                    | 0.7          | Enable new platform behavior                                                                                  |
-| `--no-tar-build-output`             | 0.7          | Do not print output when creating a tarball to load into `WITH DOCKER`                                        |
-| `--use-no-manifest-list`            | 0.7          | Enable the `SAVE IMAGE --no-manifest-list` option                                                             |
-| `--use-chmod`                       | 0.7          | Enable the `COPY --chmod` option                                                                              |
-| `--earthly-locally-arg`             | 0.7          | Enable the `EARTHLY_LOCALLY` arg                                                                              |
-| `--use-project-secrets`             | 0.7          | Enable project-based secret resolution                                                                        |
-| `--use-pipelines`                   | 0.7          | Enable the `PIPELINE` and `TRIGGER` commands                                                                  |
-| `--earthly-git-author-args`         | 0.7          | Enable the `EARTHLY_GIT_AUTHOR` and `EARTHLY_GIT_CO_AUTHORS` args                                             |
-| `--wait-block`                      | 0.7          | Enable the `WAIT` / `END` block commands                                                                      |
-| `--no-use-registry-for-with-docker` | Experimental | Disable `use-registry-for-with-docker`                                                                        |
-| `--try`                             | Experimental | Enable the `TRY` / `FINALLY` / `END` block commands                                                           |
-| `--no-network`                      | Experimental | Allow the use of `RUN --network=none` commands                                                                |
-| `--arg-scope-and-set`               | Experimental | Enable the `LET` / `SET` commands and nested `ARG` scoping                                                    |
-| `--earthly-ci-runner-arg`           | Experimental | Enable the `EARTHLY_CI_RUNNER` builtin ARG                                                                    |
-| `--use-docker-ignore`               | Experimental | Enable the use of `.dockerignore` files in `FROM DOCKERFILE` targets                                          |
-| `--pass-args`                       | Experimental | Enable the optional `--pass-args` flag for the `BUILD`, `FROM`, `COPY`, `WITH DOCKER --load` commands         |
-| `--global-cache`                    | Experimental | Enable global caches (shared across different Earthfiles), for cache mounts and `CACHE` commands having an ID |
+| Feature flag                        | status       | description                                                                                                        |
+|-------------------------------------|--------------|--------------------------------------------------------------------------------------------------------------------|
+| `--use-registry-for-with-docker`    | 0.5          | Makes use of the embedded BuildKit Docker registry (instead of tar files) for `WITH DOCKER` loads and pulls        |
+| `--use-copy-include-patterns`       | 0.6          | Speeds up COPY transfers                                                                                           |
+| `--referenced-save-only`            | 0.6          | Changes the behavior of SAVE commands in a significant way                                                         |
+| `--for-in`                          | 0.6          | Enables support for `FOR ... IN ...` commands                                                                      |
+| `--require-force-for-unsafe-saves`  | 0.6          | Requires `--force` for saving artifacts locally outside the Earthfile's directory                                  |
+| `--no-implicit-ignore`              | 0.6          | Eliminates implicit `.earthlyignore` entries, such as `Earthfile` and `.tmp-earthly-out`                           |
+| `--earthly-version-arg`             | 0.7          | Enables builtin ARGs: `EARTHLY_VERSION` and `EARTHLY_BUILD_SHA`                                                    |
+| `--shell-out-anywhere`              | 0.7          | Allows shelling-out in any earthly command (including in the middle of `ARG`)                                      |
+| `--explicit-global`                 | 0.7          | Base target args must have a `--global` flag in order to be considered global args                                 |
+| `--check-duplicate-images`          | 0.7          | Check for duplicate images during output                                                                           |
+| `--use-cache-command`               | 0.7          | Allow use of `CACHE` command in Earthfiles                                                                         |
+| `--use-host-command`                | 0.7          | Allow use of `HOST` command in Earthfiles                                                                          |
+| `--use-copy-link`                   | 0.7          | Use the equivalent of `COPY --link` for all copy-like operations                                                   |
+| `--new-platform`                    | 0.7          | Enable new platform behavior                                                                                       |
+| `--no-tar-build-output`             | 0.7          | Do not print output when creating a tarball to load into `WITH DOCKER`                                             |
+| `--use-no-manifest-list`            | 0.7          | Enable the `SAVE IMAGE --no-manifest-list` option                                                                  |
+| `--use-chmod`                       | 0.7          | Enable the `COPY --chmod` option                                                                                   |
+| `--earthly-locally-arg`             | 0.7          | Enable the `EARTHLY_LOCALLY` arg                                                                                   |
+| `--use-project-secrets`             | 0.7          | Enable project-based secret resolution                                                                             |
+| `--use-pipelines`                   | 0.7          | Enable the `PIPELINE` and `TRIGGER` commands                                                                       |
+| `--earthly-git-author-args`         | 0.7          | Enable the `EARTHLY_GIT_AUTHOR` and `EARTHLY_GIT_CO_AUTHORS` args                                                  |
+| `--wait-block`                      | 0.7          | Enable the `WAIT` / `END` block commands                                                                           |
+| `--no-use-registry-for-with-docker` | Experimental | Disable `use-registry-for-with-docker`                                                                             |
+| `--try`                             | Experimental | Enable the `TRY` / `FINALLY` / `END` block commands                                                                |
+| `--no-network`                      | Experimental | Allow the use of `RUN --network=none` commands                                                                     |
+| `--arg-scope-and-set`               | Experimental | Enable the `LET` / `SET` commands and nested `ARG` scoping                                                         |
+| `--earthly-ci-runner-arg`           | Experimental | Enable the `EARTHLY_CI_RUNNER` builtin ARG                                                                         |
+| `--use-docker-ignore`               | Experimental | Enable the use of `.dockerignore` files in `FROM DOCKERFILE` targets                                               |
+| `--pass-args`                       | Experimental | Enable the optional `--pass-args` flag for the `BUILD`, `FROM`, `COPY`, `WITH DOCKER --load` commands              |
+| `--global-cache`                    | Experimental | Enable global caches (shared across different Earthfiles), for cache mounts and `CACHE` commands having an ID      |
+| `--cache-persist-option`            | Experimental | Adds `CACHE --persist` option to persist cache content in images, Changes default `CACHE` behaviour to not persist |
 
 Note that the features flags are disabled by default in Earthly versions lower than the version listed in the "status" column above.
 

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -1541,8 +1541,12 @@ func (c *Converter) Cache(ctx context.Context, mountTarget string, opts commandf
 		if err != nil {
 			return errors.Errorf("failed to parse mount mode %s", opts.Mode)
 		}
+		persisted := true // Without new --cache-persist-option we use old behaviour which is persisted
+		if c.ftrs.CachePersistOption {
+			persisted = opts.Persisted
+		}
 		c.persistentCacheDirs[mountTarget] = states.CacheMount{
-			Persisted: opts.Persisted,
+			Persisted: persisted,
 			RunOption: pllb.AddMount(mountTarget, pllb.Scratch().File(pllb.Mkdir("/cache", os.FileMode(mountMode))), mountOpts...),
 		}
 	}

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -1544,6 +1544,8 @@ func (c *Converter) Cache(ctx context.Context, mountTarget string, opts commandf
 		persisted := true // Without new --cache-persist-option we use old behaviour which is persisted
 		if c.ftrs.CachePersistOption {
 			persisted = opts.Persist
+		} else if opts.Persist {
+			return errors.Errorf("the --persist flag is only available when VERSION --cache-persist-option is enabled")
 		}
 		c.persistentCacheDirs[mountTarget] = states.CacheMount{
 			Persisted: persisted,

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -1543,7 +1543,7 @@ func (c *Converter) Cache(ctx context.Context, mountTarget string, opts commandf
 		}
 		persisted := true // Without new --cache-persist-option we use old behaviour which is persisted
 		if c.ftrs.CachePersistOption {
-			persisted = opts.Persisted
+			persisted = opts.Persist
 		}
 		c.persistentCacheDirs[mountTarget] = states.CacheMount{
 			Persisted: persisted,

--- a/features/features.go
+++ b/features/features.go
@@ -61,6 +61,7 @@ type Features struct {
 	UseDockerIgnore                 bool `long:"use-docker-ignore" description:"fallback to .dockerignore incase .earthlyignore or .earthignore do not exist in a local \"FROM DOCKERFILE\" target"`
 	PassArgs                        bool `long:"pass-args" description:"Allow the use of the --pass-arg flag in FROM, BUILD, COPY, WITH DOCKER, and DO commands"`
 	GlobalCache                     bool `long:"global-cache" description:"enable global caches (shared across different Earthfiles), for cache mounts and CACHEs having an ID"`
+	CachePersistOption              bool `long:"cache-persist-option" description:"Adds option to persist caches, Changes default CACHE behaviour to not persist"`
 	GitRefs                         bool `long:"git-refs" description:"includes EARTHLY_GIT_REFS ARG"`
 	UseVisitedUpfrontHashCollection bool `long:"use-visited-upfront-hash-collection" description:"Uses a new target visitor implementation that computes upfront the hash of the visited targets and adds support for running all targets with the same name but different args in parallel"`
 

--- a/states/states.go
+++ b/states/states.go
@@ -2,6 +2,7 @@ package states
 
 import (
 	"context"
+	"github.com/moby/buildkit/client/llb"
 	"sync"
 
 	"github.com/earthly/earthly/domain"
@@ -23,6 +24,14 @@ type MultiTarget struct {
 	Visited VisitedCollection
 	// Final is the main target to be built.
 	Final *SingleTarget
+}
+
+// CacheMount holds run options needed to cache mounts, and some extra options.
+type CacheMount struct {
+	// Persisted should the cache be persisted to image.
+	Persisted bool
+	// RunOption Run options
+	RunOption llb.RunOption
 }
 
 // FinalTarget returns the final target of the states.

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -124,6 +124,7 @@ ga-no-qemu-group2:
     BUILD +test-cache-mount-mode
     BUILD +test-cache-mode
     BUILD +test-shared-cache
+    BUILD +test-cache-persist
     BUILD +test-visited-upfront-hash-collection
     BUILD +test-exec-stats
 
@@ -1443,6 +1444,22 @@ test-shared-cache:
       --target=+test \
       --extra_args=" --secret=content=filecontents " \
       --output_contains="filecontents"
+
+test-cache-persist:
+  DO +RUN_EARTHLY \
+      --earthfile=cache-persist.earth \
+      --target=+test-persisted \
+      --output_contains="| test persisted ok"
+
+  DO +RUN_EARTHLY \
+      --earthfile=cache-persist.earth \
+      --target=+test-non-persisted \
+      --output_contains="| test non persisted ok"
+
+  DO +RUN_EARTHLY \
+      --earthfile=cache-persist-no-flag.earth \
+      --target=+test-persisted \
+      --output_contains="| test persisted ok"
 
 test-visited-upfront-hash-collection:
   DO +RUN_EARTHLY \

--- a/tests/cache-persist-no-flag.earth
+++ b/tests/cache-persist-no-flag.earth
@@ -10,4 +10,3 @@ test-persisted:
     IF [ -e /cache/persisted/persisted.txt ]
         RUN echo "test persisted ok"
     END
-

--- a/tests/cache-persist-no-flag.earth
+++ b/tests/cache-persist-no-flag.earth
@@ -1,0 +1,13 @@
+VERSION 0.7
+FROM alpine:3.18
+
+build:
+    CACHE /cache/persisted
+    RUN touch /cache/persisted/persisted.txt
+
+test-persisted:
+    FROM +build
+    IF [ -e /cache/persisted/persisted.txt ]
+        RUN echo "test persisted ok"
+    END
+

--- a/tests/cache-persist.earth
+++ b/tests/cache-persist.earth
@@ -2,7 +2,7 @@ VERSION --cache-persist-option 0.7
 FROM alpine:3.18
 
 build:
-    CACHE --persisted /cache/persisted
+    CACHE --persist /cache/persisted
     RUN touch /cache/persisted/persisted.txt
 
     CACHE /cache/not-persisted

--- a/tests/cache-persist.earth
+++ b/tests/cache-persist.earth
@@ -1,0 +1,22 @@
+VERSION --cache-persist-option 0.7
+FROM alpine:3.18
+
+build:
+    CACHE --persisted /cache/persisted
+    RUN touch /cache/persisted/persisted.txt
+
+    CACHE /cache/not-persisted
+    RUN touch /cache/not-persisted/not-persisted.txt
+
+test-persisted:
+    FROM +build
+    IF [ -e /cache/persisted/persisted.txt ]
+        RUN echo "test persisted ok"
+    END
+
+
+test-non-persisted:
+    FROM +build
+    IF [ ! -e /cache/not-persisted/not-persisted.txt ]
+        RUN echo "test non persisted ok"
+    END


### PR DESCRIPTION
Adds option to disable persist cache.
See #3509 for details.

Im not sure if by default should be `persist` or `not-persist`.
Persisting data seems bad idea in most "global" caches, cause they will grow and it takes ages to persist them.
And caches are well, caches and I assume in most cases are not needed in image..
And if someone wants to persist it it can enable it.