### PR TITLE
Introduce a new hint error to display at the end of a failed execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 - A new experimental `earthly --exec-stats` flag, which displays per-target execution stats such as total CPU and memory usage.
 - A new experimental `earthly billing view` command to get information about the organization billing plan.
 - Messages informing used build minutes during a build.
+- Help message when a build fails due to a missing referenced cloud secret.
 
 ### Fixed
 - Remove redundant verbose error messages that were not different from messages that were already being printed.
@@ -22,7 +23,7 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 - A successful authentication with an auth token will display a warning with time left before token expires if it's 14 days or under.
 - The command `earthly registry` will attempt to use the selected org if no org is specified.
 - Clarify error messages when failing to pass secrets to a build.
-- provide information on how to get more build minutes when a build fails due to missing minutes.
+- Provide information on how to get more build minutes when a build fails due to missing minutes.
 - Provide information on how to increase the max number of allowed satellites when failing to launch a satellite.
 
 ## v0.7.21 - 2023-10-24

--- a/ast/antlrhandler/error_listener.go
+++ b/ast/antlrhandler/error_listener.go
@@ -111,5 +111,5 @@ func (rel *ReturnErrorListener) SyntaxError(recognizer antlr.Recognizer, offendi
 			}
 		}
 	}
-	rel.Errs = append(rel.Errs, hint.WrapWithDisplay(finalErr, hints[0], hints[1:]...))
+	rel.Errs = append(rel.Errs, hint.Wrap(finalErr, hints[0], hints[1:]...))
 }

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -82,7 +82,7 @@ func ParseOpts(ctx context.Context, from FromOpt, opts ...Opt) (spec.Earthfile, 
 			errorStrategy.RE.GetOffendingToken().GetColumn(),
 			errorStrategy.RE.GetOffendingToken().GetText())
 		if errorStrategy.Hint != "" {
-			err = hint.WrapWithDisplay(err, errorStrategy.Hint)
+			err = hint.Wrap(err, errorStrategy.Hint)
 		}
 		return spec.Earthfile{}, err
 	}

--- a/ast/hint/error.go
+++ b/ast/hint/error.go
@@ -5,25 +5,13 @@ import (
 	"strings"
 )
 
-// TODO: once WrapWithDisplay & WrapfWithDisplay are out of use,
-// remove displayHints field and let earthly/cmd/earthly/app/run.go use the Hint() value instead of printing it
-// as part of the Error() function
-
-// Error is an error that includes hints to be displayed after the error.
-type Error struct {
+type hintError struct {
 	err   error
 	hints []string
-	// Indicate whether to display the hint as part of the Error() function
-	// or expose the hints via Hint().
-	// Once the deprecated functions are removed, this flag can be removed as well.
-	displayHints bool
 }
 
-// Error returns the error string with or without the provided hints, depending on how the error was created
-func (e Error) Error() string {
-	if !e.displayHints {
-		return e.err.Error()
-	}
+// Error returns the error string
+func (e hintError) Error() string {
 	switch len(e.hints) {
 	case 0:
 		return e.err.Error()
@@ -41,35 +29,14 @@ func (e Error) Error() string {
 	}
 }
 
-// Hint returns all hints in a single string separated by a new line
-func (e Error) Hint() string {
-	if e.displayHints {
-		// if true we can leave this empty so that it is not displayed twice in cmd/earthly/app/run.go
-		return ""
-	}
-	return strings.Join(e.hints, "\n")
-}
-
-// Wrap wraps up an error with hints, to help display hints to a user about what
-// might fix the problem.
+// Wrap wraps up an error with hints, to help display hints to a user about what might fix the problem.
+// Deprecated: use utils/hint.Wrap instead
 func Wrap(err error, firstHint string, extraHints ...string) error {
-	return Error{err: err, hints: append([]string{firstHint}, extraHints...)}
-}
-
-// WrapWithDisplay wraps up an error with hints, to help display hints to a user about what
-// might fix the problem.
-// Deprecated: use Wrap instead after verifying hint is properly displayed
-func WrapWithDisplay(err error, firstHint string, extraHints ...string) error {
-	return Error{err: err, displayHints: true, hints: append([]string{firstHint}, extraHints...)}
+	return hintError{err: err, hints: append([]string{firstHint}, extraHints...)}
 }
 
 // Wrapf wraps an error with a single hint with formatting arguments.
+// Deprecated: use utils/hint.Wrapf instead
 func Wrapf(err error, hintf string, args ...any) error {
 	return Wrap(err, fmt.Sprintf(hintf, args...))
-}
-
-// WrapfWithDisplay wraps an error with a single hint with formatting arguments.
-// Deprecated: use Wrapf instead after verifying hint is properly displayed
-func WrapfWithDisplay(err error, hintf string, args ...any) error {
-	return WrapWithDisplay(err, fmt.Sprintf(hintf, args...))
 }

--- a/buildkitd/buildkitd.go
+++ b/buildkitd/buildkitd.go
@@ -56,7 +56,7 @@ func NewClient(ctx context.Context, console conslogging.ConsoleLogger, image, co
 					settings.ClientTLSCert,
 				}
 				if containsAny(retErr.Error(), tlsPaths...) {
-					retErr = hint.WrapWithDisplay(retErr,
+					retErr = hint.Wrap(retErr,
 						"podman now requires TLS certs by default - try stopping the earthly-buildkitd container and re-running 'earthly bootstrap'",
 						"alternatively, run 'earthly config global.tls_enabled false' to disable TLS",
 					)
@@ -69,7 +69,7 @@ func NewClient(ctx context.Context, console conslogging.ConsoleLogger, image, co
 			// verification errors can happen server-side, which means
 			// errors.Is() won't work. We use strings.Contains instead to handle
 			// that case.
-			retErr = hint.WrapWithDisplay(retErr, "did earthly's certificates get regenerated? you may need to manually stop the earthly-buildkitd container.")
+			retErr = hint.Wrap(retErr, "did earthly's certificates get regenerated? you may need to manually stop the earthly-buildkitd container.")
 			return
 		}
 	}()

--- a/buildkitd/certificates.go
+++ b/buildkitd/certificates.go
@@ -72,7 +72,7 @@ func GenCerts(cfg config.Config, hostname string) error {
 					}
 				}
 			}
-			return hint.WrapWithDisplay(errors.New("cannot generate missing certificates"),
+			return hint.Wrap(errors.New("cannot generate missing certificates"),
 				fmt.Sprintf("missing certificates: %v", missing),
 				fmt.Sprintf("found certificates: %v", found),
 				"you may want to stop earthly-buildkitd, delete your certificates, and run 'earthly bootstrap' to regenerate certificates",

--- a/cmd/earthly/app/run.go
+++ b/cmd/earthly/app/run.go
@@ -18,7 +18,6 @@ import (
 	"google.golang.org/grpc/codes"
 
 	"github.com/earthly/earthly/analytics"
-	"github.com/earthly/earthly/ast/hint"
 	"github.com/earthly/earthly/billing"
 	"github.com/earthly/earthly/buildkitd"
 	"github.com/earthly/earthly/cmd/earthly/common"
@@ -27,9 +26,11 @@ import (
 	"github.com/earthly/earthly/earthfile2llb"
 	"github.com/earthly/earthly/util/containerutil"
 	"github.com/earthly/earthly/util/errutil"
+	"github.com/earthly/earthly/util/hint"
 	"github.com/earthly/earthly/util/params"
 	"github.com/earthly/earthly/util/reflectutil"
 	"github.com/earthly/earthly/util/stringutil"
+	"google.golang.org/grpc/status"
 )
 
 var (
@@ -179,13 +180,11 @@ func (app *EarthlyApp) run(ctx context.Context, args []string) int {
 
 		grpcErr, grpcErrOK := grpcerrors.AsGRPCStatus(err)
 		var paramsErr *params.Error
-		var hintErr hint.Error
+		var hintErr *hint.Error
 		switch {
-		case errors.As(err, &hintErr):
-			app.BaseCLI.Logbus().Run().SetGenericFatalError(time.Now(), logstream.FailureType_FAILURE_TYPE_OTHER, hintErr.Error())
-			if hintErr.Hint() != "" {
-				app.BaseCLI.Console().HelpPrintf(hintErr.Hint())
-			}
+		case getHintErr(err, grpcErr, &hintErr):
+			app.BaseCLI.Logbus().Run().SetGenericFatalError(time.Now(), logstream.FailureType_FAILURE_TYPE_OTHER, hintErr.Message())
+			app.BaseCLI.Console().HelpPrintf(hintErr.Hint())
 			return 1
 		case errors.As(err, &paramsErr):
 			app.BaseCLI.Logbus().Run().SetGenericFatalError(time.Now(), logstream.FailureType_FAILURE_TYPE_INVALID_PARAM, paramsErr.ParentError())
@@ -383,4 +382,25 @@ func (app *EarthlyApp) printCrashLogs(ctx context.Context) {
 
 func errorWithPrefix(err string) string {
 	return fmt.Sprintf("Error: %s", err)
+}
+
+func getHintErr(err error, grpcError *status.Status, target **hint.Error) bool {
+	targetInitialized := false
+	if *target == nil {
+		targetInitialized = true
+		*target = &hint.Error{}
+	}
+	if errors.As(err, target) {
+		return true
+	}
+	if grpcError != nil {
+		var ok bool
+		if *target, ok = hint.FromError(errors.New(grpcError.Message())); ok {
+			return ok
+		}
+	}
+	if targetInitialized {
+		*target = nil
+	}
+	return false
 }

--- a/cmd/earthly/app/run.go
+++ b/cmd/earthly/app/run.go
@@ -389,9 +389,7 @@ func getHintErr(err error, grpcError *status.Status) (*hint.Error, bool) {
 		return res, true
 	}
 	if grpcError != nil {
-		if res, ok := hint.FromError(errors.New(grpcError.Message())); ok {
-			return res, ok
-		}
+		return hint.FromError(errors.New(grpcError.Message()))
 	}
 	return nil, false
 }

--- a/cmd/earthly/common/shared.go
+++ b/cmd/earthly/common/shared.go
@@ -12,8 +12,8 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/earthly/earthly/ast/hint"
 	"github.com/earthly/earthly/util/fileutil"
+	"github.com/earthly/earthly/util/hint"
 	"github.com/earthly/earthly/variables"
 	gsysinfo "github.com/elastic/go-sysinfo"
 	"github.com/pkg/errors"

--- a/cmd/earthly/subcmd/doc_cmds.go
+++ b/cmd/earthly/subcmd/doc_cmds.go
@@ -117,7 +117,7 @@ func docString(body string, names ...string) (string, error) {
 			return body, nil
 		}
 	}
-	return "", hint.WrapfWithDisplay(errors.New("no doc comment found"), "a comment was found but the first word was not one of (%s)", strings.Join(names, ", "))
+	return "", hint.Wrapf(errors.New("no doc comment found"), "a comment was found but the first word was not one of (%s)", strings.Join(names, ", "))
 }
 
 type docSection struct {
@@ -259,7 +259,7 @@ func parseDocSections(cliCtx *cli.Context, ft *features.Features, baseRcp, cmds 
 
 func (a *Doc) documentSingleTarget(cliCtx *cli.Context, currIndent, scopeIndent string, ft *features.Features, baseRcp spec.Block, tgt spec.Target, includeBlockDocs bool) error {
 	if tgt.Docs == "" {
-		return hint.WrapfWithDisplay(errors.New("no doc comment found"), "add a comment starting with the word '%s' on the line immediately above this target", tgt.Name)
+		return hint.Wrapf(errors.New("no doc comment found"), "add a comment starting with the word '%s' on the line immediately above this target", tgt.Name)
 	}
 
 	docs, err := docString(tgt.Docs, tgt.Name)

--- a/cmd/earthly/subcmd/init_cmds.go
+++ b/cmd/earthly/subcmd/init_cmds.go
@@ -52,7 +52,7 @@ func (a *Init) action(cliCtx *cli.Context) error {
 	efPath := filepath.Join(absWd, "Earthfile")
 	_, err = os.Stat(efPath)
 	if err == nil {
-		return hint.WrapWithDisplay(fs.ErrExist, "an Earthfile already exists; if you want to re-init the project, remove the Earthfile first.")
+		return hint.Wrap(fs.ErrExist, "an Earthfile already exists; if you want to re-init the project, remove the Earthfile first.")
 	}
 	if !errors.Is(err, fs.ErrNotExist) {
 		return errors.Wrap(err, "could not check for existing Earthfile")

--- a/earthfile2llb/interpreter.go
+++ b/earthfile2llb/interpreter.go
@@ -1430,7 +1430,7 @@ func (i *Interpreter) handleLet(ctx context.Context, cmd spec.Command) error {
 		return errors.Wrap(err, "failed to parse LET args")
 	}
 	if len(args) != 3 || args[1] != "=" {
-		return hint.WrapWithDisplay(flagutil.ErrInvalidSyntax, "LET requires a variable assignment, e.g. LET foo = bar")
+		return hint.Wrap(flagutil.ErrInvalidSyntax, "LET requires a variable assignment, e.g. LET foo = bar")
 	}
 
 	key := args[0]

--- a/logbus/solvermon/vertexmon.go
+++ b/logbus/solvermon/vertexmon.go
@@ -73,11 +73,10 @@ func (vm *vertexMonitor) parseError() {
 	if vm.meta.Internal {
 		internalStr = " internal"
 	}
+	if matches, _ := stringutil.NamedGroupMatches(errString, reHint); len(matches["msg"]) == 1 {
+		errString = matches["msg"][0]
+	}
 	switch {
-	case reHint.MatchString(errString):
-		matches, _ := stringutil.NamedGroupMatches(errString, reHint)
-		errString = matches["msg"][0] //nolint:ineffassign,staticcheck
-		fallthrough
 	case strings.Contains(errString, "context canceled"):
 		vm.isCanceled = true
 		vm.errorStr = "WARN: Canceled"

--- a/logbus/solvermon/vertexmon.go
+++ b/logbus/solvermon/vertexmon.go
@@ -76,7 +76,7 @@ func (vm *vertexMonitor) parseError() {
 	switch {
 	case reHint.MatchString(errString):
 		matches, _ := stringutil.NamedGroupMatches(errString, reHint)
-		errString = matches["msg"][0]
+		errString = matches["msg"][0] //nolint:ineffassign,staticcheck
 		fallthrough
 	case strings.Contains(errString, "context canceled"):
 		vm.isCanceled = true

--- a/logbus/solvermon/vertexmon.go
+++ b/logbus/solvermon/vertexmon.go
@@ -39,6 +39,7 @@ type vertexMonitor struct {
 
 var reErrExitCode = regexp.MustCompile(`^(?:process ".*" did not complete successfully|error calling LocalhostExec): exit code: (?P<exit_code>[0-9]+)$`)
 var reErrNotFound = regexp.MustCompile(`^failed to calculate checksum of ref ([^ ]*): (.*)$`)
+var reHint = regexp.MustCompile(`^(?P<msg>.+?):Hint: .+`)
 
 func (vm *vertexMonitor) Write(dt []byte, ts time.Time, stream int) (int, error) {
 	if stream == BuildkitStatsStream {
@@ -73,6 +74,10 @@ func (vm *vertexMonitor) parseError() {
 		internalStr = " internal"
 	}
 	switch {
+	case reHint.MatchString(errString):
+		matches, _ := stringutil.NamedGroupMatches(errString, reHint)
+		errString = matches["msg"][0]
+		fallthrough
 	case strings.Contains(errString, "context canceled"):
 		vm.isCanceled = true
 		vm.errorStr = "WARN: Canceled"

--- a/scripts/tests/secrets-integration.sh
+++ b/scripts/tests/secrets-integration.sh
@@ -137,6 +137,6 @@ exit_code="$?"
 set -e
 cat output
 test "$exit_code" != "0"
-acbgrep 'unable to lookup secret my_secret: not found' output
-
+acbgrep 'unable to lookup secret "my_secret": not found' output
+acbgrep 'Help: Make sure to set the project at the top of the Earthfile' output
 echo "=== All tests have passed ==="

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -334,7 +334,7 @@ secrets-test:
         --extra_args="--secret SECRET1 --secret SECRET2=bar --build-arg SECRET_ID=\"\" --build-arg SECRET_ID_2=\"\"" \
         --target=+test \
         --should_fail=true \
-        --output_contains="unable to lookup secret SECRET3: not found"
+        --output_contains='unable to lookup secret \"SECRET3\": not found'
 
 project-secrets-test:
     DO +RUN_EARTHLY \

--- a/util/hint/hinterror.go
+++ b/util/hint/hinterror.go
@@ -1,0 +1,76 @@
+package hint
+
+import (
+	"errors"
+	"fmt"
+	"github.com/earthly/earthly/util/stringutil"
+	"regexp"
+	"strings"
+)
+
+// note this regex should be updated in case the error format changes in Error
+var regex = regexp.MustCompile(`(?P<error>.+?):Hint: (?P<hint>(?s).+)`)
+
+// Error is an error that includes hints to be displayed after the error.
+type Error struct {
+	err   error
+	hints []string
+}
+
+// Error returns the error string
+func (e *Error) Error() string {
+	if len(e.hints) == 0 {
+		return e.err.Error()
+	}
+	return fmt.Sprintf(`%v:Hint: %v`, e.err, e.Hint())
+}
+
+func (e *Error) Message() string {
+	return e.err.Error()
+}
+
+// Hint returns all hints in a single string separated by a new line
+func (e *Error) Hint() string {
+	if len(e.hints) == 0 {
+		return ""
+	}
+	res := strings.Join(e.hints, "\n")
+	if !strings.HasSuffix(res, "\n") {
+		res = fmt.Sprintf("%s\n", res)
+	}
+	return res
+}
+
+// Wrap wraps up an error with hints, to help display hints to a user about what
+// might fix the problem.
+func Wrap(err error, firstHint string, extraHints ...string) error {
+	return &Error{err: err, hints: append([]string{firstHint}, extraHints...)}
+}
+
+// Wrapf wraps an error with a single hint with formatting arguments.
+func Wrapf(err error, hintf string, args ...any) error {
+	return Wrap(err, fmt.Sprintf(hintf, args...))
+}
+
+// FromError attempts to parse the given error's string to an *hint.Error
+func FromError(err error) (*Error, bool) {
+	if err == nil {
+		return nil, false
+	}
+	matches, _ := stringutil.NamedGroupMatches(err.Error(), regex)
+	if len(matches) != 2 && len(matches) != 2 {
+		return nil, false
+	}
+	for k := range matches {
+		if len(matches[k]) != 1 {
+			return nil, false
+		}
+	}
+	errMsg := matches["error"][0]
+	hint := matches["hint"][0]
+
+	return Wrap(
+		errors.New(errMsg),
+		hint,
+	).(*Error), true
+}

--- a/util/hint/hinterror.go
+++ b/util/hint/hinterror.go
@@ -3,9 +3,10 @@ package hint
 import (
 	"errors"
 	"fmt"
-	"github.com/earthly/earthly/util/stringutil"
 	"regexp"
 	"strings"
+
+	"github.com/earthly/earthly/util/stringutil"
 )
 
 // note this regex should be updated in case the error format changes in Error
@@ -19,9 +20,6 @@ type Error struct {
 
 // Error returns the error string
 func (e *Error) Error() string {
-	if len(e.hints) == 0 {
-		return e.err.Error()
-	}
 	return fmt.Sprintf(`%v:Hint: %v`, e.err, e.Hint())
 }
 

--- a/util/hint/hinterror.go
+++ b/util/hint/hinterror.go
@@ -9,8 +9,8 @@ import (
 	"github.com/earthly/earthly/util/stringutil"
 )
 
-// note this regex should be updated in case the error format changes in Error
-var regex = regexp.MustCompile(`(?P<error>.+?):Hint: (?P<hint>(?s).+)`)
+// note that this regex should be updated in case the error format changes in Error()
+var errWithHintRegex = regexp.MustCompile(`(?P<error>.+?):Hint: (?P<hint>(?s).+)`)
 
 // Error is an error that includes hints to be displayed after the error.
 type Error struct {
@@ -55,8 +55,8 @@ func FromError(err error) (*Error, bool) {
 	if err == nil {
 		return nil, false
 	}
-	matches, _ := stringutil.NamedGroupMatches(err.Error(), regex)
-	if len(matches) != 2 && len(matches) != 2 {
+	matches, _ := stringutil.NamedGroupMatches(err.Error(), errWithHintRegex)
+	if len(matches) != 2 {
 		return nil, false
 	}
 	for k := range matches {

--- a/util/hint/hinterror_test.go
+++ b/util/hint/hinterror_test.go
@@ -1,0 +1,90 @@
+package hint
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var internal = errors.New("internal")
+
+func TestWrapf(t *testing.T) {
+	t.Run("without args", func(t *testing.T) {
+		res := Wrapf(internal, "some hint")
+		assert.Equal(t, &Error{
+			err:   internal,
+			hints: []string{"some hint"},
+		}, res)
+	})
+	t.Run("with args", func(t *testing.T) {
+		res := Wrapf(internal, "some hint with arg %s", "my-arg")
+		assert.Equal(t, &Error{
+			err:   internal,
+			hints: []string{"some hint with arg my-arg"},
+		}, res)
+	})
+}
+
+func TestWrap(t *testing.T) {
+	t.Run("with one hint", func(t *testing.T) {
+		res := Wrap(internal, "some hint")
+		assert.Equal(t, &Error{
+			err:   internal,
+			hints: []string{"some hint"},
+		}, res)
+	})
+	t.Run("with multiple hints", func(t *testing.T) {
+		res := Wrap(internal, "some hint", "another hint")
+		assert.Equal(t, &Error{
+			err:   internal,
+			hints: []string{"some hint", "another hint"},
+		}, res)
+	})
+}
+
+func TestReceivers(t *testing.T) {
+	err := Wrap(internal, "some hint", "another hint")
+
+	t.Run("test Error", func(t *testing.T) {
+		assert.Equal(t, "internal:Hint: some hint\nanother hint\n", err.Error())
+	})
+
+	t.Run("test Message", func(t *testing.T) {
+		assert.Equal(t, "internal", err.(*Error).Message())
+	})
+
+	t.Run("test Hint", func(t *testing.T) {
+		assert.Equal(t, "internal", err.(*Error).Message())
+		assert.Equal(t, "some hint\nanother hint\n", err.(*Error).Hint())
+	})
+}
+
+func TestFromError(t *testing.T) {
+
+	tests := map[string]struct {
+		err                 error
+		expectedErr         *Error
+		expectedIsHintError bool
+	}{
+		"err is nil": {},
+		"err is not a hint err (but close)": {
+			err: errors.New("some error: Hint 123"),
+		},
+		"err is a hint error": {
+			err:                 Wrap(internal, "some hint"),
+			expectedErr:         Wrap(internal, "some hint\n").(*Error),
+			expectedIsHintError: true,
+		},
+	}
+
+	for name, tc := range tests {
+		name, tc := name, tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			res, isHintErr := FromError(tc.err)
+			assert.Equal(t, tc.expectedErr, res)
+			assert.Equal(t, tc.expectedIsHintError, isHintErr)
+		})
+	}
+}

--- a/util/llbutil/secretprovider/secrets.go
+++ b/util/llbutil/secretprovider/secrets.go
@@ -46,8 +46,8 @@ func (sp *secretProvider) GetSecret(ctx context.Context, req *secrets.GetSecretR
 	}
 
 	return nil, hint.Wrap(errors.WithStack(errors.Wrapf(secrets.ErrNotFound, "unable to lookup secret %q", v.Get("name"))),
-		"Make sure to set the project at the top of the Earthfile using the PROJECT command.",
-		"Note, if this secret was called from a UDC, the project needs to be set at the Earthfile that calls the UDC.")
+		"Make sure to set the project at the top of the Earthfile by using the PROJECT command.",
+		"Note, if this secret was called from a UDC, the project needs to be set in the Earthfile that calls the UDC.")
 
 }
 

--- a/util/llbutil/secretprovider/secrets.go
+++ b/util/llbutil/secretprovider/secrets.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 
 	"github.com/earthly/earthly/cloud"
+	"github.com/earthly/earthly/util/hint"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/secrets"
 	"github.com/pkg/errors"
@@ -44,7 +45,10 @@ func (sp *secretProvider) GetSecret(ctx context.Context, req *secrets.GetSecretR
 		}, nil
 	}
 
-	return nil, errors.WithStack(errors.Wrapf(secrets.ErrNotFound, "unable to lookup secret %s", v.Get("name")))
+	return nil, hint.Wrap(errors.WithStack(errors.Wrapf(secrets.ErrNotFound, "unable to lookup secret %q", v.Get("name"))),
+		"Make sure to set the project at the top of the Earthfile using the PROJECT command.",
+		"Note, if this secret was called from a UDC, the project needs to be set at the Earthfile that calls the UDC.")
+
 }
 
 // New returns a new secrets provider which looks up secrets

--- a/util/proj/golang.go
+++ b/util/proj/golang.go
@@ -160,7 +160,7 @@ func (g *Golang) ForDir(ctx context.Context, dir string) (Project, error) {
 	}
 	out, _, err := g.execer.Command("go", "list", "-f", "{{.Dir}}").Run(ctx)
 	if errors.Is(err, fs.ErrNotExist) {
-		return nil, hint.WrapWithDisplay(errors.Wrap(err, "go.mod and go.sum exist, but go is not installed"),
+		return nil, hint.Wrap(errors.Wrap(err, "go.mod and go.sum exist, but go is not installed"),
 			"go must be installed for 'go list' so that earthly can read information about your go project",
 		)
 	}

--- a/variables/collection.go
+++ b/variables/collection.go
@@ -328,13 +328,13 @@ func (c *Collection) DeclareVar(name string, opts ...DeclareOpt) (string, string
 	if !prefs.arg {
 		ok := c.vars().Add(name, prefs.val, scope...)
 		if !ok {
-			return "", "", hint.WrapfWithDisplay(ErrRedeclared, "if you want to change the value of '%[1]v', use 'SET %[1]v = %[2]q'", name, prefs.val)
+			return "", "", hint.Wrapf(ErrRedeclared, "if you want to change the value of '%[1]v', use 'SET %[1]v = %[2]q'", name, prefs.val)
 		}
 		return prefs.val, prefs.val, nil
 	}
 
 	if _, ok := c.vars().Get(name, WithActive()); ok {
-		return "", "", hint.WrapfWithDisplay(ErrRedeclared, "'%v' was already declared with LET and cannot be redeclared as an ARG", name)
+		return "", "", hint.Wrapf(ErrRedeclared, "'%v' was already declared with LET and cannot be redeclared as an ARG", name)
 	}
 
 	v, err := c.overridingOrDefault(name, prefs.val, prefs.pncvf)
@@ -345,17 +345,17 @@ func (c *Collection) DeclareVar(name string, opts ...DeclareOpt) (string, string
 	if prefs.global {
 		if _, ok := c.args().Get(name); ok {
 			baseErr := errors.Wrap(ErrRedeclared, "could not override non-global ARG with global ARG")
-			return "", "", hint.WrapfWithDisplay(baseErr, "'%[1]v' was already declared as a non-global ARG in this scope - did you mean to add '--global' to the original declaration?", name)
+			return "", "", hint.Wrapf(baseErr, "'%[1]v' was already declared as a non-global ARG in this scope - did you mean to add '--global' to the original declaration?", name)
 		}
 		ok := c.globals().Add(name, v, scope...)
 		if !ok {
-			return "", "", hint.WrapfWithDisplay(ErrRedeclared, "if you want to change the value of '%[1]v', redeclare it as a non-argument variable with 'LET %[1]v = %[2]q'", name, prefs.val)
+			return "", "", hint.Wrapf(ErrRedeclared, "if you want to change the value of '%[1]v', redeclare it as a non-argument variable with 'LET %[1]v = %[2]q'", name, prefs.val)
 		}
 		return v, v, nil
 	}
 	ok := c.args().Add(name, v, scope...)
 	if !ok {
-		return "", "", hint.WrapfWithDisplay(ErrRedeclared, "if you want to change the value of '%[1]v', redeclare it as a non-argument variable with 'LET %[1]v = %[2]q'", name, prefs.val)
+		return "", "", hint.Wrapf(ErrRedeclared, "if you want to change the value of '%[1]v', redeclare it as a non-argument variable with 'LET %[1]v = %[2]q'", name, prefs.val)
 	}
 	return v, prefs.val, nil
 }
@@ -389,10 +389,10 @@ func (c *Collection) UpdateVar(name, value string, pncvf ProcessNonConstantVaria
 		}
 	}()
 	if _, ok := c.effective().Get(name, WithActive()); !ok {
-		return hint.WrapfWithDisplay(ErrVarNotFound, "'%[1]v' needs to be declared with 'LET %[1]v = someValue' before it can be used with SET", name)
+		return hint.Wrapf(ErrVarNotFound, "'%[1]v' needs to be declared with 'LET %[1]v = someValue' before it can be used with SET", name)
 	}
 	if _, ok := c.vars().Get(name, WithActive()); !ok {
-		return hint.WrapfWithDisplay(ErrSetArg, "'%[1]v' is an ARG and cannot be used with SET - try declaring 'LET %[1]v = $%[1]v' first", name)
+		return hint.Wrapf(ErrSetArg, "'%[1]v' is an ARG and cannot be used with SET - try declaring 'LET %[1]v = $%[1]v' first", name)
 	}
 	v, err := parseArgValue(name, value, pncvf)
 	if err != nil {


### PR DESCRIPTION
In a recent previous PR the existing hint.Error was refactored in order to allow for hints to be displayed at the end of a failed execution in a more consistent way compared to other help messages.

In this PR that change was slightly reverted so that it would be easier to remove the deprecated hint.Error
(`WrapWithDisplay` is reverted back to `Wrap`)

So instead, this PR introduced a new hint.Error, which if used, will show the hint at the end of an execution like other help messages. In addition the mechanism was improved such that even hints going through gRPC will be properly identified.

Finally, this new hint error is used in cases where a cloud secret could not be found.