### PR TITLE
Auto-skip: support FROM DOCKERFILE & remotes for WITH DOCKER --load

### DIFF
--- a/inputgraph/hash_test.go
+++ b/inputgraph/hash_test.go
@@ -128,3 +128,23 @@ func TestHashTargetWithDockerNoAlias(t *testing.T) {
 	hex := fmt.Sprintf("%x", hash)
 	r.Equal("6aaabf6d323280d4fd23960a4ba2b159dcfb84fd", hex)
 }
+
+func TestHashTargetWithDockerRemote(t *testing.T) {
+	r := require.New(t)
+	target := domain.Target{
+		LocalPath: "./testdata/with-docker",
+		Target:    "with-docker-load-remote",
+	}
+
+	ctx := context.Background()
+	cons := conslogging.New(os.Stderr, &sync.Mutex{}, conslogging.NoColor, 0, conslogging.Info)
+
+	hashOpt := HashOpt{Console: cons, Target: target}
+	org, project, hash, err := HashTarget(ctx, hashOpt)
+	r.NoError(err)
+	r.Equal("earthly-technologies", org)
+	r.Equal("core", project)
+
+	hex := fmt.Sprintf("%x", hash)
+	r.NotEmpty(hex)
+}

--- a/inputgraph/testdata/with-docker/Earthfile
+++ b/inputgraph/testdata/with-docker/Earthfile
@@ -27,3 +27,10 @@ with-docker-load-args:
     WITH DOCKER --load foo=(+load-target --foo=2)
          RUN echo "loaded"
     END
+
+with-docker-load-remote:
+    BUILD +load-target
+    FROM earthly/dind:alpine-3.18-docker-23.0.6-r7
+    WITH DOCKER --load foo=github.com/earthly/earthly:6610b73131f94cbe594dba3b90665748f21a9b8d+license
+         RUN echo "loaded"
+    END

--- a/tests/autoskip/Dockerfile
+++ b/tests/autoskip/Dockerfile
@@ -1,0 +1,4 @@
+FROM alpine:3.18
+
+RUN ls /tmp
+ENTRYPOINT ["echo", "hello"]

--- a/tests/autoskip/Earthfile
+++ b/tests/autoskip/Earthfile
@@ -25,6 +25,7 @@ test-all:
     BUILD +test-shell-out
     BUILD +test-copy-if-exists
     BUILD +test-remote-targets
+    BUILD +test-from-dockerfile
 
 test-files:
     RUN echo hello > my-file
@@ -192,6 +193,20 @@ test-remote-targets:
     DO --pass-args +RUN_EARTHLY_ARGS --earthfile=remote-target.earth --target=+valid-build --output_contains="target .* has already been run; exiting"
 
     DO --pass-args +RUN_EARTHLY_ARGS --earthfile=remote-target.earth --target=+invalid-build --output_contains="complete Git SHA or tag"
+
+test-from-dockerfile:
+    RUN mkdir /dist
+    COPY Dockerfile /dist
+    RUN echo "foo" > /dist/my-file
+
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=from-dockerfile.earth --target=+local
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=from-dockerfile.earth --target=+local --output_contains="target .* has already been run; exiting"
+
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=from-dockerfile.earth --target=+local-target
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=from-dockerfile.earth --target=+local-target --output_contains="target .* has already been run; exiting"
+
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=from-dockerfile.earth --target=+remote
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=from-dockerfile.earth --target=+remote --output_contains="target .* has already been run; exiting"
 
 RUN_EARTHLY_ARGS:
     COMMAND

--- a/tests/autoskip/from-dockerfile.earth
+++ b/tests/autoskip/from-dockerfile.earth
@@ -1,0 +1,29 @@
+VERSION 0.7
+
+PROJECT earthly-technologies/core
+
+FROM alpine
+
+local:
+    FROM DOCKERFILE -f /dist/Dockerfile /dist
+    RUN echo "hi"
+
+local-target:
+    FROM DOCKERFILE +create-dockerfile/
+    RUN echo "hi"
+
+remote:
+    FROM DOCKERFILE github.com/earthly/test-remote/from-dockerfile:40080b4fc1fd4881f5123f03ba030055efbbbafe+create-dockerfile/
+    RUN echo "hi"
+
+create-dockerfile:
+    FROM alpine:3.18
+    RUN mkdir dist
+    RUN echo "
+FROM alpine:3.18
+ARG my_arg=default
+RUN echo \${my_arg}
+RUN echo \${my_arg} >/arg-value
+" > dist/Dockerfile
+    RUN cat dist/Dockerfile
+    SAVE ARTIFACT dist/*


### PR DESCRIPTION
Auto-skip support for targets that contain:

```
FROM DOCKERFILE -f /dist/Dockerfile /dist
````
```
FROM DOCKERFILE github.com/earthly/test-remote/from-dockerfile:40080b4fc1fd4881f5123f03ba030055efbbbafe+create-dockerfile/
```
```
FROM DOCKERFILE +create-dockerfile/
```
```
WITH DOCKER --load foo=github.com/earthly/earthly:6610b73131f94cbe594dba3b90665748f21a9b8d+license
```