### PR TITLE
Auto-skip: basic support for evaluating IF conditions

### DIFF
--- a/inputgraph/loader_test.go
+++ b/inputgraph/loader_test.go
@@ -1,6 +1,7 @@
 package inputgraph
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -38,6 +39,138 @@ func Test_containsShellExpr(t *testing.T) {
 		t.Run(c.desc, func(t *testing.T) {
 			got := containsShellExpr(c.val)
 			require.Equal(t, c.want, got)
+		})
+	}
+}
+
+func Test_evalConditions(t *testing.T) {
+	cases := []struct {
+		val  string
+		want [2]bool
+	}{
+		{
+			val:  `[ -f "file" ]`,
+			want: [2]bool{false, false},
+		},
+		{
+			val:  "[ true ]",
+			want: [2]bool{true, true},
+		},
+		{
+			val:  "[ false ]",
+			want: [2]bool{false, true},
+		},
+		{
+			val:  `[ -n "foo" ]`,
+			want: [2]bool{true, true},
+		},
+		{
+			val:  `[ -n "" ]`,
+			want: [2]bool{false, true},
+		},
+		{
+			val:  `[ -z "" ]`,
+			want: [2]bool{true, true},
+		},
+		{
+			val:  `[ -z "foo" ]`,
+			want: [2]bool{false, true},
+		},
+		{
+			val:  `[ "foo" == "bar" ]`,
+			want: [2]bool{false, true},
+		},
+		{
+			val:  `[ "foo" = "bar" ]`,
+			want: [2]bool{false, true},
+		},
+		{
+			val:  `[ "foo" != "bar" ]`,
+			want: [2]bool{true, true},
+		},
+		{
+			val:  `[ "foo" > "bar" ]`,
+			want: [2]bool{true, true},
+		},
+		{
+			val:  `[ "foo" < "bar" ]`,
+			want: [2]bool{false, true},
+		},
+		{
+			val:  `[ "2" -eq "2" ]`,
+			want: [2]bool{true, true},
+		},
+		{
+			val:  `[ "2" -eq "4" ]`,
+			want: [2]bool{false, true},
+		},
+		{
+			val:  `[ "2" -ne "4" ]`,
+			want: [2]bool{true, true},
+		},
+		{
+			val:  `[ "2" -gt "1" ]`,
+			want: [2]bool{true, true},
+		},
+		{
+			val:  `[ "2" -gt "10" ]`,
+			want: [2]bool{false, true},
+		},
+		{
+			val:  `[ "2" -gt "foo" ]`,
+			want: [2]bool{false, false},
+		},
+		{
+			val:  `[ "2" -gt "foo" ]`,
+			want: [2]bool{false, false},
+		},
+		{
+			val:  `[ "2" -lt "100" ]`,
+			want: [2]bool{true, true},
+		},
+		{
+			val:  `[ "2" -lt "1" ]`,
+			want: [2]bool{false, true},
+		},
+		{
+			val:  `[ "2" -le "2" ]`,
+			want: [2]bool{true, true},
+		},
+		{
+			val:  `[ "4" -le "2" ]`,
+			want: [2]bool{false, true},
+		},
+		{
+			val:  `[ true ] && [ false ]`,
+			want: [2]bool{false, true},
+		},
+		{
+			val:  `[ true ] && [ -z "" ]`,
+			want: [2]bool{true, true},
+		},
+		{
+			val:  `[ true ] && [ -z "" ] || [ false ]`,
+			want: [2]bool{true, true},
+		},
+		{
+			val:  `[ 2 -gt 1 ] || [ "foo" == "bar" ] && [ false ]`,
+			want: [2]bool{true, true},
+		},
+		{
+			val:  `[ 2 -gt 0 ] || [ "foo" == "foo" ] && [ true ]`,
+			want: [2]bool{true, true},
+		},
+		{
+			val:  `[ 2 -lt 0 ] && [ "foo" == "foo" ] || [ true ]`,
+			want: [2]bool{true, true},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.val, func(t *testing.T) {
+			v := strings.Fields(c.val)
+			got, ok := evalConditions(v)
+			require.Equal(t, c.want, [2]bool{got, ok})
 		})
 	}
 }

--- a/tests/autoskip/Earthfile
+++ b/tests/autoskip/Earthfile
@@ -65,6 +65,9 @@ test-if-else:
     DO --pass-args +RUN_EARTHLY_ARGS --earthfile=if-else.earth --target=+test --output_contains="condition ok"
     DO --pass-args +RUN_EARTHLY_ARGS --earthfile=if-else.earth --target=+test --output_contains="target .* has already been run; exiting"
 
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=if-else.earth --target=+test-eval --output_contains="condition ok"
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=if-else.earth --target=+test-eval --output_contains="target .* has already been run; exiting"
+
 test-for-in:
     DO --pass-args +RUN_EARTHLY_ARGS --earthfile=for.earth --target=+test --output_contains="hello 3"
     DO --pass-args +RUN_EARTHLY_ARGS --earthfile=for.earth --target=+test --output_contains="target .* has already been run; exiting"

--- a/tests/autoskip/if-else.earth
+++ b/tests/autoskip/if-else.earth
@@ -6,9 +6,29 @@ FROM alpine
 
 test:
     IF [ true ]
-       RUN echo "condition ok"
+        RUN echo "condition ok"
     ELSE IF [ false ]
-       RUN echo "never"
+        RUN echo "never"
     ELSE
-       RUN echo "nope"
+        RUN echo "nope"
+    END
+
+test-eval:
+    ARG VAL=FOO
+    IF [ -n "$VAL" ]
+        RUN echo "condition ok"
+    ELSE
+        # Unsupported op should not be visited.
+        COPY --from my-file .
+    END
+
+test-eval-2:
+    ARG VAL=2
+    IF [ "$VAL" -gt 5 ]
+        RUN echo "nope"
+    ELSE IF [ "$VAL" -lt 10 ]
+        RUN echo "condition ok"
+    ELSE
+        # Unsupported op should not be visited.
+        COPY --from my-file .
     END


### PR DESCRIPTION
This PR adds support for basic `IF` statements to auto-skip. This will allow the feature to ignore code paths that will not be visited due to a local `ARG` comparison or other simple check.

Some examples: 

```
[ true ]
[ false ]
[ -n "foo" ]
[ -n "" ]
[ -z "" ]
[ -z "foo" ]
[ "foo" == "bar" ]
[ "foo" = "bar" ]
[ "foo" != "bar" ]
[ "foo" > "bar" ]
[ "foo" < "bar" ]
[ "2" -eq "2" ]
[ "2" -le "2" ]
[ "4" -le "2" ]
[ true ] && [ false ]
[ true ] && [ -z "" ]
[ true ] && [ -z "" ] || [ false ]
[ 2 -gt 1 ] || [ "foo" == "bar" ] && [ false ]
[ 2 -gt 0 ] || [ "foo" == "foo" ] && [ true ]
[ 2 -lt 0 ] && [ "foo" == "foo" ] || [ true ]
```