### PR TITLE
Auto-skip: fixes arg parsing issues

### DIFF
--- a/cmd/earthly/subcmd/build_cmd.go
+++ b/cmd/earthly/subcmd/build_cmd.go
@@ -847,12 +847,13 @@ func (a *Build) initAutoSkip(ctx context.Context, target domain.Target, overridi
 	)
 
 	orgName, projectName, targetHash, err := inputgraph.HashTarget(ctx, inputgraph.HashOpt{
-		Target:          target,
-		Console:         a.cli.Console(),
-		CI:              a.cli.Flags().CI,
-		BuiltinArgs:     variables.DefaultArgs{EarthlyVersion: a.cli.Version(), EarthlyBuildSha: a.cli.GitSHA()},
-		OverridingVars:  overridingVars,
-		EarthlyCIRunner: a.cli.Flags().EarthlyCIRunner,
+		Target:           target,
+		Console:          a.cli.Console(),
+		CI:               a.cli.Flags().CI,
+		BuiltinArgs:      variables.DefaultArgs{EarthlyVersion: a.cli.Version(), EarthlyBuildSha: a.cli.GitSHA()},
+		OverridingVars:   overridingVars,
+		EarthlyCIRunner:  a.cli.Flags().EarthlyCIRunner,
+		SkipProjectCheck: a.cli.Flags().LocalSkipDB != "",
 	})
 	if err != nil {
 		return nil, nil, false, errors.Wrapf(err, "unable to calculate hash for %s", target)

--- a/cmd/earthly/subcmd/build_cmd.go
+++ b/cmd/earthly/subcmd/build_cmd.go
@@ -823,6 +823,7 @@ func (a *Build) platformResolver(ctx context.Context, bkClient *bkclient.Client,
 }
 
 func (a *Build) initAutoSkip(ctx context.Context, target domain.Target, overridingVars *variables.Scope, client *cloud.Client) (bk.BuildkitSkipper, []byte, bool, error) {
+
 	if !a.cli.Flags().SkipBuildkit {
 		return nil, nil, false, nil
 	}

--- a/inputgraph/hash.go
+++ b/inputgraph/hash.go
@@ -10,21 +10,24 @@ import (
 
 // HashOpt contains all of the options available to the hasher.
 type HashOpt struct {
-	Target          domain.Target
-	Console         conslogging.ConsoleLogger
-	CI              bool
-	BuiltinArgs     variables.DefaultArgs
-	OverridingVars  *variables.Scope
-	EarthlyCIRunner bool
+	Target           domain.Target
+	Console          conslogging.ConsoleLogger
+	CI               bool
+	BuiltinArgs      variables.DefaultArgs
+	OverridingVars   *variables.Scope
+	EarthlyCIRunner  bool
+	SkipProjectCheck bool
 }
 
 // HashTarget produces a hash from an Earthly target.
 func HashTarget(ctx context.Context, opt HashOpt) (org, project string, hash []byte, err error) {
 	l := newLoader(ctx, opt)
 
-	org, project, err = l.findProject(ctx)
-	if err != nil {
-		return "", "", nil, err
+	if !opt.SkipProjectCheck {
+		org, project, err = l.findProject(ctx)
+		if err != nil {
+			return "", "", nil, err
+		}
 	}
 
 	err = l.load(ctx)

--- a/inputgraph/loader.go
+++ b/inputgraph/loader.go
@@ -849,7 +849,7 @@ func (l *loader) findProject(ctx context.Context) (org, project string, err erro
 		}
 	}
 
-	return "", "", errors.New("PROJECT command missing")
+	return "", "", errors.New("PROJECT command is required for remote storage")
 }
 
 func (l *loader) load(ctx context.Context) error {

--- a/inputgraph/loader.go
+++ b/inputgraph/loader.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/earthly/earthly/ast/command"
 	"github.com/earthly/earthly/ast/commandflag"
 	"github.com/earthly/earthly/ast/spec"
@@ -308,6 +309,16 @@ func (l *loader) expandDirs(dirs ...string) ([]string, error) {
 }
 
 func (l *loader) expandArgs(ctx context.Context, args []string) ([]string, error) {
+
+	// The args passed to this method have been split on whitespace without
+	// keeping quoted strings intact. Let's split them correctly using shlex.
+	cleaned, err := flagutil.ParseArgsCleaned("", nil, args)
+	if err != nil {
+		return nil, err
+	}
+
+	spew.Dump(args, cleaned)
+
 	ret := []string{}
 	for _, arg := range args {
 		expanded, err := l.varCollection.Expand(arg, func(cmd string) (string, error) {
@@ -318,6 +329,7 @@ func (l *loader) expandArgs(ctx context.Context, args []string) ([]string, error
 		}
 		ret = append(ret, expanded)
 	}
+
 	return ret, nil
 }
 

--- a/inputgraph/loader.go
+++ b/inputgraph/loader.go
@@ -310,7 +310,6 @@ func (l *loader) expandDirs(dirs ...string) ([]string, error) {
 }
 
 func (l *loader) expandArgs(ctx context.Context, args []string) ([]string, error) {
-
 	// Reform the args such that quoted args are combined.
 	args = stringutil.ProcessParamsAndQuotes(args)
 

--- a/tests/autoskip/Earthfile
+++ b/tests/autoskip/Earthfile
@@ -56,7 +56,9 @@ test-with-subdir:
 
 test-requires-project:
     RUN echo hello > my-file
-    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=no-project.earth --target=+no-project --should_fail=true --output_contains="command missing"
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=no-project.earth --target=+no-project --output_contains="I was run"
+
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=no-project.earth --target=+no-project --should_fail=true --extra_args="--auto-skip-db-path=" --output_contains="PROJECT command is required"
 
 test-wait:
     DO --pass-args +RUN_EARTHLY_ARGS --earthfile=wait.earth --target=+test --output_contains="not skipped"

--- a/tests/autoskip/Earthfile
+++ b/tests/autoskip/Earthfile
@@ -4,6 +4,8 @@ FROM --pass-args ../..+earthly-integration-test-base
 
 IMPORT .. AS tests
 
+PROJECT earthly-technologies/core
+
 WORKDIR /test
 
 test-all:

--- a/tests/do-not-track/Earthfile
+++ b/tests/do-not-track/Earthfile
@@ -36,4 +36,6 @@ RUN_EARTHLY_ARGS:
         --output_contains=$output_contains \
         --output_does_not_contain=$output_does_not_contain \
         --pre_command=$pre_command \
-        --post_command=$post_command
+        --post_command=$post_command \
+        # Ensure no auto-skip requests when DO_NOT_TRACK enabled.
+        --extra_args="--auto-skip --auto-skip-db-path=test.db"

--- a/tests/do-not-track/Earthfile
+++ b/tests/do-not-track/Earthfile
@@ -36,5 +36,4 @@ RUN_EARTHLY_ARGS:
         --output_contains=$output_contains \
         --output_does_not_contain=$output_does_not_contain \
         --pre_command=$pre_command \
-        --post_command=$post_command \
-        --extra_args="--auto-skip --auto-skip-db-path=test.db" \
+        --post_command=$post_command

--- a/util/shell/lex.go
+++ b/util/shell/lex.go
@@ -501,6 +501,35 @@ func (sw *shellWord) processDollarCurlyBracket() (string, error) {
 			return "", errors.Errorf("%s: %s", name, message)
 		}
 		return newValue, nil
+	case '#':
+		word, _, err := sw.processStopOn('}')
+		if err != nil {
+			if sw.scanner.Peek() == scanner.EOF {
+				return "", errors.New("syntax error: missing '}'")
+			}
+			return "", err
+		}
+		newValue, err := sw.getEnv(name)
+		var found bool
+		switch err {
+		case nil:
+			found = true
+		case errEnvNotFound:
+			break
+		default:
+			return "", err
+		}
+		if !found {
+			if sw.skipUnsetEnv {
+				return fmt.Sprintf("${%s#%s}", name, word), nil
+			}
+			message := "is not allowed to be unset"
+			if word != "" {
+				message = word
+			}
+			return "", errors.Errorf("%s: %s", name, message)
+		}
+		return newValue, nil
 	case ':':
 		// Special ${xx:...} format processing
 		// Yes it allows for recursive $'s in the ... spot

--- a/util/shell/lex_test.go
+++ b/util/shell/lex_test.go
@@ -48,24 +48,52 @@ func TestShellParserMandatoryEnvVars(t *testing.T) {
 	require.Contains(t, err.Error(), "message herex")
 }
 
-func TestShellParserHash(t *testing.T) {
-	shlex := NewLex('\\')
-	setEnvs := map[string]string{"VAR": "hello world"}
-	word := "goodbye${VAR#hello}"
+func TestShellParserReplace(t *testing.T) {
+	cases := []struct {
+		envs map[string]string
+		word string
+		want string
+	}{
+		{
+			envs: map[string]string{"VAR": "image.jpg"},
+			word: "${VAR%.jpg}",
+			want: "image",
+		},
+		{
+			envs: map[string]string{"VAR": "image.jpg"},
+			word: "${VAR#.jpeg}",
+			want: "image.jpg",
+		},
+		{
+			envs: map[string]string{"VAR": "image.jpg"},
+			word: "${VAR#nope}",
+			want: "image.jpg",
+		},
+		{
+			envs: map[string]string{"VAR": "hello world"},
+			word: "${VAR#hello }",
+			want: "world",
+		},
+		{
+			envs: map[string]string{"VAR": "hello world"},
+			word: "${VAR#world}",
+			want: "hello world",
+		},
+		{
+			envs: map[string]string{"VAR": "hello world"},
+			word: "${VAR#hello world too long}",
+			want: "hello world",
+		},
+	}
 
-	newWord, err := shlex.ProcessWordWithMap(word, setEnvs, nil)
-	require.NoError(t, err)
-	require.Equal(t, "goodbye world", newWord)
-}
-
-func TestShellParserPercent(t *testing.T) {
-	shlex := NewLex('\\')
-	setEnvs := map[string]string{"VAR": "image.jpg"}
-	word := "${VAR%.jpg}"
-
-	newWord, err := shlex.ProcessWordWithMap(word, setEnvs, nil)
-	require.NoError(t, err)
-	require.Equal(t, "image", newWord)
+	for _, c := range cases {
+		t.Run(c.word, func(t *testing.T) {
+			shlex := NewLex('\\')
+			got, err := shlex.ProcessWordWithMap(c.word, c.envs, nil)
+			require.NoError(t, err)
+			require.Equal(t, c.want, got)
+		})
+	}
 }
 
 func TestShellParser4EnvVars(t *testing.T) {

--- a/util/shell/lex_test.go
+++ b/util/shell/lex_test.go
@@ -48,6 +48,26 @@ func TestShellParserMandatoryEnvVars(t *testing.T) {
 	require.Contains(t, err.Error(), "message herex")
 }
 
+func TestShellParserHash(t *testing.T) {
+	shlex := NewLex('\\')
+	setEnvs := map[string]string{"VAR": "hello world"}
+	word := "goodbye${VAR#hello}"
+
+	newWord, err := shlex.ProcessWordWithMap(word, setEnvs, nil)
+	require.NoError(t, err)
+	require.Equal(t, "goodbye world", newWord)
+}
+
+func TestShellParserPercent(t *testing.T) {
+	shlex := NewLex('\\')
+	setEnvs := map[string]string{"VAR": "image.jpg"}
+	word := "${VAR%.jpg}"
+
+	newWord, err := shlex.ProcessWordWithMap(word, setEnvs, nil)
+	require.NoError(t, err)
+	require.Equal(t, "image", newWord)
+}
+
 func TestShellParser4EnvVars(t *testing.T) {
 	fn := "envVarTest"
 	lineCount := 0


### PR DESCRIPTION
Fixes 2 issues that were blocking auto-skip on `+test` & `+for-linux`. 
* Problems parsing args with complex quoting/parens
* Arg expansion for ${$VAL#foo}. Example: https://github.com/earthly/earthly/blob/main/Earthfile#L366

The above targets now work!