### PR TITLE
--exec-stats requires logbus

### DIFF
--- a/cmd/earthly/subcmd/build_cmd.go
+++ b/cmd/earthly/subcmd/build_cmd.go
@@ -511,6 +511,8 @@ func (a *Build) ActionBuildImp(cliCtx *cli.Context, flagArgs, nonFlagArgs []stri
 	var logbusSM *solvermon.SolverMonitor
 	if a.cli.Flags().Logstream {
 		logbusSM = a.cli.LogbusSetup().SolverMonitor
+	} else if a.cli.Flags().DisplayExecStats {
+		return fmt.Errorf("the --exec-stats feature is only available when --logstream is enabled")
 	}
 
 	builderOpts := builder.Opt{

--- a/outmon/solvermon.go
+++ b/outmon/solvermon.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/dustin/go-humanize"
 	"github.com/earthly/earthly/conslogging"
+	"github.com/earthly/earthly/logbus/formatter"
 	"github.com/earthly/earthly/util/buildkitutil"
 	"github.com/earthly/earthly/util/vertexmeta"
 	"github.com/moby/buildkit/client"
@@ -191,6 +192,10 @@ func (sm *SolverMonitor) processStatus(ss *client.SolveStatus) error {
 		}
 		if !vm.headerPrinted {
 			sm.printHeader(vm)
+		}
+		if logLine.Stream == formatter.BuildkitStatsStream {
+			// --exec-stats requires logbus to be enabled
+			continue
 		}
 		err := sm.printOutput(vm, logLine.Data)
 		if err != nil {


### PR DESCRIPTION
prevent --exec-stats data from getting dumped to stdout when legacy non-logbus code is used.