### PR TITLE
add new gh job to check for broken links on PRs to docs-0.7

### DIFF
--- a/.github/workflows/docs-checks-links.yml
+++ b/.github/workflows/docs-checks-links.yml
@@ -1,11 +1,9 @@
 name: check docs broken links
 
 on:
-  push: # this can be removed if we noticed the workflow_run trigger is working as expected (after the gitbook workflow completes)
+  push:
     branches: [docs-0.7]
-  workflow_run:
-    workflows: ['GitBook']
-    types: [completed]
+  pull_request:
     branches: [docs-0.7]
 
 concurrency:
@@ -13,8 +11,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check-broken-links:
-    if: ${{ github.event_name == 'push' || github.event.workflow_run.conclusion == 'success' }}
+  check-broken-links-pr:
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: "ubuntu-latest"
+    env:
+      FORCE_COLOR: 1
+      EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"
+      EARTHLY_INSTALL_ID: "earthly-githubactions"
+      DOCKERHUB_MIRROR_USERNAME: "${{ secrets.DOCKERHUB_MIRROR_USERNAME }}"
+      DOCKERHUB_MIRROR_PASSWORD: "${{ secrets.DOCKERHUB_MIRROR_PASSWORD }}"
+      # Used in our github action as the token - TODO: look to change it into an input
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: earthly/actions-setup@main
+      - name: Check Broken Links
+        run: earthly --ci +check-broken-links-pr --VERBOSE=true
+
+  check-broken-links-branch:
+    if: ${{ github.event_name == 'push' }}
     runs-on: "ubuntu-latest"
     env:
       FORCE_COLOR: 1

--- a/.github/workflows/docs-checks-links.yml
+++ b/.github/workflows/docs-checks-links.yml
@@ -26,6 +26,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.head_ref }}
       - uses: earthly/actions-setup@main
       - name: Check Broken Links
         run: earthly --ci +check-broken-links-pr --VERBOSE=true

--- a/Earthfile
+++ b/Earthfile
@@ -890,6 +890,22 @@ check-broken-links:
         RUN --no-cache echo -e "${GREEN}No Broken Links were found${NOCOLOR}"
     END
 
+check-broken-links-pr:
+    FROM alpine/git
+    WORKDIR /tmp
+    RUN apk add github-cli
+    ARG BRANCH
+    ARG EARTHLY_GIT_BRANCH
+    LET branch=$BRANCH
+    IF [ -z $branch ]
+        SET branch=$EARTHLY_GIT_BRANCH
+    END
+    RUN --secret GH_TOKEN=littleredcorvette-github-token gh pr checks --watch $branch --repo earthly/earthly
+    RUN --secret GH_TOKEN=littleredcorvette-github-token gh pr checks $branch --repo earthly/earthly | grep GitBook|awk '{print $4}' > url
+    ARG VERBOSE
+    BUILD --pass-args +check-broken-links --ADDRESS=$(cat url)
+
+
 # BUILD_AND_FROM will issue a FROM and a BUILD commands for the provided target
 BUILD_AND_FROM:
     COMMAND

--- a/Earthfile
+++ b/Earthfile
@@ -900,7 +900,6 @@ check-broken-links-pr:
     IF [ -z $branch ]
         SET branch=$EARTHLY_GIT_BRANCH
     END
-    RUN --secret GH_TOKEN=littleredcorvette-github-token gh pr checks --watch $branch --repo earthly/earthly
     RUN --secret GH_TOKEN=littleredcorvette-github-token gh pr checks $branch --repo earthly/earthly | grep GitBook|awk '{print $4}' > url
     ARG VERBOSE
     BUILD --pass-args +check-broken-links --ADDRESS=$(cat url)

--- a/docs/caching/caching-in-earthfiles.md
+++ b/docs/caching/caching-in-earthfiles.md
@@ -113,7 +113,7 @@ Please note that remote caching via registry tends to be very difficult to get r
 
 ### Force a build step to always cache
 
-If you have already optimized your cache by maximizing its size, declaring arguments as late as possible, and implementing the other recommendations provided here, but you still encounter performance bottlenecks due to computationally intensive tasks being evicted from the cache, consider employing `SAVE IMAGE` commands at strategic points. These images can serve as manual caches and can improve efficiency at the cost of simplicity. For additional details, refer to the [Best Practices](best-practices/best-practices.md#use-save-image-to-always-cache) section.
+If you have already optimized your cache by maximizing its size, declaring arguments as late as possible, and implementing the other recommendations provided here, but you still encounter performance bottlenecks due to computationally intensive tasks being evicted from the cache, consider employing `SAVE IMAGE` commands at strategic points. These images can serve as manual caches and can improve efficiency at the cost of simplicity. For additional details, refer to the [Best Practices](../best-practices/best-practices.md#use-save-image-to-always-cache) section.
 
 ### Debugging tips
 

--- a/docs/caching/caching-via-registry.md
+++ b/docs/caching/caching-via-registry.md
@@ -4,7 +4,7 @@
 ##### Important
 **Remote caching is an advanced feature that requires significant experimentation to get right**. Remote caching is generally not recommended unless remote runners are not possible in your setup. Remote caching does not cache everything in your build, and is very difficult to debug when it doesn't work. Remote caching also does not allow concurrent writes, and can be tricky to use in a mix of main vs PR CI builds.
 
-[Remote runners](./remote-runners.md) (either self-managed, or [Earthly Satellites](cloud/satellites.md)) are faster, and easier to set up because the cache does not need any transferring between runs (allowing for the entire build to be cached efficiently), cache mounts are correctly persisted, and concurrent access is built-in.
+[Remote runners](../remote-runners.md) (either self-managed, or [Earthly Satellites](../cloud/satellites.md)) are faster, and easier to set up because the cache does not need any transferring between runs (allowing for the entire build to be cached efficiently), cache mounts are correctly persisted, and concurrent access is built-in.
 
 For a comparison between remote runners and remote caching, see the [Caching page](./caching.md).
 {% endhint %}
@@ -81,11 +81,11 @@ Use a read-write inline cache (typically in master/main branch builds):
 earthly --use-inline-cache --save-inline-cache --push +some-target
 ```
 
-The options mentioned above are also available as environment variables. See [Earthly command reference](earthly-command/earthly-command.md) for more information.
+The options mentioned above are also available as environment variables. See [Earthly command reference](../earthly-command/earthly-command.md) for more information.
 
 The way this works underneath is that Earthly uses `SAVE IMAGE --push` declarations as source and destination for any inline cache.
 
-In case different Docker tags are used in branch or PR builds, it is possible to use additional cache sources via [`SAVE IMAGE --cache-from=...`](earthfile/earthfile.md#save-image). This may be useful so that PR builds are able to use the main branch cache. Here is a simple example:
+In case different Docker tags are used in branch or PR builds, it is possible to use additional cache sources via [`SAVE IMAGE --cache-from=...`](../earthfile/earthfile.md#save-image). This may be useful so that PR builds are able to use the main branch cache. Here is a simple example:
 
 ```Dockerfile
 FROM ...
@@ -154,7 +154,7 @@ On developer's computer (optional):
 earthly --remote-cache=mycompany/myimage:cache +some-target
 ```
 
-The options mentioned above are also available as environment variables. See [Earthly command reference](earthly-command/earthly-command.md) for more information.
+The options mentioned above are also available as environment variables. See [Earthly command reference](../earthly-command/earthly-command.md) for more information.
 
 {% hint style='info' %}
 ##### Note

--- a/docs/caching/caching.md
+++ b/docs/caching/caching.md
@@ -71,4 +71,4 @@ To read more, check out the [remote runners page](../remote-runners.md), and the
 
 ## Managing Cache
 
-For information on how to manage cache either locally, or on a remote runner, like a satellite, see the [Managing Cache guide](./guides/managing-cache.md).
+For information on how to manage cache either locally, or on a remote runner, like a satellite, see the [Managing Cache guide](./managing-cache.md).


### PR DESCRIPTION
This PR fix some broken links and adds a new job
that will be triggered on a PR to docs-0.7.
This job will find the temporary link generated by Gitbook, and look for broken links.
This way we can find broken links before merging the PR