### PR TITLE
Change color used to print metadata values (such as ARG values)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 ### Added
 - A warning when a `COPY` destination includes a tilde (~). Related to [#1789](https://github.com/earthly/earthly/issues/1789).
 
+### Changed
+- Changed the color used to print metadata values (such as ARGs values) in the build log to Faint Blue.
+
 ## v0.7.22 - 2023-11-27
 
 ### Added

--- a/conslogging/color.go
+++ b/conslogging/color.go
@@ -5,7 +5,7 @@ import "github.com/fatih/color"
 var (
 	noColor            = makeNoColor()
 	cachedColor        = makeColor(color.FgGreen)
-	metadataModeColor  = makeColor(color.FgHiWhite, color.BgHiBlack)
+	metadataModeColor  = makeColor(color.FgBlue, color.Faint)
 	phaseColor         = makeColor(color.FgCyan)
 	disabledPhaseColor = makeColor(color.FgHiBlack)
 	specialPhaseColor  = makeColor(color.FgYellow)


### PR DESCRIPTION
Example of new color:
https://cloud.earthly.dev/builds/d98fbdeb-6747-41e1-8c5f-cb7ecaabb766