### PR TITLE
Askv: remove pipeline

### DIFF
--- a/cloud/askv.go
+++ b/cloud/askv.go
@@ -9,10 +9,9 @@ import (
 
 func (c *Client) AutoSkipExists(ctx context.Context, org, project, pipeline string, hash []byte) (bool, error) {
 	response, err := c.askv.Exists(c.withAuth(ctx), &askv.ExistsRequest{
-		OrgName:      org,
-		ProjectName:  project,
-		PipelineName: pipeline,
-		Hash:         hash,
+		OrgName:     org,
+		ProjectName: project,
+		Hash:        hash,
 	})
 	if err != nil {
 		return false, errors.Wrap(err, "failed querying auto-skip service")
@@ -22,10 +21,9 @@ func (c *Client) AutoSkipExists(ctx context.Context, org, project, pipeline stri
 
 func (c *Client) AutoSkipAdd(ctx context.Context, org, project, pipeline string, hash []byte) error {
 	_, err := c.askv.Add(c.withAuth(ctx), &askv.AddRequest{
-		OrgName:      org,
-		ProjectName:  project,
-		PipelineName: pipeline,
-		Hash:         hash,
+		OrgName:     org,
+		ProjectName: project,
+		Hash:        hash,
 	})
 	if err != nil {
 		return errors.Wrap(err, "failed adding to auto-skip service")


### PR DESCRIPTION
`PipelineName` is not in use and will be removed as an option for auto-skip pruning.