### PR TITLE
don't display 0.0 as supported VERSION

### DIFF
--- a/ast/validator.go
+++ b/ast/validator.go
@@ -51,6 +51,19 @@ func validateAst(ef spec.Earthfile) error {
 	return nil
 }
 
+func getValidVersionsFormatted() string {
+	if validEarthfileVersions[0] != "0.0" {
+		panic("validEarthfileVersions should start with 0.0")
+	}
+	var sb strings.Builder
+	latestIndex := len(validEarthfileVersions) - 1
+	for i := 1; i < latestIndex; i++ {
+		sb.WriteString(validEarthfileVersions[i] + ", ")
+	}
+	sb.WriteString("or " + validEarthfileVersions[latestIndex])
+	return sb.String()
+}
+
 func validVersion(ef spec.Earthfile) []error {
 	var errs []error
 
@@ -77,7 +90,7 @@ func validVersion(ef spec.Earthfile) []error {
 	}
 
 	if !isVersionValid {
-		errs = append(errs, errors.Errorf("Earthfile version is invalid, supported versions are %v", validEarthfileVersions))
+		errs = append(errs, errors.Errorf("Earthfile version is invalid, supported versions are %v", getValidVersionsFormatted()))
 	}
 
 	return errs

--- a/tests/version/Earthfile
+++ b/tests/version/Earthfile
@@ -60,9 +60,16 @@ test-whitespace-then-version:
 
 test-invalid-versions:
     DO --pass-args +RUN_EARTHLY_ARGS --should_fail=true --earthfile=invalid-major-version.earth --target=+base
+    RUN acbgrep 'Earthfile version is invalid, supported versions are 0.5, 0.6, or 0.7' earthly.output
+
     DO --pass-args +RUN_EARTHLY_ARGS --should_fail=true --earthfile=invalid-minor-version.earth --target=+base
+    RUN acbgrep 'Earthfile version is invalid, supported versions are 0.5, 0.6, or 0.7' earthly.output
+
     DO --pass-args +RUN_EARTHLY_ARGS --should_fail=true --earthfile=invalid-patch-version.earth --target=+base
+    RUN acbgrep 'unexpected VERSION arguments; should be VERSION \[flags\] <major-version>.<minor-version>' earthly.output
+
     DO --pass-args +RUN_EARTHLY_ARGS --should_fail=true --earthfile=invalid-format-version.earth --target=+base
+    RUN acbgrep 'unexpected VERSION arguments; should be VERSION \[flags\] <major-version>.<minor-version>' earthly.output
 
 test-all:
     BUILD +test-single-line


### PR DESCRIPTION
Fixes an error which stated `VERSION 0.0` is valid (when in fact it's only ever used in tests)