### PR TITLE
Show a hint to use interactive flag on relevant build failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 
 ### Added
 - A warning when a `COPY` destination includes a tilde (~). Related to [#1789](https://github.com/earthly/earthly/issues/1789).
+- A hint message to suggest the usage of `-i` flag to debug the build when a RUN command fails.
 
 ### Changed
 - Changed the color used to print metadata values (such as ARGs values) in the build log to Faint Blue.

--- a/cmd/earthly/app/run.go
+++ b/cmd/earthly/app/run.go
@@ -209,7 +209,7 @@ func (app *EarthlyApp) run(ctx context.Context, args []string) int {
 				err.Error())
 			if !app.BaseCLI.Flags().InteractiveDebugging && len(args) > 0 {
 				args[0] = args[0] + " --interactive"
-				app.BaseCLI.Console().HelpPrintf("To debug your build, please use --interactive flag: %q\n", strings.Join(args, " "))
+				app.BaseCLI.Console().HelpPrintf("To debug your build, you can use the --interactive (-i) flag to drop into a shell of the failing RUN step: %q\n", strings.Join(args, " "))
 			}
 			return 1
 		case strings.Contains(err.Error(), "security.insecure is not allowed"):

--- a/cmd/earthly/app/run.go
+++ b/cmd/earthly/app/run.go
@@ -207,6 +207,10 @@ func (app *EarthlyApp) run(ctx context.Context, args []string) int {
 			// This SetFatalError is a catch-all just in case that hasn't happened.
 			app.BaseCLI.Logbus().Run().SetGenericFatalError(time.Now(), logstream.FailureType_FAILURE_TYPE_OTHER,
 				err.Error())
+			if !app.BaseCLI.Flags().InteractiveDebugging && len(args) > 0 {
+				args[0] = args[0] + " --interactive"
+				app.BaseCLI.Console().HelpPrintf("To debug your build, please use --interactive flag: %q\n", strings.Join(args, " "))
+			}
 			return 1
 		case strings.Contains(err.Error(), "security.insecure is not allowed"):
 			app.BaseCLI.Logbus().Run().SetGenericFatalError(time.Now(), logstream.FailureType_FAILURE_TYPE_NEEDS_PRIVILEGED, err.Error())


### PR DESCRIPTION
If a build fails as a result of RUN failing with an exit code != 0, earthly will print a help message to use the interactive flag.
Example:
<img width="1281" alt="image" src="https://github.com/earthly/earthly/assets/5618521/e24ddff9-9c16-4810-9fb6-ae4185b5f5a6">

Note: this will only be printed if the interactive flag is not already in use.
