### PR TITLE
Limit the number of warnings shown when using COMMAND keyword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 ### Added
 - A warning when a `COPY` destination includes a tilde (~). Related to [#1789](https://github.com/earthly/earthly/issues/1789).
 
+### Fixed
+- Limit the number of deprecation warnings when using `COMMAND` instead of `FUNCTION` keyword.
+
 ### Changed
 - Changed the color used to print metadata values (such as ARGs values) in the build log to Faint Blue.
 - Updated default alpine/git image to v2.40.1.

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -279,6 +279,7 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 				MainTargetDetailsFunc:                opt.MainTargetDetailsFunc,
 				Runner:                               opt.Runner,
 				ProjectAdder:                         opt.ProjectAdder,
+				FilesWithCommandRenameWarning:        make(map[string]bool),
 			}
 			mts, err = earthfile2llb.Earthfile2LLB(childCtx, target, opt, true)
 			if err != nil {

--- a/earthfile2llb/earthfile2llb.go
+++ b/earthfile2llb/earthfile2llb.go
@@ -180,7 +180,7 @@ type ConvertOpt struct {
 	// ProjectAdder is a callback that is used to discover PROJECT <org>/<project> values
 	ProjectAdder ProjectAdder
 
-	// FilesWithCommandRenameWarning keeps count of the files for which the COMMAND => FUNCTION warning was displayed
+	// FilesWithCommandRenameWarning keeps track of the files for which the COMMAND => FUNCTION warning was displayed
 	// this can be removed in VERSION 0.8
 	FilesWithCommandRenameWarning map[string]bool
 }

--- a/earthfile2llb/earthfile2llb.go
+++ b/earthfile2llb/earthfile2llb.go
@@ -179,6 +179,10 @@ type ConvertOpt struct {
 
 	// ProjectAdder is a callback that is used to discover PROJECT <org>/<project> values
 	ProjectAdder ProjectAdder
+
+	// FilesWithCommandRenameWarning keeps count of the files for which the COMMAND => FUNCTION warning was displayed
+	// this can be removed in VERSION 0.8
+	FilesWithCommandRenameWarning map[string]bool
 }
 
 // TargetDetails contains details about the target being built.

--- a/earthfile2llb/interpreter.go
+++ b/earthfile2llb/interpreter.go
@@ -32,6 +32,9 @@ import (
 
 var errCannotAsync = errors.New("cannot run async operation")
 
+var filesWithCommandRenameWarning = make(map[string]bool)
+var maxCommandRenameWarnings = 3
+
 // Interpreter interprets Earthly AST's into calls to the converter.
 type Interpreter struct {
 	converter *Converter
@@ -1794,7 +1797,8 @@ func (i *Interpreter) handleDo(ctx context.Context, cmd spec.Command) error {
 
 	for _, uc := range bc.Earthfile.Functions {
 		if uc.Name == command.Command {
-			return i.handleDoFunction(ctx, command, relCommand, uc, cmd, parsedFlagArgs, allowPrivileged, opts.PassArgs, bc.Features.UseFunctionKeyword)
+			sourceFilePath := bc.Ref.ProjectCanonical() + "/Earthfile"
+			return i.handleDoFunction(ctx, command, relCommand, uc, cmd, parsedFlagArgs, allowPrivileged, opts.PassArgs, sourceFilePath, bc.Features.UseFunctionKeyword)
 		}
 	}
 	return i.errorf(cmd.SourceLocation, "user command %s not found", ucName)
@@ -1983,7 +1987,7 @@ func (i *Interpreter) handleHost(ctx context.Context, cmd spec.Command) error {
 
 // ----------------------------------------------------------------------------
 
-func (i *Interpreter) handleDoFunction(ctx context.Context, command domain.Command, relCommand domain.Command, uc spec.Function, do spec.Command, buildArgs []string, allowPrivileged, passArgs bool, useFunctionCmd bool) error {
+func (i *Interpreter) handleDoFunction(ctx context.Context, command domain.Command, relCommand domain.Command, uc spec.Function, do spec.Command, buildArgs []string, allowPrivileged, passArgs bool, sourceLocationFile string, useFunctionCmd bool) error {
 	cmdName := "FUNCTION"
 	if !useFunctionCmd {
 		cmdName = "COMMAND"
@@ -1994,11 +1998,12 @@ func (i *Interpreter) handleDoFunction(ctx context.Context, command domain.Comma
 	if len(uc.Recipe) == 0 || uc.Recipe[0].Command == nil || uc.Recipe[0].Command.Name != cmdName {
 		return i.errorf(uc.SourceLocation, "%s recipes must start with %s", strings.ToLower(cmdName), cmdName)
 	}
-	if !useFunctionCmd {
-		i.console.Warnf(
+	if !useFunctionCmd && len(filesWithCommandRenameWarning) < maxCommandRenameWarnings && !filesWithCommandRenameWarning[sourceLocationFile] {
+		i.console.Printf(
 			`Note that the COMMAND keyword will be replaced by FUNCTION starting with VERSION 0.8.
-To start using the FUNCTION keyword now (experimental) please use VERSION --use-function-keyword 0.7. Note that switching now may cause breakages for your colleagues if they are using older Earthly versions.
-`)
+To start using the FUNCTION keyword now (experimental) please use VERSION --use-function-keyword 0.7 in %s. Note that switching now may cause breakages for your colleagues if they are using older Earthly versions.
+`, sourceLocationFile)
+		filesWithCommandRenameWarning[sourceLocationFile] = true
 	}
 	if len(uc.Recipe[0].Command.Args) > 0 {
 		return i.errorf(uc.Recipe[0].SourceLocation, "%s takes no arguments", cmdName)


### PR DESCRIPTION
The previous version was too noisy.
This changes it to show 3 times max and only once per file.