### PR TITLE
updatedockerhub readme job - use semver instead of sha for dependency

### DIFF
--- a/.github/workflows/update-docker-hub-readmes.yml
+++ b/.github/workflows/update-docker-hub-readmes.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Update DockerHub description for earthly/earthly
-        uses: peter-evans/dockerhub-description@ede0e66c26c29b05c9e12e1d999564171a061c65
+        uses: peter-evans/dockerhub-description@v3.4.2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -26,7 +26,7 @@ jobs:
           readme-filepath: ./docs/docker-images/all-in-one.md
           short-description: ${{ github.event.repository.description }}
       - name: Update DockerHub description for earthly/buildkitd
-        uses: peter-evans/dockerhub-description@ede0e66c26c29b05c9e12e1d999564171a061c65
+        uses: peter-evans/dockerhub-description@v3.4.2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -34,7 +34,7 @@ jobs:
           readme-filepath: ./docs/docker-images/buildkit-standalone.md
           short-description: Standalone Earthly buildkitd image
       - name: Update DockerHub description for earthly/dind
-        uses: peter-evans/dockerhub-description@ede0e66c26c29b05c9e12e1d999564171a061c65
+        uses: peter-evans/dockerhub-description@v3.4.2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
We get a new renovate PR for each commit to the project, so moving to use an official release to make Renovate less noisy (and rely on official releases instead)