### PR TITLE
Acb/custom ssh command

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -74,9 +74,10 @@ update-buildkit:
     ARG BUILDKIT_GIT_SHA
     ARG BUILDKIT_GIT_BRANCH=earthly-main
     ARG BUILDKIT_GIT_ORG=earthly
+    ARG BUILDKIT_GIT_REPO=buildkit
     COPY (./buildkitd+buildkit-sha/buildkit_sha --BUILDKIT_GIT_ORG="$BUILDKIT_GIT_ORG" --BUILDKIT_GIT_SHA="$BUILDKIT_GIT_SHA" --BUILDKIT_GIT_BRANCH="$BUILDKIT_GIT_BRANCH") buildkit_sha
-    BUILD  ./buildkitd+update-buildkit-earthfile --BUILDKIT_GIT_ORG="$BUILDKIT_GIT_ORG" --BUILDKIT_GIT_SHA="$(cat buildkit_sha)"
-    RUN --no-cache go mod edit -replace "github.com/moby/buildkit=github.com/$BUILDKIT_GIT_ORG/buildkit@$(cat buildkit_sha)"
+    BUILD  ./buildkitd+update-buildkit-earthfile --BUILDKIT_GIT_ORG="$BUILDKIT_GIT_ORG" --BUILDKIT_GIT_SHA="$(cat buildkit_sha)" --BUILDKIT_GIT_REPO="$BUILDKIT_GIT_REPO"
+    RUN --no-cache go mod edit -replace "github.com/moby/buildkit=github.com/$BUILDKIT_GIT_ORG/$BUILDKIT_GIT_REPO@$(cat buildkit_sha)"
     RUN --no-cache go mod tidy
     SAVE ARTIFACT go.mod AS LOCAL go.mod
     SAVE ARTIFACT go.sum AS LOCAL go.sum

--- a/buildcontext/git.go
+++ b/buildcontext/git.go
@@ -179,7 +179,8 @@ func (gr *gitResolver) resolveGitProject(ctx context.Context, gwClient gwclient.
 
 	var err error
 	var keyScans []string
-	gitURL, subDir, keyScans, err = gr.gitLookup.GetCloneURL(ref.GetGitURL())
+	var sshCommand string
+	gitURL, subDir, keyScans, sshCommand, err = gr.gitLookup.GetCloneURL(ref.GetGitURL())
 	if err != nil {
 		return nil, "", "", errors.Wrap(err, "failed to get url for cloning")
 	}
@@ -206,6 +207,9 @@ func (gr *gitResolver) resolveGitProject(ctx context.Context, gwClient gwclient.
 			// TODO this should eventually be infered by the contents of a COPY command, which means the call to resolveGitProject will need to be lazy-evaluated
 			// However this makes it really difficult for an Earthfile which first has an ARG EARTHLY_GIT_HASH, then a RUN, then a COPY
 			gitOpts = append(gitOpts, llb.LFSInclude(gr.lfsInclude))
+		}
+		if sshCommand != "" {
+			gitOpts = append(gitOpts, llb.SSHCommand(sshCommand))
 		}
 
 		gitState := llb.Git(gitURL, gitRef, gitOpts...)

--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -12,7 +12,7 @@ buildkitd:
             ARG BUILDKIT_BASE_IMAGE=$BUILDKIT_PROJECT+build
         END
     ELSE
-        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:8fa3be190ed31623fdaa80b3d5da263bd5ca9f2f+build
+        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:086f60eecf5a2261bbd53299614f88b3def12746+build
     END
     ARG EARTHLY_TARGET_TAG_DOCKER
     ARG TAG="dev-$EARTHLY_TARGET_TAG_DOCKER"

--- a/cmd/earthly/subcmd/build_cmd.go
+++ b/cmd/earthly/subcmd/build_cmd.go
@@ -669,7 +669,7 @@ func (a *Build) updateGitLookupConfig(gitLookup *buildcontext.GitLookup) error {
 		if suffix == "" {
 			suffix = ".git"
 		}
-		err := gitLookup.AddMatcher(k, pattern, v.Substitute, v.User, v.Password, v.Prefix, suffix, auth, v.ServerKey, common.IfNilBoolDefault(v.StrictHostKeyChecking, true), v.Port)
+		err := gitLookup.AddMatcher(k, pattern, v.Substitute, v.User, v.Password, v.Prefix, suffix, auth, v.ServerKey, common.IfNilBoolDefault(v.StrictHostKeyChecking, true), v.Port, v.SSHCommand)
 		if err != nil {
 			return errors.Wrap(err, "gitlookup")
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -113,6 +113,7 @@ type GitConfig struct {
 	Password              string `yaml:"password"                     help:"The https password to use when auth is set to https. This setting is ignored when auth is ssh."`
 	ServerKey             string `yaml:"serverkey"                    help:"SSH fingerprints, like you would add in your known hosts file, or get from ssh-keyscan."`
 	StrictHostKeyChecking *bool  `yaml:"strict_host_key_checking"     help:"Allow ssh access to hosts with unknown server keys (e.g. no entries in known_hosts), defaults to true."`
+	SSHCommand            string `yaml:"ssh_command"                  help:"Set a value for the core.sshCommand git config option, which allows you to provide custom SSH configuration."`
 }
 
 // Satellite contains satellite config values

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -1403,7 +1403,7 @@ func (c *Converter) Label(ctx context.Context, labels map[string]string) error {
 }
 
 // GitClone applies the GIT CLONE command.
-func (c *Converter) GitClone(ctx context.Context, gitURL string, branch string, dest string, keepTs bool) error {
+func (c *Converter) GitClone(ctx context.Context, gitURL string, sshCommand string, branch string, dest string, keepTs bool) error {
 	err := c.checkAllowed(gitCloneCmd)
 	if err != nil {
 		return err
@@ -1414,6 +1414,9 @@ func (c *Converter) GitClone(ctx context.Context, gitURL string, branch string, 
 		llb.WithCustomNamef(
 			"%sGIT CLONE (--branch %s) %s", c.vertexPrefixWithURL(gitURLScrubbed), branch, gitURLScrubbed),
 		llb.KeepGitDir(),
+	}
+	if sshCommand != "" {
+		gitOpts = append(gitOpts, llb.SSHCommand(sshCommand))
 	}
 	gitState := pllb.Git(gitURL, branch, gitOpts...)
 	c.mts.Final.MainState, err = llbutil.CopyOp(ctx,

--- a/earthfile2llb/interpreter.go
+++ b/earthfile2llb/interpreter.go
@@ -1562,12 +1562,12 @@ func (i *Interpreter) handleGitClone(ctx context.Context, cmd spec.Command) erro
 		return i.wrapError(err, cmd.SourceLocation, "failed to expand GIT CLONE dest: %s", opts.Branch)
 	}
 
-	convertedGitURL, _, err := i.gitLookup.ConvertCloneURL(gitURL)
+	convertedGitURL, _, sshCommand, err := i.gitLookup.ConvertCloneURL(gitURL)
 	if err != nil {
 		return i.wrapError(err, cmd.SourceLocation, "unable to use %v with configured earthly credentials from ~/.earthly/config.yml", cmd.Args)
 	}
 
-	err = i.converter.GitClone(ctx, convertedGitURL, gitBranch, gitCloneDest, opts.KeepTs)
+	err = i.converter.GitClone(ctx, convertedGitURL, sshCommand, gitBranch, gitCloneDest, opts.KeepTs)
 	if err != nil {
 		return i.wrapError(err, cmd.SourceLocation, "git clone")
 	}

--- a/go.mod
+++ b/go.mod
@@ -150,6 +150,6 @@ replace (
 	github.com/jdxcode/netrc => github.com/mikejholly/netrc v0.0.0-20221121193719-a154cb29ec2a
 	github.com/jessevdk/go-flags => github.com/alexcb/go-flags v0.0.0-20210722203016-f11d7ecb5ee5
 
-	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.0-20231201233313-8fa3be190ed3
+	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.0-20231213184914-086f60eecf5a
 	github.com/tonistiigi/fsutil => github.com/earthly/fsutil v0.0.0-20231030221755-644b08355b65
 )

--- a/go.sum
+++ b/go.sum
@@ -191,8 +191,8 @@ github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
-github.com/earthly/buildkit v0.0.0-20231201233313-8fa3be190ed3 h1:glTieFqAdPkfgm6XhSYDY1q54Xx4XOVJ3cteHeAh3K8=
-github.com/earthly/buildkit v0.0.0-20231201233313-8fa3be190ed3/go.mod h1:9YV/0upRPk36WbLrmr2bf2MZ0M27fvjxiBr5VD/ia80=
+github.com/earthly/buildkit v0.0.0-20231213184914-086f60eecf5a h1:LjFYB1dm0Pq9T9tpSpIwppy7SUGRsVQpn+RhWEz1bqQ=
+github.com/earthly/buildkit v0.0.0-20231213184914-086f60eecf5a/go.mod h1:9YV/0upRPk36WbLrmr2bf2MZ0M27fvjxiBr5VD/ia80=
 github.com/earthly/cloud-api v1.0.1-0.20231104021724-b38162a550cb h1:a5u2YnTVZGScHBHo3qugai43RTXRYnt1x33lsKTOy2I=
 github.com/earthly/cloud-api v1.0.1-0.20231104021724-b38162a550cb/go.mod h1:rU/tYJ7GFBjdKAITV2heDbez++glpGSbtJaZcp73rNI=
 github.com/earthly/fsutil v0.0.0-20231030221755-644b08355b65 h1:6oyWHoxHXwcTt4EqmMw6361scIV87uEAB1N42+VpIwk=

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -177,6 +177,8 @@ ga-no-qemu-group4:
     BUILD +dotenv-test
     BUILD +allow-privileged-test
     BUILD ./with-docker-registry+all
+    BUILD +test-ssh-command-config-via-remote-target
+    BUILD +test-ssh-command-config-via-git-clone-earthfile-command
 
 ga-no-qemu-slow:
     BUILD +server
@@ -1511,6 +1513,46 @@ test-exec-stats:
       --target=+sleep \
       --extra_args=" --exec-stats " \
       --output_contains="total CPU:.*total memory:.*"
+
+# test-ssh-command-config-via-remote-target tests that we can set a custom ssh_command
+# The test intentionally sets a bad cipher type, then tests that buildkit fails, and the failure message
+# contains the underlying ssh failure due to attempting to use an invalid cipher
+test-ssh-command-config-via-remote-target:
+    RUN ssh-keygen -b 3072 -t rsa -f /root/dont-steal-my-key -q -N "" -C "rsa-testkey"
+    RUN echo "#!/bin/sh
+set -ex
+
+# needed to get past the \"no SSH key default forwarded from the client\" error
+eval \$(ssh-agent)
+ssh-add /root/dont-steal-my-key
+
+earthly --config \$earthly_config config git \"{github.com: {auth: ssh, user: git, strict_host_key_checking: false, ssh_command: ssh -c badcipher}}\"
+earthly --config \$earthly_config github.com/earthly/earthly+base 2>&1 | tee output.txt;
+" >/tmp/run-earthly-with-bad-ssh-cipher && chmod +x /tmp/run-earthly-with-bad-ssh-cipher
+    DO +RUN_EARTHLY --exec_cmd=/tmp/run-earthly-with-bad-ssh-cipher
+    RUN cat output.txt | acbgrep "Unknown cipher type 'badcipher'"
+
+test-ssh-command-config-via-git-clone-earthfile-command:
+    RUN ssh-keygen -b 3072 -t rsa -f /root/dont-steal-my-key -q -N "" -C "rsa-testkey"
+
+    RUN echo "VERSION 0.7
+test:
+    FROM alpine
+    GIT CLONE ssh://git@github.com/earthly/earthly.git ./earthly_repo # the command we are testing
+" > Earthfile
+
+    RUN echo "#!/bin/sh
+set -ex
+
+# needed to get past the \"no SSH key default forwarded from the client\" error
+eval \$(ssh-agent)
+ssh-add /root/dont-steal-my-key
+
+earthly --config \$earthly_config config git \"{github.com: {auth: ssh, user: git, strict_host_key_checking: false, ssh_command: ssh -c badcipher}}\"
+earthly --config \$earthly_config +test 2>&1 | tee output.txt;
+" >/tmp/run-earthly-with-bad-ssh-cipher && chmod +x /tmp/run-earthly-with-bad-ssh-cipher
+    DO +RUN_EARTHLY --exec_cmd=/tmp/run-earthly-with-bad-ssh-cipher
+    RUN cat output.txt | acbgrep "Unknown cipher type 'badcipher'"
 
 RUN_EARTHLY:
     FUNCTION


### PR DESCRIPTION
fixes #3499

- Adds ssh_command option to the Git site config
- Updates Earthfile to support building a buildkit fork with a repo name other than "buildkit"