### PR TITLE
Auto-skip: include source file & line for all error message

### DIFF
--- a/cmd/earthly/app/run.go
+++ b/cmd/earthly/app/run.go
@@ -24,6 +24,7 @@ import (
 	"github.com/earthly/earthly/cmd/earthly/helper"
 	"github.com/earthly/earthly/conslogging"
 	"github.com/earthly/earthly/earthfile2llb"
+	"github.com/earthly/earthly/inputgraph"
 	"github.com/earthly/earthly/util/containerutil"
 	"github.com/earthly/earthly/util/errutil"
 	"github.com/earthly/earthly/util/hint"
@@ -181,10 +182,14 @@ func (app *EarthlyApp) run(ctx context.Context, args []string) int {
 		grpcErr, grpcErrOK := grpcerrors.AsGRPCStatus(err)
 		hintErr, hintErrOK := getHintErr(err, grpcErr)
 		var paramsErr *params.Error
+		var autoSkipErr *inputgraph.Error
 		switch {
 		case hintErrOK:
 			app.BaseCLI.Logbus().Run().SetGenericFatalError(time.Now(), logstream.FailureType_FAILURE_TYPE_OTHER, hintErr.Message())
 			app.BaseCLI.Console().HelpPrintf(hintErr.Hint())
+			return 1
+		case errors.As(err, &autoSkipErr):
+			app.BaseCLI.Logbus().Run().SetGenericFatalError(time.Now(), logstream.FailureType_FAILURE_TYPE_SYNTAX, inputgraph.FormatError(err))
 			return 1
 		case errors.As(err, &paramsErr):
 			app.BaseCLI.Logbus().Run().SetGenericFatalError(time.Now(), logstream.FailureType_FAILURE_TYPE_INVALID_PARAM, paramsErr.ParentError())

--- a/cmd/earthly/app/run.go
+++ b/cmd/earthly/app/run.go
@@ -185,7 +185,7 @@ func (app *EarthlyApp) run(ctx context.Context, args []string) int {
 		var autoSkipErr *inputgraph.Error
 		switch {
 		case hintErrOK:
-			app.BaseCLI.Logbus().Run().SetGenericFatalError(time.Now(), logstream.FailureType_FAILURE_TYPE_OTHER, hintErr.Message())
+			app.BaseCLI.Logbus().Run().SetGenericFatalError(time.Now(), logstream.FailureType_FAILURE_TYPE_AUTO_SKIP, hintErr.Message())
 			app.BaseCLI.Console().HelpPrintf(hintErr.Hint())
 			return 1
 		case errors.As(err, &autoSkipErr):

--- a/cmd/earthly/app/run.go
+++ b/cmd/earthly/app/run.go
@@ -185,7 +185,7 @@ func (app *EarthlyApp) run(ctx context.Context, args []string) int {
 		var autoSkipErr *inputgraph.Error
 		switch {
 		case hintErrOK:
-			app.BaseCLI.Logbus().Run().SetGenericFatalError(time.Now(), logstream.FailureType_FAILURE_TYPE_SYNTAX, hintErr.Message())
+			app.BaseCLI.Logbus().Run().SetGenericFatalError(time.Now(), logstream.FailureType_FAILURE_TYPE_OTHER, hintErr.Message())
 			app.BaseCLI.Console().HelpPrintf(hintErr.Hint())
 			return 1
 		case errors.As(err, &autoSkipErr):

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/docker/distribution v2.8.2+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/dustin/go-humanize v1.0.1
-	github.com/earthly/cloud-api v1.0.1-0.20231213235853-6518dbbb32ee
+	github.com/earthly/cloud-api v1.0.1-0.20231214223040-20dabccd7dce
 	github.com/earthly/earthly/ast v0.0.0-00010101000000-000000000000
 	github.com/earthly/earthly/util/deltautil v0.0.0-20231103163539-3521397eed7e
 	github.com/elastic/go-sysinfo v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -205,6 +205,8 @@ github.com/earthly/cloud-api v1.0.1-0.20231213194557-d574c0cd3f00 h1:gj7JuwdHVeB
 github.com/earthly/cloud-api v1.0.1-0.20231213194557-d574c0cd3f00/go.mod h1:rU/tYJ7GFBjdKAITV2heDbez++glpGSbtJaZcp73rNI=
 github.com/earthly/cloud-api v1.0.1-0.20231213235853-6518dbbb32ee h1:1l/IBhTvBr2W95JU4H4f8s6riquPeEhvnErffqvCyl0=
 github.com/earthly/cloud-api v1.0.1-0.20231213235853-6518dbbb32ee/go.mod h1:rU/tYJ7GFBjdKAITV2heDbez++glpGSbtJaZcp73rNI=
+github.com/earthly/cloud-api v1.0.1-0.20231214223040-20dabccd7dce h1:xe69RMXDI7X16GMartCeQe/f7zGsIlwwCeNd61Ys9RQ=
+github.com/earthly/cloud-api v1.0.1-0.20231214223040-20dabccd7dce/go.mod h1:rU/tYJ7GFBjdKAITV2heDbez++glpGSbtJaZcp73rNI=
 github.com/earthly/fsutil v0.0.0-20231030221755-644b08355b65 h1:6oyWHoxHXwcTt4EqmMw6361scIV87uEAB1N42+VpIwk=
 github.com/earthly/fsutil v0.0.0-20231030221755-644b08355b65/go.mod h1:9kMVqMyQ/Sx2df5LtnGG+nbrmiZzCS7V6gjW3oGHsvI=
 github.com/elastic/go-sysinfo v1.9.0 h1:usICqY/Nw4Mpn9f4LdtpFrKxXroJDe81GaxxUlCckIo=

--- a/inputgraph/error.go
+++ b/inputgraph/error.go
@@ -1,0 +1,56 @@
+package inputgraph
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/earthly/earthly/ast/spec"
+	"github.com/pkg/errors"
+)
+
+type Error struct {
+	srcLoc *spec.SourceLocation
+	msg    string
+	err    error
+}
+
+func (e *Error) Error() string {
+	parts := []string{}
+	if e.msg != "" {
+		parts = append(parts, e.msg)
+	}
+	if e.err != nil {
+		parts = append(parts, e.err.Error())
+	}
+	return strings.Join(parts, ": ")
+}
+
+func FormatError(err error) string {
+	e := &Error{}
+	if ok := errors.As(err, &e); ok {
+		return fmt.Sprintf("%s line %d:%d: %s", e.srcLoc.File, e.srcLoc.StartLine, e.srcLoc.StartColumn, err)
+	}
+	return e.Error()
+}
+
+func newError(srcLoc *spec.SourceLocation, format string, args ...any) error {
+	return &Error{
+		srcLoc: srcLoc,
+		msg:    fmt.Sprintf(format, args...),
+	}
+}
+
+func wrapError(err error, srcLoc *spec.SourceLocation, format string, args ...any) error {
+	e := &Error{
+		srcLoc: srcLoc,
+		err:    err,
+	}
+	if format != "" {
+		e.msg = fmt.Sprintf(format, args...)
+	}
+	return e
+}
+
+func addErrorSrc(err error, srcLoc *spec.SourceLocation) error {
+	return wrapError(err, srcLoc, "")
+}

--- a/inputgraph/error.go
+++ b/inputgraph/error.go
@@ -8,6 +8,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+// Error represents an auto-skip error that can include the source file name and
+// associated line number.
 type Error struct {
 	srcLoc *spec.SourceLocation
 	msg    string
@@ -25,9 +27,12 @@ func (e *Error) Error() string {
 	return strings.Join(parts, ": ")
 }
 
+// FormatError looks for a wrapped instance of Error in the error list. If one
+// is found, it will prefix the error message with source file information
+// associated with the error.
 func FormatError(err error) string {
 	e := &Error{}
-	if ok := errors.As(err, &e); ok {
+	if errors.As(err, &e) {
 		return fmt.Sprintf("%s line %d:%d: %s", e.srcLoc.File, e.srcLoc.StartLine, e.srcLoc.StartColumn, err)
 	}
 	return e.Error()

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -1642,6 +1642,3 @@ RUN_EARTHLY:
     RUN --privileged \
         --mount=type=tmpfs,target=/tmp/earthly-tmpfs \
         /bin/sh /tmp/earthly-script
-
-bad-remote:
-    BUILD github.com/earthly/earthly:main+license

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -1642,3 +1642,6 @@ RUN_EARTHLY:
     RUN --privileged \
         --mount=type=tmpfs,target=/tmp/earthly-tmpfs \
         /bin/sh /tmp/earthly-script
+
+bad-remote:
+    BUILD github.com/earthly/earthly:main+license


### PR DESCRIPTION
Prepends file location & line numbers to auto-skip error messages.
```
Error: tests/Earthfile line 1647:4: auto-skip is unable to calculate hash for ./tests+bad-remote: only remote targets referenced by a complete Git SHA or an explicit tag referenced as 'tags/...' are supported
```