### PR TITLE
Auto-skip: reinstate --push support

### DIFF
--- a/cmd/earthly/subcmd/build_cmd.go
+++ b/cmd/earthly/subcmd/build_cmd.go
@@ -832,10 +832,6 @@ func (a *Build) initAutoSkip(ctx context.Context, target domain.Target, overridi
 	console := a.cli.Console().WithPrefix(autoSkipPrefix)
 	consoleNoPrefix := a.cli.Console()
 
-	if a.cli.Flags().Push {
-		return nil, nil, false, errors.New("--push cannot be used with --auto-skip")
-	}
-
 	if a.cli.Flags().NoCache {
 		return nil, nil, false, errors.New("--no-cache cannot be used with --auto-skip")
 	}

--- a/tests/autoskip/Earthfile
+++ b/tests/autoskip/Earthfile
@@ -160,8 +160,8 @@ test-no-cache:
     DO --pass-args +RUN_EARTHLY_ARGS --earthfile=simple.earth --target=+no-cache --should_fail=true --extra_args="--no-cache" --output_does_not_contain="Target .* has already been run. Skipping."
 
 test-push:
-    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=simple.earth --target=+simple --should_fail=true --extra_args="--push" --output_contains="push cannot be used"
-    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=simple.earth --target=+simple --should_fail=true --extra_args="--push" --output_does_not_contain="Target .* has already been run. Skipping."
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=simple.earth --target=+simple --extra_args="--push" --output_contains="hello"
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=simple.earth --target=+simple --extra_args="--push" --output_contains="Target .* has already been run. Skipping."
 
 test-shell-out:
     DO --pass-args +RUN_EARTHLY_ARGS --earthfile=shell-out.earth --target=+shell-out


### PR DESCRIPTION
This PR removes the check against using `--push` with auto-skip. 