### PR TITLE
tests for https-based non-standard repo URL

### DIFF
--- a/tests/private-https/Earthfile
+++ b/tests/private-https/Earthfile
@@ -77,6 +77,18 @@ earthly --config \$earthly_config --verbose -D selfsigned.example.com/testuser/r
 " >> /tmp/test-earthly-script
     DO --pass-args +RUN_EARTHLY_ARGS --pre_command=start-nginx-with-git --earthfile=git-clone-private-https.earth --exec_cmd=/tmp/test-earthly-script
 
+git-clone-private-https-with-pattern-substitute:
+    FROM +git-clone-private-https-base
+    RUN mkdir -p /var/git/repos/testuser/testproject/testsubproject
+    RUN mv /var/git/repos/testuser/repo.git /var/git/repos/testuser/testproject/testsubproject/nestedrepo.git
+    RUN echo "
+earthly --config \$earthly_config  config git \"{selfsigned.example.com: {auth: https, pattern: 'selfsigned.example.com/testuser/testproject/([^/]+)/([^/]+)', substitute: 'https://testuser:keepitsecret@selfsigned.example.com/testuser/testproject/\\\$1/\\\$2.git'}}\"
+cat \$earthly_config
+earthly --config \$earthly_config --verbose -D +test
+earthly --config \$earthly_config --verbose -D selfsigned.example.com/testuser/testproject/testsubproject/nestedrepo:main+hello
+" >> /tmp/test-earthly-script
+    DO --pass-args +RUN_EARTHLY_ARGS --pre_command=start-nginx-with-git --earthfile=git-clone-private-https-nestedrepo.earth --exec_cmd=/tmp/test-earthly-script
+
 RUN_EARTHLY_ARGS:
     FUNCTION
     ARG earthfile

--- a/tests/private-https/git-clone-private-https-nestedrepo.earth
+++ b/tests/private-https/git-clone-private-https-nestedrepo.earth
@@ -1,0 +1,22 @@
+VERSION 0.7
+FROM alpine/git:v2.40.1
+test:
+    WORKDIR /test
+
+    # TODO: it is not possible to clone this repo using the user/password that's configured in the earthly config
+    # GIT CLONE --branch main https://selfsigned.example.com/testuser/testproject/testsubproject/nestedrepo.git myrepo
+
+    # Nor, is it possible to reference the repo via ssh, like this
+    # GIT CLONE --branch main git@selfsigned.example.com:testuser/testproject/testsubproject/nestedrepo.git myrepo
+
+    # instead it's required to include the username/password here
+    GIT CLONE --branch main https://testuser:keepitsecret@selfsigned.example.com/testuser/testproject/testsubproject/nestedrepo.git myrepo
+
+    # however the substitute/pattern is working when calling earthly from the cli
+    # e.g. earthly --config \$earthly_config --verbose -D selfsigned.example.com/testuser/testproject/testsubproject/nestedrepo:main+hello (which is done immediately after by the Earthfile that calls this test)
+    # which implies this earthfile could do a BUILD selfsigned.example.com/testuser/testproject/testsubproject/nestedrepo+hello
+
+    WORKDIR /test/myrepo
+    RUN git status
+    RUN git branch
+    RUN grep $(echo OThlMTVmYjUtMTk3Yy00M2JmLTg4NmUtMzI5MWU2NWQ2NDZl | base64 -d) Earthfile


### PR DESCRIPTION
This test shows a bug that exists when trying to perform a GIT CLONE of a repo that doesn't follow the two directory user/repo git URL.