### PR TITLE
Fix hanging when process killed by user

### DIFF
--- a/cmd/earthly/app/run.go
+++ b/cmd/earthly/app/run.go
@@ -161,7 +161,7 @@ func (app *EarthlyApp) run(ctx context.Context, args []string) int {
 	}()
 
 	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGINT)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 
 	userKilled := atomic.Bool{}
 

--- a/logbus/ship/ship.go
+++ b/logbus/ship/ship.go
@@ -43,8 +43,7 @@ func NewLogShipper(cl streamer, man *pb.RunManifest, verbose bool) *LogShipper {
 
 func (l *LogShipper) Write(delta *pb.Delta) {
 	if l.closed.Load() {
-		logMsg := string(delta.GetDeltaFormattedLog().GetData())
-		fmt.Fprintf(os.Stderr, "WARNING: Message sent to closed log stream: %s", logMsg)
+		fmt.Fprintf(os.Stderr, "WARNING: Message sent to closed log stream: %s\n", delta.String())
 		return
 	}
 	l.ch <- delta
@@ -53,7 +52,7 @@ func (l *LogShipper) Write(delta *pb.Delta) {
 // Start the log streaming process and begin writing logs to the server.
 func (l *LogShipper) Start(ctx context.Context) {
 	go func() {
-		ctx, l.cancel = context.WithCancel(ctx)
+		ctx, l.cancel = context.WithCancel(context.Background())
 		defer l.cancel()
 		out := bufferedDeltaChan(ctx, l.ch)
 		errCh := l.cl.StreamLogs(ctx, l.man, out)

--- a/util/syncutil/signal.go
+++ b/util/syncutil/signal.go
@@ -1,0 +1,26 @@
+package syncutil
+
+import (
+	"os"
+	"sync"
+)
+
+// Signal allows for an os.Signal to be passed and accessed in a thread-safe way.
+type Signal struct {
+	mu     sync.Mutex
+	signal os.Signal
+}
+
+// Set the underlying signal in a thread-safe way.
+func (s *Signal) Set(v os.Signal) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.signal = v
+}
+
+// Get the underlying signal in a thread-safe way.
+func (s *Signal) Get() os.Signal {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.signal
+}


### PR DESCRIPTION
Control-C was leading to a hung process. The log streaming context was being canceled which led to a deadlock with writing new messages. 
![image](https://github.com/earthly/earthly/assets/332408/15f9383b-243e-40ee-bafa-8a6e14683ac4)
