### PR TITLE
Ensure "latest" DockerHub image is identical to version-tagged image

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -516,7 +516,7 @@ prerelease:
         --platform=linux/amd64 \
         --platform=linux/arm64 \
         ./buildkitd+buildkitd --TAG=prerelease  --BUILDKIT_PROJECT="$BUILDKIT_PROJECT"
-    COPY (+earthly-all/* --VERSION=prerelease --DEFAULT_INSTALLATION_NAME=earthly) ./
+    COPY (+earthly-all/* --TAG=prerelease --DEFAULT_INSTALLATION_NAME=earthly) ./
     SAVE IMAGE --push earthly/earthlybinaries:prerelease
 
 # prerelease-script copies the earthly folder and saves it as an artifact
@@ -538,7 +538,7 @@ ci-release:
     BUILD \
         --platform=linux/amd64 \
         ./buildkitd+buildkitd --TAG=${EARTHLY_GIT_HASH}-${TAG_SUFFIX} --BUILDKIT_PROJECT="$BUILDKIT_PROJECT" --DOCKERHUB_BUILDKIT_IMG="buildkitd-staging"
-    COPY (+earthly/earthly --DEFAULT_BUILDKITD_IMAGE="docker.io/earthly/buildkitd-staging:${EARTHLY_GIT_HASH}-${TAG_SUFFIX}" --VERSION=${EARTHLY_GIT_HASH}-${TAG_SUFFIX} --DEFAULT_INSTALLATION_NAME=earthly) ./earthly-linux-amd64
+    COPY (+earthly/earthly --DEFAULT_BUILDKITD_IMAGE="docker.io/earthly/buildkitd-staging:${EARTHLY_GIT_HASH}-${TAG_SUFFIX}" --TAG=${EARTHLY_GIT_HASH}-${TAG_SUFFIX} --DEFAULT_INSTALLATION_NAME=earthly) ./earthly-linux-amd64
     SAVE IMAGE --push earthly/earthlybinaries:${EARTHLY_GIT_HASH}-${TAG_SUFFIX}
 
 # dind builds both the alpine and ubuntu dind containers for earthly

--- a/Earthfile
+++ b/Earthfile
@@ -523,7 +523,7 @@ prerelease:
         --platform=linux/amd64 \
         --platform=linux/arm64 \
         ./buildkitd+buildkitd --TAG=prerelease  --BUILDKIT_PROJECT="$BUILDKIT_PROJECT"
-    COPY (+earthly-all/* --TAG=prerelease --DEFAULT_INSTALLATION_NAME=earthly) ./
+    COPY (+earthly-all/* --VERSION=prerelease --DEFAULT_INSTALLATION_NAME=earthly) ./
     SAVE IMAGE --push earthly/earthlybinaries:prerelease
 
 # prerelease-script copies the earthly folder and saves it as an artifact

--- a/Earthfile
+++ b/Earthfile
@@ -535,6 +535,7 @@ ci-release:
     ARG BUILDKIT_PROJECT
     ARG EARTHLY_GIT_HASH
     ARG --required TAG_SUFFIX
+    RUN echo "BUILDING ${EARTHLY_GIT_HASH}-${TAG_SUFFIX}"
     BUILD \
         --platform=linux/amd64 \
         ./buildkitd+buildkitd --TAG=${EARTHLY_GIT_HASH}-${TAG_SUFFIX} --BUILDKIT_PROJECT="$BUILDKIT_PROJECT" --DOCKERHUB_BUILDKIT_IMG="buildkitd-staging"

--- a/release/Earthfile
+++ b/release/Earthfile
@@ -65,7 +65,7 @@ perform-release-dockerhub:
         --platform=linux/arm64 \
         ../+earthly-docker \
         --TAG="$RELEASE_TAG" \
-        --BIN_VERSION="$BIN_VERSION"
+        --BIN_VERSION="$BIN_VERSION" \
         --DOCKERHUB_USER="$DOCKERHUB_USER" \
         --DOCKERHUB_IMG="$DOCKERHUB_IMG"
     BUILD \
@@ -73,7 +73,7 @@ perform-release-dockerhub:
         --platform=linux/arm64 \
         ../buildkitd+buildkitd \
         --TAG="$RELEASE_TAG" \
-        --BIN_VERSION="$BIN_VERSION"
+        --BIN_VERSION="$BIN_VERSION" \
         --DOCKERHUB_USER="$DOCKERHUB_USER" \
         --DOCKERHUB_BUILDKIT_IMG="$DOCKERHUB_BUILDKIT_IMG"
 
@@ -106,7 +106,7 @@ release-github:
     COPY +release-notes/notes.txt release-notes.txt
     COPY (../+earthly-all/* \
          --TAG=$RELEASE_TAG \
-         --BIN_VERSION=$RELEASE_TAG
+         --BIN_VERSION=$RELEASE_TAG \
          --DEFAULT_BUILDKITD_IMAGE="$DOCKERHUB_HOST/$DOCKERHUB_USER/$DOCKERHUB_BUILDKIT_IMG:$RELEASE_TAG" \
          --DEFAULT_INSTALLATION_NAME="earthly" \
          ) ./release/

--- a/release/Earthfile
+++ b/release/Earthfile
@@ -12,7 +12,7 @@ release:
     ARG SKIP_GHA_CHECK
     ARG PRERELEASE="false"
     IF --no-cache test -n "$SKIP_GHA_CHECK" || ensure_gha_passing --sha $EARTHLY_GIT_HASH
-        BUILD +release-dockerhub --RELEASE_TAG="$RELEASE_TAG"
+        BUILD +release-dockerhub --RELEASE_TAG="$RELEASE_TAG" --BIN_VERSION="$RELEASE_TAG"
         BUILD +release-github --RELEASE_TAG="$RELEASE_TAG" --PRERELEASE="$PRERELEASE"
     ELSE
         RUN echo "github status check failed; to force the release without performing this check, set --build-arg SKIP_GHA_CHECK=1"
@@ -31,16 +31,32 @@ release-dockerhub:
     ARG DOCKERHUB_BUILDKIT_IMG="buildkitd"
     ARG PUSH_LATEST_TAG="false"
     ARG PUSH_PRERELEASE_TAG="false"
-    BUILD +perform-release-dockerhub --RELEASE_TAG="$RELEASE_TAG" --DOCKERHUB_USER="$DOCKERHUB_USER" --DOCKERHUB_IMG="$DOCKERHUB_IMG" --DOCKERHUB_BUILDKIT_IMG="$DOCKERHUB_BUILDKIT_IMG"
+    BUILD +perform-release-dockerhub \
+          --RELEASE_TAG="$RELEASE_TAG" \
+          --BIN_VERSION="$RELEASE_TAG" \
+          --DOCKERHUB_USER="$DOCKERHUB_USER" \
+          --DOCKERHUB_IMG="$DOCKERHUB_IMG" \
+          --DOCKERHUB_BUILDKIT_IMG="$DOCKERHUB_BUILDKIT_IMG"
     IF [ "$PUSH_LATEST_TAG" = "true" ]
-      BUILD +perform-release-dockerhub --RELEASE_TAG="latest" --DOCKERHUB_USER="$DOCKERHUB_USER" --DOCKERHUB_IMG="$DOCKERHUB_IMG" --DOCKERHUB_BUILDKIT_IMG="$DOCKERHUB_BUILDKIT_IMG"
+      BUILD +perform-release-dockerhub \
+            --RELEASE_TAG="latest" \
+            --BIN_VERSION="$RELEASE_TAG" \
+            --DOCKERHUB_USER="$DOCKERHUB_USER" \
+            --DOCKERHUB_IMG="$DOCKERHUB_IMG" \
+            --DOCKERHUB_BUILDKIT_IMG="$DOCKERHUB_BUILDKIT_IMG"
     END
     IF [ "$PUSH_PRERELEASE_TAG" = "true" ]
-      BUILD +perform-release-dockerhub --RELEASE_TAG="prerelease" --DOCKERHUB_USER="$DOCKERHUB_USER" --DOCKERHUB_IMG="$DOCKERHUB_IMG" --DOCKERHUB_BUILDKIT_IMG="$DOCKERHUB_BUILDKIT_IMG"
+      BUILD +perform-release-dockerhub \
+            --RELEASE_TAG="prerelease" \
+            --BIN_VERSION="$RELEASE_TAG" \
+            --DOCKERHUB_USER="$DOCKERHUB_USER" \
+            --DOCKERHUB_IMG="$DOCKERHUB_IMG" \
+            --DOCKERHUB_BUILDKIT_IMG="$DOCKERHUB_BUILDKIT_IMG"
     END
 
 perform-release-dockerhub:
     ARG --required RELEASE_TAG
+    ARG --required BIN_VERSION
     ARG DOCKERHUB_USER="earthly"
     ARG DOCKERHUB_IMG="earthly"
     ARG DOCKERHUB_BUILDKIT_IMG="buildkitd"
@@ -49,6 +65,7 @@ perform-release-dockerhub:
         --platform=linux/arm64 \
         ../+earthly-docker \
         --TAG="$RELEASE_TAG" \
+        --BIN_VERSION="$BIN_VERSION"
         --DOCKERHUB_USER="$DOCKERHUB_USER" \
         --DOCKERHUB_IMG="$DOCKERHUB_IMG"
     BUILD \
@@ -56,6 +73,7 @@ perform-release-dockerhub:
         --platform=linux/arm64 \
         ../buildkitd+buildkitd \
         --TAG="$RELEASE_TAG" \
+        --BIN_VERSION="$BIN_VERSION"
         --DOCKERHUB_USER="$DOCKERHUB_USER" \
         --DOCKERHUB_BUILDKIT_IMG="$DOCKERHUB_BUILDKIT_IMG"
 
@@ -76,6 +94,7 @@ release-github:
     RUN npm install -g github-release-cli@v1.3.1
     WORKDIR /earthly
     ARG --required RELEASE_TAG
+    ARG BIN_VERSION=$RELEASE_TAG
     ARG GITHUB_USER="earthly"
     ARG EARTHLY_REPO="earthly"
     ARG DOCKERHUB_HOST="docker.io"
@@ -86,7 +105,8 @@ release-github:
     RUN test -n "$EARTHLY_GIT_HASH"
     COPY +release-notes/notes.txt release-notes.txt
     COPY (../+earthly-all/* \
-         --VERSION=$RELEASE_TAG \
+         --TAG=$RELEASE_TAG \
+         --BIN_VERSION=$RELEASE_TAG
          --DEFAULT_BUILDKITD_IMAGE="$DOCKERHUB_HOST/$DOCKERHUB_USER/$DOCKERHUB_BUILDKIT_IMG:$RELEASE_TAG" \
          --DEFAULT_INSTALLATION_NAME="earthly" \
          ) ./release/

--- a/release/Earthfile
+++ b/release/Earthfile
@@ -36,27 +36,15 @@ release-dockerhub:
           --BIN_VERSION="$RELEASE_TAG" \
           --DOCKERHUB_USER="$DOCKERHUB_USER" \
           --DOCKERHUB_IMG="$DOCKERHUB_IMG" \
-          --DOCKERHUB_BUILDKIT_IMG="$DOCKERHUB_BUILDKIT_IMG"
-    IF [ "$PUSH_LATEST_TAG" = "true" ]
-      BUILD +perform-release-dockerhub \
-            --RELEASE_TAG="latest" \
-            --BIN_VERSION="$RELEASE_TAG" \
-            --DOCKERHUB_USER="$DOCKERHUB_USER" \
-            --DOCKERHUB_IMG="$DOCKERHUB_IMG" \
-            --DOCKERHUB_BUILDKIT_IMG="$DOCKERHUB_BUILDKIT_IMG"
-    END
-    IF [ "$PUSH_PRERELEASE_TAG" = "true" ]
-      BUILD +perform-release-dockerhub \
-            --RELEASE_TAG="prerelease" \
-            --BIN_VERSION="$RELEASE_TAG" \
-            --DOCKERHUB_USER="$DOCKERHUB_USER" \
-            --DOCKERHUB_IMG="$DOCKERHUB_IMG" \
-            --DOCKERHUB_BUILDKIT_IMG="$DOCKERHUB_BUILDKIT_IMG"
-    END
+          --DOCKERHUB_BUILDKIT_IMG="$DOCKERHUB_BUILDKIT_IMG" \
+          --PUSH_LATEST_TAG="$PUSH_LATEST_TAG" \
+          --PUSH_PRERELEASE_TAG="$PUSH_PRERELEASE_TAG"
 
 perform-release-dockerhub:
     ARG --required RELEASE_TAG
     ARG --required BIN_VERSION
+    ARG PUSH_LATEST_TAG="false"
+    ARG PUSH_PRERELEASE_TAG="false"
     ARG DOCKERHUB_USER="earthly"
     ARG DOCKERHUB_IMG="earthly"
     ARG DOCKERHUB_BUILDKIT_IMG="buildkitd"
@@ -67,7 +55,9 @@ perform-release-dockerhub:
         --TAG="$RELEASE_TAG" \
         --BIN_VERSION="$BIN_VERSION" \
         --DOCKERHUB_USER="$DOCKERHUB_USER" \
-        --DOCKERHUB_IMG="$DOCKERHUB_IMG"
+        --DOCKERHUB_IMG="$DOCKERHUB_IMG" \
+        --PUSH_LATEST_TAG="$PUSH_LATEST_TAG" \
+        --PUSH_PRERELEASE_TAG="$PUSH_PRERELEASE_TAG"
     BUILD \
         --platform=linux/amd64 \
         --platform=linux/arm64 \

--- a/release/Earthfile
+++ b/release/Earthfile
@@ -12,7 +12,7 @@ release:
     ARG SKIP_GHA_CHECK
     ARG PRERELEASE="false"
     IF --no-cache test -n "$SKIP_GHA_CHECK" || ensure_gha_passing --sha $EARTHLY_GIT_HASH
-        BUILD +release-dockerhub --RELEASE_TAG="$RELEASE_TAG" --BIN_VERSION="$RELEASE_TAG"
+        BUILD +release-dockerhub --RELEASE_TAG="$RELEASE_TAG"
         BUILD +release-github --RELEASE_TAG="$RELEASE_TAG" --PRERELEASE="$PRERELEASE"
     ELSE
         RUN echo "github status check failed; to force the release without performing this check, set --build-arg SKIP_GHA_CHECK=1"
@@ -33,7 +33,6 @@ release-dockerhub:
     ARG PUSH_PRERELEASE_TAG="false"
     BUILD +perform-release-dockerhub \
           --RELEASE_TAG="$RELEASE_TAG" \
-          --BIN_VERSION="$RELEASE_TAG" \
           --DOCKERHUB_USER="$DOCKERHUB_USER" \
           --DOCKERHUB_IMG="$DOCKERHUB_IMG" \
           --DOCKERHUB_BUILDKIT_IMG="$DOCKERHUB_BUILDKIT_IMG" \
@@ -42,7 +41,6 @@ release-dockerhub:
 
 perform-release-dockerhub:
     ARG --required RELEASE_TAG
-    ARG --required BIN_VERSION
     ARG PUSH_LATEST_TAG="false"
     ARG PUSH_PRERELEASE_TAG="false"
     ARG DOCKERHUB_USER="earthly"
@@ -53,7 +51,6 @@ perform-release-dockerhub:
         --platform=linux/arm64 \
         ../+earthly-docker \
         --TAG="$RELEASE_TAG" \
-        --BIN_VERSION="$BIN_VERSION" \
         --DOCKERHUB_USER="$DOCKERHUB_USER" \
         --DOCKERHUB_IMG="$DOCKERHUB_IMG" \
         --PUSH_LATEST_TAG="$PUSH_LATEST_TAG" \
@@ -63,7 +60,6 @@ perform-release-dockerhub:
         --platform=linux/arm64 \
         ../buildkitd+buildkitd \
         --TAG="$RELEASE_TAG" \
-        --BIN_VERSION="$BIN_VERSION" \
         --DOCKERHUB_USER="$DOCKERHUB_USER" \
         --DOCKERHUB_BUILDKIT_IMG="$DOCKERHUB_BUILDKIT_IMG"
 
@@ -84,7 +80,6 @@ release-github:
     RUN npm install -g github-release-cli@v1.3.1
     WORKDIR /earthly
     ARG --required RELEASE_TAG
-    ARG BIN_VERSION=$RELEASE_TAG
     ARG GITHUB_USER="earthly"
     ARG EARTHLY_REPO="earthly"
     ARG DOCKERHUB_HOST="docker.io"
@@ -95,8 +90,7 @@ release-github:
     RUN test -n "$EARTHLY_GIT_HASH"
     COPY +release-notes/notes.txt release-notes.txt
     COPY (../+earthly-all/* \
-         --TAG=$RELEASE_TAG \
-         --BIN_VERSION=$RELEASE_TAG \
+         --VERSION=$RELEASE_TAG \
          --DEFAULT_BUILDKITD_IMAGE="$DOCKERHUB_HOST/$DOCKERHUB_USER/$DOCKERHUB_BUILDKIT_IMG:$RELEASE_TAG" \
          --DEFAULT_INSTALLATION_NAME="earthly" \
          ) ./release/


### PR DESCRIPTION
Addresses https://github.com/earthly/earthly/issues/2142

There's a new `BIN_VERSION` arg which can be manually set to differentiate between the binary version & the container image tag. It will fall back to the container image tag if it's not provided. 

Example:

```
$ earthly ./release+release-dockerhub --PUSH_LATEST_TAG=true --RELEASE_TAG="v8.8.8"
...
...
 Push Summary ⏫ (disabled)
————————————————————————————————————————————————————————————————————————————————

To enable pushing use earthly --push
Did not push image docker.io/earthly/buildkitd:v8.8.8
Did not push image docker.io/earthly/buildkitd:v8.8.8
Did not push image docker.io/earthly/buildkitd:v8.8.8
Did not push image docker.io/earthly/buildkitd:v8.8.8
Did not push image docker.io/earthly/buildkitd:latest
Did not push image docker.io/earthly/buildkitd:latest
Did not push image docker.io/earthly/buildkitd:latest
Did not push image docker.io/earthly/buildkitd:latest
Did not push image earthly/earthly:v8.8.8
Did not push image earthly/earthly:v8.8.8
Did not push image earthly/earthly:latest
Did not push image earthly/earthly:latest

 Local Output Summary 🎁
————————————————————————————————————————————————————————————————————————————————

Image +earthly-docker output as earthly/earthly:v8.8.8
Image +earthly-docker output as earthly/earthly:v8.8.8
Image +earthly-docker output as earthly/earthly:latest
Image +earthly-docker output as earthly/earthly:latest
Image ./buildkitd+buildkitd output as docker.io/earthly/buildkitd:v8.8.8
Image ./buildkitd+buildkitd output as docker.io/earthly/buildkitd:v8.8.8
Image ./buildkitd+buildkitd output as docker.io/earthly/buildkitd:latest
Image ./buildkitd+buildkitd output as docker.io/earthly/buildkitd:latest

```
And when checking the version string:

```
$ docker run --rm --entrypoint='' earthly/earthly:latest /usr/bin/earthly --version
earthly version v8.8.8 de7de9e0541b7478050dd3e50df6709a007be5bc linux/amd64; Alpine Linux 
$ docker run --rm --entrypoint='' earthly/earthly:v8.8.8 /usr/bin/earthly --version
earthly version v8.8.8 de7de9e0541b7478050dd3e50df6709a007be5bc linux/amd64; Alpine Linux
```

It doesn't seem like any doc changes are required as the new arg is specified in `release/Earthfile`.