### PR TITLE
Fix flaky Podman test

### DIFF
--- a/util/llbutil/authprovider/imports_test.go
+++ b/util/llbutil/authprovider/imports_test.go
@@ -14,6 +14,7 @@ const (
 
 var (
 	beTrue       = matchers.BeTrue
+	beFalse      = matchers.BeFalse
 	not          = matchers.Not
 	haveOccurred = matchers.HaveOccurred
 	equal        = matchers.Equal

--- a/util/llbutil/authprovider/imports_test.go
+++ b/util/llbutil/authprovider/imports_test.go
@@ -18,7 +18,6 @@ var (
 	not          = matchers.Not
 	haveOccurred = matchers.HaveOccurred
 	equal        = matchers.Equal
-	beClosed     = matchers.BeClosed
 	matchRegexp  = matchers.MatchRegexp
 	beNil        = matchers.BeNil
 

--- a/util/llbutil/authprovider/podman_test.go
+++ b/util/llbutil/authprovider/podman_test.go
@@ -60,8 +60,8 @@ func TestPodmanProvider(topT *testing.T) {
 	defer o.Run()
 
 	o.AfterEach(func(tt testCtx) {
-		<-tt.result
-		tt.expect(tt.result).To(beClosed()) // Ensure tests don't leak goroutines.
+		_, ok := <-tt.result
+		tt.expect(ok).To(beFalse()) // Ensure that the channel was closed
 	})
 
 	type authFile struct {

--- a/util/llbutil/authprovider/podman_test.go
+++ b/util/llbutil/authprovider/podman_test.go
@@ -60,6 +60,7 @@ func TestPodmanProvider(topT *testing.T) {
 	defer o.Run()
 
 	o.AfterEach(func(tt testCtx) {
+		<-tt.result
 		tt.expect(tt.result).To(beClosed()) // Ensure tests don't leak goroutines.
 	})
 


### PR DESCRIPTION
The test was checking for the chan to be closed before waiting on the goroutine in `BeforeEach` to close the chan.

Before:

```bash
go test -count 2000 -run TestPodmanProvider 
--- FAIL: TestPodmanProvider (0.00s)
    --- FAIL: TestPodmanProvider/it_falls_back_to_XDG_RUNTIME_DIR/containers/auth.json (0.00s)
        podman_test.go:63: channel open
            podman_test.go:63
--- FAIL: TestPodmanProvider (0.00s)
    --- FAIL: TestPodmanProvider/it_prefers_REGISTRY_AUTH_FILE (0.00s)
        podman_test.go:63: channel open
            podman_test.go:63
--- FAIL: TestPodmanProvider (0.00s)
    --- FAIL: TestPodmanProvider/it_prefers_REGISTRY_AUTH_FILE (0.00s)
        podman_test.go:63: channel open
            podman_test.go:63
--- FAIL: TestPodmanProvider (0.00s)
    --- FAIL: TestPodmanProvider/it_falls_back_to_XDG_RUNTIME_DIR/containers/auth.json (0.00s)
        podman_test.go:63: channel open
            podman_test.go:63
--- FAIL: TestPodmanProvider (0.00s)
    --- FAIL: TestPodmanProvider/it_falls_back_to_XDG_RUNTIME_DIR/containers/auth.json (0.00s)
        podman_test.go:63: channel open
            podman_test.go:63
FAIL
exit status 1
FAIL    github.com/earthly/earthly/util/llbutil/authprovider    4.130s
```
After:
```bash
$ go test -count 2000 -run TestPodmanProvider
PASS
ok      github.com/earthly/earthly/util/llbutil/authprovider    4.243s
