### PR TITLE
Remove second var declaration in +smoke-test

### DIFF
--- a/tests/with-docker-kind/Earthfile
+++ b/tests/with-docker-kind/Earthfile
@@ -10,7 +10,6 @@ all:
 alpine-kind:
     FROM earthly/dind:alpine-3.18-docker-23.0.6-r7
     RUN apk add curl
-    ARG --required KIND_VERSION
     RUN curl -Lo ./kind https://kind.sigs.k8s.io/dl/v$KIND_VERSION/kind-linux-amd64 && chmod +x kind
     WITH DOCKER
         RUN ./kind create cluster --verbosity 99999 --retain
@@ -18,7 +17,6 @@ alpine-kind:
 
 ubuntu-kind:
     FROM earthly/dind:ubuntu-23.04-docker-24.0.5-1
-    ARG --required KIND_VERSION
     RUN curl -Lo ./kind https://kind.sigs.k8s.io/dl/v$KIND_VERSION/kind-linux-amd64 && chmod +x kind
     WITH DOCKER
         RUN ./kind create cluster --verbosity 99999 --retain

--- a/tests/with-docker-kind/Earthfile
+++ b/tests/with-docker-kind/Earthfile
@@ -4,8 +4,8 @@ FROM earthly/dind:alpine-3.18-docker-23.0.6-r7
 ARG --global KIND_VERSION=0.20.0
 
 all:
-    BUILD +alpine-kind --KIND_VERSION=$KIND_VERSION
-    BUILD +ubuntu-kind --KIND_VERSION=$KIND_VERSION
+    BUILD +alpine-kind
+    BUILD +ubuntu-kind
 
 alpine-kind:
     FROM earthly/dind:alpine-3.18-docker-23.0.6-r7


### PR DESCRIPTION
Declaring an ARG that's meant to depend on a global doesn't seem to be supported. Perhaps this should be supported by Earthly, but for now, here's a fix for the CircleCI test. 