### PR TITLE
Auto-skip: retain quotes when expanding args

### DIFF
--- a/inputgraph/loader.go
+++ b/inputgraph/loader.go
@@ -894,8 +894,10 @@ func (l *loader) load(ctx context.Context) error {
 
 	// Ensure that args passed to this target are always hashed. Globals,
 	// built-ins, and ARG values are hashed elsewhere.
-	for _, val := range l.overridingVars.BuildArgs() {
-		l.hasher.HashString(fmt.Sprintf("VAR %s", val))
+	if l.overridingVars != nil {
+		for _, val := range l.overridingVars.BuildArgs() {
+			l.hasher.HashString(fmt.Sprintf("VAR %s", val))
+		}
 	}
 
 	ef := buildCtx.Earthfile

--- a/inputgraph/loader.go
+++ b/inputgraph/loader.go
@@ -314,7 +314,7 @@ func (l *loader) expandArgs(ctx context.Context, args []string) ([]string, error
 	for _, arg := range args {
 		expanded, err := l.varCollection.Expand(arg, func(cmd string) (string, error) {
 			return arg, nil // Return the original expression so it can be referenced later.
-		})
+		}, variables.WithRawQuotes(), variables.WithRawEscapes())
 		if err != nil {
 			return nil, err
 		}

--- a/tests/autoskip/Earthfile
+++ b/tests/autoskip/Earthfile
@@ -29,6 +29,7 @@ test-all:
     BUILD +test-remote-targets
     BUILD +test-from-dockerfile
     BUILD +test-import
+    BUILD +test-copy-target-args-quoted
 
 test-files:
     RUN echo hello > my-file
@@ -141,6 +142,10 @@ test-copy-target-args:
 
     DO --pass-args +RUN_EARTHLY_ARGS --target=+copy-target-args --output_contains="+copy-target-args | changed"
     DO --pass-args +RUN_EARTHLY_ARGS --target=+copy-target-args --output_contains="Target .* has already been run. Skipping."
+
+test-copy-target-args-quoted:
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=expand-args.earth --target=+copy-target-args-quoted --output_contains="hello world"
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=expand-args.earth --target=+copy-target-args-quoted --output_contains="Target .* has already been run. Skipping."
 
 test-arg-matrix:
     DO --pass-args +RUN_EARTHLY_ARGS --earthfile=matrix.earth --target=+arg-matrix --output_contains="Hello Bob. From Todd"

--- a/tests/autoskip/expand-args.earth
+++ b/tests/autoskip/expand-args.earth
@@ -58,3 +58,7 @@ copy-target:
 copy-target-args:
     COPY (+copy-target/x --foo=hello) .
     RUN cat x
+
+copy-target-args-quoted:
+    COPY (+copy-target/x --foo="hello world") .
+    RUN cat x

--- a/variables/collection.go
+++ b/variables/collection.go
@@ -217,32 +217,10 @@ func (c *Collection) ExpandOld(word string) string {
 	return ret
 }
 
-// ExpandOpt can be used to modified the behavior of Expand.
-type ExpandOpt func(shlex *shell.Lex)
-
-// WithRawQuotes will enable the RawQuotes option on the shell lexer and will
-// not strip quotes from strings.
-func WithRawQuotes() ExpandOpt {
-	return func(shlex *shell.Lex) {
-		shlex.RawQuotes = true
-	}
-}
-
-// WithRawEscapes will retain escape characters. This can be used in tandem with
-// WithRawQuotes to preserve quotes and escaped characters.
-func WithRawEscapes() ExpandOpt {
-	return func(shlex *shell.Lex) {
-		shlex.RawEscapes = true
-	}
-}
-
 // Expand expands variables within the given word.
-func (c *Collection) Expand(word string, shellOut shell.EvalShellOutFn, opts ...ExpandOpt) (string, error) {
+func (c *Collection) Expand(word string, shellOut shell.EvalShellOutFn) (string, error) {
 	shlex := shell.NewLex('\\')
 	shlex.ShellOut = shellOut
-	for _, opt := range opts {
-		opt(shlex)
-	}
 	varMap := c.effective().Map(WithActive())
 	return shlex.ProcessWordWithMap(word, varMap, ShellOutEnvs)
 }

--- a/variables/collection.go
+++ b/variables/collection.go
@@ -217,10 +217,32 @@ func (c *Collection) ExpandOld(word string) string {
 	return ret
 }
 
+// ExpandOpt can be used to modified the behavior of Expand.
+type ExpandOpt func(shlex *shell.Lex)
+
+// WithRawQuotes will enable the RawQuotes option on the shell lexer and will
+// not strip quotes from strings.
+func WithRawQuotes() ExpandOpt {
+	return func(shlex *shell.Lex) {
+		shlex.RawQuotes = true
+	}
+}
+
+// WithRawEscapes will retain escape characters. This can be used in tandem with
+// WithRawQuotes to preserve quotes and escaped characters.
+func WithRawEscapes() ExpandOpt {
+	return func(shlex *shell.Lex) {
+		shlex.RawEscapes = true
+	}
+}
+
 // Expand expands variables within the given word.
-func (c *Collection) Expand(word string, shellOut shell.EvalShellOutFn) (string, error) {
+func (c *Collection) Expand(word string, shellOut shell.EvalShellOutFn, opts ...ExpandOpt) (string, error) {
 	shlex := shell.NewLex('\\')
 	shlex.ShellOut = shellOut
+	for _, opt := range opts {
+		opt(shlex)
+	}
 	varMap := c.effective().Map(WithActive())
 	return shlex.ProcessWordWithMap(word, varMap, ShellOutEnvs)
 }


### PR DESCRIPTION
This fixes an issue with stripping quotes when expanding arguments.

The new code retains quotes and ensures the argument values are maintained after expansion.

Previous:

```
Original: COPY (+my-target --my-arg="hello world" --other="$FOO")
Expanded: COPY (+my-target --my-arg=hello world --other=value)
```

Note that the above `--my-arg` value will lead to an invalid argument error.

New:

```
Original: COPY (+my-target --my-arg="hello world" --other="$FOO")
Expanded: COPY (+my-target --my-arg="hello world" --other="value")
```