### PR TITLE
Improve user secret ls ergonomics

### DIFF
--- a/cmd/earthly/subcmd/common.go
+++ b/cmd/earthly/subcmd/common.go
@@ -2,10 +2,16 @@ package subcmd
 
 import (
 	"context"
+	"strings"
+
 	"github.com/earthly/earthly/cloud"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"
 )
+
+type orgLister interface {
+	ListOrgs(ctx context.Context) ([]*cloud.OrgDetail, error)
+}
 
 // projectOrgName returns the specified org or retrieves the default org from the API.
 func projectOrgName(cli CLI, ctx context.Context, cloudClient *cloud.Client) (string, error) {
@@ -46,29 +52,49 @@ func concatCmds(slices [][]*cli.Command) []*cli.Command {
 	return result
 }
 
-func getOrgAndProject(cli CLI, ctx context.Context, client *cloud.Client) (org, project string, isPersonal bool, err error) {
-	org = cli.OrgName()
-	if org == "" {
-		return org, project, isPersonal, errors.Errorf("provide an org using the --org flag or `org select` command")
-	}
+func getOrgAndProject(ctx context.Context, orgFlag, projectFlag string, client orgLister, path string) (org, project string, isPersonal bool, err error) {
+
 	allOrgs, err := client.ListOrgs(ctx)
 	if err != nil {
-		return org, project, isPersonal, errors.Wrap(err, "failed listing orgs from cloud")
+		err = errors.Wrap(err, "failed listing orgs from cloud")
+		return
 	}
-	var cloudOrg *cloud.OrgDetail
-	for _, o := range allOrgs {
-		if o.Name == org {
-			cloudOrg = o
-			break
+
+	org, project = orgFlag, projectFlag
+
+	if org == "" || strings.HasPrefix(path, "/user") {
+		for _, o := range allOrgs {
+			if o.Personal {
+				org = o.Name
+				project = ""
+				isPersonal = true
+				break
+			}
+		}
+	} else {
+		var found bool
+		for _, o := range allOrgs {
+			if o.Name == org {
+				isPersonal = o.Personal
+				found = true
+				break
+			}
+		}
+		if !found {
+			err = errors.Errorf("not a member of org %q", org)
+			return
 		}
 	}
-	if cloudOrg == nil {
-		return org, project, isPersonal, errors.Errorf("not a member of org %q", org)
+
+	if org == "" {
+		err = errors.New("provide an org using the --org flag or `org select` command")
+		return
 	}
-	isPersonal = cloudOrg.Personal
-	project = cli.Flags().ProjectName
-	if project == "" && !cloudOrg.Personal {
-		return org, project, isPersonal, errors.Errorf("the --project flag is required")
+
+	if project == "" && !isPersonal {
+		err = errors.Errorf("the --project flag is required")
+		return
 	}
-	return org, project, isPersonal, nil
+
+	return
 }

--- a/cmd/earthly/subcmd/common_test.go
+++ b/cmd/earthly/subcmd/common_test.go
@@ -1,0 +1,157 @@
+package subcmd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/earthly/earthly/cloud"
+	"github.com/stretchr/testify/require"
+)
+
+type testOrgLister struct {
+	results []*cloud.OrgDetail
+	err     error
+}
+
+func (l *testOrgLister) ListOrgs(ctx context.Context) ([]*cloud.OrgDetail, error) {
+	return l.results, l.err
+}
+
+func Test_getOrgAndProject(t *testing.T) {
+
+	tests := []struct {
+		desc                 string
+		orgLister            orgLister
+		orgFlag, projectFlag string
+		path                 string
+		wantOrg, wantProject string
+		wantPersonal         bool
+		errString            string
+	}{
+		{
+			desc:         "org & project provided (not personal)",
+			orgFlag:      "my-org",
+			projectFlag:  "my-project",
+			wantOrg:      "my-org",
+			wantProject:  "my-project",
+			wantPersonal: false,
+			orgLister: &testOrgLister{
+				results: []*cloud.OrgDetail{
+					{
+						Name:     "my-org",
+						Personal: false,
+					},
+				},
+			},
+		},
+		{
+			desc:         "org & project provided (org not found)",
+			orgFlag:      "my-org",
+			projectFlag:  "my-project",
+			wantOrg:      "my-org",
+			wantProject:  "my-project",
+			wantPersonal: false,
+			errString:    "not a member",
+			orgLister:    &testOrgLister{},
+		},
+		{
+			desc:         "org & project provided (/user/ prefix)",
+			orgFlag:      "my-org",
+			projectFlag:  "my-project",
+			wantOrg:      "personal-org",
+			wantProject:  "",
+			wantPersonal: true,
+			path:         "/user/",
+			orgLister: &testOrgLister{
+				results: []*cloud.OrgDetail{
+					{
+						Name:     "personal-org",
+						Personal: true,
+					},
+				},
+			},
+		},
+		{
+			desc:         "org & project provided (is personal)",
+			orgFlag:      "my-org",
+			projectFlag:  "my-project",
+			wantOrg:      "my-org",
+			wantProject:  "my-project",
+			wantPersonal: true,
+			orgLister: &testOrgLister{
+				results: []*cloud.OrgDetail{
+					{
+						Name:     "my-org",
+						Personal: true,
+					},
+				},
+			},
+		},
+		{
+			desc:         "org provided but not project",
+			orgFlag:      "my-org",
+			projectFlag:  "",
+			wantOrg:      "my-org",
+			wantProject:  "",
+			wantPersonal: false,
+			errString:    "--project flag is required",
+			orgLister: &testOrgLister{
+				results: []*cloud.OrgDetail{
+					{
+						Name:     "my-org",
+						Personal: false,
+					},
+				},
+			},
+		},
+		{
+			desc:         "no org/project & personal not found",
+			orgFlag:      "",
+			projectFlag:  "",
+			wantOrg:      "",
+			wantProject:  "",
+			wantPersonal: false,
+			errString:    "provide an org",
+			orgLister: &testOrgLister{
+				results: []*cloud.OrgDetail{
+					{
+						Name:     "my-org",
+						Personal: false,
+					},
+				},
+			},
+		},
+		{
+			desc:         "no org/project & personal found",
+			orgFlag:      "",
+			projectFlag:  "",
+			wantOrg:      "personal-org",
+			wantProject:  "",
+			wantPersonal: true,
+			orgLister: &testOrgLister{
+				results: []*cloud.OrgDetail{
+					{
+						Name:     "personal-org",
+						Personal: true,
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		ctx := context.Background()
+		t.Run(test.desc, func(t *testing.T) {
+			r := require.New(t)
+			org, project, isPersonal, err := getOrgAndProject(ctx, test.orgFlag, test.projectFlag, test.orgLister, test.path)
+			r.Equal(test.wantOrg, org, "org does not match")
+			r.Equal(test.wantProject, project, "project does not match")
+			r.Equal(test.wantPersonal, isPersonal, "personal value does not match")
+			if test.errString != "" {
+				r.ErrorContains(err, test.errString)
+			} else {
+				r.NoError(err, "no error expected")
+			}
+		})
+	}
+}

--- a/cmd/earthly/subcmd/registry_cmds.go
+++ b/cmd/earthly/subcmd/registry_cmds.go
@@ -200,7 +200,7 @@ func (a *Registry) getRegistriesPath(ctx context.Context, cloudClient *cloud.Cli
 	if user {
 		return "/user/std/registry/", nil
 	}
-	orgName, projectName, _, err := getOrgAndProject(a.cli, ctx, cloudClient)
+	orgName, projectName, _, err := getOrgAndProject(ctx, a.cli.OrgName(), a.cli.Flags().ProjectName, cloudClient, "")
 	if err != nil {
 		return "", err
 	}

--- a/cmd/earthly/subcmd/secret_cmds.go
+++ b/cmd/earthly/subcmd/secret_cmds.go
@@ -192,7 +192,7 @@ func (a *Secret) actionListV2(cliCtx *cli.Context) error {
 		return nil
 	}
 
-	orgName, projectName, isPersonal, err := getOrgAndProject(a.cli, cliCtx.Context, cloudClient)
+	orgName, projectName, isPersonal, err := getOrgAndProject(cliCtx.Context, a.cli.OrgName(), a.cli.Flags().ProjectName, cloudClient, path)
 	if err != nil {
 		return err
 	}
@@ -349,7 +349,7 @@ func (a *Secret) fullSecretPath(ctx context.Context, cloudClient *cloud.Client, 
 		return path, nil
 	}
 
-	orgName, projectName, isPersonal, err := getOrgAndProject(a.cli, ctx, cloudClient)
+	orgName, projectName, isPersonal, err := getOrgAndProject(ctx, a.cli.OrgName(), a.cli.Flags().ProjectName, cloudClient, "")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Addresses https://github.com/earthly/earthly/issues/3158

This change ensures the following user secret listing styles all behave as expected:

```bash
$ EARTHLY_ORG="" EARTHLY_PROJECT="" earthly secrets ls /user
$ EARTHLY_ORG="my-org" EARTHLY_PROJECT="my-project" earthly secrets ls /user
$ EARTHLY_ORG="my-org" EARTHLY_PROJECT="" earthly secrets ls /user
$ EARTHLY_ORG="my-personal-org" EARTHLY_PROJECT="" earthly secrets ls
```

However, because of how user secret names are stripped of the `/user/` prefix on display, users may be confused by the following scenario:

```bash
# Using the /user prefix here will essentially ignore the organization & project envs.
$ EARTHLY_ORG="my-org" EARTHLY_PROJECT="my-project" earthly secrets ls /user
/my/secret
# The above secret is stored as a user secret, but the /user prefix has been removed.
$ EARTHLY_ORG="my-org" EARTHLY_PROJECT="my-project" earthly secrets set /my/secret foo
# The new /my/secret secret will be stored in the specified organization & project.
```

We can either leave this as is or disallow non-personal organizations when interacting with `/user` secrets. The latter may break existing workflows as organizations & projects are often set as environmental variables. 