### PR TITLE
Guard against empty COPY sources

### DIFF
--- a/ast/tests/copy.ast.json
+++ b/ast/tests/copy.ast.json
@@ -1171,6 +1171,55 @@
           }
         }
       ]
+    },
+    {
+      "name": "copy-empty-src",
+      "recipe": [
+        {
+          "command": {
+            "args": [
+              "SRC",
+              "=",
+              "\"\""
+            ],
+            "name": "ARG"
+          }
+        },
+        {
+          "command": {
+            "args": [
+              "$SRC",
+              "$SRC"
+            ],
+            "name": "COPY"
+          }
+        }
+      ]
+    },
+    {
+      "name": "copy-empty-src-if-exists",
+      "recipe": [
+        {
+          "command": {
+            "args": [
+              "SRC",
+              "=",
+              "\"\""
+            ],
+            "name": "ARG"
+          }
+        },
+        {
+          "command": {
+            "args": [
+              "--if-exists",
+              "$SRC",
+              "$SRC"
+            ],
+            "name": "COPY"
+          }
+        }
+      ]
     }
   ],
   "version": {

--- a/earthfile2llb/interpreter.go
+++ b/earthfile2llb/interpreter.go
@@ -971,11 +971,6 @@ func (i *Interpreter) handleCopy(ctx context.Context, cmd spec.Command) error {
 	if !allClassical && !allArtifacts {
 		return i.errorf(cmd.SourceLocation, "combining artifacts and build context arguments in a single COPY command is not allowed: %v", srcs)
 	}
-	for _, src := range srcs {
-		if src == "" {
-			return i.wrapError(err, cmd.SourceLocation, "empty COPY source encountered")
-		}
-	}
 	if slices.ContainsFunc(strings.Split(dest, "/"), func(s string) bool {
 		return s == "~" || strings.HasPrefix(s, "~")
 	}) {

--- a/earthfile2llb/interpreter.go
+++ b/earthfile2llb/interpreter.go
@@ -922,7 +922,6 @@ func (i *Interpreter) handleCopy(ctx context.Context, cmd spec.Command) error {
 	if err != nil {
 		return i.wrapError(err, cmd.SourceLocation, "parse platform %s", expandedPlatform)
 	}
-
 	allClassical := true
 	allArtifacts := true
 	for index, src := range srcs {
@@ -972,7 +971,11 @@ func (i *Interpreter) handleCopy(ctx context.Context, cmd spec.Command) error {
 	if !allClassical && !allArtifacts {
 		return i.errorf(cmd.SourceLocation, "combining artifacts and build context arguments in a single COPY command is not allowed: %v", srcs)
 	}
-
+	for _, src := range srcs {
+		if src == "" {
+			return i.wrapError(err, cmd.SourceLocation, "empty COPY source encountered")
+		}
+	}
 	if slices.ContainsFunc(strings.Split(dest, "/"), func(s string) bool {
 		return s == "~" || strings.HasPrefix(s, "~")
 	}) {

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -232,8 +232,9 @@ copy-test:
     DO +RUN_EARTHLY --earthfile=copy.earth --output_does_not_contain="which does not expand to a home directory"
 
 copy-test-empty-src:
-    DO +RUN_EARTHLY --earthfile=copy.earth --target=+copy-empty-src --should_fail=true --output_contains="empty COPY source encountered"
-    DO +RUN_EARTHLY --earthfile=copy.earth --target=+copy-empty-src-if-exists --should_fail=true --output_contains="empty COPY source encountered"
+    # Regression tests for 'COPY --if-exists "" <dst>' (empty string)
+    DO +RUN_EARTHLY --earthfile=copy.earth --target=+copy-empty-src
+    DO +RUN_EARTHLY --earthfile=copy.earth --target=+copy-empty-src-if-exists
 
 copy-test-verbose-output:
     RUN mkdir -p subdir/a.txt && \

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -30,6 +30,7 @@ ga-no-qemu-group1:
     BUILD +copy-test-verbose-output
     BUILD +copy-tilde-test
     BUILD +copy-keep-own-test
+    BUILD +copy-test-empty-src
     BUILD +git-clone-test
     BUILD +builtin-args-invalid-default-test
     BUILD +builtin-args-invalid-pass-test
@@ -229,6 +230,10 @@ copy-test:
         echo "2" > in/sub/2/file && \
         echo "sub" > in/sub/file
     DO +RUN_EARTHLY --earthfile=copy.earth --output_does_not_contain="which does not expand to a home directory"
+
+copy-test-empty-src:
+    DO +RUN_EARTHLY --earthfile=copy.earth --target=+copy-empty-src --should_fail=true --output_contains="empty COPY source encountered"
+    DO +RUN_EARTHLY --earthfile=copy.earth --target=+copy-empty-src-if-exists --should_fail=true --output_contains="empty COPY source encountered"
 
 copy-test-verbose-output:
     RUN mkdir -p subdir/a.txt && \

--- a/tests/copy.earth
+++ b/tests/copy.earth
@@ -214,3 +214,11 @@ copy-chmod:
     COPY --chmod=666 in/root .
     RUN echo "./root file-mode=$(stat -c %a ./root)"
     RUN test "$(stat -c %a ./root)" = "666"
+
+copy-empty-src:
+    ARG SRC=""
+    COPY $SRC $SRC
+
+copy-empty-src-if-exists:
+    ARG SRC=""
+    COPY --if-exists $SRC $SRC

--- a/util/llbutil/copyop.go
+++ b/util/llbutil/copyop.go
@@ -30,14 +30,14 @@ func CopyOp(ctx context.Context, srcState pllb.State, srcs []string, destState p
 		baseCopyOpts = append(baseCopyOpts, llb.WithCreatedTime(*defaultTs()))
 	}
 	for _, src := range srcs {
-		if ifExists {
+		if ifExists && len(src) != 0 {
 			// If the copy came in as optional (ifExists), then we need to trigger the
 			// underlying wildcard matching and allow empty wildcards. The matching uses
-			// the filepath.Match syntax, so by simply creating a wildcard where the
+			// the filepath. Match syntax, so by simply creating a wildcard where the
 			// first letter needs to match the current first letter gets us the single
 			// match; and no error if it is missing.
 
-			//Normalize path by dropping './'
+			// Normalize path by dropping './'
 			src = strings.TrimPrefix(src, "./")
 			// A target source will always have a leading '/' and never match, so strip that as well
 			src = strings.TrimPrefix(src, "/")


### PR DESCRIPTION
Addresses https://github.com/earthly/earthly/issues/3147

This PR adds a check against empty COPY source arguments. This fixes the above `--if-exists` panic and validates all other sources that expand to empty strings. Another option would be to fail during arg expansion if the arg doesn't exist. 