### PR TITLE
Prefer auth token to SSH login when provided

### DIFF
--- a/cloud/client.go
+++ b/cloud/client.go
@@ -76,11 +76,20 @@ type Client struct {
 	lastAuthMethodExpiry     time.Time
 }
 
+// ClientOpt is used to customize the Cloud client.
 type ClientOpt func(*Client)
 
+// WithLogstreamGRPCAddressOverride can be used to override the Logstream gRPC address.
 func WithLogstreamGRPCAddressOverride(address string) ClientOpt {
 	return func(client *Client) {
 		client.logstreamAddressOverride = address
+	}
+}
+
+// WithAuthToken can be used to specify a custom auth token to the Cloud client.
+func WithAuthToken(token string) ClientOpt {
+	return func(client *Client) {
+		client.authCredToken = token
 	}
 }
 

--- a/cloud/client.go
+++ b/cloud/client.go
@@ -86,10 +86,13 @@ func WithLogstreamGRPCAddressOverride(address string) ClientOpt {
 	}
 }
 
-// WithAuthToken can be used to specify a custom auth token to the Cloud client.
+// WithAuthToken can be used to ignore other authentication mechanisms
+// besides the given token. Any previously set JWT tokens are cleared.
 func WithAuthToken(token string) ClientOpt {
 	return func(client *Client) {
 		client.authCredToken = token
+		client.authToken = ""
+		client.authTokenExpiry = time.Time{}
 	}
 }
 

--- a/cmd/earthly/subcmd/account_cmds.go
+++ b/cmd/earthly/subcmd/account_cmds.go
@@ -591,7 +591,12 @@ func (a *Account) actionLogin(cliCtx *cli.Context) error {
 	token := a.token
 	pass := a.password
 
-	cloudClient, err := helper.NewCloudClient(a.cli)
+	opts := []cloud.ClientOpt{}
+	if token != "" {
+		opts = append(opts, cloud.WithAuthToken(token))
+	}
+
+	cloudClient, err := helper.NewCloudClient(a.cli, opts...)
 	if err != nil {
 		return err
 	}

--- a/tests/account/test-login.sh
+++ b/tests/account/test-login.sh
@@ -32,3 +32,10 @@ echo "== it should be able to login as user2 with ssh =="
 earthly account logout
 echo "$USER2_SSH_KEY" | ssh-add -
 earthly account login 2>&1 | acbgrep 'Logged in as "other-service.earthly-user2@earthly.dev" using ssh auth'
+
+echo "== using token param should behave similarly to EARTHLY_TOKEN env =="
+earthly account login --token "$USER2_TOKEN" 2>&1 | acbgrep 'Logged in as "other-service.earthly-user2@earthly.dev" using token auth'
+
+echo "== same as above but first ensure we're logged out =="
+earthly account logout
+earthly account login --token "$USER2_TOKEN" 2>&1 | acbgrep 'Logged in as "other-service.earthly-user2@earthly.dev" using token auth'


### PR DESCRIPTION
Addresses #3284

This change allows for the Cloud client's auth token to be set when using the below command to log in. Previously, the command was performing SSH-based auth despite the `--token` parameter.

```
earthly account login --token <token>
```

Setting the `--token` parameter will also ignore any cached JWT. This seems more intuitive as the token is explicitly provided.
