### PR TITLE
Ensure satellite is ready before running test

### DIFF
--- a/scripts/tests/earthly-image-sat.sh
+++ b/scripts/tests/earthly-image-sat.sh
@@ -35,6 +35,24 @@ function finish {
 }
 trap finish EXIT
 
+# Wait for a stopped satellite to finish shutting down. Other states may continue.
+while true; do
+  state=$(earthly sat inspect core-test 2>&1 | grep State | awk '{print $2}')
+  echo "Current state: $state"
+  case $state in
+    Stopping)
+      echo "Waiting for shutdown to finish"
+      ;;
+    *)
+      break
+      ;;
+  esac
+  sleep 10
+done
+
+# This will catch the case where the satellite was previously stopping. No effect when already awake.
+earthly sat wake core-test
+
 echo "Test earthly sat inspect."
 "$FRONTEND" run --rm --privileged -e EARTHLY_TOKEN="${EARTHLY_TOKEN}" "${EARTHLY_IMAGE}" sat --org earthly-technologies inspect core-test 2>&1 | tee output.txt
 acbgrep "core-test" output.txt

--- a/scripts/tests/earthly-image-sat.sh
+++ b/scripts/tests/earthly-image-sat.sh
@@ -37,7 +37,7 @@ trap finish EXIT
 
 # Wait for a stopped satellite to finish shutting down. Other states may continue.
 while true; do
-  state=$(earthly sat inspect core-test 2>&1 | grep State | awk '{print $2}')
+  state=$("$FRONTEND" run --rm --privileged -e EARTHLY_TOKEN="${EARTHLY_TOKEN}" "${EARTHLY_IMAGE}" sat --org earthly-technologies inspect core-test 2>&1 | grep State | awk '{print $2}')
   echo "Current state: $state"
   case $state in
     Stopping)
@@ -51,7 +51,7 @@ while true; do
 done
 
 # This will catch the case where the satellite was previously stopping. No effect when already awake.
-earthly sat wake core-test
+"$FRONTEND" run --rm --privileged -e EARTHLY_TOKEN="${EARTHLY_TOKEN}" "${EARTHLY_IMAGE}" sat --org earthly-technologies wake core-test
 
 echo "Test earthly sat inspect."
 "$FRONTEND" run --rm --privileged -e EARTHLY_TOKEN="${EARTHLY_TOKEN}" "${EARTHLY_IMAGE}" sat --org earthly-technologies inspect core-test 2>&1 | tee output.txt


### PR DESCRIPTION
The `earthly-image-sat.sh` test has been failing periodically due to hitting unexpected states. This change will handle all states appropriately & wait for the satellite to become available. 

![image](https://github.com/earthly/earthly/assets/332408/1bd3375c-b3e4-4e44-9bdd-e07314b2e1e6)
