### PR TITLE
Add extra Compose healthcheck for WITH DOCKER test

### DIFF
--- a/tests/local/with-docker-compose-local-reg/docker-compose.yml
+++ b/tests/local/with-docker-compose-local-reg/docker-compose.yml
@@ -4,10 +4,16 @@ services:
   fetch:
     image: fetch:latest
     depends_on:
-      - webserver
+      webserver:
+        condition: service_healthy
     environment:
       - WEBHOST=webserver
       - WEBPORT=80
 
   webserver:
     image: nginxdemos/hello
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://webserver:80"]
+      interval: 2s
+      timeout: 2s
+      retries: 5

--- a/tests/local/with-docker-compose-local/docker-compose.yml
+++ b/tests/local/with-docker-compose-local/docker-compose.yml
@@ -4,10 +4,16 @@ services:
   fetch:
     image: fetch:latest
     depends_on:
-      - webserver
+      webserver:
+        condition: service_healthy
     environment:
       - WEBHOST=webserver
       - WEBPORT=80
 
   webserver:
     image: nginxdemos/hello
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://webserver:80"]
+      interval: 2s
+      timeout: 2s
+      retries: 5


### PR DESCRIPTION
This adds an extra readiness check at the Compose level for a flaky test. Interestingly, the `curl` retry options (below) don't appear to support `CURLE_COULDNT_CONNECT` (i.e., "Couldn't connect to server") so an extra, external check is likely required here. 

```
curl --connect-timeout 1 \
    --max-time 1 \
    --retry 5 \
    --retry-delay 0 \
    --retry-max-time 10 \
    "http://${WEBHOST}:${WEBPORT}"
```