### PR TITLE
Renovate config - Fix regex for alpine/git updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -61,7 +61,7 @@
         'ast/tests/git-clone.ast.json',
       ],
       matchStrings: [
-        '= "alpine/git:(?<currentValue>.+?)"',
+        '"alpine/git:(?<currentValue>.+?)"',
       ],
       depNameTemplate: 'alpine/git',
       datasourceTemplate: 'docker',


### PR DESCRIPTION
This would update the alpine/git version in the git-clone.ast.json file so that tests will pass, unlike in this PR which was opened by Renovate - https://github.com/earthly/earthly/pull/3654