### PR TITLE
remote-cache test: check exit code

### DIFF
--- a/tests/remote-cache/Earthfile
+++ b/tests/remote-cache/Earthfile
@@ -24,28 +24,28 @@ test1:
 
     # Not cached - before copy.
     #RUN cat ./output && cat /var/log/buildkitd.log && exit 1
-    RUN nl=$(cat ./output | grep "execute-test1-run-before-copy" | wc -l) && test "$nl" -eq 2
+    RUN nl=$(cat ./output | grep "execute-test1-run-before-copy" | wc -l) && acbtest "$nl" -eq 2
 
     # Not cached - after copy.
     RUN cat ./output
-    RUN nl=$(cat ./output | grep "execute-test1-run-after-copy" | wc -l) && test "$nl" -eq 2
+    RUN nl=$(cat ./output | grep "execute-test1-run-after-copy" | wc -l) && acbtest "$nl" -eq 2
 
     # No change & re-run - should only have 1 line output and not re-echo.
     DO --pass-args +DO_REMOTE_CACHE_EARTHLY --target=+test1
 
-    RUN nl=$(cat ./output | grep "execute-test1-run-before-copy" | wc -l) && cat /var/log/buildkitd.log && test "$nl" -eq 1
+    RUN nl=$(cat ./output | grep "execute-test1-run-before-copy" | wc -l) && cat /var/log/buildkitd.log && acbtest "$nl" -eq 1
 
     # Cached - should only have 1 line output and not re-echo.
-    RUN nl=$(cat ./output | grep "execute-test1-run-after-copy" | grep -v '\[.*\] [0-9]\+%' | wc -l) && test "$nl" -eq 1
+    RUN nl=$(cat ./output | grep "execute-test1-run-after-copy" | grep -v '\[.*\] [0-9]\+%' | wc -l) && acbtest "$nl" -eq 1
 
     RUN echo "other content" >./input
     DO --pass-args +DO_REMOTE_CACHE_EARTHLY --target=+test1
 
     # Cached.
-    RUN nl=$(cat ./output | grep "execute-test1-run-before-copy" | grep -v '\[.*\] [0-9]\+%' | wc -l) && test "$nl" -eq 1
+    RUN nl=$(cat ./output | grep "execute-test1-run-before-copy" | grep -v '\[.*\] [0-9]\+%' | wc -l) && acbtest "$nl" -eq 1
 
     # Not cached.
-    RUN nl=$(cat ./output | grep "execute-test1-run-after-copy" | wc -l) && test "$nl" -eq 2
+    RUN nl=$(cat ./output | grep "execute-test1-run-after-copy" | wc -l) && acbtest "$nl" -eq 2
 
 test2:
     RUN echo "a"
@@ -75,7 +75,7 @@ DO_REMOTE_CACHE_EARTHLY:
     RUN --privileged \
         --mount=type=tmpfs,target=/tmp/earthly \
         -- \
-        EARTHLY_ADDITIONAL_BUILDKIT_CONFIG=$EARTHLY_ADDITIONAL_BUILDKIT_CONFIG$REGISTRY_CONFIG \
+        ( EARTHLY_ADDITIONAL_BUILDKIT_CONFIG=$EARTHLY_ADDITIONAL_BUILDKIT_CONFIG$REGISTRY_CONFIG \
         /usr/bin/earthly-entrypoint.sh --use-inline-cache --save-inline-cache --strict --no-output --push \
             --build-arg REGISTRY=$REGISTRY \
-            $target 2>&1 | tee ./output
+            $target; echo "exit_code=$?" ) 2>&1 | tee ./output && acbtest "$(tail -n 1 output)" = "exit_code=0"


### PR DESCRIPTION
check the exit code of earthly in the remote-cache test.

additionally use acbtest (which will print out values if it fails)