### PR TITLE
Wildcard BUILDs

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -918,3 +918,6 @@ BUILD_AND_FROM:
     ARG --required TARGET
     FROM --pass-args +$TARGET
     BUILD --pass-args +$TARGET
+
+wildcard-build:
+    BUILD ./wildcard-build/*+test --ARG=1

--- a/Earthfile
+++ b/Earthfile
@@ -918,6 +918,3 @@ BUILD_AND_FROM:
     ARG --required TARGET
     FROM --pass-args +$TARGET
     BUILD --pass-args +$TARGET
-
-wildcard-build:
-    BUILD ./wildcard-build/*+test --ARG=1

--- a/ast/spec/earthfile.go
+++ b/ast/spec/earthfile.go
@@ -54,6 +54,16 @@ type Command struct {
 	SourceLocation *SourceLocation `json:"sourceLocation,omitempty"`
 }
 
+func (c Command) Clone() Command {
+	newCmd := c
+	args := make([]string, len(c.Args))
+	copy(args, c.Args)
+	newCmd.Args = args
+	srcLoc := *c.SourceLocation
+	newCmd.SourceLocation = &srcLoc
+	return newCmd
+}
+
 // WithStatement is the AST representation of a with statement.
 type WithStatement struct {
 	Command        Command         `json:"command"`

--- a/buildcontext/detectbuildfile.go
+++ b/buildcontext/detectbuildfile.go
@@ -64,7 +64,7 @@ func detectBuildFileInRef(ctx context.Context, earthlyRef domain.Reference, ref 
 	if exists {
 		return buildEarthPath, nil
 	}
-	return "", errors.Errorf("no build file found in %s", subDir)
+	return "", ErrEarthfileNotExist{Target: earthlyRef.String()}
 }
 
 func fileExists(ctx context.Context, ref gwclient.Reference, fpath string) (bool, error) {

--- a/buildcontext/git.go
+++ b/buildcontext/git.go
@@ -66,7 +66,7 @@ type resolvedGitProject struct {
 	state pllb.State
 }
 
-func (gr *gitResolver) expandWildcardPath(ctx context.Context, gwClient gwclient.Client, platr *platutil.Resolver, target domain.Target, pattern string) ([]string, error) {
+func (gr *gitResolver) expandWildcard(ctx context.Context, gwClient gwclient.Client, platr *platutil.Resolver, target domain.Target, pattern string) ([]string, error) {
 	if !target.IsRemote() {
 		return nil, errors.Errorf("unexpected local reference %s", target.String())
 	}

--- a/buildcontext/git.go
+++ b/buildcontext/git.go
@@ -77,7 +77,10 @@ func (gr *gitResolver) expandWildcard(ctx context.Context, gwClient gwclient.Cli
 		return nil, err
 	}
 
-	fullPattern := filepath.Clean("./" + filepath.Join(subDir, pattern))
+	fullPattern := filepath.Join(subDir, pattern)
+	if !strings.HasPrefix(fullPattern, ".") {
+		fullPattern = "./" + fullPattern
+	}
 
 	var matches []string
 

--- a/buildcontext/git.go
+++ b/buildcontext/git.go
@@ -77,7 +77,7 @@ func (gr *gitResolver) expandWildcard(ctx context.Context, gwClient gwclient.Cli
 		return nil, err
 	}
 
-	fullPattern := "./" + filepath.Join(subDir, pattern)
+	fullPattern := filepath.Clean("./" + filepath.Join(subDir, pattern))
 
 	var matches []string
 
@@ -266,7 +266,7 @@ func (gr *gitResolver) resolveGitProject(ctx context.Context, gwClient gwclient.
 					"git log -1 --format=%ae >/dest/git-author || touch /dest/git-author ; " +
 					"git log -1 --format=%b >/dest/git-body || touch /dest/git-body ; " +
 					"git for-each-ref --contains HEAD --format '%(refname:lstrip=-1)' >/dest/git-refs || touch /dest/git-refs ; " +
-					"find -name Earthfile > /dest/Earthfile-paths || touch /dest/Earthfile-paths ; " +
+					"find -type f -name Earthfile > /dest/Earthfile-paths || touch /dest/Earthfile-paths ; " +
 					"",
 			}),
 			llb.Dir("/git-src"),

--- a/buildcontext/resolver.go
+++ b/buildcontext/resolver.go
@@ -83,6 +83,17 @@ func NewResolver(cleanCollection *cleanup.Collection, gitLookup *GitLookup, cons
 	}
 }
 
+// ExpandWildcard will expand a wildcard BUILD target in a remote Git
+// repository. The pattern is the path relative to the target path and should be
+// in the form 'my/path/*'
+func (r *Resolver) ExpandWildcard(ctx context.Context, gwClient gwclient.Client, platr *platutil.Resolver, target domain.Target, pattern string) ([]string, error) {
+	if !target.IsRemote() {
+		return nil, errors.Errorf("unexpected local reference %s", target.String())
+	}
+
+	return r.gr.expandWildcardPath(ctx, gwClient, platr, target, pattern)
+}
+
 // Resolve returns resolved context data for a given Earthly reference. If the reference is a target,
 // then the context will include a build context and possibly additional local directories.
 func (r *Resolver) Resolve(ctx context.Context, gwClient gwclient.Client, platr *platutil.Resolver, ref domain.Reference) (*Data, error) {

--- a/buildcontext/resolver.go
+++ b/buildcontext/resolver.go
@@ -11,6 +11,7 @@ import (
 	"github.com/earthly/earthly/conslogging"
 	"github.com/earthly/earthly/domain"
 	"github.com/earthly/earthly/features"
+	"github.com/earthly/earthly/util/fileutil"
 	"github.com/earthly/earthly/util/gitutil"
 	"github.com/earthly/earthly/util/llbutil/llbfactory"
 	"github.com/earthly/earthly/util/platutil"
@@ -83,15 +84,25 @@ func NewResolver(cleanCollection *cleanup.Collection, gitLookup *GitLookup, cons
 	}
 }
 
-// ExpandWildcard will expand a wildcard BUILD target in a remote Git
-// repository. The pattern is the path relative to the target path and should be
-// in the form 'my/path/*'
+// ExpandWildcard will expand a wildcard BUILD target in a local path or remote
+// Git repository. The pattern is the path relative to the target path and
+// should be in the form 'my/path/*'
 func (r *Resolver) ExpandWildcard(ctx context.Context, gwClient gwclient.Client, platr *platutil.Resolver, target domain.Target, pattern string) ([]string, error) {
-	if !target.IsRemote() {
-		return nil, errors.Errorf("unexpected local reference %s", target.String())
+	var (
+		matches []string
+		err     error
+	)
+
+	if target.IsRemote() {
+		matches, err = r.gr.expandWildcard(ctx, gwClient, platr, target, pattern)
+	} else {
+		matches, err = fileutil.GlobDirs(target.GetLocalPath())
+	}
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to expand BUILD target path")
 	}
 
-	return r.gr.expandWildcardPath(ctx, gwClient, platr, target, pattern)
+	return matches, nil
 }
 
 // Resolve returns resolved context data for a given Earthly reference. If the reference is a target,

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -1602,9 +1602,8 @@ func (c *Converter) ExpandWildcard(ctx context.Context, fullTargetName string, c
 		return nil, err
 	}
 
-	dir, base := filepath.Split(parsedTarget.GetLocalPath())
-	if strings.Contains(dir, "*") || base != "*" {
-		return nil, errors.New("pattern must end with a single '*'")
+	if strings.Contains(fullTargetName, "**") {
+		return nil, errors.New("globstar (**) pattern not yet supported")
 	}
 
 	var target domain.Target

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -24,6 +24,7 @@ import (
 	"github.com/earthly/cloud-api/logstream"
 	"github.com/earthly/earthly/analytics"
 	"github.com/earthly/earthly/ast/commandflag"
+	"github.com/earthly/earthly/ast/spec"
 	"github.com/earthly/earthly/buildcontext"
 	debuggercommon "github.com/earthly/earthly/debugger/common"
 	"github.com/earthly/earthly/domain"
@@ -1594,8 +1595,70 @@ func (c *Converter) Pipeline(ctx context.Context) error {
 	return nil
 }
 
-func (c *Converter) ExpandRemoteWildcard(ctx context.Context, target domain.Target, pattern string) ([]string, error) {
-	return c.opt.Resolver.ExpandWildcard(ctx, c.opt.GwClient, c.platr, target, pattern)
+func (c *Converter) ExpandWildcard(ctx context.Context, fullTargetName string, cmd spec.Command) ([]spec.Command, error) {
+
+	parsedTarget, err := domain.ParseTarget(fullTargetName)
+	if err != nil {
+		return nil, err
+	}
+
+	dir, base := filepath.Split(parsedTarget.GetLocalPath())
+	if strings.Contains(dir, "*") || base != "*" {
+		return nil, errors.New("pattern must end with a single '*'")
+	}
+
+	var target domain.Target
+	if c.target.IsRemote() {
+		target = c.target
+	} else {
+		target = parsedTarget
+	}
+
+	matches, err := c.opt.Resolver.ExpandWildcard(ctx, c.opt.GwClient, c.platr, target, parsedTarget.GetLocalPath())
+	if err != nil {
+		return nil, err
+	}
+
+	children := []spec.Command{}
+	for _, match := range matches {
+		childTargetName := fmt.Sprintf("./%s+%s", match, parsedTarget.GetName())
+
+		childTarget, err := domain.ParseTarget(childTargetName)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to parse target %q", childTargetName)
+		}
+
+		data, _, _, err := c.ResolveReference(ctx, childTarget)
+		if err != nil {
+			notExist := buildcontext.ErrEarthfileNotExist{}
+			if errors.As(err, &notExist) {
+				continue
+			}
+			return nil, errors.Wrapf(err, "unable to resolve target %q", childTargetName)
+		}
+
+		var found bool
+		for _, target := range data.Earthfile.Targets {
+			if target.Name == childTarget.GetName() {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			continue
+		}
+
+		cloned := cmd.Clone()
+		cloned.Args[0] = childTargetName
+		children = append(children, cloned)
+	}
+
+	if len(children) == 0 {
+		return nil, errors.Wrapf(err, "no matching targets found for pattern %q", parsedTarget.GetLocalPath())
+	}
+
+	return children, nil
 }
 
 // ResolveReference resolves a reference's build context given the current state: relativity to the Earthfile, imports etc.

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -1594,6 +1594,10 @@ func (c *Converter) Pipeline(ctx context.Context) error {
 	return nil
 }
 
+func (c *Converter) ExpandRemoteWildcard(ctx context.Context, target domain.Target, pattern string) ([]string, error) {
+	return c.opt.Resolver.ExpandWildcard(ctx, c.opt.GwClient, c.platr, target, pattern)
+}
+
 // ResolveReference resolves a reference's build context given the current state: relativity to the Earthfile, imports etc.
 func (c *Converter) ResolveReference(ctx context.Context, ref domain.Reference) (bc *buildcontext.Data, allowPrivileged, allowPrivilegedSet bool, err error) {
 	derefed, allowPrivileged, allowPrivilegedSet, err := c.varCollection.Imports().Deref(ref)

--- a/earthfile2llb/interpreter.go
+++ b/earthfile2llb/interpreter.go
@@ -1174,6 +1174,9 @@ func (i *Interpreter) handleBuild(ctx context.Context, cmd spec.Command, async b
 	}
 	// Expand wildcards into a set of BUILD spec.Command's, one for each discovered Earthfile.
 	if strings.Contains(fullTargetName, "*") {
+		if !i.converter.ftrs.WildcardBuilds {
+			return i.errorf(cmd.SourceLocation, "wildcard BUILD commands are not enabled")
+		}
 		return i.handleWildcardBuilds(ctx, fullTargetName, cmd, async)
 	}
 	platformsSlice := make([]platutil.Platform, 0, len(opts.Platforms))

--- a/features/features.go
+++ b/features/features.go
@@ -69,7 +69,8 @@ type Features struct {
 	UseFunctionKeyword              bool `long:"use-function-keyword" description:"Use the FUNCTION key word instead of COMMAND"`
 
 	// unreleased
-	TryFinally bool `long:"try" description:"allow the use of the TRY/FINALLY commands"`
+	TryFinally     bool `long:"try" description:"allow the use of the TRY/FINALLY commands"`
+	WildcardBuilds bool `long:"wildcard-builds" description:"allow for the expansion of wildcard (glob) paths for BUILD commands"`
 
 	Major int
 	Minor int

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -574,13 +574,25 @@ wildcard-build:
     RUN cat earthly.output | acbgrep 'hello world 2'
     RUN cat earthly.output | acbgrep 'hello world 3'
     RUN cat earthly.output | acbgrep -v 'not-test run'
-    DO +RUN_EARTHLY --earthfile=wildcard-build.earth --target=+wildcard-globstar --should_fail=true --output_contains="pattern must end with a single"
+    DO +RUN_EARTHLY --earthfile=wildcard-build.earth --target=+wildcard-globstar --should_fail=true --output_contains="pattern not yet supported"
+
+    DO +RUN_EARTHLY --earthfile=wildcard-build.earth --target=+wildcard-glob
+    RUN cat earthly.output | acbgrep 'hello world 2'
+    RUN cat earthly.output | acbgrep 'hello world 3'
+    RUN cat earthly.output | acbgrep -v 'hello world 1'
+    RUN cat earthly.output | acbgrep -v 'not-test run'
 
 wildcard-build-remote:
     DO +RUN_EARTHLY --earthfile=wildcard-build.earth --target=+wildcard-remote
     RUN cat earthly.output | acbgrep 'hello world 1'
     RUN cat earthly.output | acbgrep 'hello world 2'
     RUN cat earthly.output | acbgrep 'hello world 3'
+    RUN cat earthly.output | acbgrep -v 'not-test run'
+
+    DO +RUN_EARTHLY --earthfile=wildcard-build.earth --target=+wildcard-remote-glob
+    RUN cat earthly.output | acbgrep 'hello world 2'
+    RUN cat earthly.output | acbgrep 'hello world 3'
+    RUN cat earthly.output | acbgrep -v 'hello world 1'
     RUN cat earthly.output | acbgrep -v 'not-test run'
 
 push-test:

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -569,6 +569,7 @@ fail-invalid-artifact-test:
 wildcard-build:
     COPY --dir wildcard-build .
     DO +RUN_EARTHLY --earthfile=wildcard-build.earth --target=+wildcard-build --output_does_not_contain="not-test run"
+    DO +RUN_EARTHLY --earthfile=wildcard-build.earth --target=+wildcard-globstar --should_fail=true --output_contains="not yet supported"
 
 push-test:
     DO +RUN_EARTHLY --earthfile=push.earth --target=+push-test \

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -572,7 +572,7 @@ wildcard-build:
     RUN cat earthly.output | acbgrep 'hello world 1'
     RUN cat earthly.output | acbgrep 'hello world 2'
     RUN cat earthly.output | acbgrep 'hello world 3'
-    RUN cat earthly.output | (! acbgrep 'not-test run')
+    RUN cat earthly.output | acbgrep -v 'not-test run'
     DO +RUN_EARTHLY --earthfile=wildcard-build.earth --target=+wildcard-globstar --should_fail=true --output_contains="not yet supported"
 
 push-test:

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -574,7 +574,7 @@ wildcard-build:
     RUN cat earthly.output | acbgrep 'hello world 2'
     RUN cat earthly.output | acbgrep 'hello world 3'
     RUN cat earthly.output | acbgrep -v 'not-test run'
-    DO +RUN_EARTHLY --earthfile=wildcard-build.earth --target=+wildcard-globstar --should_fail=true --output_contains="BUILD pattern must end"
+    DO +RUN_EARTHLY --earthfile=wildcard-build.earth --target=+wildcard-globstar --should_fail=true --output_contains="pattern must end with a single"
 
 wildcard-build-remote:
     DO +RUN_EARTHLY --earthfile=wildcard-build.earth --target=+wildcard-remote

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -75,6 +75,7 @@ ga-no-qemu-group1:
     BUILD +escape-dir-test
     BUILD +fail-invalid-artifact-test
     BUILD +wildcard-build
+    BUILD +wildcard-build-remote
 
 ga-no-qemu-group2:
     BUILD +target-first-line
@@ -574,6 +575,13 @@ wildcard-build:
     RUN cat earthly.output | acbgrep 'hello world 3'
     RUN cat earthly.output | acbgrep -v 'not-test run'
     DO +RUN_EARTHLY --earthfile=wildcard-build.earth --target=+wildcard-globstar --should_fail=true --output_contains="not yet supported"
+
+wildcard-build-remote:
+    DO +RUN_EARTHLY --earthfile=wildcard-build.earth --target=+wildcard-remote
+    RUN cat earthly.output | acbgrep 'hello world 1'
+    RUN cat earthly.output | acbgrep 'hello world 2'
+    RUN cat earthly.output | acbgrep 'hello world 3'
+    RUN cat earthly.output | acbgrep -v 'not-test run'
 
 push-test:
     DO +RUN_EARTHLY --earthfile=push.earth --target=+push-test \

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -568,7 +568,11 @@ fail-invalid-artifact-test:
 
 wildcard-build:
     COPY --dir wildcard-build .
-    DO +RUN_EARTHLY --earthfile=wildcard-build.earth --target=+wildcard-build --output_does_not_contain="not-test run"
+    DO +RUN_EARTHLY --earthfile=wildcard-build.earth --target=+wildcard-build
+    RUN cat earthly.output | acbgrep 'hello world 1'
+    RUN cat earthly.output | acbgrep 'hello world 2'
+    RUN cat earthly.output | acbgrep 'hello world 3'
+    RUN cat earthly.output | (! acbgrep 'not-test run')
     DO +RUN_EARTHLY --earthfile=wildcard-build.earth --target=+wildcard-globstar --should_fail=true --output_contains="not yet supported"
 
 push-test:

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -574,7 +574,7 @@ wildcard-build:
     RUN cat earthly.output | acbgrep 'hello world 2'
     RUN cat earthly.output | acbgrep 'hello world 3'
     RUN cat earthly.output | acbgrep -v 'not-test run'
-    DO +RUN_EARTHLY --earthfile=wildcard-build.earth --target=+wildcard-globstar --should_fail=true --output_contains="not yet supported"
+    DO +RUN_EARTHLY --earthfile=wildcard-build.earth --target=+wildcard-globstar --should_fail=true --output_contains="BUILD pattern must end"
 
 wildcard-build-remote:
     DO +RUN_EARTHLY --earthfile=wildcard-build.earth --target=+wildcard-remote

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -74,6 +74,7 @@ ga-no-qemu-group1:
     BUILD +escape-test
     BUILD +escape-dir-test
     BUILD +fail-invalid-artifact-test
+    BUILD +wildcard-build
 
 ga-no-qemu-group2:
     BUILD +target-first-line
@@ -564,6 +565,10 @@ fail-invalid-artifact-test:
     # test that the artifact fails to be copied
     DO +RUN_EARTHLY --earthfile=fail-invalid-artifact.earth --should_fail=true --target="--artifact +test/foo /tmp/stuff" \
         --output_contains="cannot save artifact +test/foo, since it does not exist"
+
+wildcard-build:
+    COPY --dir wildcard-build .
+    DO +RUN_EARTHLY --earthfile=wildcard-build.earth --target=+wildcard-build --output_does_not_contain="not-test run"
 
 push-test:
     DO +RUN_EARTHLY --earthfile=push.earth --target=+push-test \

--- a/tests/wildcard-build.earth
+++ b/tests/wildcard-build.earth
@@ -1,0 +1,5 @@
+VERSION 0.7
+
+wildcard-build:
+    FROM alpine
+    BUILD ./wildcard-build/*+test

--- a/tests/wildcard-build.earth
+++ b/tests/wildcard-build.earth
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.8
 
 wildcard-build:
     FROM alpine

--- a/tests/wildcard-build.earth
+++ b/tests/wildcard-build.earth
@@ -1,4 +1,4 @@
-VERSION 0.8
+VERSION --wildcard-builds 0.8
 
 wildcard-build:
     FROM alpine

--- a/tests/wildcard-build.earth
+++ b/tests/wildcard-build.earth
@@ -8,5 +8,12 @@ wildcard-globstar:
     FROM alpine
     BUILD ./wildcard-build/**/*+test
 
+wildcard-glob:
+    FROM alpine
+    BUILD ./wildcard-build/b*[rz]+test
+
 wildcard-remote:
-    BUILD github.com/earthly/test-remote/wildcard-build:832569022fc7ff853c0e062a48eaa6fd62b59a40+wildcard-build
+    BUILD github.com/earthly/test-remote/wildcard-build:fb0ebe1c6181bdfc5a7d92165f3317e85e199794+wildcard-build
+
+wildcard-remote-glob:
+    BUILD github.com/earthly/test-remote/wildcard-build:fb0ebe1c6181bdfc5a7d92165f3317e85e199794+wildcard-glob

--- a/tests/wildcard-build.earth
+++ b/tests/wildcard-build.earth
@@ -3,3 +3,7 @@ VERSION 0.7
 wildcard-build:
     FROM alpine
     BUILD ./wildcard-build/*+test
+
+wildcard-globstar:
+    FROM alpine
+    BUILD ./wildcard-build/**/*+test

--- a/tests/wildcard-build.earth
+++ b/tests/wildcard-build.earth
@@ -7,3 +7,6 @@ wildcard-build:
 wildcard-globstar:
     FROM alpine
     BUILD ./wildcard-build/**/*+test
+
+wildcard-remote:
+    BUILD github.com/earthly/test-remote/wildcard-build:882190030762e620e932e3fab1091bdd50c93131+wildcard-build

--- a/tests/wildcard-build.earth
+++ b/tests/wildcard-build.earth
@@ -9,4 +9,4 @@ wildcard-globstar:
     BUILD ./wildcard-build/**/*+test
 
 wildcard-remote:
-    BUILD github.com/earthly/test-remote/wildcard-build:882190030762e620e932e3fab1091bdd50c93131+wildcard-build
+    BUILD github.com/earthly/test-remote/wildcard-build:832569022fc7ff853c0e062a48eaa6fd62b59a40+wildcard-build

--- a/tests/wildcard-build/bar/Earthfile
+++ b/tests/wildcard-build/bar/Earthfile
@@ -1,0 +1,5 @@
+VERSION 0.7
+
+test:
+  FROM alpine
+  RUN echo "hello world 3"

--- a/tests/wildcard-build/bar/Earthfile
+++ b/tests/wildcard-build/bar/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.8
 
 test:
   FROM alpine

--- a/tests/wildcard-build/baz/Earthfile
+++ b/tests/wildcard-build/baz/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.8
 
 test:
   FROM alpine

--- a/tests/wildcard-build/baz/Earthfile
+++ b/tests/wildcard-build/baz/Earthfile
@@ -1,0 +1,5 @@
+VERSION 0.7
+
+test:
+  FROM alpine
+  RUN echo "hello world 2"

--- a/tests/wildcard-build/foo/Earthfile
+++ b/tests/wildcard-build/foo/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.8
 
 test:
   FROM alpine

--- a/tests/wildcard-build/foo/Earthfile
+++ b/tests/wildcard-build/foo/Earthfile
@@ -1,0 +1,5 @@
+VERSION 0.7
+
+test:
+  FROM alpine
+  RUN echo "hello world 1"

--- a/tests/wildcard-build/no-target/Earthfile
+++ b/tests/wildcard-build/no-target/Earthfile
@@ -1,0 +1,5 @@
+VERSION 0.7
+
+not-test:
+  FROM alpine
+  RUN echo "not-test run"

--- a/tests/wildcard-build/no-target/Earthfile
+++ b/tests/wildcard-build/no-target/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.8
 
 not-test:
   FROM alpine

--- a/util/fileutil/fileutil.go
+++ b/util/fileutil/fileutil.go
@@ -65,3 +65,24 @@ func EnsureUserOwned(dir string, owner *user.User) error {
 		return os.Chown(path, uid, gid)
 	})
 }
+
+// GlobDirs will return any sub-directories which match the provided glob
+// pattern. Example: "/tmp/*" will return all sub-directories under "/tmp/".
+func GlobDirs(pattern string) ([]string, error) {
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to expand glob path %q", pattern)
+	}
+	var ret []string
+	for _, match := range matches {
+		st, err := os.Stat(match)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to stat expanded path %q", match)
+		}
+		if !st.IsDir() {
+			continue
+		}
+		ret = append(ret, match)
+	}
+	return ret, nil
+}

--- a/util/fileutil/fileutil_test.go
+++ b/util/fileutil/fileutil_test.go
@@ -1,0 +1,37 @@
+package fileutil
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGlobDirs(t *testing.T) {
+	tests := []struct {
+		pattern string
+		results []string
+	}{
+		{
+			pattern: "testdata/globdirs/*",
+			results: []string{"testdata/globdirs/bar", "testdata/globdirs/baz", "testdata/globdirs/foo"},
+		},
+		{
+			pattern: "testdata/globdirs/b*",
+			results: []string{"testdata/globdirs/bar", "testdata/globdirs/baz"},
+		},
+		{
+			pattern: "testdata/globdirs/file.txt",
+			results: nil,
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			results, err := GlobDirs(test.pattern)
+			r := require.New(t)
+			r.Equal(test.results, results)
+			r.NoError(err)
+		})
+	}
+}

--- a/wildcard-build/bar/Earthfile
+++ b/wildcard-build/bar/Earthfile
@@ -1,5 +1,0 @@
-VERSION 0.7
-
-test:
-  FROM alpine
-  RUN echo "hello world"

--- a/wildcard-build/bar/Earthfile
+++ b/wildcard-build/bar/Earthfile
@@ -1,0 +1,5 @@
+VERSION 0.7
+
+test:
+  FROM alpine
+  RUN echo "hello world"

--- a/wildcard-build/baz/Earthfile
+++ b/wildcard-build/baz/Earthfile
@@ -1,5 +1,0 @@
-VERSION 0.7
-
-test:
-  FROM alpine
-  RUN echo "hello world"

--- a/wildcard-build/baz/Earthfile
+++ b/wildcard-build/baz/Earthfile
@@ -1,0 +1,5 @@
+VERSION 0.7
+
+test:
+  FROM alpine
+  RUN echo "hello world"

--- a/wildcard-build/foo/Earthfile
+++ b/wildcard-build/foo/Earthfile
@@ -1,5 +1,0 @@
-VERSION 0.7
-
-test:
-  FROM alpine
-  RUN echo "hello world"

--- a/wildcard-build/foo/Earthfile
+++ b/wildcard-build/foo/Earthfile
@@ -1,0 +1,5 @@
+VERSION 0.7
+
+test:
+  FROM alpine
+  RUN echo "hello world"


### PR DESCRIPTION
This PR is my first pass on wildcard BUILD expansion. That is, builds in the form of `BUILD ./*+target`. This code will attempt to expand the BUILD into multiple commands if both the Earthfile & the target exist. The code will only explore directories 1 level beneath the referenced directory and globstar (`**`) is not yet supported.

Example: 

```
$ tree tests/wildcard-build 
tests/wildcard-build
├── bar
│   └── Earthfile
├── baz
│   └── Earthfile
├── foo
│   └── Earthfile
├── no-earthfile
└── no-target
    └── Earthfile
```

```
VERSION 0.7

test:
    FROM alpine
    BUILD ./wildcard-build/*+test
```

https://cloud.earthly.dev/builds/ec88fff1-d353-4045-a345-e3ce10cadff0

![image](https://github.com/earthly/earthly/assets/332408/be80f980-9b96-4d1b-9a90-12ee90d897ba)


