### PR TITLE
Updating GitHub Actions CI Link based on issue #3659

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </div>
 <br/>
 
-[![GitHub Actions CI](https://github.com/earthly/earthly/workflows/GitHub%20Actions%20CI/badge.svg)](https://github.com/earthly/earthly/actions?query=workflow%3A%22GitHub+Actions+CI%22+branch%3Amain)
+[![GitHub Actions CI](https://github.com/earthly/earthly/workflows/GitHub%20Actions%20CI/badge.svg)](https://github.com/earthly/earthly/actions?query=branch%3Amain++)
 [![Join the chat on Slack](https://img.shields.io/badge/slack-join%20chat-red.svg)](https://earthly.dev/slack)
 [![Docs](https://img.shields.io/badge/docs-git%20book-blue)](https://docs.earthly.dev)
 [![Website](https://img.shields.io/badge/website-earthly.dev-blue)](https://earthly.dev)


### PR DESCRIPTION
The current link directs to a workflow that is not running.

I have linked the badge to all the workflows in the main branch. 

This will ensure that all the running workflows can be viewed from the README.