### PR TITLE
tests: use --pass-args to configure mirror

### DIFF
--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -14,17 +14,17 @@ ga:
     BUILD +ga-qemu
 
 ga-qemu:
-    BUILD ./platform+test
+    BUILD --pass-args ./platform+test
 
 ga-no-qemu-group1:
     BUILD --pass-args ./autocompletion+test-all
-    BUILD ./dockerfile+test
-    BUILD ./dockerfile2/subdir+test
+    BUILD --pass-args ./dockerfile+test
+    BUILD --pass-args ./dockerfile2/subdir+test
     BUILD --pass-args ./locally-in-command+all
     BUILD --pass-args ./locally-in-function+all
-    BUILD ./command-to-function-rename+all
-    BUILD ./import+build
-    BUILD ./import+build-imported
+    BUILD --pass-args ./command-to-function-rename+all
+    BUILD --pass-args ./import+build
+    BUILD --pass-args ./import+build-imported
     BUILD +privileged-test
     BUILD +copy-test
     BUILD +copy-test-verbose-output
@@ -143,7 +143,7 @@ ga-no-qemu-group2:
     ARG GLOBAL_WAIT_END="false"
     IF [ "$GLOBAL_WAIT_END" = "false" ]
         BUILD +save-artifact-after-push
-        BUILD ./with-docker-via-command+test
+        BUILD --pass-args ./with-docker-via-command+test
     END
 
 ga-no-qemu-group3:
@@ -158,7 +158,7 @@ ga-no-qemu-group3:
     BUILD +builtin-args-test
     BUILD +remote-test
     BUILD +save-artifact-dont-overwrite
-    BUILD ./with-docker-expose+all
+    BUILD --pass-args ./with-docker-expose+all
 
 ga-no-qemu-group4:
     BUILD +cache-mount-arg
@@ -170,16 +170,16 @@ ga-no-qemu-group4:
     BUILD +save-artifact-selective-referencing-remote
     BUILD --pass-args ./secret-provider-config+test-all
     BUILD --pass-args ./shell-out+test-all
-    BUILD ./with-docker-compose+all
+    BUILD --pass-args ./with-docker-compose+all
     BUILD +dotenv-test
     BUILD +allow-privileged-test
-    BUILD ./with-docker-registry+all
+    BUILD --pass-args ./with-docker-registry+all
     BUILD +test-ssh-command-config-via-remote-target
     BUILD +test-ssh-command-config-via-git-clone-earthfile-command
 
 ga-no-qemu-slow:
     BUILD +server
-    BUILD ./with-docker+all
+    BUILD --pass-args ./with-docker+all
     # this has been moved to a seperate target until we get the flakey "tell me who you are" bug
     # fixed; see https://github.com/earthly/earthly/issues/2567
     #BUILD --pass-args ./git-metadata+test
@@ -188,7 +188,7 @@ ga-no-qemu-slow:
     BUILD --pass-args ./version+test-all
 
 ga-no-qemu-kind:
-    BUILD ./with-docker-kind+all
+    BUILD --pass-args ./with-docker-kind+all
 
 ga-no-qemu:
     BUILD +ga-no-qemu-group1
@@ -211,7 +211,7 @@ ga-linux-amd64:
     BUILD +user-arg-test
 
 experimental:
-    BUILD ./dind-auto-install+all
+    BUILD --pass-args ./dind-auto-install+all
 
 ast-test-input:
     FROM alpine:3.18


### PR DESCRIPTION
Add some missing --pass-args to builds to propagate the registry mirror
settings to +earthly-integration-test-base