### PR TITLE
Add Logbus/Logstream target link to allow for association

### DIFF
--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -1836,6 +1836,7 @@ func (c *Converter) prepBuildTarget(ctx context.Context, fullTargetName string, 
 	opt.PlatformResolver = c.platr.SubResolver(platform)
 	opt.HasDangling = isDangling
 	opt.AllowPrivileged = allowPrivileged
+	opt.ParentTargetID = c.mts.Final.ID
 
 	if cmdT == buildCmd {
 		// only BUILD commands get propigated

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -158,15 +158,6 @@ func NewConverter(ctx context.Context, target domain.Target, bc *buildcontext.Da
 
 	logbusTarget.SetStart(time.Now())
 
-	if opt.ParentTargetID != "" {
-		if parentTarget, ok := opt.Logbus.Run().Target(opt.ParentTargetID); ok {
-			parentTarget.AddDependsOn(sts.ID)
-		}
-	}
-
-	// Update the target ID that child converters will reference as the parent.
-	opt.ParentTargetID = sts.ID
-
 	c := &Converter{
 		target:              target,
 		gitMeta:             bc.GitMetadata,

--- a/earthfile2llb/earthfile2llb.go
+++ b/earthfile2llb/earthfile2llb.go
@@ -276,9 +276,6 @@ func Earthfile2LLB(ctx context.Context, target domain.Target, opt ConvertOpt, in
 		}
 	}
 
-	// Update the target ID that child converters will reference as the parent.
-	opt.ParentTargetID = sts.ID
-
 	tiHash, err := sts.TargetInput().Hash()
 	if err != nil {
 		return nil, err

--- a/earthfile2llb/earthfile2llb.go
+++ b/earthfile2llb/earthfile2llb.go
@@ -183,6 +183,10 @@ type ConvertOpt struct {
 	// FilesWithCommandRenameWarning keeps track of the files for which the COMMAND => FUNCTION warning was displayed
 	// this can be removed in VERSION 0.8
 	FilesWithCommandRenameWarning map[string]bool
+
+	// ParentTargetID is the Logbus target ID of the parent target, if any. It
+	// is used to link together targets.
+	ParentTargetID string
 }
 
 // TargetDetails contains details about the target being built.

--- a/earthfile2llb/earthfile2llb.go
+++ b/earthfile2llb/earthfile2llb.go
@@ -269,6 +269,16 @@ func Earthfile2LLB(ctx context.Context, target domain.Target, opt ConvertOpt, in
 	if err != nil {
 		return nil, err
 	}
+
+	if opt.ParentTargetID != "" {
+		if parentTarget, ok := opt.Logbus.Run().Target(opt.ParentTargetID); ok {
+			parentTarget.AddDependsOn(sts.ID)
+		}
+	}
+
+	// Update the target ID that child converters will reference as the parent.
+	opt.ParentTargetID = sts.ID
+
 	tiHash, err := sts.TargetInput().Hash()
 	if err != nil {
 		return nil, err

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/docker/distribution v2.8.2+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/dustin/go-humanize v1.0.1
-	github.com/earthly/cloud-api v1.0.1-0.20240105134001-49d68a012790
+	github.com/earthly/cloud-api v1.0.1-0.20240109224637-d374ffd93463
 	github.com/earthly/earthly/ast v0.0.0-00010101000000-000000000000
 	github.com/earthly/earthly/util/deltautil v0.0.0-20231221211955-0fd4ae2cc257
 	github.com/elastic/go-sysinfo v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -195,6 +195,10 @@ github.com/earthly/buildkit v0.0.0-20231213184914-086f60eecf5a h1:LjFYB1dm0Pq9T9
 github.com/earthly/buildkit v0.0.0-20231213184914-086f60eecf5a/go.mod h1:9YV/0upRPk36WbLrmr2bf2MZ0M27fvjxiBr5VD/ia80=
 github.com/earthly/cloud-api v1.0.1-0.20240105134001-49d68a012790 h1:UOhvBxm5bVGBZ0wlHTOTSxkq5GnRiQKbNJ3fXGD/COY=
 github.com/earthly/cloud-api v1.0.1-0.20240105134001-49d68a012790/go.mod h1:rU/tYJ7GFBjdKAITV2heDbez++glpGSbtJaZcp73rNI=
+github.com/earthly/cloud-api v1.0.1-0.20240109222428-6e72a4d43742 h1:yitpQF3QLsQ2gRCqIN7HEWmNbJRY1pDEKOZYYNyp/7w=
+github.com/earthly/cloud-api v1.0.1-0.20240109222428-6e72a4d43742/go.mod h1:rU/tYJ7GFBjdKAITV2heDbez++glpGSbtJaZcp73rNI=
+github.com/earthly/cloud-api v1.0.1-0.20240109224637-d374ffd93463 h1:avPg8xiv9HSeQ0mBWX6AoUOf2CZRuXYscB/AUqQRmfc=
+github.com/earthly/cloud-api v1.0.1-0.20240109224637-d374ffd93463/go.mod h1:rU/tYJ7GFBjdKAITV2heDbez++glpGSbtJaZcp73rNI=
 github.com/earthly/fsutil v0.0.0-20231030221755-644b08355b65 h1:6oyWHoxHXwcTt4EqmMw6361scIV87uEAB1N42+VpIwk=
 github.com/earthly/fsutil v0.0.0-20231030221755-644b08355b65/go.mod h1:9kMVqMyQ/Sx2df5LtnGG+nbrmiZzCS7V6gjW3oGHsvI=
 github.com/elastic/go-sysinfo v1.9.0 h1:usICqY/Nw4Mpn9f4LdtpFrKxXroJDe81GaxxUlCckIo=

--- a/logbus/target.go
+++ b/logbus/target.go
@@ -20,28 +20,36 @@ func newTarget(b *Bus, targetID string) *Target {
 }
 
 // SetStart sets the start time of the target.
-func (target *Target) SetStart(start time.Time) {
-	target.targetDelta(&logstream.DeltaTargetManifest{
+func (t *Target) SetStart(start time.Time) {
+	t.targetDelta(&logstream.DeltaTargetManifest{
 		Status:             logstream.RunStatus_RUN_STATUS_IN_PROGRESS,
-		StartedAtUnixNanos: target.b.TsUnixNanos(start),
+		StartedAtUnixNanos: t.b.TsUnixNanos(start),
 	})
 }
 
 // SetEnd sets the end time of the target.
-func (target *Target) SetEnd(end time.Time, status logstream.RunStatus, finalPlatform string) {
-	target.targetDelta(&logstream.DeltaTargetManifest{
+func (t *Target) SetEnd(end time.Time, status logstream.RunStatus, finalPlatform string) {
+	t.targetDelta(&logstream.DeltaTargetManifest{
 		Status:           status,
-		EndedAtUnixNanos: target.b.TsUnixNanos(end),
+		EndedAtUnixNanos: t.b.TsUnixNanos(end),
 		FinalPlatform:    finalPlatform,
 	})
 }
 
-func (target *Target) targetDelta(dtm *logstream.DeltaTargetManifest) {
-	target.b.WriteDeltaManifest(&logstream.DeltaManifest{
+// AddDependsOn creates a delta that will be used to merge the specified target
+// ID into the current target's list of targets on which it depends.
+func (t *Target) AddDependsOn(targetID string) {
+	t.targetDelta(&logstream.DeltaTargetManifest{
+		DependsOn: []string{targetID},
+	})
+}
+
+func (t *Target) targetDelta(dtm *logstream.DeltaTargetManifest) {
+	t.b.WriteDeltaManifest(&logstream.DeltaManifest{
 		DeltaManifestOneof: &logstream.DeltaManifest_Fields{
 			Fields: &logstream.DeltaManifest_FieldsDelta{
 				Targets: map[string]*logstream.DeltaTargetManifest{
-					target.targetID: dtm,
+					t.targetID: dtm,
 				},
 			},
 		},

--- a/util/deltautil/apply.go
+++ b/util/deltautil/apply.go
@@ -124,6 +124,9 @@ func setManifestFields(dm *pb.DeltaManifest, ret *pb.RunManifest) {
 		if t2.GetLocalPath() != "" {
 			t.LocalPath = t2.GetLocalPath()
 		}
+		if len(t2.GetDependsOn()) > 0 {
+			t.DependsOn = append(t.DependsOn, t2.GetDependsOn()...)
+		}
 	}
 	for commandID, c2 := range f.GetCommands() {
 		c := ensureCommandExists(ret, commandID)

--- a/util/deltautil/go.mod
+++ b/util/deltautil/go.mod
@@ -3,7 +3,7 @@ module github.com/earthly/earthly/util/deltautil
 go 1.21
 
 require (
-	github.com/earthly/cloud-api v1.0.1-0.20231027183434-d79534194d95
+	github.com/earthly/cloud-api v1.0.1-0.20240109224637-d374ffd93463
 	google.golang.org/protobuf v1.30.0
 )
 

--- a/util/deltautil/go.sum
+++ b/util/deltautil/go.sum
@@ -2,6 +2,8 @@ github.com/earthly/cloud-api v1.0.1-0.20221201210730-b407492c9901 h1:HBmy3zsOcRr
 github.com/earthly/cloud-api v1.0.1-0.20221201210730-b407492c9901/go.mod h1:38rj6sccWnuk+C981DeFFomBmAtwuuvchoPrXdKXi2I=
 github.com/earthly/cloud-api v1.0.1-0.20231027183434-d79534194d95 h1:stFmLhGY7dbf4UhBtbMIN+oaIMEDZez/epwHt7g6MqM=
 github.com/earthly/cloud-api v1.0.1-0.20231027183434-d79534194d95/go.mod h1:rU/tYJ7GFBjdKAITV2heDbez++glpGSbtJaZcp73rNI=
+github.com/earthly/cloud-api v1.0.1-0.20240109224637-d374ffd93463 h1:avPg8xiv9HSeQ0mBWX6AoUOf2CZRuXYscB/AUqQRmfc=
+github.com/earthly/cloud-api v1.0.1-0.20240109224637-d374ffd93463/go.mod h1:rU/tYJ7GFBjdKAITV2heDbez++glpGSbtJaZcp73rNI=
 github.com/golang/glog v1.1.0 h1:/d3pCKDPWNnvIWe0vVUpNP32qc8U3PDVxySP/y360qE=
 github.com/golang/glog v1.1.0/go.mod h1:pfYeQZ3JWZoXTV5sFc986z3HTpwQs9At6P4ImfuP3NQ=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=


### PR DESCRIPTION
This is rather simple but it seems to work. Perhaps I'm missing something. 

Example debug output:
```
Parent target 523272c3-de17-45db-af41-372af13e1b0b +for-linux
Parent target dd0122f0-fcb3-4901-b512-f9fe4a470ccf ./ast/parser+parser
Parent target 523272c3-de17-45db-af41-372af13e1b0b +for-linux
Parent target 901cf3be-0061-49f3-99e6-1c98d9ed72af ./buildkitd+buildkitd
```