### PR TITLE
Auto-skip: expand dynamic COPY target names

### DIFF
--- a/inputgraph/loader.go
+++ b/inputgraph/loader.go
@@ -198,12 +198,20 @@ func (l *loader) handleCopySrc(ctx context.Context, cmd spec.Command, src string
 		if err != nil {
 			return wrapError(err, cmd.SourceLocation, "failed to parse COPY params")
 		}
-		artifactSrc, err = domain.ParseArtifact(artifactName)
+		expandedArtifact, err := l.expandArgs(ctx, artifactName)
+		if err != nil {
+			return wrapError(err, cmd.SourceLocation, "failed to expand COPY artifact")
+		}
+		artifactSrc, err = domain.ParseArtifact(expandedArtifact)
 		if err != nil {
 			return wrapError(err, cmd.SourceLocation, "failed to parse artifact")
 		}
 	} else { // Simpler form: '+target/artifact' or 'file/path'
-		artifactSrc, err = domain.ParseArtifact(src)
+		expandedSrc, err := l.expandArgs(ctx, src)
+		if err != nil {
+			return wrapError(err, cmd.SourceLocation, "failed to expand COPY artifact")
+		}
+		artifactSrc, err = domain.ParseArtifact(expandedSrc)
 		if err != nil {
 			classical = true
 		}

--- a/tests/autoskip/Earthfile
+++ b/tests/autoskip/Earthfile
@@ -143,6 +143,12 @@ test-copy-target-args:
     DO --pass-args +RUN_EARTHLY_ARGS --target=+copy-target-args --output_contains="+copy-target-args | changed"
     DO --pass-args +RUN_EARTHLY_ARGS --target=+copy-target-args --output_contains="Target .* has already been run. Skipping."
 
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=expand-args.earth --target=+copy-target-dynamic --output_contains="+copy-target-dynamic | goodbye"
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=expand-args.earth --target=+copy-target-dynamic --output_contains="Target .* has already been run. Skipping."
+
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=expand-args.earth --target=+copy-target-dynamic-2 --output_contains="+copy-target-dynamic-2 | foobar"
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=expand-args.earth --target=+copy-target-dynamic-2 --output_contains="Target .* has already been run. Skipping."
+
 test-copy-target-args-quoted:
     DO --pass-args +RUN_EARTHLY_ARGS --earthfile=expand-args.earth --target=+copy-target-args-quoted --output_contains="hello world"
     DO --pass-args +RUN_EARTHLY_ARGS --earthfile=expand-args.earth --target=+copy-target-args-quoted --output_contains="Target .* has already been run. Skipping."

--- a/tests/autoskip/expand-args.earth
+++ b/tests/autoskip/expand-args.earth
@@ -55,10 +55,24 @@ copy-target:
     RUN echo $foo > x
     SAVE ARTIFACT x
 
+copy-target-2:
+    RUN echo "foobar" > x
+    SAVE ARTIFACT x
+
 copy-target-args:
     COPY (+copy-target/x --foo=hello) .
     RUN cat x
 
 copy-target-args-quoted:
     COPY (+copy-target/x --foo="hello world") .
+    RUN cat x
+
+copy-target-dynamic:
+    ARG name="+copy-target"
+    COPY ($name/x --foo=goodbye) .
+    RUN cat x
+
+copy-target-dynamic-2:
+    ARG name="+copy-target-2"
+    COPY $name/x .
     RUN cat x


### PR DESCRIPTION
Addresses: https://github.com/earthly/earthly/issues/3694

It looks like support for the case below may have been dropped during a refactor. Fixed and added some tests. 

```
copy-target-dynamic:
    ARG name="+copy-target"
    COPY ($name/x --foo=goodbye) .
    RUN cat x
```