### PR TITLE
Logstream: use recoverable error in test

### DIFF
--- a/cloud/logstream_test.go
+++ b/cloud/logstream_test.go
@@ -71,7 +71,7 @@ func (f *flakyStream) Recv() (*pb.StreamLogResponse, error) {
 	case r := <-f.recv:
 		return r, nil
 	case <-f.done:
-		return nil, status.Error(codes.Canceled, "canceled")
+		return nil, status.Error(codes.Unknown, "unknown")
 	}
 }
 


### PR DESCRIPTION
Probably best to use a recoverable error for the resumption tests! This was failing a few times per 100 runs.