### PR TITLE
Auto-skip: cache target hash results for reuse

### DIFF
--- a/cmd/earthly/subcmd/build_cmd.go
+++ b/cmd/earthly/subcmd/build_cmd.go
@@ -850,7 +850,7 @@ func (a *Build) initAutoSkip(ctx context.Context, target domain.Target, overridi
 		return nil, nil, false, errors.Wrapf(err, "auto-skip is unable to calculate hash for %s", target)
 	}
 
-	console.VerbosePrintf("targets hashed: %d; target cache hits: %d", stats.TargetsHashed, stats.TargetCacheHits)
+	console.VerbosePrintf("targets visited: %d; targets hashed: %d; target cache hits: %d", stats.TargetsVisited, stats.TargetsHashed, stats.TargetCacheHits)
 	console.VerbosePrintf("hash calculation took %s", stats.Duration)
 
 	if a.cli.Flags().LocalSkipDB == "" && orgName == "" {

--- a/cmd/earthly/subcmd/build_cmd.go
+++ b/cmd/earthly/subcmd/build_cmd.go
@@ -838,6 +838,8 @@ func (a *Build) initAutoSkip(ctx context.Context, target domain.Target, overridi
 
 	orgName := a.cli.Flags().OrgName
 
+	start := time.Now()
+
 	targetHash, err := inputgraph.HashTarget(ctx, inputgraph.HashOpt{
 		Target:          target,
 		Console:         a.cli.Console(),
@@ -849,6 +851,8 @@ func (a *Build) initAutoSkip(ctx context.Context, target domain.Target, overridi
 	if err != nil {
 		return nil, nil, false, errors.Wrapf(err, "auto-skip is unable to calculate hash for %s", target)
 	}
+
+	console.VerbosePrintf("hash calculation took %s", time.Now().Sub(start))
 
 	if a.cli.Flags().LocalSkipDB == "" && orgName == "" {
 		orgName, _, err = inputgraph.ParseProjectCommand(ctx, target, console)

--- a/cmd/earthly/subcmd/build_cmd.go
+++ b/cmd/earthly/subcmd/build_cmd.go
@@ -838,8 +838,6 @@ func (a *Build) initAutoSkip(ctx context.Context, target domain.Target, overridi
 
 	orgName := a.cli.Flags().OrgName
 
-	start := time.Now()
-
 	targetHash, stats, err := inputgraph.HashTarget(ctx, inputgraph.HashOpt{
 		Target:          target,
 		Console:         a.cli.Console(),
@@ -853,7 +851,7 @@ func (a *Build) initAutoSkip(ctx context.Context, target domain.Target, overridi
 	}
 
 	console.VerbosePrintf("targets hashed: %d; target cache hits: %d", stats.TargetsHashed, stats.TargetCacheHits)
-	console.VerbosePrintf("hash calculation took %s", time.Now().Sub(start))
+	console.VerbosePrintf("hash calculation took %s", stats.Duration)
 
 	if a.cli.Flags().LocalSkipDB == "" && orgName == "" {
 		orgName, _, err = inputgraph.ParseProjectCommand(ctx, target, console)

--- a/cmd/earthly/subcmd/build_cmd.go
+++ b/cmd/earthly/subcmd/build_cmd.go
@@ -840,7 +840,7 @@ func (a *Build) initAutoSkip(ctx context.Context, target domain.Target, overridi
 
 	start := time.Now()
 
-	targetHash, err := inputgraph.HashTarget(ctx, inputgraph.HashOpt{
+	targetHash, stats, err := inputgraph.HashTarget(ctx, inputgraph.HashOpt{
 		Target:          target,
 		Console:         a.cli.Console(),
 		CI:              a.cli.Flags().CI,
@@ -852,6 +852,7 @@ func (a *Build) initAutoSkip(ctx context.Context, target domain.Target, overridi
 		return nil, nil, false, errors.Wrapf(err, "auto-skip is unable to calculate hash for %s", target)
 	}
 
+	console.VerbosePrintf("targets hashed: %d; target cache hits: %d", stats.TargetsHashed, stats.TargetCacheHits)
 	console.VerbosePrintf("hash calculation took %s", time.Now().Sub(start))
 
 	if a.cli.Flags().LocalSkipDB == "" && orgName == "" {

--- a/inputgraph/hash.go
+++ b/inputgraph/hash.go
@@ -2,7 +2,6 @@ package inputgraph
 
 import (
 	"context"
-	"time"
 
 	"github.com/earthly/earthly/conslogging"
 	"github.com/earthly/earthly/domain"
@@ -20,17 +19,18 @@ type HashOpt struct {
 }
 
 // HashTarget produces a hash from an Earthly target.
-func HashTarget(ctx context.Context, opt HashOpt) ([]byte, *Stats, error) {
+func HashTarget(ctx context.Context, opt HashOpt) ([]byte, Stats, error) {
 	l := newLoader(ctx, opt)
-
-	start := time.Now()
 
 	b, err := l.load(ctx)
 	if err != nil {
-		return nil, nil, err
+		return nil, Stats{}, err
 	}
 
-	l.stats.Duration = time.Since(start)
+	stats := Stats{}
+	if l.stats != nil {
+		stats = *l.stats
+	}
 
-	return b, l.stats, nil
+	return b, stats, nil
 }

--- a/inputgraph/hash.go
+++ b/inputgraph/hash.go
@@ -2,6 +2,7 @@ package inputgraph
 
 import (
 	"context"
+	"time"
 
 	"github.com/earthly/earthly/conslogging"
 	"github.com/earthly/earthly/domain"
@@ -22,10 +23,14 @@ type HashOpt struct {
 func HashTarget(ctx context.Context, opt HashOpt) ([]byte, *Stats, error) {
 	l := newLoader(ctx, opt)
 
+	start := time.Now()
+
 	b, err := l.load(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
+
+	l.stats.Duration = time.Now().Sub(start)
 
 	return b, l.stats, nil
 }

--- a/inputgraph/hash.go
+++ b/inputgraph/hash.go
@@ -30,7 +30,7 @@ func HashTarget(ctx context.Context, opt HashOpt) ([]byte, *Stats, error) {
 		return nil, nil, err
 	}
 
-	l.stats.Duration = time.Now().Sub(start)
+	l.stats.Duration = time.Since(start)
 
 	return b, l.stats, nil
 }

--- a/inputgraph/hash.go
+++ b/inputgraph/hash.go
@@ -22,10 +22,10 @@ type HashOpt struct {
 func HashTarget(ctx context.Context, opt HashOpt) (hash []byte, err error) {
 	l := newLoader(ctx, opt)
 
-	err = l.load(ctx)
+	b, err := l.load(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	return l.hasher.GetHash(), nil
+	return b, nil
 }

--- a/inputgraph/hash.go
+++ b/inputgraph/hash.go
@@ -19,13 +19,13 @@ type HashOpt struct {
 }
 
 // HashTarget produces a hash from an Earthly target.
-func HashTarget(ctx context.Context, opt HashOpt) (hash []byte, err error) {
+func HashTarget(ctx context.Context, opt HashOpt) ([]byte, *Stats, error) {
 	l := newLoader(ctx, opt)
 
 	b, err := l.load(ctx)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return b, nil
+	return b, l.stats, nil
 }

--- a/inputgraph/hash_test.go
+++ b/inputgraph/hash_test.go
@@ -26,7 +26,7 @@ func TestHashTargetWithDocker(t *testing.T) {
 	cons := conslogging.New(os.Stderr, &sync.Mutex{}, conslogging.NoColor, 0, conslogging.Info)
 
 	hashOpt := HashOpt{Console: cons, Target: target}
-	hash, err := HashTarget(ctx, hashOpt)
+	hash, _, err := HashTarget(ctx, hashOpt)
 	r.NoError(err)
 
 	hex := fmt.Sprintf("%x", hash)
@@ -55,7 +55,7 @@ func TestHashTargetWithDocker(t *testing.T) {
 	}
 
 	hashOpt = HashOpt{Console: cons, Target: target}
-	hash, err = HashTarget(ctx, hashOpt)
+	hash, _, err = HashTarget(ctx, hashOpt)
 	r.NoError(err)
 
 	second := fmt.Sprintf("%x", hash)
@@ -119,7 +119,7 @@ func TestHashTargetWithDockerNoAlias(t *testing.T) {
 	cons := conslogging.New(os.Stderr, &sync.Mutex{}, conslogging.NoColor, 0, conslogging.Info)
 
 	hashOpt := HashOpt{Console: cons, Target: target}
-	hash, err := HashTarget(ctx, hashOpt)
+	hash, _, err := HashTarget(ctx, hashOpt)
 	r.NoError(err)
 
 	hex := fmt.Sprintf("%x", hash)
@@ -137,8 +137,50 @@ func TestHashTargetWithDockerRemote(t *testing.T) {
 	cons := conslogging.New(os.Stderr, &sync.Mutex{}, conslogging.NoColor, 0, conslogging.Info)
 
 	hashOpt := HashOpt{Console: cons, Target: target}
-	hash, err := HashTarget(ctx, hashOpt)
+	hash, _, err := HashTarget(ctx, hashOpt)
 	r.NoError(err)
+
+	hex := fmt.Sprintf("%x", hash)
+	r.NotEmpty(hex)
+}
+
+func TestHashTargetNoCache(t *testing.T) {
+	r := require.New(t)
+	target := domain.Target{
+		LocalPath: "./testdata/target-cache",
+		Target:    "no-cache-hits",
+	}
+
+	ctx := context.Background()
+	cons := conslogging.New(os.Stderr, &sync.Mutex{}, conslogging.NoColor, 0, conslogging.Info)
+
+	hashOpt := HashOpt{Console: cons, Target: target}
+	hash, stats, err := HashTarget(ctx, hashOpt)
+	r.NoError(err)
+
+	r.Equal(3, stats.TargetsHashed)
+	r.Equal(0, stats.TargetCacheHits)
+
+	hex := fmt.Sprintf("%x", hash)
+	r.NotEmpty(hex)
+}
+
+func TestHashTargetCache(t *testing.T) {
+	r := require.New(t)
+	target := domain.Target{
+		LocalPath: "./testdata/target-cache",
+		Target:    "cache-hits",
+	}
+
+	ctx := context.Background()
+	cons := conslogging.New(os.Stderr, &sync.Mutex{}, conslogging.NoColor, 0, conslogging.Info)
+
+	hashOpt := HashOpt{Console: cons, Target: target}
+	hash, stats, err := HashTarget(ctx, hashOpt)
+	r.NoError(err)
+
+	r.Equal(3, stats.TargetsHashed)
+	r.Equal(4, stats.TargetCacheHits)
 
 	hex := fmt.Sprintf("%x", hash)
 	r.NotEmpty(hex)

--- a/inputgraph/loader.go
+++ b/inputgraph/loader.go
@@ -44,6 +44,7 @@ type loader struct {
 	earthlyCIRunner  bool
 	globalImports    map[string]domain.ImportTrackerVal
 	importsProcessed bool
+	hashCache        map[string][]byte
 }
 
 func newLoader(ctx context.Context, opt HashOpt) *loader {
@@ -61,6 +62,7 @@ func newLoader(ctx context.Context, opt HashOpt) *loader {
 		overridingVars:  opt.OverridingVars,
 		earthlyCIRunner: opt.EarthlyCIRunner,
 		globalImports:   map[string]domain.ImportTrackerVal{},
+		hashCache:       map[string][]byte{},
 	}
 }
 
@@ -806,12 +808,13 @@ func (l *loader) forTarget(ctx context.Context, target domain.Target, args []str
 		conslog:         l.conslog,
 		target:          target,
 		visited:         visited,
-		hasher:          l.hasher,
+		hasher:          hasher.New(),
 		isBaseTarget:    target.Target == "base",
 		ci:              l.ci,
 		builtinArgs:     l.builtinArgs,
 		overridingVars:  overriding,
 		earthlyCIRunner: l.earthlyCIRunner,
+		hashCache:       l.hashCache,
 	}
 
 	if target.IsLocalInternal() {
@@ -870,19 +873,46 @@ func (l *loader) loadTargetFromString(ctx context.Context, targetName string, ar
 		return wrapError(err, srcLoc, "failed to create loader for target %q", targetName)
 	}
 
-	return newLoader.load(ctx)
+	hash, err := newLoader.load(ctx)
+	if err != nil {
+		return err
+	}
+
+	l.hasher.HashBytes(hash)
+
+	return nil
 }
 
-func (l *loader) load(ctx context.Context) error {
+func (l *loader) targetCacheKey() string {
+	h := hasher.New()
+	h.HashString(l.target.StringCanonical())
+	if l.overridingVars != nil {
+		for _, val := range l.overridingVars.BuildArgs() {
+			h.HashString(fmt.Sprintf("VAR %s", val))
+		}
+	}
+	return fmt.Sprintf("%x", h.GetHash())
+}
+
+func (l *loader) load(ctx context.Context) ([]byte, error) {
+
 	if l.target.IsRemote() {
-		return errCannotLoadRemoteTarget
+		return nil, errCannotLoadRemoteTarget
+	}
+
+	// We can avoid processing this target if it's already been hashed. This
+	// hash key is computed using the canonical target name & the provided
+	// arguments.
+	cacheKey := l.targetCacheKey()
+	if b, ok := l.hashCache[cacheKey]; ok {
+		return b, nil
 	}
 
 	resolver := buildcontext.NewResolver(nil, nil, l.conslog, "", "", "", 0, "")
 
 	buildCtx, err := resolver.Resolve(ctx, nil, nil, l.target)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	l.features = buildCtx.Features
@@ -918,21 +948,36 @@ func (l *loader) load(ctx context.Context) error {
 		for _, stmt := range ef.BaseRecipe {
 			if stmt.Command != nil && stmt.Command.Name == command.Import {
 				if err := l.handleImport(ctx, *stmt.Command, true); err != nil {
-					return err
+					return nil, err
 				}
 			}
 		}
 	}
 
-	if l.target.Target == "base" {
-		return l.loadBlock(ctx, ef.BaseRecipe)
-	}
+	var block spec.Block
 
-	for _, t := range ef.Targets {
-		if t.Name == l.target.Target {
-			return l.loadBlock(ctx, t.Recipe)
+	if l.target.Target == "base" {
+		block = ef.BaseRecipe
+	} else {
+		for _, t := range ef.Targets {
+			if t.Name == l.target.Target {
+				block = t.Recipe
+				break
+			}
 		}
 	}
 
-	return fmt.Errorf("target %q not found", l.target.Target)
+	if block == nil {
+		return nil, fmt.Errorf("target %q not found", l.target.Target)
+	}
+
+	err = l.loadBlock(ctx, block)
+	if err != nil {
+		return nil, err
+	}
+
+	v := l.hasher.GetHash()
+	l.hashCache[cacheKey] = v
+
+	return v, nil
 }

--- a/inputgraph/loader.go
+++ b/inputgraph/loader.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/earthly/earthly/ast/command"
 	"github.com/earthly/earthly/ast/commandflag"
@@ -34,6 +35,7 @@ var (
 type Stats struct {
 	TargetsHashed   int
 	TargetCacheHits int
+	Duration        time.Duration
 }
 
 type loader struct {

--- a/inputgraph/testdata/target-cache/Earthfile
+++ b/inputgraph/testdata/target-cache/Earthfile
@@ -1,0 +1,23 @@
+VERSION 0.8
+
+FROM alpine
+
+no-cache-hits:
+    BUILD +a --FOO=bar
+    BUILD +a --FOO=baz
+
+cache-hits:
+    BUILD +a --FOO=bar
+    BUILD +a --FOO=bar
+    BUILD +a --FOO=bar
+    BUILD +b --FOO=foo
+    BUILD +b --FOO=foo
+    BUILD +b --FOO=foo
+
+a:
+    ARG FOO
+    RUN echo $FOO
+
+b:
+    ARG FOO
+    RUN echo $FOO


### PR DESCRIPTION
Addresses: https://github.com/earthly/earthly/issues/3691

This PR adds code to cache already hashed targets for auto-skip hash calculation. A cache key is created using the canonical target value & all supplied arguments. The computed hash value is stored as the map value. If another target then refers to a cached target, the pre-computed hash value will be used instead of wastefully revisiting the same target. This approach makes some auto-skip checks upwards of 10 times faster as some project graphs balloon in complexity (execution-wise) when many targets import several complex sub-targets. 

I looked into using `synccache.SyncCache` for this, but it didn't seem to expose whether the cache was used or not (see stats values below). Plus this code is not yet used concurrently so using a regular map seemed reasonable.

I've also added some simple statistics to the `--verbose` output that includes total time & info about visited targets.

```
auto-skip | targets visited: 84; targets hashed: 28; target cache hits: 56
auto-skip | hash calculation took 1.007257512s
```

![image](https://github.com/earthly/earthly/assets/332408/7607a4a0-9a15-412c-ab54-c4315a887cd9)
