### PR TITLE
split up tests-that-require-earthly-technologies-account-access

### DIFF
--- a/.github/workflows/ci-docker-ubuntu.yml
+++ b/.github/workflows/ci-docker-ubuntu.yml
@@ -207,12 +207,13 @@ jobs:
       EXTRA_ARGS: "--auto-skip"
     secrets: inherit
 
-  docker-tests-require-account-access:
+  # tests-that-require-earthly-technologies-account-access
+  docker-test-earthly-mirror-was-setup:
     if: ${{ !failure() && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
     needs: build-earthly
     uses: ./.github/workflows/reusable-test.yml
     with:
-      TEST_TARGET: "./tests+tests-that-require-earthly-technologies-account-access"
+      TEST_TARGET: "./tests+test-earthly-mirror-was-setup"
       BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
       RUNS_ON: "ubuntu-latest"
       BINARY: "docker"
@@ -220,6 +221,49 @@ jobs:
       SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
       EXTRA_ARGS: "--auto-skip"
     secrets: inherit
+
+  docker-tests-test-account:
+    if: ${{ !failure() && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    needs: build-earthly
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      TEST_TARGET: "./tests/account+test"
+      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
+      RUNS_ON: "ubuntu-latest"
+      BINARY: "docker"
+      SUDO: ""
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
+      EXTRA_ARGS: "--auto-skip"
+    secrets: inherit
+
+  docker-test-registry-command:
+    if: ${{ !failure() && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    needs: build-earthly
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      TEST_TARGET: "./tests/registry-command+test"
+      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
+      RUNS_ON: "ubuntu-latest"
+      BINARY: "docker"
+      SUDO: ""
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
+      EXTRA_ARGS: "--auto-skip"
+    secrets: inherit
+
+  docker-test-web-command:
+    if: ${{ !failure() && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    needs: build-earthly
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      TEST_TARGET: "./tests/web+test"
+      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
+      RUNS_ON: "ubuntu-latest"
+      BINARY: "docker"
+      SUDO: ""
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
+      EXTRA_ARGS: "--auto-skip"
+    secrets: inherit
+  # end of tests-that-require-earthly-technologies-account-access
 
   docker-tests-qemu:
     needs: build-earthly

--- a/.github/workflows/ci-docker-ubuntu.yml
+++ b/.github/workflows/ci-docker-ubuntu.yml
@@ -207,7 +207,6 @@ jobs:
       EXTRA_ARGS: "--auto-skip"
     secrets: inherit
 
-  # tests-that-require-earthly-technologies-account-access
   docker-test-earthly-mirror-was-setup:
     if: ${{ !failure() && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
     needs: build-earthly
@@ -236,7 +235,6 @@ jobs:
       EXTRA_ARGS: "--auto-skip"
     secrets: inherit
 
-  ## docker-test-registry-command
   docker-test-registry-command-dockerhub:
     if: ${{ !failure() && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
     needs: build-earthly
@@ -292,7 +290,6 @@ jobs:
       SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
       EXTRA_ARGS: "--auto-skip"
     secrets: inherit
-  ## end of docker-test-registry-command
 
   docker-test-web-command:
     if: ${{ !failure() && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
@@ -307,7 +304,6 @@ jobs:
       SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
       EXTRA_ARGS: "--auto-skip"
     secrets: inherit
-  # end of tests-that-require-earthly-technologies-account-access
 
   docker-tests-qemu:
     needs: build-earthly

--- a/.github/workflows/ci-docker-ubuntu.yml
+++ b/.github/workflows/ci-docker-ubuntu.yml
@@ -236,12 +236,13 @@ jobs:
       EXTRA_ARGS: "--auto-skip"
     secrets: inherit
 
-  docker-test-registry-command:
+  ## docker-test-registry-command
+  docker-test-registry-command-dockerhub:
     if: ${{ !failure() && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
     needs: build-earthly
     uses: ./.github/workflows/reusable-test.yml
     with:
-      TEST_TARGET: "./tests/registry-command+test"
+      TEST_TARGET: "./tests/registry-command+test-dockerhub"
       BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
       RUNS_ON: "ubuntu-latest"
       BINARY: "docker"
@@ -249,6 +250,49 @@ jobs:
       SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
       EXTRA_ARGS: "--auto-skip"
     secrets: inherit
+
+  docker-test-registry-command-ecr:
+    if: ${{ !failure() && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    needs: build-earthly
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      TEST_TARGET: "./tests/registry-command+test-ecr"
+      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
+      RUNS_ON: "ubuntu-latest"
+      BINARY: "docker"
+      SUDO: ""
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
+      EXTRA_ARGS: "--auto-skip"
+    secrets: inherit
+
+  docker-test-registry-command-gcp:
+    if: ${{ !failure() && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    needs: build-earthly
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      TEST_TARGET: "./tests/registry-command+test-gcp"
+      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
+      RUNS_ON: "ubuntu-latest"
+      BINARY: "docker"
+      SUDO: ""
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
+      EXTRA_ARGS: "--auto-skip"
+    secrets: inherit
+
+  docker-test-registry-command-multi:
+    if: ${{ !failure() && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    needs: build-earthly
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      TEST_TARGET: "./tests/registry-command+test-multi"
+      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
+      RUNS_ON: "ubuntu-latest"
+      BINARY: "docker"
+      SUDO: ""
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
+      EXTRA_ARGS: "--auto-skip"
+    secrets: inherit
+  ## end of docker-test-registry-command
 
   docker-test-web-command:
     if: ${{ !failure() && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}

--- a/.github/workflows/ci-podman-ubuntu.yml
+++ b/.github/workflows/ci-podman-ubuntu.yml
@@ -131,18 +131,59 @@ jobs:
       SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
 
-  podman-tests-require-account-access:
+  # tests-that-require-earthly-technologies-account-access
+  podman-test-earthly-mirror-was-setup:
     if: ${{ !failure() && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
     needs: build-earthly
     uses: ./.github/workflows/reusable-test.yml
     with:
-      TEST_TARGET: "./tests+tests-that-require-earthly-technologies-account-access"
+      TEST_TARGET: "./tests+test-earthly-mirror-was-setup"
       BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
       RUNS_ON: "ubuntu-latest"
       BINARY: "podman"
       SUDO: "sudo -E"
       SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
+
+  podman-tests-test-account:
+    if: ${{ !failure() && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    needs: build-earthly
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      TEST_TARGET: "./tests/account+test"
+      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
+      RUNS_ON: "ubuntu-latest"
+      BINARY: "podman"
+      SUDO: "sudo -E"
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
+    secrets: inherit
+
+  podman-test-registry-command:
+    if: ${{ !failure() && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    needs: build-earthly
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      TEST_TARGET: "./tests/registry-command+test"
+      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
+      RUNS_ON: "ubuntu-latest"
+      BINARY: "podman"
+      SUDO: "sudo -E"
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
+    secrets: inherit
+
+  podman-test-web-command:
+    if: ${{ !failure() && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    needs: build-earthly
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      TEST_TARGET: "./tests/web+test"
+      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
+      RUNS_ON: "ubuntu-latest"
+      BINARY: "podman"
+      SUDO: "sudo -E"
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
+    secrets: inherit
+  # end of tests-that-require-earthly-technologies-account-access
 
   podman-tests-qemu:
     needs: build-earthly

--- a/.github/workflows/ci-podman-ubuntu.yml
+++ b/.github/workflows/ci-podman-ubuntu.yml
@@ -158,18 +158,60 @@ jobs:
       SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
 
-  podman-test-registry-command:
+  ## test-registry-command
+  podman-test-registry-command-dockerhub:
     if: ${{ !failure() && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
     needs: build-earthly
     uses: ./.github/workflows/reusable-test.yml
     with:
-      TEST_TARGET: "./tests/registry-command+test"
+      TEST_TARGET: "./tests/registry-command+test-dockerhub"
       BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
       RUNS_ON: "ubuntu-latest"
       BINARY: "podman"
       SUDO: "sudo -E"
       SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
+
+  podman-test-registry-command-ecr:
+    if: ${{ !failure() && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    needs: build-earthly
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      TEST_TARGET: "./tests/registry-command+test-ecr"
+      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
+      RUNS_ON: "ubuntu-latest"
+      BINARY: "podman"
+      SUDO: "sudo -E"
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
+    secrets: inherit
+
+  podman-test-registry-command-gcp:
+    if: ${{ !failure() && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    needs: build-earthly
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      TEST_TARGET: "./tests/registry-command+test-gcp"
+      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
+      RUNS_ON: "ubuntu-latest"
+      BINARY: "podman"
+      SUDO: "sudo -E"
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
+    secrets: inherit
+
+  podman-test-registry-command-multi:
+    if: ${{ !failure() && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    needs: build-earthly
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      TEST_TARGET: "./tests/registry-command+test-multi"
+      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
+      RUNS_ON: "ubuntu-latest"
+      BINARY: "podman"
+      SUDO: "sudo -E"
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
+    secrets: inherit
+
+  ## end of test-registry-command
 
   podman-test-web-command:
     if: ${{ !failure() && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}

--- a/.github/workflows/ci-podman-ubuntu.yml
+++ b/.github/workflows/ci-podman-ubuntu.yml
@@ -131,7 +131,6 @@ jobs:
       SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
 
-  # tests-that-require-earthly-technologies-account-access
   podman-test-earthly-mirror-was-setup:
     if: ${{ !failure() && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
     needs: build-earthly
@@ -158,7 +157,6 @@ jobs:
       SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
 
-  ## test-registry-command
   podman-test-registry-command-dockerhub:
     if: ${{ !failure() && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
     needs: build-earthly
@@ -211,8 +209,6 @@ jobs:
       SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
 
-  ## end of test-registry-command
-
   podman-test-web-command:
     if: ${{ !failure() && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
     needs: build-earthly
@@ -225,7 +221,6 @@ jobs:
       SUDO: "sudo -E"
       SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
-  # end of tests-that-require-earthly-technologies-account-access
 
   podman-tests-qemu:
     needs: build-earthly

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -200,6 +200,9 @@ ga-no-qemu:
     BUILD +ga-no-qemu-group4
     BUILD +ga-no-qemu-slow
 
+# Note that this target is split up under github action workflows
+# since they are flaky and having the ability to restart them individually
+# saves a lot of time
 tests-that-require-earthly-technologies-account-access:
     BUILD --pass-args +test-earthly-mirror-was-setup
     BUILD --pass-args ./account+test


### PR DESCRIPTION
split up the the
`tests-that-require-earthly-technologies-account-access` target into the 4 seperate targets it builds.