### PR TITLE
Fix SAVE ARTIFACT --if-exists wildcard bug

### DIFF
--- a/ast/tests/if-exists.ast.json
+++ b/ast/tests/if-exists.ast.json
@@ -412,6 +412,32 @@
           }
         }
       ]
+    },
+    {
+      "name": "artifact-copy-not-exist-wildcard",
+      "recipe": [
+        {
+          "command": {
+            "args": [
+              "--if-exists",
+              "+save/*_ok",
+              "."
+            ],
+            "name": "COPY"
+          }
+        },
+        {
+          "command": {
+            "args": [
+              "test",
+              "!",
+              "-f",
+              "not_ok"
+            ],
+            "name": "RUN"
+          }
+        }
+      ]
     }
   ],
   "version": {

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -781,7 +781,7 @@ func (c *Converter) runCommand(ctx context.Context, outputFileName string, isExp
 }
 
 // SaveArtifact applies the earthly SAVE ARTIFACT command.
-func (c *Converter) SaveArtifact(ctx context.Context, saveFrom string, saveTo string, saveAsLocalTo string, keepTs bool, keepOwn bool, ifExists, symlinkNoFollow, force bool, isPush bool) error {
+func (c *Converter) SaveArtifact(ctx context.Context, saveFrom, saveTo, saveAsLocalTo string, keepTs, keepOwn, ifExists, symlinkNoFollow, force, isPush bool) error {
 	err := c.checkAllowed(saveArtifactCmd)
 	if err != nil {
 		return err

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -773,6 +773,7 @@ if-exists:
       --output_contains="bad-wildcard-save"
     DO +RUN_EARTHLY --earthfile=if-exists.earth --target=+artifact-copy-exists
     DO +RUN_EARTHLY --earthfile=if-exists.earth --target=+artifact-copy-not-exist
+    DO +RUN_EARTHLY --earthfile=if-exists.earth --target=+artifact-copy-not-exist-wildcard
     RUN mkdir in && \
         echo "this-file-does-exist" > ./in/this-file-does-exist && \
         echo "so-does-this-one" > so-does-this-one

--- a/tests/if-exists.earth
+++ b/tests/if-exists.earth
@@ -63,3 +63,7 @@ artifact-copy-exists:
 artifact-copy-not-exist:
     COPY --if-exists +save/not_ok .
     RUN test ! -f not_ok
+
+artifact-copy-not-exist-wildcard:
+    COPY --if-exists +save/*_ok .
+    RUN test ! -f not_ok

--- a/util/llbutil/copyop.go
+++ b/util/llbutil/copyop.go
@@ -35,8 +35,7 @@ func CopyOp(ctx context.Context, srcState pllb.State, srcs []string, destState p
 		// matching uses the filepath match syntax. So by simply creating a
 		// wildcard where the first letter needs to match the current first
 		// letter gets us the single match; and no error if it is missing. Paths
-		// with wildcards are ignored as they will be automatically ignored
-		// without matches.
+		// with wildcards will be automatically ignored when no match is present.
 		if ifExists && len(src) != 0 && !strings.Contains(src, "*") {
 			// Normalize path by dropping './'
 			src = strings.TrimPrefix(src, "./")

--- a/util/llbutil/copyop.go
+++ b/util/llbutil/copyop.go
@@ -16,7 +16,7 @@ import (
 )
 
 // CopyOp is a simplified llb copy operation.
-func CopyOp(ctx context.Context, srcState pllb.State, srcs []string, destState pllb.State, dest string, allowWildcard bool, isDir bool, keepTs bool, chown string, chmod *fs.FileMode, ifExists, symlinkNoFollow, merge bool, opts ...llb.ConstraintsOpt) (pllb.State, error) {
+func CopyOp(ctx context.Context, srcState pllb.State, srcs []string, destState pllb.State, dest string, allowWildcard, isDir, keepTs bool, chown string, chmod *fs.FileMode, ifExists, symlinkNoFollow, merge bool, opts ...llb.ConstraintsOpt) (pllb.State, error) {
 	destAdjusted := dest
 	if dest == "." || dest == "" || len(srcs) > 1 {
 		destAdjusted += string("/") // TODO: needs to be the containers platform, not the earthly hosts platform. For now, this is always Linux.
@@ -30,16 +30,18 @@ func CopyOp(ctx context.Context, srcState pllb.State, srcs []string, destState p
 		baseCopyOpts = append(baseCopyOpts, llb.WithCreatedTime(*defaultTs()))
 	}
 	for _, src := range srcs {
-		if ifExists && len(src) != 0 {
-			// If the copy came in as optional (ifExists), then we need to trigger the
-			// underlying wildcard matching and allow empty wildcards. The matching uses
-			// the filepath. Match syntax, so by simply creating a wildcard where the
-			// first letter needs to match the current first letter gets us the single
-			// match; and no error if it is missing.
-
+		// If the copy came in as optional (ifExists), then we need to trigger
+		// the underlying wildcard matching and allow empty wildcards. The
+		// matching uses the filepath match syntax. So by simply creating a
+		// wildcard where the first letter needs to match the current first
+		// letter gets us the single match; and no error if it is missing. Paths
+		// with wildcards are ignored as they will be automatically ignored
+		// without matches.
+		if ifExists && len(src) != 0 && !strings.Contains(src, "*") {
 			// Normalize path by dropping './'
 			src = strings.TrimPrefix(src, "./")
-			// A target source will always have a leading '/' and never match, so strip that as well
+			// A target source will always have a leading '/' and never match,
+			// so strip that as well.
 			src = strings.TrimPrefix(src, "/")
 			src = fmt.Sprintf("[%s]%s", string(src[0]), string(src[1:]))
 		}


### PR DESCRIPTION
Addresses: https://github.com/earthly/earthly/issues/1679

A previously added special case for `SAVE ARTIFACT --if-exists` was interfering with wildcard expansion. When the path includes a wildcard, there's no need to use the globbing pattern (e.g., `[g]o.mod` to optionally match `go.mod`) to make the match optional.