### PR TITLE
do-not-track test: display stub server logs

### DIFF
--- a/tests/do-not-track/Earthfile
+++ b/tests/do-not-track/Earthfile
@@ -14,24 +14,19 @@ test-do-not-track:
     ENV DO_NOT_TRACK 1
     COPY api-earthly-stub-server.py /bin/api-earthly-stub-server
     COPY api-earthly-stub-server-shutdown.py /bin/api-earthly-stub-server-shutdown
+    COPY true.earth Earthfile
+    COPY test-earthly-script.sh /tmp/test-earthly-script
+    DO +RUN_EARTHLY_ARGS --exec_cmd=/tmp/test-earthly-script
 
-    # prevent earthly auto-login
-    RUN /bin/api-earthly-stub-server && earthly account logout && api-earthly-stub-server-shutdown
-
-    DO --pass-args +RUN_EARTHLY_ARGS --pre_command=/bin/api-earthly-stub-server --post_command=" && api-earthly-stub-server-shutdown" --earthfile=true.earth --target=+true
 
 RUN_EARTHLY_ARGS:
     FUNCTION
-    ARG earthfile
-    ARG target
     ARG should_fail=false
     ARG output_contains
     ARG output_does_not_contain
     ARG pre_command
     ARG post_command
     DO --pass-args tests+RUN_EARTHLY \
-        --earthfile=$earthfile \
-        --target=$target \
         --should_fail=$should_fail \
         --output_contains=$output_contains \
         --output_does_not_contain=$output_does_not_contain \

--- a/tests/do-not-track/api-earthly-stub-server-shutdown.py
+++ b/tests/do-not-track/api-earthly-stub-server-shutdown.py
@@ -12,21 +12,29 @@ pidfile='/do-not-track-tracker.pid'
 server_got_a_connection_path = '/server-got-a-connection'
 
 if os.path.exists(server_got_a_connection_path):
-    print('A connection was made, when it should not have')
+    print('ERROR: A connection was made, when it should not have')
     sys.exit(1)
 
 # next make sure the server is still working
+# if it is *not* working, then this test is invalid, since we wouldn't have
+# detected if earthly ever attempted to connect to it
 
-with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-    s.connect((host, port))
-    s.sendall(b"Hello, world")
+try:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.connect((host, port))
+        s.sendall(b"Hello, world")
+except Exception as e:
+    print('ERROR: stub server malfunction; failed to connect to stub server: {e}')
+    sys.exit(1)
 
 time.sleep(0.1)
 
 if not os.path.exists('/server-got-a-connection'):
-    print('stub server malfunction; it should have created a file but didnt. The results of the DO_NOT_TRACK test can not be trusted')
+    print('ERROR: stub server malfunction; it should have created a file but didnt. The results of the DO_NOT_TRACK test can not be trusted')
     sys.exit(1)
 
-
-pid = int(open(pidfile, 'r').read())
-os.kill(pid, signal.SIGKILL)
+try:
+    pid = int(open(pidfile, 'r').read())
+    os.kill(pid, signal.SIGKILL)
+except Exception as e:
+    print('WARN: failed to shutdown api-earthly-stub-server: {e}')

--- a/tests/do-not-track/api-earthly-stub-server.py
+++ b/tests/do-not-track/api-earthly-stub-server.py
@@ -15,7 +15,7 @@ server_got_a_connection_path = '/server-got-a-connection'
 pidfile='/do-not-track-tracker.pid'
 stdin='/dev/null'
 stdout='/dev/null'
-stderr='/dev/null'
+stderr='/var/log/do-not-track-server.log'
 
 ready_pipe_r, ready_pipe_w = os.pipe()
 
@@ -78,14 +78,22 @@ try:
     with suppress(FileNotFoundError):
         os.remove(server_got_a_connection_path)
 
+    print(f'creating socket', file=sys.stderr)
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        print(f'binding socket to {host}:{port}', file=sys.stderr)
         s.bind((host, port))
+        print(f'listening on socket', file=sys.stderr)
         s.listen()
         conn, addr = s.accept()
+        print(f'received connection from {addr}', file=sys.stderr)
         with conn:
             with open(server_got_a_connection_path, 'w') as f:
                 f.write('this should not have happened')
 except Exception as e:
+    # log to stderr
+    print(f'received connection from {conn}', file=sys.stderr)
+
+    # send the exception back over the ready_pipe (so the initial process can display the error if it is still running)
     os.write(ready_pipe_w, f'unexpected exception while starting server: {e}'.encode('utf8'))
     os.close(ready_pipe_w)
     raise

--- a/tests/do-not-track/test-earthly-script.sh
+++ b/tests/do-not-track/test-earthly-script.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+set -e
+test -n "$earthly_config"
+
+# Start the stub server; it will create a file under /server-got-a-connection if any connections are received.
+# If this file is created, we know that earthly attempted to connect to the server (which means the DO_NOT_TRACK setting was ignored).
+/bin/api-earthly-stub-server
+
+# prevent earthly auto-login
+earthly --config $earthly_config account logout
+
+# build a target
+earthly --config $earthly_config +true
+
+# shutdown the stub-server
+set +e
+echo ""
+echo "== shutting down api-earthly-stub-server =="
+api-earthly-stub-server-shutdown
+export exit_code="$?"
+set -e
+
+# display logs
+echo ""
+echo "== api-earthly-stub-server log =="
+cat /var/log/do-not-track-server.log
+echo ""
+
+# check test result
+acbtest "$exit_code" = "0"


### PR DESCRIPTION
If the do-not-track test fails, display the api.earthly.dev stub server logs.