### PR TITLE
Put satellites to sleep before starting updates

### DIFF
--- a/cmd/earthly/subcmd/common.go
+++ b/cmd/earthly/subcmd/common.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"strings"
 
-	"github.com/earthly/earthly/cloud"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"
+
+	"github.com/earthly/earthly/cloud"
 )
 
 type orgLister interface {
@@ -97,4 +98,9 @@ func getOrgAndProject(ctx context.Context, orgFlag, projectFlag string, client o
 	}
 
 	return
+}
+
+func isResponseYes(s string) bool {
+	s = strings.TrimSpace(strings.ToLower(s))
+	return s == "yes" || s == "y"
 }

--- a/cmd/earthly/subcmd/project_cmds.go
+++ b/cmd/earthly/subcmd/project_cmds.go
@@ -3,13 +3,13 @@ package subcmd
 import (
 	"fmt"
 	"os"
-	"strings"
 	"text/tabwriter"
+
+	"github.com/pkg/errors"
+	"github.com/urfave/cli/v2"
 
 	"github.com/earthly/earthly/cmd/earthly/common"
 	"github.com/earthly/earthly/cmd/earthly/helper"
-	"github.com/pkg/errors"
-	"github.com/urfave/cli/v2"
 )
 
 const dateFormat = "2006-01-02"
@@ -180,8 +180,7 @@ func (a *Project) actionRemove(cliCtx *cli.Context) error {
 		if err != nil {
 			return errors.Wrap(err, "failed requesting user input")
 		}
-		answer = strings.TrimSpace(strings.ToLower(answer))
-		if answer != "y" && answer != "yes" {
+		if !isResponseYes(answer) {
 			a.cli.Console().Printf("Operation aborted.")
 			return nil
 		}

--- a/cmd/earthly/subcmd/satellite_cmds.go
+++ b/cmd/earthly/subcmd/satellite_cmds.go
@@ -1004,7 +1004,7 @@ func (a *Satellite) actionUpdate(cliCtx *cli.Context) error {
 			a.cli.Console().Printf("")
 			answer, err := common.PromptInput(cliCtx.Context, "Would you like to put it to sleep now? [y/N]: ")
 			if err != nil {
-				return errors.Wrap(err, "failed to read permission")
+				return errors.Wrap(err, "failed to prompt input")
 			}
 			if !isResponseYes(answer) {
 				a.cli.Console().Printf("Update aborted.")

--- a/cmd/earthly/subcmd/satellite_cmds.go
+++ b/cmd/earthly/subcmd/satellite_cmds.go
@@ -18,7 +18,6 @@ import (
 	"github.com/earthly/earthly/buildkitd"
 	"github.com/earthly/earthly/cloud"
 	"github.com/earthly/earthly/cmd/earthly/base"
-	"github.com/earthly/earthly/cmd/earthly/common"
 	"github.com/earthly/earthly/cmd/earthly/helper"
 	"github.com/earthly/earthly/config"
 	"github.com/earthly/earthly/conslogging"
@@ -1000,17 +999,10 @@ func (a *Satellite) actionUpdate(cliCtx *cli.Context) error {
 		if !a.forceUpdate {
 			a.cli.Console().Printf("")
 			a.cli.Console().Printf("The satellite must be asleep to start the update.")
-			a.cli.Console().Printf("Putting the satellite to sleep will interrupt any running builds.")
+			a.cli.Console().Printf("You can re-run this command with the `--force` flag to force the satellite asleep and start the update now.")
+			a.cli.Console().Printf("Note that Putting the satellite to sleep will interrupt any running builds.")
 			a.cli.Console().Printf("")
-			answer, err := common.PromptInput(cliCtx.Context, "Would you like to put it to sleep now? [y/N]: ")
-			if err != nil {
-				return errors.Wrap(err, "failed to prompt input")
-			}
-			if !isResponseYes(answer) {
-				a.cli.Console().Printf("Update aborted.")
-				return nil
-			}
-			a.cli.Console().Printf("")
+			return errors.New("update aborted: satellite is not asleep.")
 		}
 		out := cloudClient.SleepSatellite(cliCtx.Context, sat.Name, orgName)
 		err = showSatelliteStopping(a.cli.Console(), a.cli.Flags().SatelliteName, out)


### PR DESCRIPTION
Satellites must be asleep to start a manual update. We would previously produce an error if the satellite was not asleep, but this has been confusing to users.

This PR introduces ~~a prompt which will ask the user permission~~ flag which will need to provided before automatically sleeping the satellite and starting the update.

<img width="547" alt="Screen Shot 2024-01-19 at 14 49 28" src="https://github.com/earthly/earthly/assets/3247216/90b6aafb-2257-47cc-b9d9-946fd03705f3">
