### PR TITLE
Docs: Add satellites best practices to summary

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -84,3 +84,4 @@
 * [Earthly Satellites](cloud/satellites.md)
     * [Managing Satellites](cloud/satellites/managing.md)
     * [Using Satellites](cloud/satellites/using.md)
+    * [Best Practices](cloud/satellites/best-practices.md)


### PR DESCRIPTION
The new doc page wasn't being listed in the side-bar, presumably because this entry was missing in the summary.md. 