### PR TITLE
Display warning message when configured cache size is too small

### DIFF
--- a/buildkitd/buildkitd.go
+++ b/buildkitd/buildkitd.go
@@ -938,19 +938,20 @@ func printBuildkitInfo(bkCons conslogging.ConsoleLogger, info *client.Info, work
 		}
 	}
 
-	var cacheInfo *client.PruneInfo
-	for _, p := range workerInfo.GCPolicy {
-		if p.All {
-			cacheInfo = &p
-			break
-		}
-	}
-
-	if cacheInfo != nil && cacheInfo.KeepBytes < minRecommendedCacheSize {
+	if size, ok := getGCPolicySize(*workerInfo); ok && size < minRecommendedCacheSize {
 		bkCons.Warnf("Configured cache size of %s is smaller than the minimum recommended size of %s",
-			units.HumanSize(float64(cacheInfo.KeepBytes)), units.HumanSize(minRecommendedCacheSize))
+			units.HumanSize(float64(size)), units.HumanSize(minRecommendedCacheSize))
 		bkCons.Warnf("Please consider increasing the cache size: https://docs.earthly.dev/docs/caching/managing-cache")
 	}
+}
+
+func getGCPolicySize(workerInfo client.WorkerInfo) (int64, bool) {
+	for _, p := range workerInfo.GCPolicy {
+		if p.All {
+			return p.KeepBytes, true
+		}
+	}
+	return 0, false
 }
 
 // getCacheSize returns the size of the earthly cache in bytes.

--- a/buildkitd/buildkitd.go
+++ b/buildkitd/buildkitd.go
@@ -938,14 +938,14 @@ func printBuildkitInfo(bkCons conslogging.ConsoleLogger, info *client.Info, work
 		}
 	}
 
-	if size, ok := getGCPolicySize(*workerInfo); ok && size < minRecommendedCacheSize {
+	if size, ok := getGCPolicySize(workerInfo); ok && size < minRecommendedCacheSize {
 		bkCons.Warnf("Configured cache size of %s is smaller than the minimum recommended size of %s",
 			units.HumanSize(float64(size)), units.HumanSize(minRecommendedCacheSize))
 		bkCons.Warnf("Please consider increasing the cache size: https://docs.earthly.dev/docs/caching/managing-cache")
 	}
 }
 
-func getGCPolicySize(workerInfo client.WorkerInfo) (int64, bool) {
+func getGCPolicySize(workerInfo *client.WorkerInfo) (int64, bool) {
 	for _, p := range workerInfo.GCPolicy {
 		if p.All {
 			return p.KeepBytes, true


### PR DESCRIPTION
It looks like the computed cache values are already exposed by the `ListWorkers` endpoint via the `GCPolicy` attribute. 

The [`CACHE_ALL_KEEP_BYTES`](https://github.com/earthly/earthly/blob/main/buildkitd/entrypoint.sh#L186) variable is set to the byte value of `CACHE_SIZE_MB`, so it should be ok to rely on this value.

It should be possible to add the `gckeepstorage` value to the endpoint response, but that will require a few code changes in BuildKit. 

![image](https://github.com/earthly/earthly/assets/332408/55769932-2089-42a7-8010-94c922795e3f)
