### PR TITLE
Add flag to disable remote registry proxy

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -85,6 +85,7 @@ type Opt struct {
 	DarwinProxyImage                      string
 	DarwinProxyWait                       time.Duration
 	LocalRegistryAddr                     string
+	DisableRemoteRegistryProxy            bool
 	FeatureFlagOverrides                  string
 	ContainerFrontend                     containerutil.ContainerFrontend
 	InternalSecretStore                   *secretprovider.MutableMapStore
@@ -165,6 +166,11 @@ func (b *Builder) BuildTarget(ctx context.Context, target domain.Target, opt Bui
 
 func (b *Builder) startRegistryProxy(ctx context.Context, caps apicaps.CapSet) (func(), bool) {
 	cons := b.opt.Console.WithPrefix("registry-proxy")
+
+	if b.opt.DisableRemoteRegistryProxy {
+		cons.VerbosePrintf("Registry proxy disabled via --disable-remote-registry-proxy")
+		return nil, false
+	}
 
 	if err := caps.Supports(pb.CapEarthlyRegistryProxy); err != nil {
 		cons.Printf(err.Error())

--- a/cmd/earthly/flag/global.go
+++ b/cmd/earthly/flag/global.go
@@ -98,6 +98,7 @@ type Global struct {
 	GlobalWaitEnd              bool
 	RemoteCache                string
 	LocalSkipDB                string
+	DisableRemoteRegistryProxy bool
 }
 
 func (global *Global) RootFlags(installName string, bkImage string) []cli.Flag {
@@ -515,6 +516,13 @@ func (global *Global) RootFlags(installName string, bkImage string) []cli.Flag {
 			EnvVars:     []string{"EARTHLY_REMOTE_CACHE"},
 			Usage:       "A remote docker image tag use as explicit cache",
 			Destination: &global.RemoteCache,
+		},
+		&cli.BoolFlag{
+			Name:        "disable-remote-registry-proxy",
+			EnvVars:     []string{"EARTHLY_DISABLE_REMOTE_REGISTRY_PROXY"},
+			Usage:       "Don't use the Docker registry proxy when transferring images",
+			Destination: &global.DisableRemoteRegistryProxy,
+			Value:       false,
 		},
 	}
 }

--- a/cmd/earthly/subcmd/build_cmd.go
+++ b/cmd/earthly/subcmd/build_cmd.go
@@ -553,6 +553,7 @@ func (a *Build) ActionBuildImp(cliCtx *cli.Context, flagArgs, nonFlagArgs []stri
 		GitImage:                              a.cli.Cfg().Global.GitImage,
 		GitLFSInclude:                         a.cli.Flags().GitLFSPullInclude,
 		GitLogLevel:                           a.gitLogLevel(),
+		DisableRemoteRegistryProxy:            a.cli.Flags().DisableRemoteRegistryProxy,
 	}
 
 	b, err := builder.NewBuilder(cliCtx.Context, builderOpts)


### PR DESCRIPTION
Adds `--disable-remote-registry-proxy` as a workaround for users who may have problems with the remote registry proxy. 