### PR TITLE
Fix issue with Darwin proxy container wait time

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/docker/cli v24.0.5+incompatible
 	github.com/docker/distribution v2.8.2+incompatible
 	github.com/docker/go-connections v0.4.0
+	github.com/docker/go-units v0.5.0
 	github.com/dustin/go-humanize v1.0.1
 	github.com/earthly/cloud-api v1.0.1-0.20240109224637-d374ffd93463
 	github.com/earthly/earthly/ast v0.0.0-00010101000000-000000000000
@@ -92,7 +93,6 @@ require (
 	github.com/distribution/reference v0.5.0 // indirect
 	github.com/docker/docker v24.0.0-rc.2.0.20230905130451-032797ea4bcb+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.7.0 // indirect
-	github.com/docker/go-units v0.5.0 // indirect
 	github.com/elastic/go-windows v1.0.0 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/regproxy/controller.go
+++ b/regproxy/controller.go
@@ -45,6 +45,7 @@ func NewController(
 		containerFrontend: containerFrontend,
 		darwinProxy:       darwinProxy,
 		darwinProxyImage:  darwinProxyImage,
+		darwinProxyWait:   darwinProxyWait,
 		cons:              cons,
 	}
 }
@@ -153,7 +154,7 @@ func (c *Controller) startDarwinProxy(ctx context.Context, containerName string,
 		return 0, errors.Wrap(err, "failed to start support container")
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, c.darwinProxyWait)
+	childCtx, cancel := context.WithTimeout(ctx, c.darwinProxyWait)
 	defer cancel()
 
 	// Wait for the proxy chain to resolve to the BK registry. The /v2/ path
@@ -167,8 +168,8 @@ func (c *Controller) startDarwinProxy(ctx context.Context, containerName string,
 			break
 		}
 		select {
-		case <-ctx.Done():
-			return 0, ctx.Err()
+		case <-childCtx.Done():
+			return 0, childCtx.Err()
 		case <-time.After(time.Second):
 			continue
 		}

--- a/regproxy/controller_test.go
+++ b/regproxy/controller_test.go
@@ -1,0 +1,19 @@
+package regproxy
+
+import (
+	"testing"
+	"time"
+
+	conslog "github.com/earthly/earthly/conslogging"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewController(t *testing.T) {
+	// A simple regression test that ensures the values are passed correctly.
+	cons := conslog.Current(conslog.NoColor, 0, conslog.Info)
+	c := NewController(nil, nil, true, "proxy-image", time.Second, cons)
+	r := require.New(t)
+	r.Equal("proxy-image", c.darwinProxyImage)
+	r.Equal(time.Second, c.darwinProxyWait)
+	r.True(c.darwinProxy)
+}


### PR DESCRIPTION
Fixes: https://github.com/earthly/earthly/issues/3740

The Darwin proxy healthcheck was timing out immediately. This wasn't obvious on faster machines where the proxy came up immediately. 

I also renamed a context value to disambiguate it from the one in the `defer`. 

Thanks to @brandonSc for the testing and confirmation help!