### PR TITLE
override buildkit's automatic cache size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 
 ## Unreleased
 
+### Changed
+
+- Changed the default buildkit cache size to be adaptively set to 20GB, which is then clamped between the range of 10%-55% of the disk size.
+  This logic can expressed as `min(55%, max(10%, 20GB))`.
+
 ## v0.8.1 - 2024-01-23
 
 ### Added

--- a/buildkitd/entrypoint.sh
+++ b/buildkitd/entrypoint.sh
@@ -177,16 +177,11 @@ if [ "$CACHE_SIZE_PCT" -gt "0" ]; then
     fi
 fi
 
-# Remains unset if neither percent nor size were specified.  It would be simpler to just process whether it was
+# EFFECTIVE_CACHE_SIZE_MB remains unset if neither percent nor size were specified.  It would be simpler to just process whether it was
 # set (or not), but we'll continue setting to "0" in case anyone has become dependent on that behavior.
 CACHE_SIZE_MB="${EFFECTIVE_CACHE_SIZE_MB:-0}"
-if [ "$CACHE_SIZE_MB" -gt "0" ]; then
-    SOURCE_FILE_KEEP_BYTES="$(echo "($CACHE_SIZE_MB * 1024 * 1024 * 0.5) / 1" | bc)" # Note /1 division truncates to int
-    export SOURCE_FILE_KEEP_BYTES
-    CATCH_ALL_KEEP_BYTES="$(echo "$CACHE_SIZE_MB * 1024 * 1024" | bc)"
-    export CATCH_ALL_KEEP_BYTES
-    CACHE_SETTINGS="$(envsubst </etc/buildkitd.cache.template)"
-else
+
+if [ "$CACHE_SIZE_MB" -eq "0" ]; then
     # no config value was set by the user; buildkit would set this to 10% by default:
     #   https://github.com/moby/buildkit/blob/54b8ff2fc8648c86b1b8c35e5cd07517b56ac2d5/cmd/buildkitd/config/gcpolicy_unix.go#L16
     # however, we will be aggresive and set it to min(55%, max(10%, 20GB))
@@ -200,6 +195,17 @@ else
     fi
     echo "cache size set automatically to $CACHE_SIZE_MB MB; this can be changed via the cache_size_mb or cache_size_pct config options"
 fi
+
+# Calculate the cache for source files to be 10% of the overall cache
+SOURCE_FILE_KEEP_BYTES="$(echo "($CACHE_SIZE_MB * 1024 * 1024 * 0.5) / 1" | bc)" # Note /1 division truncates to int
+export SOURCE_FILE_KEEP_BYTES
+
+# convert the cache size into bytes
+CATCH_ALL_KEEP_BYTES="$(echo "$CACHE_SIZE_MB * 1024 * 1024" | bc)"
+export CATCH_ALL_KEEP_BYTES
+
+# finally populate the cache section of the buildkit toml config
+CACHE_SETTINGS="$(envsubst </etc/buildkitd.cache.template)"
 export CACHE_SETTINGS
 
 # Set up TCP feature flag, and  also profiling (which has TCP as prerequisite)

--- a/buildkitd/settings.go
+++ b/buildkitd/settings.go
@@ -65,3 +65,8 @@ func (s Settings) VerifyHash(hash string) (bool, error) {
 
 	return oldHash == newHash, nil
 }
+
+// HasConfiguredCacheSize returns if the buildkitd cache size was configured
+func (s Settings) HasConfiguredCacheSize() bool {
+	return s.CacheSizeMb > 0 || s.CacheSizePct > 0
+}

--- a/docs/caching/managing-cache.md
+++ b/docs/caching/managing-cache.md
@@ -10,7 +10,7 @@ Earthly cache is persisted in a docker (or podman) volume called `earthly-cache`
 
 ### Specifying the local cache size limit
 
-The default cache size is adaptable depending on available space on your system. It defaults to 10% or 10 GB, whichever is greater. If you would like to change the cache size, you can specify a different limit by modifying the `cache_size_mb` and/or `cache_size_pct` settings in the [configuration](../earthly-config/earthly-config.md). For example:
+The default cache size is adaptable depending on available space on your system. It defaults to `min(55%, max(10%, 20GB))`. If you would like to change the cache size, you can specify a different limit by modifying the `cache_size_mb` and/or `cache_size_pct` settings in the [configuration](../earthly-config/earthly-config.md). For example:
 
 ```yaml
 global:


### PR DESCRIPTION
automatically set cache size to min(55%, max(10%, 20GB)), rather than using buildkit's 10% default.