### PR TITLE
Fix panic on empty docker ps result

### DIFF
--- a/util/containerutil/shell_shared.go
+++ b/util/containerutil/shell_shared.go
@@ -68,11 +68,18 @@ func (sf *shellFrontend) ContainerList(ctx context.Context) ([]*ContainerInfo, e
 	if err != nil {
 		return nil, err
 	}
+	return parseContainerList(output.stdout.String())
+}
+
+func parseContainerList(output string) ([]*ContainerInfo, error) {
 	ret := []*ContainerInfo{}
 	// The Docker & Podman JSON output format differs, so we parse the standard output here.
-	lines := strings.Split(strings.Trim(output.stdout.String(), "\n"), "\n")
+	lines := strings.Split(strings.TrimSpace(output), "\n")
 	for _, line := range lines {
 		parts := strings.Split(line, ",")
+		if len(parts) != 5 {
+			continue
+		}
 		createdAt, err := time.Parse(containerDateFormat, parts[4])
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to parse container date")

--- a/util/containerutil/shell_shared_test.go
+++ b/util/containerutil/shell_shared_test.go
@@ -2,7 +2,6 @@ package containerutil
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -20,7 +19,7 @@ func Test_parseContainerList(t *testing.T) {
 	r.Equal("earthly-darwin-proxy-T58UvV", ret[0].Name)
 	r.Equal("Up 5 hours", ret[0].Status)
 	r.Equal("alpine/socat:1.7.4.4", ret[0].Image)
-	r.Equal(time.Time(time.Date(2024, time.January, 23, 12, 53, 32, 0, time.Local)), ret[0].Created)
+	r.Equal(int64(1706043212), ret[0].Created.Unix())
 }
 
 func Test_parseContainerList_whitespace(t *testing.T) {

--- a/util/containerutil/shell_shared_test.go
+++ b/util/containerutil/shell_shared_test.go
@@ -1,0 +1,38 @@
+package containerutil
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const containerListText = `7a3c4741b86e,earthly-darwin-proxy-T58UvV,Up 5 hours,alpine/socat:1.7.4.4,2024-01-23 12:53:32 -0800 PST
+d8183461827c,earthly-dev-buildkitd,Up 5 hours,earthly/buildkitd:dev-main,2024-01-23 12:50:02 -0800 PST
+3084cac7996e,earthly-buildkitd,Up 6 hours,earthly/buildkitd:prerelease,2024-01-23 12:31:06 -0800 PST`
+
+func Test_parseContainerList(t *testing.T) {
+	ret, err := parseContainerList(containerListText)
+	r := require.New(t)
+	r.NoError(err)
+	r.Len(ret, 3)
+	r.Equal("7a3c4741b86e", ret[0].ID)
+	r.Equal("earthly-darwin-proxy-T58UvV", ret[0].Name)
+	r.Equal("Up 5 hours", ret[0].Status)
+	r.Equal("alpine/socat:1.7.4.4", ret[0].Image)
+	r.Equal(time.Time(time.Date(2024, time.January, 23, 12, 53, 32, 0, time.Local)), ret[0].Created)
+}
+
+func Test_parseContainerList_whitespace(t *testing.T) {
+	ret, err := parseContainerList(containerListText + "\n\n")
+	r := require.New(t)
+	r.NoError(err)
+	r.Len(ret, 3)
+}
+
+func Test_parseContainerList_empty(t *testing.T) {
+	ret, err := parseContainerList("\n\n")
+	r := require.New(t)
+	r.NoError(err)
+	r.Len(ret, 0)
+}


### PR DESCRIPTION
An empty result was leading to the below panic:

```
panic: runtime error: index out of range [4] with length 1

goroutine 126 [running]:
github.com/earthly/earthly/util/containerutil.(*shellFrontend).ContainerList(0x0?, {0x105d40148?, 0x1400049a1e0?})
	github.com/earthly/earthly/util/containerutil/shell_shared.go:76 +0x334
github.com/earthly/earthly/regproxy.(*Controller).stopOldDarwinProxies(0x1400013a000, {0x105d40148, 0x1400049a1e0})
	github.com/earthly/earthly/regproxy/controller.go:181 +0x38
github.com/earthly/earthly/regproxy.(*Controller).startDarwinProxy.func1()
	github.com/earthly/earthly/regproxy/controller.go:123 +0x38
created by github.com/earthly/earthly/regproxy.(*Controller).startDarwinProxy in goroutine 112
	github.com/earthly/earthly/regproxy/controller.go:122 +0xd4
```