### PR TITLE
don't suggest using both --interactive and --ci

### DIFF
--- a/cmd/earthly/app/run_test.go
+++ b/cmd/earthly/app/run_test.go
@@ -1,0 +1,42 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRedactSecretsFromArgs(t *testing.T) {
+	for _, testCase := range []struct {
+		args     []string
+		expected []string
+	}{
+		{
+			args:     []string{"earthly", "--secret", "foo=bar"},
+			expected: []string{"earthly", "--secret", "foo=XXXXX"},
+		},
+		{
+			args:     []string{"earthly", "--secret", "foo=bar", "--ci"},
+			expected: []string{"earthly", "--secret", "foo=XXXXX", "--ci"},
+		},
+		{
+			args:     []string{"earthly", "--secret", "foo", "--ci"},
+			expected: []string{"earthly", "--secret", "foo", "--ci"},
+		},
+		{
+			args:     []string{"earthly", "-s", "foo=bar"},
+			expected: []string{"earthly", "-s", "foo=XXXXX"},
+		},
+		{
+			args:     []string{"earthly", "-s", "foo=bar", "--ci"},
+			expected: []string{"earthly", "-s", "foo=XXXXX", "--ci"},
+		},
+		{
+			args:     []string{"earthly", "-s", "foo", "--ci"},
+			expected: []string{"earthly", "-s", "foo", "--ci"},
+		},
+	} {
+		actual := redactSecretsFromArgs(testCase.args)
+		require.ElementsMatch(t, testCase.expected, actual)
+	}
+}

--- a/util/stringutil/filter.go
+++ b/util/stringutil/filter.go
@@ -1,0 +1,22 @@
+package stringutil
+
+// ListContains returns true if the string, s, is contained in the list, l, of strings
+func ListContains(l []string, s string) bool {
+	for _, x := range l {
+		if x == s {
+			return true
+		}
+	}
+	return false
+}
+
+// FilterElementsFromList filters out elements from a given list
+func FilterElementsFromList(l []string, without ...string) []string {
+	filtered := []string{}
+	for _, s := range l {
+		if !ListContains(without, s) {
+			filtered = append(filtered, s)
+		}
+	}
+	return filtered
+}

--- a/util/stringutil/filter.go
+++ b/util/stringutil/filter.go
@@ -1,20 +1,12 @@
 package stringutil
 
-// ListContains returns true if the string, s, is contained in the list, l, of strings
-func ListContains(l []string, s string) bool {
-	for _, x := range l {
-		if x == s {
-			return true
-		}
-	}
-	return false
-}
+import "golang.org/x/exp/slices"
 
 // FilterElementsFromList filters out elements from a given list
 func FilterElementsFromList(l []string, without ...string) []string {
 	filtered := []string{}
 	for _, s := range l {
-		if !ListContains(without, s) {
+		if !slices.Contains(without, s) {
 			filtered = append(filtered, s)
 		}
 	}

--- a/util/stringutil/filter_test.go
+++ b/util/stringutil/filter_test.go
@@ -1,0 +1,36 @@
+package stringutil_test
+
+import (
+	"testing"
+
+	. "github.com/earthly/earthly/util/stringutil"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRemoveFromFromArgs(t *testing.T) {
+	for _, testCase := range []struct {
+		args     []string
+		remove   []string
+		expected []string
+	}{
+		{
+			args:     []string{"a", "b", "c"},
+			remove:   []string{"a"},
+			expected: []string{"b", "c"},
+		},
+		{
+			args:     []string{"a", "b", "c"},
+			remove:   []string{"b", "c"},
+			expected: []string{"a"},
+		},
+		{
+			args:     []string{"a", "b", "c"},
+			remove:   []string{},
+			expected: []string{"a", "b", "c"},
+		},
+	} {
+		actual := FilterElementsFromList(testCase.args, testCase.remove...)
+		require.ElementsMatch(t, testCase.expected, actual)
+	}
+}


### PR DESCRIPTION
fixes #3746

when running `earthly --secret foo=bar --ci +test`, earthly will now display

    earthly -i --secret foo=XXXXX +test

previously it wouldn't display a suggested command when secrets were present, when no secrets were specified, it would incorrectly suggest to run:

    earthly -i --ci +test

which would return an error.