### PR TITLE
EARTHLY_GIT_REFS: use git-each-ref --points-at

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 
 ## Unreleased
 
+### Fixed
+
+- `EARTHLY_GIT_REFS` was incorrectly returning all references which contained the commit rather than pointed to the current commit. This also increases performance of looking up the branches. [#3752](https://github.com/earthly/earthly/issues/3752)
+
 ## v0.8.2 - 2024-01-25
 
 ### Added

--- a/buildcontext/git.go
+++ b/buildcontext/git.go
@@ -268,7 +268,7 @@ func (gr *gitResolver) resolveGitProject(ctx context.Context, gwClient gwclient.
 					"git log -1 --format=%at >/dest/git-author-ts || touch /dest/git-author-ts ; " +
 					"git log -1 --format=%ae >/dest/git-author || touch /dest/git-author ; " +
 					"git log -1 --format=%b >/dest/git-body || touch /dest/git-body ; " +
-					"git for-each-ref --contains HEAD --format '%(refname:lstrip=-1)' >/dest/git-refs || touch /dest/git-refs ; " +
+					"git for-each-ref --points-at HEAD --format '%(refname:lstrip=-1)' >/dest/git-refs || touch /dest/git-refs ; " +
 					"find -type f -name Earthfile > /dest/Earthfile-paths || touch /dest/Earthfile-paths ; " +
 					"",
 			}),

--- a/tests/git-metadata/Earthfile
+++ b/tests/git-metadata/Earthfile
@@ -54,7 +54,7 @@ export expected_author_timestamp=\$(git -C repo log -1 --format=\"%at\")
 test \"\$expected_committer_timestamp\" -ne \"\$expected_author_timestamp\"
 export expected_branch=\"\$(git -C repo rev-parse --abbrev-ref HEAD)\"
 test -n \"\$expected_branch\"
-export expected_refs=\"\$(git -C repo for-each-ref --contains HEAD --format '%(refname:lstrip=-1)' | grep -v 'HEAD' | awk '!a[\$0]++' | tr '\n' ' ' | sed 's/ *$//')\"
+export expected_refs=\"\$(git -C repo for-each-ref --points-at HEAD --format '%(refname:lstrip=-1)' | grep -v 'HEAD' | awk '!a[\$0]++' | tr '\n' ' ' | sed 's/ *$//')\"
 test -n \"\$expected_refs\"
 
 # finally perform earthly tests

--- a/util/gitutil/detectgit.go
+++ b/util/gitutil/detectgit.go
@@ -292,7 +292,7 @@ func detectGitTags(ctx context.Context, dir string) ([]string, error) {
 }
 
 func detectGitRefs(ctx context.Context, dir string) ([]string, error) {
-	cmd := exec.CommandContext(ctx, "git", "for-each-ref", "--contains", "HEAD", "--format", "'%(refname:lstrip=-1)'")
+	cmd := exec.CommandContext(ctx, "git", "for-each-ref", "--points-at", "HEAD", "--format", "'%(refname:lstrip=-1)'")
 	cmd.Dir = dir
 	out, err := cmd.Output()
 	if err != nil {


### PR DESCRIPTION
EARTHLY_GIT_REFS should only return refernces that point at the commit rather than contains the commit.