### PR TITLE
Ensure auth.credentials file is created with --token

### DIFF
--- a/cmd/earthly/subcmd/account_cmds.go
+++ b/cmd/earthly/subcmd/account_cmds.go
@@ -609,7 +609,7 @@ func (a *Account) actionLogin(cliCtx *cli.Context) error {
 		return nil
 	}
 
-	if c := errors.Cause(err); c != nil && c != cloud.ErrUnauthorized && c != cloud.ErrAuthTokenExpired {
+	if err != nil && !errors.Is(err, cloud.ErrUnauthorized) && !errors.Is(err, cloud.ErrAuthTokenExpired) {
 		return errors.Wrap(err, "failed to login")
 	}
 

--- a/cmd/earthly/subcmd/account_cmds.go
+++ b/cmd/earthly/subcmd/account_cmds.go
@@ -602,12 +602,14 @@ func (a *Account) actionLogin(cliCtx *cli.Context) error {
 	}
 
 	loggedInEmail, authType, _, err := cloudClient.WhoAmI(cliCtx.Context)
-	if err == nil {
+
+	if err == nil && authType == cloud.AuthMethodCachedJWT {
 		// already logged in, don't re-attempt a login
 		a.cli.Console().Printf("Logged in as %q using %s auth\n", loggedInEmail, authType)
 		return nil
 	}
-	if errors.Cause(err) != cloud.ErrUnauthorized && errors.Cause(err) != cloud.ErrAuthTokenExpired {
+
+	if c := errors.Cause(err); c != nil && c != cloud.ErrUnauthorized && c != cloud.ErrAuthTokenExpired {
 		return errors.Wrap(err, "failed to login")
 	}
 

--- a/tests/account/test-login.sh
+++ b/tests/account/test-login.sh
@@ -38,4 +38,10 @@ earthly account login --token "$USER2_TOKEN" 2>&1 | acbgrep 'Logged in as "other
 
 echo "== same as above but first ensure we're logged out =="
 earthly account logout
+
+rm -v ~/.earthly/auth.*
 earthly account login --token "$USER2_TOKEN" 2>&1 | acbgrep 'Logged in as "other-service.earthly-user2@earthly.dev" using token auth'
+
+echo "== ensure auth files are recreated =="
+acbtest -f ~/.earthly/auth.credentials
+acbtest -f ~/.earthly/auth.jwt

--- a/tests/account/test-login.sh
+++ b/tests/account/test-login.sh
@@ -38,8 +38,7 @@ earthly account login --token "$USER2_TOKEN" 2>&1 | acbgrep 'Logged in as "other
 
 echo "== same as above but first ensure we're logged out =="
 earthly account logout
-
-rm -v ~/.earthly/auth.*
+rm -vf ~/.earthly/auth.*
 earthly account login --token "$USER2_TOKEN" 2>&1 | acbgrep 'Logged in as "other-service.earthly-user2@earthly.dev" using token auth'
 
 echo "== ensure auth files are recreated =="


### PR DESCRIPTION
Fixes: https://github.com/earthly/earthly/issues/3761

Using `--token` was working correctly, but did not ultimately create the `auth.credentials` file as the code assumed the user was already logged in. This led to some issues with Satellite commands. This change ensures that using `--token` will always create `auth.credentials`.