### PR TITLE
Allow for --auto-skip on BUILD commands

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -924,7 +924,3 @@ BUILD_AND_FROM:
     ARG --required TARGET
     FROM --pass-args +$TARGET
     BUILD --pass-args +$TARGET
-
-fun:
-    BUILD +license
-    BUILD --auto-skip +lint

--- a/Earthfile
+++ b/Earthfile
@@ -924,3 +924,7 @@ BUILD_AND_FROM:
     ARG --required TARGET
     FROM --pass-args +$TARGET
     BUILD --pass-args +$TARGET
+
+fun:
+    BUILD +license
+    BUILD --auto-skip +lint

--- a/ast/commandflag/flags.go
+++ b/ast/commandflag/flags.go
@@ -89,6 +89,7 @@ type BuildOpts struct {
 	BuildArgs       []string `long:"build-arg" description:"A build arg override passed on to a referenced Earthly target"`
 	AllowPrivileged bool     `long:"allow-privileged" description:"Allow targets to assume privileged mode"`
 	PassArgs        bool     `long:"pass-args" description:"Pass arguments to external targets"`
+	AutoSkip        bool     `long:"auto-skip" description:"Use auto-skip to bypass the target if nothing has changed"`
 }
 
 type GitCloneOpts struct {

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -96,6 +96,7 @@ type Opt struct {
 	GitLFSInclude                         string
 	GitLogLevel                           buildkitgitutil.GitLogLevel
 	BuildkitSkipper                       bk.BuildkitSkipper
+	NoAutoSkip                            bool
 }
 
 type ProjectAdder interface {
@@ -293,6 +294,7 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 				ProjectAdder:                         opt.ProjectAdder,
 				FilesWithCommandRenameWarning:        make(map[string]bool),
 				BuildkitSkipper:                      b.opt.BuildkitSkipper,
+				NoAutoSkip:                           b.opt.NoAutoSkip,
 			}
 			mts, err = earthfile2llb.Earthfile2LLB(childCtx, target, opt, true)
 			if err != nil {

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -14,6 +14,7 @@ import (
 	"github.com/earthly/earthly/buildcontext"
 	"github.com/earthly/earthly/buildcontext/provider"
 	"github.com/earthly/earthly/cleanup"
+	"github.com/earthly/earthly/cmd/earthly/bk"
 	"github.com/earthly/earthly/conslogging"
 	"github.com/earthly/earthly/domain"
 	"github.com/earthly/earthly/earthfile2llb"
@@ -22,7 +23,6 @@ import (
 	"github.com/earthly/earthly/outmon"
 	"github.com/earthly/earthly/regproxy"
 	"github.com/earthly/earthly/states"
-	"github.com/earthly/earthly/util/buildkitskipper"
 	"github.com/earthly/earthly/util/containerutil"
 	"github.com/earthly/earthly/util/dockerutil"
 	"github.com/earthly/earthly/util/gatewaycrafter"
@@ -95,8 +95,7 @@ type Opt struct {
 	GitImage                              string
 	GitLFSInclude                         string
 	GitLogLevel                           buildkitgitutil.GitLogLevel
-	AutoSkipClient                        buildkitskipper.ASKVClient
-	AutoSkipLocalDB                       string
+	BuildkitSkipper                       bk.BuildkitSkipper
 }
 
 type ProjectAdder interface {
@@ -293,8 +292,7 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 				Runner:                               opt.Runner,
 				ProjectAdder:                         opt.ProjectAdder,
 				FilesWithCommandRenameWarning:        make(map[string]bool),
-				AutoSkipClient:                       b.opt.AutoSkipClient,
-				AutoSkipLocalDB:                      b.opt.AutoSkipLocalDB,
+				BuildkitSkipper:                      b.opt.BuildkitSkipper,
 			}
 			mts, err = earthfile2llb.Earthfile2LLB(childCtx, target, opt, true)
 			if err != nil {

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -22,6 +22,7 @@ import (
 	"github.com/earthly/earthly/outmon"
 	"github.com/earthly/earthly/regproxy"
 	"github.com/earthly/earthly/states"
+	"github.com/earthly/earthly/util/buildkitskipper"
 	"github.com/earthly/earthly/util/containerutil"
 	"github.com/earthly/earthly/util/dockerutil"
 	"github.com/earthly/earthly/util/gatewaycrafter"
@@ -94,6 +95,8 @@ type Opt struct {
 	GitImage                              string
 	GitLFSInclude                         string
 	GitLogLevel                           buildkitgitutil.GitLogLevel
+	AutoSkipClient                        buildkitskipper.ASKVClient
+	AutoSkipLocalDB                       string
 }
 
 type ProjectAdder interface {
@@ -290,6 +293,8 @@ func (b *Builder) convertAndBuild(ctx context.Context, target domain.Target, opt
 				Runner:                               opt.Runner,
 				ProjectAdder:                         opt.ProjectAdder,
 				FilesWithCommandRenameWarning:        make(map[string]bool),
+				AutoSkipClient:                       b.opt.AutoSkipClient,
+				AutoSkipLocalDB:                      b.opt.AutoSkipLocalDB,
 			}
 			mts, err = earthfile2llb.Earthfile2LLB(childCtx, target, opt, true)
 			if err != nil {

--- a/cmd/earthly/bk/buildkitskipper_create.go
+++ b/cmd/earthly/bk/buildkitskipper_create.go
@@ -3,18 +3,19 @@ package bk
 import (
 	"context"
 
-	"github.com/earthly/earthly/domain"
 	"github.com/earthly/earthly/util/buildkitskipper"
 	"github.com/pkg/errors"
 )
 
+// BuildkitSkipper adds new auto-skip hashes to the backing datastore & allows
+// us to check for their existence.
 type BuildkitSkipper interface {
-	Add(ctx context.Context, key []byte) error
-	Exists(ctx context.Context, key []byte) (bool, error)
+	Add(ctx context.Context, org, target string, key []byte) error
+	Exists(ctx context.Context, org string, key []byte) (bool, error)
 }
 
 // NewBuildkitSkipper returns a local buildkitskipper when localSkipDB is specified, or alternatively a cloud-based skipper
-func NewBuildkitSkipper(localSkipDB, orgName string, target domain.Target, cloudClient buildkitskipper.ASKVClient) (BuildkitSkipper, error) {
+func NewBuildkitSkipper(localSkipDB string, cloudClient buildkitskipper.ASKVClient) (BuildkitSkipper, error) {
 	if localSkipDB != "" {
 		skipDB, err := buildkitskipper.NewLocal(localSkipDB)
 		if err != nil {
@@ -23,9 +24,10 @@ func NewBuildkitSkipper(localSkipDB, orgName string, target domain.Target, cloud
 		return skipDB, nil
 	}
 
-	skipDB, err := buildkitskipper.NewCloud(orgName, target, cloudClient)
+	skipDB, err := buildkitskipper.NewCloud(cloudClient)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create cloud-based buildkit skipper database")
 	}
+
 	return skipDB, nil
 }

--- a/cmd/earthly/flag/global.go
+++ b/cmd/earthly/flag/global.go
@@ -99,6 +99,7 @@ type Global struct {
 	RemoteCache                string
 	LocalSkipDB                string
 	DisableRemoteRegistryProxy bool
+	NoAutoSkip                 bool
 }
 
 func (global *Global) RootFlags(installName string, bkImage string) []cli.Flag {
@@ -522,6 +523,13 @@ func (global *Global) RootFlags(installName string, bkImage string) []cli.Flag {
 			EnvVars:     []string{"EARTHLY_DISABLE_REMOTE_REGISTRY_PROXY"},
 			Usage:       "Don't use the Docker registry proxy when transferring images",
 			Destination: &global.DisableRemoteRegistryProxy,
+			Value:       false,
+		},
+		&cli.BoolFlag{
+			Name:        "no-auto-skip",
+			EnvVars:     []string{"EARTHLY_NO_AUTO_SKIP"},
+			Usage:       "Disable auto-skip functionality",
+			Destination: &global.NoAutoSkip,
 			Value:       false,
 		},
 	}

--- a/cmd/earthly/subcmd/build_cmd.go
+++ b/cmd/earthly/subcmd/build_cmd.go
@@ -554,6 +554,8 @@ func (a *Build) ActionBuildImp(cliCtx *cli.Context, flagArgs, nonFlagArgs []stri
 		GitLFSInclude:                         a.cli.Flags().GitLFSPullInclude,
 		GitLogLevel:                           a.gitLogLevel(),
 		DisableRemoteRegistryProxy:            a.cli.Flags().DisableRemoteRegistryProxy,
+		AutoSkipClient:                        cloudClient,
+		AutoSkipLocalDB:                       a.cli.Flags().LocalSkipDB,
 	}
 
 	b, err := builder.NewBuilder(cliCtx.Context, builderOpts)
@@ -845,12 +847,11 @@ func (a *Build) initAutoSkip(ctx context.Context, target domain.Target, overridi
 	orgName := a.cli.Flags().OrgName
 
 	targetHash, stats, err := inputgraph.HashTarget(ctx, inputgraph.HashOpt{
-		Target:          target,
-		Console:         a.cli.Console(),
-		CI:              a.cli.Flags().CI,
-		BuiltinArgs:     variables.DefaultArgs{EarthlyVersion: a.cli.Version(), EarthlyBuildSha: a.cli.GitSHA()},
-		OverridingVars:  overridingVars,
-		EarthlyCIRunner: a.cli.Flags().EarthlyCIRunner,
+		Target:         target,
+		Console:        a.cli.Console(),
+		CI:             a.cli.Flags().CI,
+		BuiltinArgs:    variables.DefaultArgs{EarthlyVersion: a.cli.Version(), EarthlyBuildSha: a.cli.GitSHA()},
+		OverridingVars: overridingVars,
 	})
 	if err != nil {
 		return nil, nil, false, errors.Wrapf(err, "auto-skip is unable to calculate hash for %s", target)

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -1857,7 +1857,7 @@ func (c *Converter) checkAutoSkip(ctx context.Context, fullTargetName string, al
 	exists, err := skipDB.Exists(ctx, targetHash)
 	if err != nil {
 		console.Warnf("Unable to check if target %s (hash %x) has already been run: %s", target.String(), targetHash, err.Error())
-		return false, nil, nil
+		return false, func() {}, nil
 	}
 
 	if exists {

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -26,9 +26,11 @@ import (
 	"github.com/earthly/earthly/ast/commandflag"
 	"github.com/earthly/earthly/ast/spec"
 	"github.com/earthly/earthly/buildcontext"
+	"github.com/earthly/earthly/cmd/earthly/bk"
 	debuggercommon "github.com/earthly/earthly/debugger/common"
 	"github.com/earthly/earthly/domain"
 	"github.com/earthly/earthly/features"
+	"github.com/earthly/earthly/inputgraph"
 	"github.com/earthly/earthly/logbus"
 	"github.com/earthly/earthly/states"
 	"github.com/earthly/earthly/states/dedup"
@@ -1799,39 +1801,117 @@ func (c *Converter) ExpandArgs(ctx context.Context, runOpts ConvertRunOpts, word
 	})
 }
 
-func (c *Converter) prepBuildTarget(ctx context.Context, fullTargetName string, platform platutil.Platform, allowPrivileged, passArgs bool, buildArgs []string, isDangling bool, cmdT cmdType) (domain.Target, ConvertOpt, bool, error) {
+func (c *Converter) absolutizeTarget(fullTargetName string, allowPrivileged bool) (domain.Target, domain.Target, bool, error) {
 	relTarget, err := domain.ParseTarget(fullTargetName)
 	if err != nil {
-		return domain.Target{}, ConvertOpt{}, false, errors.Wrapf(err, "earthly target parse %s", fullTargetName)
+		return domain.Target{}, domain.Target{}, false, errors.Wrapf(err, "earthly target parse %s", fullTargetName)
 	}
+
 	derefedTarget, allowPrivilegedImport, isImport, err := c.varCollection.Imports().Deref(relTarget)
 	if err != nil {
-		return domain.Target{}, ConvertOpt{}, false, err
+		return domain.Target{}, domain.Target{}, false, err
 	}
+
 	if isImport {
 		allowPrivileged = allowPrivileged && allowPrivilegedImport
 	}
+
 	targetRef, err := c.joinRefs(derefedTarget)
 	if err != nil {
-		return domain.Target{}, ConvertOpt{}, false, errors.Wrap(err, "join targets")
-	}
-	target := targetRef.(domain.Target)
-
-	var pncvf variables.ProcessNonConstantVariableFunc
-	if !c.opt.Features.ShellOutAnywhere {
-		pncvf = c.processNonConstantBuildArgFunc(ctx)
+		return domain.Target{}, domain.Target{}, false, errors.Wrap(err, "join targets")
 	}
 
-	overriding, err := variables.ParseArgs(buildArgs, pncvf, c.varCollection)
+	return targetRef.(domain.Target), relTarget, allowPrivileged, nil
+}
+
+func (c *Converter) checkAutoSkip(ctx context.Context, fullTargetName string, allowPrivileged, passArgs bool, buildArgs []string) (bool, func(), error) {
+
+	target, relTarget, _, err := c.absolutizeTarget(fullTargetName, allowPrivileged)
 	if err != nil {
-		return domain.Target{}, ConvertOpt{}, false, errors.Wrap(err, "parse build args")
+		return false, nil, err
 	}
+
+	overriding, _, err := c.prepOverridingVars(ctx, relTarget, passArgs, buildArgs)
+	if err != nil {
+		return false, nil, err
+	}
+
+	targetHash, _, err := inputgraph.HashTarget(ctx, inputgraph.HashOpt{
+		Target:         target,
+		Console:        c.opt.Console,
+		CI:             c.opt.IsCI,
+		BuiltinArgs:    c.opt.BuiltinArgs,
+		OverridingVars: overriding,
+	})
+	if err != nil {
+		return false, nil, errors.Wrapf(err, "auto-skip is unable to calculate hash for %s", target)
+	}
+
+	skipDB, err := bk.NewBuildkitSkipper(c.opt.AutoSkipLocalDB, c.varCollection.Org(), target, c.opt.AutoSkipClient)
+	if err != nil {
+		return false, nil, err
+	}
+
+	console := c.opt.Console.WithPrefix("auto-skip")
+
+	exists, err := skipDB.Exists(ctx, targetHash)
+	if err != nil {
+		console.Warnf("Unable to check if target %s (hash %x) has already been run: %s", target.String(), targetHash, err.Error())
+		return false, nil, nil
+	}
+
+	if exists {
+		console.Printf("Target %s (hash %x) has already been run. Skipping.", target.String(), targetHash)
+		return true, nil, nil
+	}
+
+	return exists, func() {
+		err := skipDB.Add(ctx, targetHash)
+		if err != nil {
+			console.Warnf("Failed to add target %s (hash %x) to the auto-skip DB.", target.String(), targetHash)
+		}
+	}, nil
+}
+
+func (c *Converter) prepOverridingVars(ctx context.Context, relTarget domain.Target, passArgs bool, buildArgs []string) (*variables.Scope, bool, error) {
+	var buildArgFunc variables.ProcessNonConstantVariableFunc
+	if !c.opt.Features.ShellOutAnywhere {
+		buildArgFunc = c.processNonConstantBuildArgFunc(ctx)
+	}
+
+	overriding, err := variables.ParseArgs(buildArgs, buildArgFunc, c.varCollection)
+	if err != nil {
+		return nil, false, errors.Wrap(err, "parse build args")
+	}
+
 	// Don't allow transitive overriding variables to cross project boundaries (unless --pass-args is used).
 	propagateBuildArgs := !relTarget.IsExternal()
 	if passArgs {
 		overriding = variables.CombineScopes(overriding, c.varCollection.Overriding(), c.varCollection.Args(), c.varCollection.Globals())
 	} else if propagateBuildArgs {
 		overriding = variables.CombineScopes(overriding, c.varCollection.Overriding())
+	}
+
+	return overriding, propagateBuildArgs, nil
+}
+
+func (c *Converter) prepBuildTarget(
+	ctx context.Context,
+	fullTargetName string,
+	platform platutil.Platform,
+	allowPrivileged, passArgs bool,
+	buildArgs []string,
+	isDangling bool,
+	cmdT cmdType,
+) (domain.Target, ConvertOpt, bool, error) {
+	target, relTarget, allowPrivileged, err := c.absolutizeTarget(fullTargetName, allowPrivileged)
+	if err != nil {
+		return domain.Target{}, ConvertOpt{}, false, err
+	}
+
+	overriding, propagateBuildArgs, err := c.prepOverridingVars(ctx, relTarget, passArgs, buildArgs)
+	if err != nil {
+		return domain.Target{}, ConvertOpt{}, false, err
 	}
 
 	// Recursion.

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -1828,8 +1828,17 @@ func (c *Converter) checkAutoSkip(ctx context.Context, fullTargetName string, al
 
 	nopFn := func() {}
 
+	if !c.opt.Features.BuildAutoSkip {
+		return false, nopFn, nil
+	}
+
 	if c.opt.BuildkitSkipper == nil {
-		console.Warnf("--auto-skip flags are disabled due to client initialization failure")
+		console.Warnf("BUILD --auto-skip option disabled due to client initialization failure")
+		return false, nopFn, nil
+	}
+
+	if c.opt.NoAutoSkip {
+		console.VerbosePrintf("BUILD --auto-skip ignored due to --no-auto-skip flag")
 		return false, nopFn, nil
 	}
 

--- a/earthfile2llb/earthfile2llb.go
+++ b/earthfile2llb/earthfile2llb.go
@@ -191,6 +191,9 @@ type ConvertOpt struct {
 
 	// BuildkitSkipper allows for additions and existence checks for auto-skip hash values.
 	BuildkitSkipper bk.BuildkitSkipper
+
+	// NoAutoSkip disables auto-skip usages.
+	NoAutoSkip bool
 }
 
 // TargetDetails contains details about the target being built.

--- a/earthfile2llb/earthfile2llb.go
+++ b/earthfile2llb/earthfile2llb.go
@@ -6,12 +6,12 @@ import (
 	"github.com/earthly/earthly/buildcontext"
 	"github.com/earthly/earthly/buildcontext/provider"
 	"github.com/earthly/earthly/cleanup"
+	"github.com/earthly/earthly/cmd/earthly/bk"
 	"github.com/earthly/earthly/conslogging"
 	"github.com/earthly/earthly/domain"
 	"github.com/earthly/earthly/features"
 	"github.com/earthly/earthly/logbus"
 	"github.com/earthly/earthly/states"
-	"github.com/earthly/earthly/util/buildkitskipper"
 	"github.com/earthly/earthly/util/containerutil"
 	"github.com/earthly/earthly/util/gatewaycrafter"
 	"github.com/earthly/earthly/util/llbutil/secretprovider"
@@ -189,8 +189,8 @@ type ConvertOpt struct {
 	// is used to link together targets.
 	ParentTargetID string
 
-	AutoSkipClient  buildkitskipper.ASKVClient
-	AutoSkipLocalDB string
+	// BuildkitSkipper allows for additions and existence checks for auto-skip hash values.
+	BuildkitSkipper bk.BuildkitSkipper
 }
 
 // TargetDetails contains details about the target being built.

--- a/earthfile2llb/earthfile2llb.go
+++ b/earthfile2llb/earthfile2llb.go
@@ -11,6 +11,7 @@ import (
 	"github.com/earthly/earthly/features"
 	"github.com/earthly/earthly/logbus"
 	"github.com/earthly/earthly/states"
+	"github.com/earthly/earthly/util/buildkitskipper"
 	"github.com/earthly/earthly/util/containerutil"
 	"github.com/earthly/earthly/util/gatewaycrafter"
 	"github.com/earthly/earthly/util/llbutil/secretprovider"
@@ -187,6 +188,9 @@ type ConvertOpt struct {
 	// ParentTargetID is the Logbus target ID of the parent target, if any. It
 	// is used to link together targets.
 	ParentTargetID string
+
+	AutoSkipClient  buildkitskipper.ASKVClient
+	AutoSkipLocalDB string
 }
 
 // TargetDetails contains details about the target being built.

--- a/earthfile2llb/interpreter.go
+++ b/earthfile2llb/interpreter.go
@@ -1228,19 +1228,32 @@ func (i *Interpreter) handleBuild(ctx context.Context, cmd spec.Command, async b
 		return i.errorf(cmd.SourceLocation, "the BUILD --pass-args flag must be enabled with the VERSION --pass-args feature flag.")
 	}
 
-	for _, bas := range crossProductBuildArgs {
+	for _, buildArgs := range crossProductBuildArgs {
+		saveHashFn := func() {}
+		if opts.AutoSkip {
+			skip, fn, err := i.converter.checkAutoSkip(ctx, fullTargetName, allowPrivileged, opts.PassArgs, buildArgs)
+			if err != nil {
+				return i.wrapError(err, cmd.SourceLocation, "failed to determine whether target can be skipped")
+			}
+			if skip {
+				continue
+			}
+			saveHashFn = fn
+		}
 		for _, platform := range platformsSlice {
 			if async {
-				err := i.converter.BuildAsync(ctx, fullTargetName, platform, allowPrivileged, opts.PassArgs, bas, buildCmd, nil, nil)
+				err := i.converter.BuildAsync(ctx, fullTargetName, platform, allowPrivileged, opts.PassArgs, buildArgs, buildCmd, nil, nil)
 				if err != nil {
 					return i.wrapError(err, cmd.SourceLocation, "apply BUILD %s", fullTargetName)
 				}
+				saveHashFn()
 				continue
 			}
-			err := i.converter.Build(ctx, fullTargetName, platform, allowPrivileged, opts.PassArgs, bas)
+			err := i.converter.Build(ctx, fullTargetName, platform, allowPrivileged, opts.PassArgs, buildArgs)
 			if err != nil {
 				return i.wrapError(err, cmd.SourceLocation, "apply BUILD %s", fullTargetName)
 			}
+			saveHashFn()
 		}
 	}
 	return nil
@@ -1708,7 +1721,7 @@ func (i *Interpreter) handleWithDocker(ctx context.Context, cmd spec.Command) er
 		})
 	}
 	for _, loadStr := range opts.Loads {
-		loadImg, loadTarget, flagArgs, err := ParseLoad(loadStr)
+		loadImg, loadTarget, flagArgs, err := flagutil.ParseLoad(loadStr)
 		if err != nil {
 			return i.wrapError(err, cmd.SourceLocation, "parse load")
 		}
@@ -2111,39 +2124,6 @@ func escapeSlashPlus(str string) string {
 func unescapeSlashPlus(str string) string {
 	// TODO: This is not entirely correct in a string like "\\\\+".
 	return strings.ReplaceAll(str, "\\+", "+")
-}
-
-// ParseLoad splits a --load value into the image, target, & extra args.
-// Example: --load my-image=(+target --arg1 foo --arg2=bar)
-func ParseLoad(loadStr string) (image string, target string, extraArgs []string, err error) {
-	words := strings.SplitN(loadStr, " ", 2)
-	if len(words) == 0 {
-		return "", "", nil, nil
-	}
-	firstWord := words[0]
-	splitFirstWord := strings.SplitN(firstWord, "=", 2)
-	if len(splitFirstWord) < 2 {
-		// <target-name>
-		// (will infer image name from SAVE IMAGE of that target)
-		image = ""
-		target = loadStr
-	} else {
-		// <image-name>=<target-name>
-		image = splitFirstWord[0]
-		if len(words) == 1 {
-			target = splitFirstWord[1]
-		} else {
-			words[0] = splitFirstWord[1]
-			target = strings.Join(words, " ")
-		}
-	}
-	if flagutil.IsInParamsForm(target) {
-		target, extraArgs, err = flagutil.ParseParams(target)
-		if err != nil {
-			return "", "", nil, err
-		}
-	}
-	return image, target, extraArgs, nil
 }
 
 // requiresShellOutOrCmdInvalid returns true if

--- a/earthfile2llb/interpreter.go
+++ b/earthfile2llb/interpreter.go
@@ -1247,7 +1247,6 @@ func (i *Interpreter) handleBuild(ctx context.Context, cmd spec.Command, async b
 				if err != nil {
 					return i.wrapError(err, cmd.SourceLocation, "apply BUILD %s", fullTargetName)
 				}
-				saveHashFn()
 				continue
 			}
 			err := i.converter.Build(ctx, fullTargetName, platform, allowPrivileged, opts.PassArgs, buildArgs)

--- a/earthfile2llb/interpreter.go
+++ b/earthfile2llb/interpreter.go
@@ -1191,10 +1191,11 @@ func (i *Interpreter) handleBuild(ctx context.Context, cmd spec.Command, async b
 		}
 		platformsSlice = append(platformsSlice, platform)
 	}
-	if async && !(isSafeAsyncBuildArgsKVStyle(opts.BuildArgs) && isSafeAsyncBuildArgs(args[1:])) {
+	asyncSafeArgs := isSafeAsyncBuildArgsKVStyle(opts.BuildArgs) && isSafeAsyncBuildArgs(args[1:])
+	if async && (!asyncSafeArgs || opts.AutoSkip) {
 		return errCannotAsync
 	}
-	if i.local && !(isSafeAsyncBuildArgsKVStyle(opts.BuildArgs) && isSafeAsyncBuildArgs(args[1:])) {
+	if i.local && !asyncSafeArgs {
 		return i.errorf(cmd.SourceLocation, "BUILD args do not currently support shelling-out in combination with LOCALLY")
 	}
 	expandedBuildArgs, err := i.expandArgsSlice(ctx, opts.BuildArgs, true, async)

--- a/features/features.go
+++ b/features/features.go
@@ -71,6 +71,7 @@ type Features struct {
 	// unreleased
 	TryFinally     bool `long:"try" description:"allow the use of the TRY/FINALLY commands"`
 	WildcardBuilds bool `long:"wildcard-builds" description:"allow for the expansion of wildcard (glob) paths for BUILD commands"`
+	BuildAutoSkip  bool `long:"build-auto-skip" description:"allow for --auto-skip to be used on individual BUILD commands"`
 
 	Major int
 	Minor int

--- a/inputgraph/hash.go
+++ b/inputgraph/hash.go
@@ -10,12 +10,11 @@ import (
 
 // HashOpt contains all of the options available to the hasher.
 type HashOpt struct {
-	Target          domain.Target
-	Console         conslogging.ConsoleLogger
-	CI              bool
-	BuiltinArgs     variables.DefaultArgs
-	OverridingVars  *variables.Scope
-	EarthlyCIRunner bool
+	Target         domain.Target
+	Console        conslogging.ConsoleLogger
+	CI             bool
+	BuiltinArgs    variables.DefaultArgs
+	OverridingVars *variables.Scope
 }
 
 // HashTarget produces a hash from an Earthly target.

--- a/inputgraph/hash.go
+++ b/inputgraph/hash.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/earthly/earthly/conslogging"
 	"github.com/earthly/earthly/domain"
+	"github.com/earthly/earthly/util/buildkitskipper/hasher"
 	"github.com/earthly/earthly/variables"
 )
 
@@ -19,6 +20,19 @@ type HashOpt struct {
 
 // HashTarget produces a hash from an Earthly target.
 func HashTarget(ctx context.Context, opt HashOpt) ([]byte, Stats, error) {
+
+	// Bypass further analysis for remote targets as there's nothing to do
+	// beyond hashing the full target name.
+	if t := opt.Target; t.IsRemote() {
+		if supportedRemoteTarget(t) {
+			h := hasher.New()
+			h.HashString(t.StringCanonical())
+			return h.GetHash(), Stats{}, nil
+		}
+		return nil, Stats{}, errInvalidRemoteTarget
+	}
+
+	// Continue processing local targets (which may include remote transitive targets).
 	l := newLoader(ctx, opt)
 
 	b, err := l.load(ctx)

--- a/inputgraph/loader.go
+++ b/inputgraph/loader.go
@@ -18,7 +18,6 @@ import (
 	"github.com/earthly/earthly/buildcontext"
 	"github.com/earthly/earthly/conslogging"
 	"github.com/earthly/earthly/domain"
-	"github.com/earthly/earthly/earthfile2llb"
 	"github.com/earthly/earthly/features"
 	"github.com/earthly/earthly/util/buildkitskipper/hasher"
 	"github.com/earthly/earthly/util/flagutil"
@@ -55,7 +54,6 @@ type loader struct {
 	ci               bool
 	builtinArgs      variables.DefaultArgs
 	overridingVars   *variables.Scope
-	earthlyCIRunner  bool
 	globalImports    map[string]domain.ImportTrackerVal
 }
 
@@ -64,19 +62,18 @@ func newLoader(ctx context.Context, opt HashOpt) *loader {
 	h.HashJSONMarshalled(opt.BuiltinArgs)
 	// Other important values are set by load().
 	return &loader{
-		conslog:         opt.Console,
-		target:          opt.Target,
-		visited:         map[string]struct{}{},
-		hasher:          h,
-		isBaseTarget:    opt.Target.Target == "base",
-		ci:              opt.CI,
-		builtinArgs:     opt.BuiltinArgs,
-		overridingVars:  opt.OverridingVars,
-		earthlyCIRunner: opt.EarthlyCIRunner,
-		globalImports:   map[string]domain.ImportTrackerVal{},
-		hashCache:       map[string][]byte{},
-		stats:           &Stats{StartTime: time.Now()},
-		primaryTarget:   true,
+		conslog:        opt.Console,
+		target:         opt.Target,
+		visited:        map[string]struct{}{},
+		hasher:         h,
+		isBaseTarget:   opt.Target.Target == "base",
+		ci:             opt.CI,
+		builtinArgs:    opt.BuiltinArgs,
+		overridingVars: opt.OverridingVars,
+		globalImports:  map[string]domain.ImportTrackerVal{},
+		hashCache:      map[string][]byte{},
+		stats:          &Stats{StartTime: time.Now()},
+		primaryTarget:  true,
 	}
 }
 
@@ -486,7 +483,7 @@ func (l *loader) handleWithDocker(ctx context.Context, cmd spec.Command) error {
 	}
 
 	for _, load := range opts.Loads {
-		_, target, extraArgs, err := earthfile2llb.ParseLoad(load)
+		_, target, extraArgs, err := flagutil.ParseLoad(load)
 		if err != nil {
 			return wrapError(err, cmd.SourceLocation, "failed to parse --load value")
 		}
@@ -819,18 +816,17 @@ func (l *loader) forTarget(ctx context.Context, target domain.Target, args []str
 	}
 
 	ret := &loader{
-		conslog:         l.conslog,
-		target:          target,
-		visited:         visited,
-		hasher:          hasher.New(),
-		isBaseTarget:    target.Target == "base",
-		ci:              l.ci,
-		builtinArgs:     l.builtinArgs,
-		overridingVars:  overriding,
-		earthlyCIRunner: l.earthlyCIRunner,
-		hashCache:       l.hashCache,
-		stats:           l.stats,
-		primaryTarget:   false,
+		conslog:        l.conslog,
+		target:         target,
+		visited:        visited,
+		hasher:         hasher.New(),
+		isBaseTarget:   target.Target == "base",
+		ci:             l.ci,
+		builtinArgs:    l.builtinArgs,
+		overridingVars: overriding,
+		hashCache:      l.hashCache,
+		stats:          l.stats,
+		primaryTarget:  false,
 	}
 
 	if target.IsLocalInternal() {
@@ -937,15 +933,14 @@ func (l *loader) load(ctx context.Context) ([]byte, error) {
 	l.features = buildCtx.Features
 
 	collOpt := variables.NewCollectionOpt{
-		Console:         l.conslog,
-		Target:          l.target,
-		CI:              l.ci,
-		BuiltinArgs:     l.builtinArgs,
-		OverridingVars:  l.overridingVars,
-		EarthlyCIRunner: l.earthlyCIRunner,
-		GitMeta:         buildCtx.GitMetadata,
-		Features:        l.features,
-		GlobalImports:   l.globalImports,
+		Console:        l.conslog,
+		Target:         l.target,
+		CI:             l.ci,
+		BuiltinArgs:    l.builtinArgs,
+		OverridingVars: l.overridingVars,
+		GitMeta:        buildCtx.GitMetadata,
+		Features:       l.features,
+		GlobalImports:  l.globalImports,
 	}
 	l.varCollection = variables.NewCollection(collOpt)
 

--- a/inputgraph/loader.go
+++ b/inputgraph/loader.go
@@ -27,6 +27,7 @@ import (
 
 var (
 	errCannotLoadRemoteTarget = errors.New("cannot load remote target")
+	errInvalidRemoteTarget    = errors.New("only remote targets referenced by a complete Git SHA or an explicit tag referenced as 'tags/...' are supported")
 	errComplexCondition       = errors.New("condition cannot be evaluated")
 )
 
@@ -865,8 +866,7 @@ func (l *loader) loadTargetFromString(ctx context.Context, targetName string, ar
 			l.hasher.HashString(target.StringCanonical())
 			return nil
 		}
-		msg := "only remote targets referenced by a complete Git SHA or an explicit tag referenced as 'tags/...' are supported"
-		return newError(srcLoc, msg)
+		return addErrorSrc(errInvalidRemoteTarget, srcLoc)
 	}
 
 	fullTargetName := target.String()

--- a/tests/autoskip/Earthfile
+++ b/tests/autoskip/Earthfile
@@ -31,6 +31,8 @@ test-all:
     BUILD +test-import
     BUILD +test-copy-target-args-quoted
     BUILD +test-build-flag
+    BUILD +test-flag-conflict
+    BUILD +test-init-failure
 
 test-files:
     RUN echo hello > my-file
@@ -247,29 +249,33 @@ test-import:
     DO --pass-args +RUN_EARTHLY_ARGS --earthfile=import.earth --target=+global --output_contains="Target .* has already been run. Skipping."
 
 test-build-flag:
-    DO --pass-args +RUN_EARTHLY_ARGS_NO_FLAG --earthfile=build-flag.earth --target=+basic
+    DO --pass-args tests+RUN_EARTHLY --extra_args="--auto-skip-db-path=test.db" --earthfile=build-flag.earth --target=+basic
     RUN cat earthly.output | acbgrep 'hello from a'
     RUN cat earthly.output | acbgrep 'hello from b'
 
-    DO --pass-args +RUN_EARTHLY_ARGS_NO_FLAG --earthfile=build-flag.earth --target=+basic
+    DO --pass-args tests+RUN_EARTHLY --extra_args="--auto-skip-db-path=test.db" --earthfile=build-flag.earth --target=+basic
     RUN cat earthly.output | acbgrep 'hello from a'
     RUN cat earthly.output | acbgrep -v 'hello from b'
     RUN cat earthly.output | acbgrep 'Target +b .* has already been run'
 
-    DO --pass-args +RUN_EARTHLY_ARGS_NO_FLAG --earthfile=build-flag.earth --target=+remote
+    DO --pass-args tests+RUN_EARTHLY --extra_args="--auto-skip-db-path=test.db" --earthfile=build-flag.earth --target=+remote
     RUN cat earthly.output | acbgrep 'Hello World'
     RUN cat earthly.output | acbgrep 'hello from b'
 
-    DO --pass-args +RUN_EARTHLY_ARGS_NO_FLAG --earthfile=build-flag.earth --target=+remote
+    DO --pass-args tests+RUN_EARTHLY --extra_args="--auto-skip-db-path=test.db" --earthfile=build-flag.earth --target=+remote
     RUN cat earthly.output | acbgrep -v 'Hello World'
     RUN cat earthly.output | acbgrep 'Target github.com/earthly/test-remote:6accddaba346aeda062ab47bae62e65dcdcc513f+basic .* has already been run'
     RUN cat earthly.output | acbgrep 'hello from b'
 
-RUN_EARTHLY_ARGS_NO_FLAG:
-    FUNCTION
-    ARG extra_args
-    DO --pass-args tests+RUN_EARTHLY \
-        --extra_args="--auto-skip-db-path=test.db $extra_args"
+test-flag-conflict:
+    DO --pass-args tests+RUN_EARTHLY --extra_args="--auto-skip-db-path=test.db --auto-skip --no-auto-skip" \
+                                     --earthfile=build-flag.earth --target=+basic --should_fail=true \
+                                     --output_contains="\-\-no-auto-skip cannot be used with \-\-auto-skip"
+
+test-init-failure:
+    DO --pass-args tests+RUN_EARTHLY --extra_args="--auto-skip-db-path=/tmp --auto-skip" \
+                                     --earthfile=build-flag.earth --target=+basic \
+                                     --output_contains="Failed to initialize auto-skip database"
 
 RUN_EARTHLY_ARGS:
     FUNCTION

--- a/tests/autoskip/Earthfile
+++ b/tests/autoskip/Earthfile
@@ -30,6 +30,7 @@ test-all:
     BUILD +test-from-dockerfile
     BUILD +test-import
     BUILD +test-copy-target-args-quoted
+    BUILD +test-build-flag
 
 test-files:
     RUN echo hello > my-file
@@ -244,6 +245,31 @@ test-import:
 
     DO --pass-args +RUN_EARTHLY_ARGS --earthfile=import.earth --target=+global
     DO --pass-args +RUN_EARTHLY_ARGS --earthfile=import.earth --target=+global --output_contains="Target .* has already been run. Skipping."
+
+test-build-flag:
+    DO --pass-args +RUN_EARTHLY_ARGS_NO_FLAG --earthfile=build-flag.earth --target=+basic
+    RUN cat earthly.output | acbgrep 'hello from a'
+    RUN cat earthly.output | acbgrep 'hello from b'
+
+    DO --pass-args +RUN_EARTHLY_ARGS_NO_FLAG --earthfile=build-flag.earth --target=+basic
+    RUN cat earthly.output | acbgrep 'hello from a'
+    RUN cat earthly.output | acbgrep -v 'hello from b'
+    RUN cat earthly.output | acbgrep 'Target +b .* has already been run'
+
+    DO --pass-args +RUN_EARTHLY_ARGS_NO_FLAG --earthfile=build-flag.earth --target=+remote
+    RUN cat earthly.output | acbgrep 'Hello World'
+    RUN cat earthly.output | acbgrep 'hello from b'
+
+    DO --pass-args +RUN_EARTHLY_ARGS_NO_FLAG --earthfile=build-flag.earth --target=+remote
+    RUN cat earthly.output | acbgrep -v 'Hello World'
+    RUN cat earthly.output | acbgrep 'Target +basic .* has already been run'
+    RUN cat earthly.output | acbgrep 'hello from b'
+
+RUN_EARTHLY_ARGS_NO_FLAG:
+    FUNCTION
+    ARG extra_args
+    DO --pass-args tests+RUN_EARTHLY \
+        --extra_args="--auto-skip-db-path=test.db $extra_args"
 
 RUN_EARTHLY_ARGS:
     FUNCTION

--- a/tests/autoskip/Earthfile
+++ b/tests/autoskip/Earthfile
@@ -262,7 +262,7 @@ test-build-flag:
 
     DO --pass-args +RUN_EARTHLY_ARGS_NO_FLAG --earthfile=build-flag.earth --target=+remote
     RUN cat earthly.output | acbgrep -v 'Hello World'
-    RUN cat earthly.output | acbgrep 'Target +basic .* has already been run'
+    RUN cat earthly.output | acbgrep 'Target github.com/earthly/test-remote:6accddaba346aeda062ab47bae62e65dcdcc513f+basic .* has already been run'
     RUN cat earthly.output | acbgrep 'hello from b'
 
 RUN_EARTHLY_ARGS_NO_FLAG:

--- a/tests/autoskip/build-flag.earth
+++ b/tests/autoskip/build-flag.earth
@@ -1,4 +1,4 @@
-VERSION 0.8
+VERSION --build-auto-skip 0.8
 
 FROM alpine
 

--- a/tests/autoskip/build-flag.earth
+++ b/tests/autoskip/build-flag.earth
@@ -1,0 +1,17 @@
+VERSION 0.8
+
+FROM alpine
+
+a:
+    RUN echo "hello from a"
+
+b:
+    RUN echo "hello from b"
+
+basic:
+    BUILD +a
+    BUILD --auto-skip +b
+
+remote:
+    BUILD --auto-skip github.com/earthly/test-remote:6accddaba346aeda062ab47bae62e65dcdcc513f+basic
+    BUILD +b

--- a/util/buildkitskipper/cloud.go
+++ b/util/buildkitskipper/cloud.go
@@ -2,9 +2,8 @@ package buildkitskipper
 
 import (
 	"context"
+	"errors"
 	"strings"
-
-	"github.com/earthly/earthly/domain"
 )
 
 type ASKVClient interface {
@@ -12,27 +11,25 @@ type ASKVClient interface {
 	AutoSkipAdd(ctx context.Context, org, path, target string, hash []byte) error
 }
 
-func NewCloud(org string, target domain.Target, client ASKVClient) (*CloudClient, error) {
-	parts := strings.Split(target.StringCanonical(), "+")
+func NewCloud(client ASKVClient) (*CloudClient, error) {
 	return &CloudClient{
-		org:    org,
-		path:   parts[0],
-		target: parts[1],
 		client: client,
 	}, nil
 }
 
 type CloudClient struct {
 	org    string
-	target string
-	path   string
 	client ASKVClient
 }
 
-func (c *CloudClient) Add(ctx context.Context, data []byte) error {
-	return c.client.AutoSkipAdd(ctx, c.org, c.path, c.target, data)
+func (c *CloudClient) Add(ctx context.Context, org, target string, data []byte) error {
+	parts := strings.Split(target, "+")
+	if len(parts) < 2 {
+		return errors.New("invalid target format")
+	}
+	return c.client.AutoSkipAdd(ctx, org, parts[0], parts[1], data)
 }
 
-func (c *CloudClient) Exists(ctx context.Context, data []byte) (bool, error) {
-	return c.client.AutoSkipExists(ctx, c.org, data)
+func (c *CloudClient) Exists(ctx context.Context, org string, data []byte) (bool, error) {
+	return c.client.AutoSkipExists(ctx, org, data)
 }

--- a/util/buildkitskipper/cloud.go
+++ b/util/buildkitskipper/cloud.go
@@ -6,22 +6,27 @@ import (
 	"strings"
 )
 
+// ASKVClient provides methods which allow for adding & checking the existence
+// of an auto-skip hash. The current implementations are a local BoltDB & a
+// remote gRPC service.
 type ASKVClient interface {
 	AutoSkipExists(ctx context.Context, org string, hash []byte) (bool, error)
 	AutoSkipAdd(ctx context.Context, org, path, target string, hash []byte) error
 }
 
+// NewCloud creates and returns a new Cloud API implementation.
 func NewCloud(client ASKVClient) (*CloudClient, error) {
 	return &CloudClient{
 		client: client,
 	}, nil
 }
 
+// CloudClient implements the Cloud API version of the ASKVClient.
 type CloudClient struct {
-	org    string
 	client ASKVClient
 }
 
+// Add a new hash to the Cloud DB.
 func (c *CloudClient) Add(ctx context.Context, org, target string, data []byte) error {
 	parts := strings.Split(target, "+")
 	if len(parts) < 2 {
@@ -30,6 +35,7 @@ func (c *CloudClient) Add(ctx context.Context, org, target string, data []byte) 
 	return c.client.AutoSkipAdd(ctx, org, parts[0], parts[1], data)
 }
 
+// Exists checks if an auto-skip hash exists.
 func (c *CloudClient) Exists(ctx context.Context, org string, data []byte) (bool, error) {
 	return c.client.AutoSkipExists(ctx, org, data)
 }

--- a/util/buildkitskipper/local.go
+++ b/util/buildkitskipper/local.go
@@ -35,7 +35,7 @@ type LocalBuildkitSkipper struct {
 	db *bolt.DB
 }
 
-func (lbks *LocalBuildkitSkipper) Add(ctx context.Context, data []byte) error {
+func (lbks *LocalBuildkitSkipper) Add(ctx context.Context, org, target string, data []byte) error {
 	if len(data) != sha1.Size {
 		return errInvalidHash
 	}
@@ -49,7 +49,7 @@ func (lbks *LocalBuildkitSkipper) Add(ctx context.Context, data []byte) error {
 	})
 }
 
-func (lbks *LocalBuildkitSkipper) Exists(ctx context.Context, data []byte) (bool, error) {
+func (lbks *LocalBuildkitSkipper) Exists(ctx context.Context, org string, data []byte) (bool, error) {
 	if len(data) != sha1.Size {
 		return false, errInvalidHash
 	}

--- a/util/buildkitskipper/local.go
+++ b/util/buildkitskipper/local.go
@@ -11,6 +11,7 @@ import (
 
 var errInvalidHash = fmt.Errorf("invalid sha1 hash")
 
+// NewLocal creates and returns a BoltDB implementation of the auto-skip client.
 func NewLocal(path string) (*LocalBuildkitSkipper, error) {
 	db, err := bolt.Open(path, 0600, nil)
 	if err != nil {
@@ -31,15 +32,17 @@ func NewLocal(path string) (*LocalBuildkitSkipper, error) {
 	}, nil
 }
 
+// LocalBuildkitSkipper uses BoltDB to store & retrieve auto-skip hashes.
 type LocalBuildkitSkipper struct {
 	db *bolt.DB
 }
 
-func (lbks *LocalBuildkitSkipper) Add(ctx context.Context, org, target string, data []byte) error {
+// Add a new hash value (org & target are ignored in this implementation).
+func (l *LocalBuildkitSkipper) Add(ctx context.Context, org, target string, data []byte) error {
 	if len(data) != sha1.Size {
 		return errInvalidHash
 	}
-	return lbks.db.Update(func(tx *bolt.Tx) error {
+	return l.db.Update(func(tx *bolt.Tx) error {
 		payload := []byte(time.Now().String()) // could be serialized into a structure; however LocalBuildkitSkipper is only meant for dev/testing
 		err := tx.Bucket([]byte("builds")).Put(data, payload)
 		if err != nil {
@@ -49,12 +52,13 @@ func (lbks *LocalBuildkitSkipper) Add(ctx context.Context, org, target string, d
 	})
 }
 
-func (lbks *LocalBuildkitSkipper) Exists(ctx context.Context, org string, data []byte) (bool, error) {
+// Exists checks if the hash exists.
+func (l *LocalBuildkitSkipper) Exists(ctx context.Context, org string, data []byte) (bool, error) {
 	if len(data) != sha1.Size {
 		return false, errInvalidHash
 	}
 	var found bool
-	err := lbks.db.View(func(tx *bolt.Tx) error {
+	err := l.db.View(func(tx *bolt.Tx) error {
 		payload := tx.Bucket([]byte("builds")).Get(data)
 		if payload != nil {
 			found = true


### PR DESCRIPTION
Implements: https://github.com/earthly/earthly/issues/3581

Adds support for `BUILD --auto-skip <target-name>` where individual targets may be auto-skipped. 

Example: 

```
VERSION 0.8

FROM alpine

PROJECT earthly-technologies/core

a:
    RUN echo "hello from a"

b:
    RUN echo "hello from b"

basic:
    BUILD --auto-skip +a --foo=1
    BUILD --auto-skip +b
```

Output for second run (after auto-skip results captured): 

```
 Init 🚀
————————————————————————————————————————————————————————————————————————————————

           buildkitd | Found buildkit daemon as docker container (earthly-dev-buildkitd)

Streaming logs to https://cloud.earthly.dev/builds/75a1763e-9995-4494-b115-ba6bbf361621

 Build 🔧
————————————————————————————————————————————————————————————————————————————————

              alpine | --> Load metadata alpine linux/amd64
           /tmp+base | DOCKERHUB_AUTH=true
           /tmp+base | --> FROM alpine
           /tmp+base | [----------] 100% FROM alpine
           auto-skip | Target /tmp+a (hash 0f81324c8af0001d1b53451da4fcb3a1eada3e00) has already been run. Skipping.
           auto-skip | Target /tmp+b (hash 2f3459fae0f3b5bb071e869fde11360f8856675b) has already been run. Skipping.
              output | --> exporting outputs

 Push Summary ⏫ (disabled)
————————————————————————————————————————————————————————————————————————————————

To enable pushing use earthly --push

 Local Output Summary 🎁
————————————————————————————————————————————————————————————————————————————————



========================== 🌍 Earthly Build  ✅ SUCCESS ==========================

View logs at https://cloud.earthly.dev/builds/75a1763e-9995-4494-b115-ba6bbf361621
```
