### PR TITLE
Satellite `rm` requires a `--force` if it's running

### DIFF
--- a/cloud/satellite.go
+++ b/cloud/satellite.go
@@ -145,7 +145,7 @@ func (c *Client) GetSatellite(ctx context.Context, name, orgName string) (*Satel
 	}, nil
 }
 
-func (c *Client) DeleteSatellite(ctx context.Context, name, orgName string) error {
+func (c *Client) DeleteSatellite(ctx context.Context, name, orgName string, force bool) error {
 	orgID, err := c.GetOrgID(ctx, orgName)
 	if err != nil {
 		return errors.Wrap(err, "failed deleting satellite")
@@ -153,6 +153,7 @@ func (c *Client) DeleteSatellite(ctx context.Context, name, orgName string) erro
 	_, err = c.compute.DeleteSatellite(c.withAuth(ctx), &pb.DeleteSatelliteRequest{
 		OrgId: orgID,
 		Name:  name,
+		Force: force,
 	})
 	if err != nil {
 		return errors.Wrap(err, "failed deleting satellite")

--- a/cmd/earthly/subcmd/satellite_cmds.go
+++ b/cmd/earthly/subcmd/satellite_cmds.go
@@ -33,7 +33,7 @@ type Satellite struct {
 	maintenanceWindow      string
 	maintenaceWeekendsOnly bool
 	version                string
-	forceUpdate            bool
+	force                  bool
 	printJSON              bool
 	listAll                bool
 	dropCache              bool
@@ -133,6 +133,15 @@ as well as run builds in native architectures independent of where the Earthly c
 					UsageText: "earthly satellite rm <satellite-name>\n" +
 						"	earthly satellite [--org <organization-name>] rm <satellite-name>",
 					Action: a.actionRemove,
+					Flags: []cli.Flag{
+						&cli.BoolFlag{
+							Name:        "force",
+							Aliases:     []string{"f"},
+							Usage:       "Forces the removal of the satellite, even if it's running",
+							Required:    false,
+							Destination: &a.force,
+						},
+					},
 				},
 				{
 					Name:        "ls",
@@ -261,7 +270,7 @@ as well as run builds in native architectures independent of where the Earthly c
 							Aliases:     []string{"f"},
 							Usage:       "Forces the satellite to sleep (if necessary) before starting the updating",
 							Required:    false,
-							Destination: &a.forceUpdate,
+							Destination: &a.force,
 						},
 					},
 				},
@@ -612,21 +621,31 @@ func (a *Satellite) actionRemove(cliCtx *cli.Context) error {
 		return err
 	}
 
-	found := false
+	var sat *cloud.SatelliteInstance
 	for _, s := range satellites {
 		if a.cli.Flags().SatelliteName == s.Name {
-			found = true
+			sat = &s
 			if s.Hidden {
 				return errors.New("cannot delete hidden satellites")
 			}
 		}
 	}
-	if !found {
+	if sat == nil {
 		return fmt.Errorf("could not find %q for deletion", a.cli.Flags().SatelliteName)
 	}
 
+	isOffline := sat.State == cloud.SatelliteStatusOperational || sat.State == cloud.SatelliteStatusOffline
+	if !a.force && !isOffline {
+		a.cli.Console().Printf("")
+		a.cli.Console().Printf("Cannot destroy a running satellite.")
+		a.cli.Console().Printf("Please sleep the satellite first, or use the --force flag.")
+		a.cli.Console().Printf("Note that force removing a satellite may interrupt ongoing builds.")
+		a.cli.Console().Printf("")
+		return errors.New("satellite is running")
+	}
+
 	a.cli.Console().Printf("Destroying Satellite %q. This may take a few minutes...\n", a.cli.Flags().SatelliteName)
-	err = cloudClient.DeleteSatellite(cliCtx.Context, a.cli.Flags().SatelliteName, orgName)
+	err = cloudClient.DeleteSatellite(cliCtx.Context, a.cli.Flags().SatelliteName, orgName, a.force)
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
 			a.cli.Console().Printf("Operation interrupted. Satellite should finish destroying in background (if server received request).\n")
@@ -996,7 +1015,7 @@ func (a *Satellite) actionUpdate(cliCtx *cli.Context) error {
 	}
 
 	if sat.State != cloud.SatelliteStatusSleep {
-		if !a.forceUpdate {
+		if !a.force {
 			a.cli.Console().Printf("")
 			a.cli.Console().Printf("The satellite must be asleep to start the update.")
 			a.cli.Console().Printf("You can re-run this command with the `--force` flag to force the satellite asleep and start the update now.")

--- a/cmd/earthly/subcmd/satellite_cmds.go
+++ b/cmd/earthly/subcmd/satellite_cmds.go
@@ -635,8 +635,8 @@ func (a *Satellite) actionRemove(cliCtx *cli.Context) error {
 		return fmt.Errorf("could not find %q for deletion", a.cli.Flags().SatelliteName)
 	}
 
-	isOffline := sat.State == cloud.SatelliteStatusOperational || sat.State == cloud.SatelliteStatusOffline
-	if !a.force && !isOffline {
+	isOffline := sat.State == cloud.SatelliteStatusSleep || sat.State == cloud.SatelliteStatusOffline
+	if !a.force && isOffline {
 		a.cli.Console().Printf("")
 		a.cli.Console().Printf("Cannot destroy a running satellite.")
 		a.cli.Console().Printf("Please sleep the satellite first, or use the --force flag.")

--- a/cmd/earthly/subcmd/satellite_cmds.go
+++ b/cmd/earthly/subcmd/satellite_cmds.go
@@ -200,9 +200,10 @@ as well as run builds in native architectures independent of where the Earthly c
 					Action: a.actionWake,
 				},
 				{
-					Name:        "sleep",
-					Usage:       "Manually force an Earthly Satellite to sleep from an operational state",
-					Description: "Manually force an Earthly Satellite to sleep from an operational state.",
+					Name:  "sleep",
+					Usage: "Manually force an Earthly Satellite to sleep from an operational state",
+					Description: "Manually force an Earthly Satellite to sleep from an operational state.\n" +
+						"Note that this may interrupt ongoing builds.",
 					UsageText: "earthly satellite sleep <satellite-name>\n" +
 						"	earthly satellite [--org <organization-name>] sleep <satellite-name>",
 					Action: a.actionSleep,

--- a/cmd/earthly/subcmd/satellite_cmds.go
+++ b/cmd/earthly/subcmd/satellite_cmds.go
@@ -636,7 +636,7 @@ func (a *Satellite) actionRemove(cliCtx *cli.Context) error {
 	}
 
 	isOffline := sat.State == cloud.SatelliteStatusSleep || sat.State == cloud.SatelliteStatusOffline
-	if !a.force && isOffline {
+	if !a.force && !isOffline {
 		a.cli.Console().Printf("")
 		a.cli.Console().Printf("Cannot destroy a running satellite.")
 		a.cli.Console().Printf("Please sleep the satellite first, or use the --force flag.")

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-units v0.5.0
 	github.com/dustin/go-humanize v1.0.1
-	github.com/earthly/cloud-api v1.0.1-0.20240109224637-d374ffd93463
+	github.com/earthly/cloud-api v1.0.1-0.20240131185619-ae21c52da478
 	github.com/earthly/earthly/ast v0.0.0-00010101000000-000000000000
 	github.com/earthly/earthly/util/deltautil v0.0.0-20231221211955-0fd4ae2cc257
 	github.com/elastic/go-sysinfo v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -193,8 +193,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/earthly/buildkit v0.0.0-20240126211752-a5526551beaa h1:I8J24eKyImBztgsy/A7FOgmAPv1OskWxoCeOT04+iWw=
 github.com/earthly/buildkit v0.0.0-20240126211752-a5526551beaa/go.mod h1:1/yAC8A0Tu94Bdmv07gaG1pFBp+CetVwO7oB3qvZXUc=
-github.com/earthly/cloud-api v1.0.1-0.20240109224637-d374ffd93463 h1:avPg8xiv9HSeQ0mBWX6AoUOf2CZRuXYscB/AUqQRmfc=
-github.com/earthly/cloud-api v1.0.1-0.20240109224637-d374ffd93463/go.mod h1:rU/tYJ7GFBjdKAITV2heDbez++glpGSbtJaZcp73rNI=
+github.com/earthly/cloud-api v1.0.1-0.20240131185619-ae21c52da478 h1:t2LPRps9MPCQ6tqujycP0Zh48Mun7WWIlm9jEEBIhdg=
+github.com/earthly/cloud-api v1.0.1-0.20240131185619-ae21c52da478/go.mod h1:rU/tYJ7GFBjdKAITV2heDbez++glpGSbtJaZcp73rNI=
 github.com/earthly/fsutil v0.0.0-20231030221755-644b08355b65 h1:6oyWHoxHXwcTt4EqmMw6361scIV87uEAB1N42+VpIwk=
 github.com/earthly/fsutil v0.0.0-20231030221755-644b08355b65/go.mod h1:9kMVqMyQ/Sx2df5LtnGG+nbrmiZzCS7V6gjW3oGHsvI=
 github.com/elastic/go-sysinfo v1.9.0 h1:usICqY/Nw4Mpn9f4LdtpFrKxXroJDe81GaxxUlCckIo=


### PR DESCRIPTION
If a satellite is not in a sleep or "offline" state, then the command will ask the user to re-run using a `--force` flag instead. This prevents a user from mistakenly killing builds that may be running.

![Screenshot 2024-01-31 151626](https://github.com/earthly/earthly/assets/3247216/81c192a9-9bf7-42f9-80e1-07d5a0da9197)
