### PR TITLE
dockerd-wrapper: execute pre-script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 
 ## Unreleased
 
+### Added
+
+- The internal `dockerd-wrapper.sh` script, which is used to implement `WITH DOCKER`, will execute `/usr/share/earthly/dockerd-wrapper-pre-script`, if present, prior to starting the
+  inner dockerd process. This can be used to configure options that depend on the host's kernel at run-time.
+
 ## v0.8.3 - 2024-01-31
 
 ### Fixed

--- a/ast/tests/with-docker.ast.json
+++ b/ast/tests/with-docker.ast.json
@@ -108,6 +108,14 @@
             ],
             "name": "BUILD"
           }
+        },
+        {
+          "command": {
+            "args": [
+              "+pre-script-test"
+            ],
+            "name": "BUILD"
+          }
         }
       ]
     },
@@ -987,6 +995,40 @@
                 "--pull",
                 "ubuntu:$ubuntu_img_tag"
               ],
+              "name": "DOCKER"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "pre-script-test",
+      "recipe": [
+        {
+          "command": {
+            "args": [
+              "pre-script.sh",
+              "/usr/share/earthly/dockerd-wrapper-pre-script"
+            ],
+            "name": "COPY"
+          }
+        },
+        {
+          "with": {
+            "body": [
+              {
+                "command": {
+                  "args": [
+                    "test",
+                    "-f",
+                    "/the-prescript-was-run"
+                  ],
+                  "name": "RUN"
+                }
+              }
+            ],
+            "command": {
+              "args": [],
               "name": "DOCKER"
             }
           }

--- a/buildkitd/dockerd-wrapper.sh
+++ b/buildkitd/dockerd-wrapper.sh
@@ -314,6 +314,11 @@ if [ -n "$EARTHLY_DOCKER_WRAPPER_DEBUG_CMD" ]; then
     exit 1
 fi
 
+EARTHLY_DOCKER_WRAPPER_PRE_SCRIPT=${EARTHLY_DOCKER_WRAPPER_PRE_SCRIPT:-"/usr/share/earthly/dockerd-wrapper-pre-script"}
+if [ -f "$EARTHLY_DOCKER_WRAPPER_PRE_SCRIPT" ]; then
+    "$EARTHLY_DOCKER_WRAPPER_PRE_SCRIPT"
+fi
+
 case "$1" in
     get-compose-config)
         write_compose_config

--- a/tests/with-docker/Earthfile
+++ b/tests/with-docker/Earthfile
@@ -14,6 +14,7 @@ all:
     BUILD +one-target-many-names
     BUILD +if-after
     BUILD +cgroup-v2-test-all
+    BUILD +pre-script-test
 
 empty-test:
     WITH DOCKER
@@ -171,4 +172,10 @@ cgroup-v2-test:
     ARG ubuntu_img_tag=23.04
     WITH DOCKER --pull ubuntu:$ubuntu_img_tag
         RUN ./test-cgroup-v2.sh
+    END
+
+pre-script-test:
+    COPY pre-script.sh /usr/share/earthly/dockerd-wrapper-pre-script
+    WITH DOCKER
+        RUN test -f /the-prescript-was-run
     END

--- a/tests/with-docker/pre-script.sh
+++ b/tests/with-docker/pre-script.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -e
+touch /the-prescript-was-run


### PR DESCRIPTION
This is to allow for runtime configuration before executing a `WITH DOCKER` statement, such as selecting which version of iptables to use.