### PR TITLE
Update BK to fbd249f8

### DIFF
--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -12,7 +12,7 @@ buildkitd:
             ARG BUILDKIT_BASE_IMAGE=$BUILDKIT_PROJECT+build
         END
     ELSE
-        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:de543202414b18a01026ad42966472742f60cb01+build
+        ARG BUILDKIT_BASE_IMAGE=github.com/earthly/buildkit:fbd249f838cc215eef3f5c900884ae0779ff4e50+build
     END
     ARG EARTHLY_TARGET_TAG_DOCKER
     ARG TAG="dev-$EARTHLY_TARGET_TAG_DOCKER"

--- a/go.mod
+++ b/go.mod
@@ -151,6 +151,6 @@ replace (
 	github.com/jdxcode/netrc => github.com/mikejholly/netrc v0.0.0-20221121193719-a154cb29ec2a
 	github.com/jessevdk/go-flags => github.com/alexcb/go-flags v0.0.0-20210722203016-f11d7ecb5ee5
 
-	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.0-20240208170734-de543202414b
+	github.com/moby/buildkit => github.com/earthly/buildkit v0.0.0-20240208233503-fbd249f838cc
 	github.com/tonistiigi/fsutil => github.com/earthly/fsutil v0.0.0-20231030221755-644b08355b65
 )

--- a/go.sum
+++ b/go.sum
@@ -191,8 +191,8 @@ github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
-github.com/earthly/buildkit v0.0.0-20240208170734-de543202414b h1:0axtalGApkgAYZ5ObGoowUW20WsuKuMOWHIwI4VvmmI=
-github.com/earthly/buildkit v0.0.0-20240208170734-de543202414b/go.mod h1:1/yAC8A0Tu94Bdmv07gaG1pFBp+CetVwO7oB3qvZXUc=
+github.com/earthly/buildkit v0.0.0-20240208233503-fbd249f838cc h1:+m89xt7JlBQvwbvUn/0/idck2Ry3DI0aOHeOhETlDn0=
+github.com/earthly/buildkit v0.0.0-20240208233503-fbd249f838cc/go.mod h1:1/yAC8A0Tu94Bdmv07gaG1pFBp+CetVwO7oB3qvZXUc=
 github.com/earthly/cloud-api v1.0.1-0.20240202022707-2e046f82d1df h1:b7iT0tlIjgnvUY8FmFCX0kCy/IFgRHp4mqKTF2WJikw=
 github.com/earthly/cloud-api v1.0.1-0.20240202022707-2e046f82d1df/go.mod h1:rU/tYJ7GFBjdKAITV2heDbez++glpGSbtJaZcp73rNI=
 github.com/earthly/fsutil v0.0.0-20231030221755-644b08355b65 h1:6oyWHoxHXwcTt4EqmMw6361scIV87uEAB1N42+VpIwk=


### PR DESCRIPTION
I accidentally merged this [Core PR](https://github.com/earthly/earthly/pull/3794) before the [BK one](https://github.com/earthly/buildkit/pull/42). This PR updates the correct `earthly-main` commit SHA. 