### PR TITLE
Append platform to git project errors

### DIFF
--- a/buildcontext/git.go
+++ b/buildcontext/git.go
@@ -74,7 +74,7 @@ func (gr *gitResolver) expandWildcard(ctx context.Context, gwClient gwclient.Cli
 
 	rgp, _, subDir, err := gr.resolveGitProject(ctx, gwClient, platr, target)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "failed resolving git project [platform: %s]", platr.LLBNative())
 	}
 
 	fullPattern := filepath.Join(subDir, pattern)
@@ -106,7 +106,7 @@ func (gr *gitResolver) resolveEarthProject(ctx context.Context, gwClient gwclien
 	}
 	rgp, gitURL, subDir, err := gr.resolveGitProject(ctx, gwClient, platr, ref)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "failed resolving git project [platform: %s]", platr.LLBNative())
 	}
 
 	var buildContextFactory llbfactory.Factory

--- a/buildcontext/git.go
+++ b/buildcontext/git.go
@@ -74,7 +74,8 @@ func (gr *gitResolver) expandWildcard(ctx context.Context, gwClient gwclient.Cli
 
 	rgp, _, subDir, err := gr.resolveGitProject(ctx, gwClient, platr, target)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed resolving git project [platform: %s]", platr.LLBNative())
+		return nil, errors.Wrapf(err, "failed resolving git project [platform: %s/%s]",
+			platr.LLBNative().OS, platr.LLBNative().Architecture)
 	}
 
 	fullPattern := filepath.Join(subDir, pattern)
@@ -106,7 +107,8 @@ func (gr *gitResolver) resolveEarthProject(ctx context.Context, gwClient gwclien
 	}
 	rgp, gitURL, subDir, err := gr.resolveGitProject(ctx, gwClient, platr, ref)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed resolving git project [platform: %s]", platr.LLBNative())
+		return nil, errors.Wrapf(err, "failed resolving git project [platform: %s/%s]",
+			platr.LLBNative().OS, platr.LLBNative().Architecture)
 	}
 
 	var buildContextFactory llbfactory.Factory


### PR DESCRIPTION
We've had reports of internal errors resolving git projects, which could be related to using an image for the wrong architecture.  Appending the intended platform to the error could shed some light on the issue.

Example error: 

```
 exec /bin/sh: exec format error
 ERROR
       The internal command
           GET GIT META github.com/org/repo:refs/main
    did not complete successfully. Exit code 1 
```