### PR TITLE
Expand args in CACHE --id

### DIFF
--- a/earthfile2llb/interpreter.go
+++ b/earthfile2llb/interpreter.go
@@ -1987,6 +1987,12 @@ func (i *Interpreter) handleCache(ctx context.Context, cmd spec.Command) error {
 	if !path.IsAbs(dir) {
 		dir = path.Clean(path.Join("/", i.converter.mts.Final.MainImage.Config.WorkingDir, dir))
 	}
+	if opts.ID != "" {
+		opts.ID, err = i.expandArgs(ctx, opts.ID, false, false)
+		if err != nil {
+			return i.wrapError(err, cmd.SourceLocation, "failed to expand CACHE id %s", opts.ID)
+		}
+	}
 	if err := i.converter.Cache(ctx, dir, opts); err != nil {
 		return i.wrapError(err, cmd.SourceLocation, "apply CACHE")
 	}

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -1328,7 +1328,7 @@ cache-cmd:
     RUN test "$(cat ./artifacts2/2)" = "artifact 2"
     DO +RUN_EARTHLY --earthfile=cache-cmd.earth --target=+test-no-sharing
     DO +RUN_EARTHLY --earthfile=cache-cmd.earth --target=+test-arg
-    DO +RUN_EARTHLY --earthfile=cache-cmd.earthly --target=+test-id-expand-args
+    DO +RUN_EARTHLY --earthfile=cache-cmd.earth --target=+test-id-expand-args
 
 ls:
     COPY ls.earth Earthfile

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -1328,6 +1328,7 @@ cache-cmd:
     RUN test "$(cat ./artifacts2/2)" = "artifact 2"
     DO +RUN_EARTHLY --earthfile=cache-cmd.earth --target=+test-no-sharing
     DO +RUN_EARTHLY --earthfile=cache-cmd.earth --target=+test-arg
+    DO +RUN_EARTHLY --earthfile=cache-cmd.earthly --target=+test-id-expand-args
 
 ls:
     COPY ls.earth Earthfile

--- a/tests/cache-cmd.earth
+++ b/tests/cache-cmd.earth
@@ -67,4 +67,4 @@ test-id-expand-args:
     END
     ARG ID_2=test
     CACHE --id $ID_2 /id-test
-    RUN test "$(cat /id-test/hello)" = "hello"
+    RUN test "$(cat /id-test/hello)" = "hi"

--- a/tests/cache-cmd.earth
+++ b/tests/cache-cmd.earth
@@ -63,8 +63,8 @@ id-expand-args:
 
 test-id-expand-args:
     WAIT
-        BUILD +id-expand-args
+        BUILD +id-expand-args --ID_1=test
     END
-    ARG --required ID_2
+    ARG ID_2=test
     CACHE --id $ID_2 /id-test
     RUN test "$(cat /id-test/hello)" = "hello"

--- a/tests/cache-cmd.earth
+++ b/tests/cache-cmd.earth
@@ -55,3 +55,16 @@ test-no-sharing:
     COPY +test-no-sharing-prev/nothing . # Only to make sure +test-no-sharing-prev runs first
     CACHE --persist /no-sharing
     RUN ! test -f /no-sharing/should-not-see-me
+
+id-expand-args:
+    ARG --required ID_1
+    CACHE --id $ID_1 /id-test
+    RUN echo "hi" > /id-test/hello
+
+test-id-expand-args:
+    WAIT
+        BUILD +id-expand-args
+    END
+    ARG --required ID_2
+    CACHE --id $ID_2 /id-test
+    RUN test "$(cat /id-test/hello)" = "hello"


### PR DESCRIPTION
Users reported that that ARGs were not expanded in the `--id` of `CACHE` commands. For example, the following would not expand the arg, and result in a cache id of the literal string `$something`:
```
ARG something
CACHE --id $something
```