### PR TITLE
Mark AWS ECR explicit registry caching as supported

### DIFF
--- a/docs/caching/caching-via-registry.md
+++ b/docs/caching/caching-via-registry.md
@@ -49,8 +49,8 @@ Not all registries support the needed manifest formats to allow the usage of eac
 
 | Registry                  | Supports Inline Cache | Supports Explicit Cache | Notes                                                                               |
 |---------------------------|:---------------------:|:-----------------------:|-------------------------------------------------------------------------------------|
-| AWS ECR                   |           ✅           |            ❌            | https://github.com/aws/containers-roadmap/issues/876                                |
 | Google GCR                |           ✅           |            ❌            |                                                                                     |
+| AWS ECR                   |           ✅           |            ✅            |                                                                                     |
 | Google Artifact Registry  |           ✅           |            ✅            |                                                                                     |
 | Azure ACR                 |           ✅           |            ✅            |                                                                                     |
 | Docker Hub                |           ✅           |            ✅            |                                                                                     |


### PR DESCRIPTION
https://aws.amazon.com/blogs/containers/announcing-remote-cache-support-in-amazon-ecr-for-buildkit-clients/