### PR TITLE
Logstream: link nested targets to parent commands & BUILD command

### DIFF
--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -2205,6 +2206,7 @@ func (c *Converter) internalRun(ctx context.Context, opts ConvertRunOpts) (pllb.
 		strIf(opts.Interactive, "--interactive "),
 		strIf(opts.InteractiveKeep, "--interactive-keep "),
 		strings.Join(opts.Args, " "))
+
 	prefix, _, err := c.newVertexMeta(ctx, opts.Locally, isInteractive, false, opts.Secrets)
 	if err != nil {
 		return pllb.State{}, err
@@ -2701,6 +2703,12 @@ func (c *Converter) newVertexMeta(ctx context.Context, local, interactive, inter
 	cmdID := c.newCmdID()
 	fullID := fmt.Sprintf("%s/%d", c.mts.Final.ID, cmdID)
 	srcLoc := SourceLocationFromContext(ctx)
+
+	pc, _, _, ok := runtime.Caller(1)
+	details := runtime.FuncForPC(pc)
+	if ok && details != nil {
+		fmt.Println("unknown created for", fullID, details.Name())
+	}
 
 	_, err := c.opt.Logbus.Run().NewCommand(
 		fullID,

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -1116,7 +1116,7 @@ func (c *Converter) PopWaitBlock(ctx context.Context) error {
 }
 
 // SaveImage applies the earthly SAVE IMAGE command.
-func (c *Converter) SaveImage(ctx context.Context, imageNames []string, hasPushFlag bool, insecurePush bool, cacheHint bool, cacheFrom []string, noManifestList bool) error {
+func (c *Converter) SaveImage(ctx context.Context, imageNames []string, hasPushFlag bool, insecurePush bool, cacheHint bool, cacheFrom []string, noManifestList bool) (retErr error) {
 	err := c.checkAllowed(saveImageCmd)
 	if err != nil {
 		return err
@@ -1124,6 +1124,13 @@ func (c *Converter) SaveImage(ctx context.Context, imageNames []string, hasPushF
 	if noManifestList && !c.ftrs.UseNoManifestList {
 		return fmt.Errorf("SAVE IMAGE --no-manifest-list is not supported in this version")
 	}
+	_, cmd, err := c.newLogbusCommand(ctx, fmt.Sprintf("SAVE IMAGE %s", strings.Join(imageNames, " ")))
+	if err != nil {
+		return errors.Wrap(err, "failed to create command")
+	}
+	defer func() {
+		cmd.SetEndError(retErr)
+	}()
 	for _, cf := range cacheFrom {
 		c.opt.CacheImports.Add(cf)
 	}

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -884,7 +884,7 @@ func (c *Converter) SaveArtifact(ctx context.Context, saveFrom, saveTo, saveAsLo
 		return errors.New("command not found")
 	}
 
-	cmd.SetName("SAVE ARTIFACT")
+	cmd.SetName(fmt.Sprintf("SAVE ARTIFACT %s %s", saveFrom, artifact))
 
 	defer func() {
 		cmd.SetEndError(retErr)
@@ -1222,7 +1222,7 @@ func (c *Converter) Build(ctx context.Context, fullTargetName string, platform p
 
 	cmd.SetEndError(err)
 
-	return nil
+	return err
 }
 
 type afterParallelFunc func(context.Context, *states.MultiTarget) error

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -2205,7 +2205,6 @@ func (c *Converter) internalRun(ctx context.Context, opts ConvertRunOpts) (pllb.
 		strIf(opts.InteractiveKeep, "--interactive-keep "),
 		strings.Join(opts.Args, " "))
 
-	ctx = context.WithValue(ctx, "internal", true)
 	prefix, _, err := c.newVertexMeta(ctx, opts.Locally, isInteractive, false, opts.Secrets, false)
 	if err != nil {
 		return pllb.State{}, err

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -222,7 +222,7 @@ func (c *Converter) fromClassical(ctx context.Context, imageName string, platfor
 	} else {
 		internal = false
 	}
-	prefix, _, err := c.newVertexMeta(ctx, local, false, internal, nil, true)
+	prefix, _, err := c.newVertexMeta(ctx, local, false, internal, nil)
 	if err != nil {
 		return err
 	}
@@ -345,7 +345,7 @@ func (c *Converter) FromDockerfile(ctx context.Context, contextPath string, dfPa
 	var BuildContextFactory llbfactory.Factory
 	contextArtifact, parseErr := domain.ParseArtifact(contextPath)
 	if parseErr == nil {
-		prefix, cmdID, err := c.newVertexMeta(ctx, false, false, true, nil, true)
+		prefix, cmdID, err := c.newVertexMeta(ctx, false, false, true, nil)
 		if err != nil {
 			return err
 		}
@@ -495,7 +495,7 @@ func (c *Converter) CopyArtifactLocal(ctx context.Context, artifactName string, 
 	if err != nil {
 		return errors.Wrapf(err, "parse artifact name %s", artifactName)
 	}
-	prefix, cmdID, err := c.newVertexMeta(ctx, false, false, false, nil, true)
+	prefix, cmdID, err := c.newVertexMeta(ctx, false, false, false, nil)
 	if err != nil {
 		return err
 	}
@@ -549,7 +549,7 @@ func (c *Converter) CopyArtifact(ctx context.Context, artifactName string, dest 
 	if err != nil {
 		return errors.Wrapf(err, "parse artifact name %s", artifactName)
 	}
-	prefix, cmdID, err := c.newVertexMeta(ctx, false, false, false, nil, true)
+	prefix, cmdID, err := c.newVertexMeta(ctx, false, false, false, nil)
 	if err != nil {
 		return err
 	}
@@ -603,7 +603,7 @@ func (c *Converter) CopyClassical(ctx context.Context, srcs []string, dest strin
 	}
 
 	c.nonSaveCommand()
-	prefix, _, err := c.newVertexMeta(ctx, false, false, false, nil, true)
+	prefix, _, err := c.newVertexMeta(ctx, false, false, false, nil)
 	if err != nil {
 		return err
 	}
@@ -688,7 +688,7 @@ func (c *Converter) RunExitCode(ctx context.Context, opts ConvertRunOpts) (int, 
 		})
 	} else {
 		exitCodeFile = "/tmp/earthly_if_statement_exit_code"
-		prefix, _, err := c.newVertexMeta(ctx, false, false, true, nil, true)
+		prefix, _, err := c.newVertexMeta(ctx, false, false, true, nil)
 		if err != nil {
 			return 0, err
 		}
@@ -784,7 +784,7 @@ func (c *Converter) runCommand(ctx context.Context, outputFileName string, isExp
 		})
 	} else {
 		srcBuildArgDir := "/run/buildargs"
-		prefix, _, err := c.newVertexMeta(ctx, false, false, true, nil, true)
+		prefix, _, err := c.newVertexMeta(ctx, false, false, true, nil)
 		if err != nil {
 			return "", err
 		}
@@ -874,7 +874,7 @@ func (c *Converter) SaveArtifact(ctx context.Context, saveFrom, saveTo, saveAsLo
 	// accessed within the CopyOps below.
 	pcState := c.persistCache(c.mts.Final.MainState)
 
-	prefix, cmdID, err := c.newVertexMeta(ctx, false, false, false, nil, true)
+	prefix, cmdID, err := c.newVertexMeta(ctx, false, false, false, nil)
 	if err != nil {
 		return err
 	}
@@ -884,7 +884,7 @@ func (c *Converter) SaveArtifact(ctx context.Context, saveFrom, saveTo, saveAsLo
 		return errors.New("command not found")
 	}
 
-	cmd.SetName(fmt.Sprintf("SAVE ARTIFACT %s %s", saveFrom, artifact))
+	cmd.SetName(fmt.Sprintf("SAVE ARTIFACT %s", saveFrom))
 
 	defer func() {
 		cmd.SetEndError(retErr)
@@ -908,7 +908,7 @@ func (c *Converter) SaveArtifact(ctx context.Context, saveFrom, saveTo, saveAsLo
 		separateArtifactsState := c.platr.Scratch()
 		if isPush {
 			pushState := c.persistCache(c.mts.Final.RunPush.State)
-			prefix, _, err := c.newVertexMeta(ctx, false, false, false, nil, false)
+			prefix, _, err := c.newVertexMeta(ctx, false, false, false, nil)
 			if err != nil {
 				return err
 			}
@@ -928,7 +928,7 @@ func (c *Converter) SaveArtifact(ctx context.Context, saveFrom, saveTo, saveAsLo
 				return errors.Wrapf(err, "copyOp save artifact as local")
 			}
 		} else {
-			prefix, _, err := c.newVertexMeta(ctx, false, false, false, nil, false)
+			prefix, _, err := c.newVertexMeta(ctx, false, false, false, nil)
 			if err != nil {
 				return err
 			}
@@ -1039,7 +1039,7 @@ func (c *Converter) SaveArtifactFromLocal(ctx context.Context, saveFrom, saveTo 
 	}
 
 	// first load the files into a snapshot
-	prefix, _, err := c.newVertexMeta(ctx, true, false, true, nil, true)
+	prefix, _, err := c.newVertexMeta(ctx, true, false, true, nil)
 	if err != nil {
 		return err
 	}
@@ -1294,7 +1294,7 @@ func (c *Converter) Workdir(ctx context.Context, workdirPath string) error {
 		if c.mts.Final.MainImage.Config.User != "" {
 			mkdirOpts = append(mkdirOpts, llb.WithUser(c.mts.Final.MainImage.Config.User))
 		}
-		prefix, _, err := c.newVertexMeta(ctx, false, false, false, nil, true)
+		prefix, _, err := c.newVertexMeta(ctx, false, false, false, nil)
 		if err != nil {
 			return err
 		}
@@ -1524,7 +1524,7 @@ func (c *Converter) GitClone(ctx context.Context, gitURL string, sshCommand stri
 		gitOpts = append(gitOpts, llb.SSHCommand(sshCommand))
 	}
 	gitState := pllb.Git(gitURL, branch, gitOpts...)
-	prefix, _, err := c.newVertexMeta(ctx, false, false, false, nil, true)
+	prefix, _, err := c.newVertexMeta(ctx, false, false, false, nil)
 	if err != nil {
 		return err
 	}
@@ -2212,7 +2212,7 @@ func (c *Converter) internalRun(ctx context.Context, opts ConvertRunOpts) (pllb.
 		strIf(opts.InteractiveKeep, "--interactive-keep "),
 		strings.Join(opts.Args, " "))
 
-	prefix, _, err := c.newVertexMeta(ctx, opts.Locally, isInteractive, false, opts.Secrets, false)
+	prefix, _, err := c.newVertexMeta(ctx, opts.Locally, isInteractive, false, opts.Secrets)
 	if err != nil {
 		return pllb.State{}, err
 	}
@@ -2685,7 +2685,7 @@ func (c *Converter) newLogbusCommand(ctx context.Context, name string) (string, 
 	return cmdID, cmd, nil
 }
 
-func (c *Converter) newVertexMeta(ctx context.Context, local, interactive, internal bool, secrets []string, createCmd bool) (string, string, error) {
+func (c *Converter) newVertexMeta(ctx context.Context, local, interactive, internal bool, secrets []string) (string, string, error) {
 	activeOverriding := make(map[string]string)
 	for _, arg := range c.varCollection.SortedOverridingVariables() {
 		v, ok := c.varCollection.Get(arg, variables.WithActive())
@@ -2705,34 +2705,28 @@ func (c *Converter) newVertexMeta(ctx context.Context, local, interactive, inter
 		fileRelToRepo = path.Join(c.gitMeta.RelDir, "Earthfile")
 	}
 
-	fullID := ""
-	srcLoc := SourceLocationFromContext(ctx)
+	var (
+		srcLoc = SourceLocationFromContext(ctx)
+		cmdID  = fmt.Sprintf("%s/%d", c.mts.Final.ID, c.newCmdID())
+		name   = "" // Name is initially empty. It will be set by SolverMonitor in most cases.
+	)
 
-	// Some commands (internal, etc.) should not have Logbus commands created
-	// ahead of time. These commands sometimes differ WRT the specified command
-	// versus the underlying command that BuildKit ultimately runs. An example
-	// is SAVE ARTIFACT.
-	if createCmd {
-		cmdID := c.newCmdID()
-		fullID = fmt.Sprintf("%s/%d", c.mts.Final.ID, cmdID)
-
-		_, err := c.opt.Logbus.Run().NewCommand(
-			fullID,
-			"unknown",
-			c.mts.Final.ID,
-			c.mts.Final.Target.String(),
-			platformStr,
-			false, // cached
-			local,
-			interactive,
-			srcLoc,
-			gitURL,
-			gitHash,
-			fileRelToRepo,
-		)
-		if err != nil {
-			return "", "", err
-		}
+	_, err := c.opt.Logbus.Run().NewCommand(
+		cmdID,
+		name,
+		c.mts.Final.ID,
+		c.mts.Final.Target.String(),
+		platformStr,
+		false, // cached
+		local,
+		interactive,
+		srcLoc,
+		gitURL,
+		gitHash,
+		fileRelToRepo,
+	)
+	if err != nil {
+		return "", "", err
 	}
 
 	vm := &vertexmeta.VertexMeta{
@@ -2740,7 +2734,7 @@ func (c *Converter) newVertexMeta(ctx context.Context, local, interactive, inter
 		RepoGitURL:          gitURL,
 		RepoGitHash:         gitHash,
 		RepoFileRelToRepo:   fileRelToRepo,
-		CommandID:           fullID,
+		CommandID:           cmdID,
 		TargetID:            c.mts.Final.ID,
 		TargetName:          c.mts.Final.Target.String(),
 		CanonicalTargetName: c.mts.Final.Target.StringCanonical(),
@@ -2754,7 +2748,7 @@ func (c *Converter) newVertexMeta(ctx context.Context, local, interactive, inter
 		Runner:              c.opt.Runner,
 	}
 
-	return vm.ToVertexPrefix(), fullID, nil
+	return vm.ToVertexPrefix(), cmdID, nil
 }
 
 func (c *Converter) imageVertexPrefix(id string, platform platutil.Platform) string {

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -2535,7 +2535,7 @@ func (c *Converter) processNonConstantBuildArgFunc(ctx context.Context) variable
 	}
 }
 
-func (c *Converter) vertexPrefix(ctx context.Context, cmdID int, local bool, interactive bool, internal bool, secrets []string) string {
+func (c *Converter) vertexPrefix(ctx context.Context, cmdID int, local, interactive, internal bool, secrets []string) string {
 	activeOverriding := make(map[string]string)
 	for _, arg := range c.varCollection.SortedOverridingVariables() {
 		v, ok := c.varCollection.Get(arg, variables.WithActive())

--- a/earthfile2llb/earthfile2llb.go
+++ b/earthfile2llb/earthfile2llb.go
@@ -2,6 +2,7 @@ package earthfile2llb
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/earthly/earthly/buildcontext"
 	"github.com/earthly/earthly/buildcontext/provider"
@@ -189,11 +190,18 @@ type ConvertOpt struct {
 	// is used to link together targets.
 	ParentTargetID string
 
+	// ParentCommandID is the Logbus command ID of whichever command initiated
+	// the convert operation. It's used to link commands to their referenced targets.
+	ParentCommandID string
+
 	// BuildkitSkipper allows for additions and existence checks for auto-skip hash values.
 	BuildkitSkipper bk.BuildkitSkipper
 
 	// NoAutoSkip disables auto-skip usages.
 	NoAutoSkip bool
+
+	// BuildCommand reflects whether the convert was initialized by a BUILD.
+	BuildCommand bool
 }
 
 // TargetDetails contains details about the target being built.
@@ -280,6 +288,14 @@ func Earthfile2LLB(ctx context.Context, target domain.Target, opt ConvertOpt, in
 	if opt.ParentTargetID != "" {
 		if parentTarget, ok := opt.Logbus.Run().Target(opt.ParentTargetID); ok {
 			parentTarget.AddDependsOn(sts.ID)
+		}
+	}
+
+	if opt.ParentCommandID != "" {
+		fmt.Println("Parent command ID", opt.ParentCommandID)
+		if _, ok := opt.Logbus.Run().Command(opt.ParentCommandID); ok {
+			fmt.Printf("Linking target to %q\n", opt.ParentCommandID)
+			//parentCmd.AddDependsOn(sts.ID)
 		}
 	}
 

--- a/earthfile2llb/earthfile2llb.go
+++ b/earthfile2llb/earthfile2llb.go
@@ -2,7 +2,6 @@ package earthfile2llb
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/earthly/earthly/buildcontext"
 	"github.com/earthly/earthly/buildcontext/provider"
@@ -186,22 +185,19 @@ type ConvertOpt struct {
 	// this can be removed in VERSION 0.8
 	FilesWithCommandRenameWarning map[string]bool
 
-	// ParentTargetID is the Logbus target ID of the parent target, if any. It
+	// parentTargetID is the Logbus target ID of the parent target, if any. It
 	// is used to link together targets.
-	ParentTargetID string
+	parentTargetID string
 
-	// ParentCommandID is the Logbus command ID of whichever command initiated
+	// parentCommandID is the Logbus command ID of whichever command initiated
 	// the convert operation. It's used to link commands to their referenced targets.
-	ParentCommandID string
+	parentCommandID string
 
 	// BuildkitSkipper allows for additions and existence checks for auto-skip hash values.
 	BuildkitSkipper bk.BuildkitSkipper
 
 	// NoAutoSkip disables auto-skip usages.
 	NoAutoSkip bool
-
-	// BuildCommand reflects whether the convert was initialized by a BUILD.
-	BuildCommand bool
 }
 
 // TargetDetails contains details about the target being built.
@@ -285,17 +281,15 @@ func Earthfile2LLB(ctx context.Context, target domain.Target, opt ConvertOpt, in
 		return nil, err
 	}
 
-	if opt.ParentTargetID != "" {
-		if parentTarget, ok := opt.Logbus.Run().Target(opt.ParentTargetID); ok {
+	if opt.parentTargetID != "" {
+		if parentTarget, ok := opt.Logbus.Run().Target(opt.parentTargetID); ok {
 			parentTarget.AddDependsOn(sts.ID)
 		}
 	}
 
-	if opt.ParentCommandID != "" {
-		fmt.Println("Parent command ID", opt.ParentCommandID)
-		if _, ok := opt.Logbus.Run().Command(opt.ParentCommandID); ok {
-			fmt.Printf("Linking target to %q\n", opt.ParentCommandID)
-			//parentCmd.AddDependsOn(sts.ID)
+	if opt.parentCommandID != "" {
+		if parentCmd, ok := opt.Logbus.Run().Command(opt.parentCommandID); ok {
+			parentCmd.AddDependsOn(sts.ID, target.GetName())
 		}
 	}
 

--- a/earthfile2llb/with_docker_run_base.go
+++ b/earthfile2llb/with_docker_run_base.go
@@ -70,7 +70,7 @@ func (w *withDockerRunBase) installDeps(ctx context.Context, opt WithDockerOpt) 
 			strings.Join(params, " "),
 			dockerAutoInstallScriptPath),
 	}
-	prefix, _, err := w.c.newVertexMeta(ctx, false, false, false, opt.Secrets, true)
+	prefix, _, err := w.c.newVertexMeta(ctx, false, false, false, opt.Secrets)
 	if err != nil {
 		return err
 	}
@@ -155,7 +155,7 @@ func (w *withDockerRunBase) getComposeConfig(ctx context.Context, opt WithDocker
 			strings.Join(params, " "),
 			dockerdWrapperPath),
 	}
-	prefix, _, err := w.c.newVertexMeta(ctx, false, false, false, opt.Secrets, true)
+	prefix, _, err := w.c.newVertexMeta(ctx, false, false, false, opt.Secrets)
 	if err != nil {
 		return nil, err
 	}

--- a/earthfile2llb/with_docker_run_base.go
+++ b/earthfile2llb/with_docker_run_base.go
@@ -71,7 +71,7 @@ func (w *withDockerRunBase) installDeps(ctx context.Context, opt WithDockerOpt) 
 			dockerAutoInstallScriptPath),
 	}
 	vm := w.c.vertexMeta(ctx, w.c.newCmdID(), false, false, false, opt.Secrets)
-	err := w.c.newLogbusCommand(ctx, vm)
+	err := w.c.newLogbusCommandFromVertex(ctx, vm)
 	if err != nil {
 		return err
 	}
@@ -157,7 +157,7 @@ func (w *withDockerRunBase) getComposeConfig(ctx context.Context, opt WithDocker
 			dockerdWrapperPath),
 	}
 	vm := w.c.vertexMeta(ctx, w.c.newCmdID(), false, false, false, opt.Secrets)
-	err := w.c.newLogbusCommand(ctx, vm)
+	err := w.c.newLogbusCommandFromVertex(ctx, vm)
 	if err != nil {
 		return nil, err
 	}

--- a/earthfile2llb/with_docker_run_base.go
+++ b/earthfile2llb/with_docker_run_base.go
@@ -70,7 +70,7 @@ func (w *withDockerRunBase) installDeps(ctx context.Context, opt WithDockerOpt) 
 			strings.Join(params, " "),
 			dockerAutoInstallScriptPath),
 	}
-	prefix, _, err := w.c.newVertexMeta(ctx, false, false, false, opt.Secrets)
+	prefix, _, err := w.c.newVertexMeta(ctx, false, false, false, opt.Secrets, true)
 	if err != nil {
 		return err
 	}
@@ -155,7 +155,7 @@ func (w *withDockerRunBase) getComposeConfig(ctx context.Context, opt WithDocker
 			strings.Join(params, " "),
 			dockerdWrapperPath),
 	}
-	prefix, _, err := w.c.newVertexMeta(ctx, false, false, false, opt.Secrets)
+	prefix, _, err := w.c.newVertexMeta(ctx, false, false, false, opt.Secrets, true)
 	if err != nil {
 		return nil, err
 	}

--- a/earthfile2llb/with_docker_run_base.go
+++ b/earthfile2llb/with_docker_run_base.go
@@ -70,11 +70,16 @@ func (w *withDockerRunBase) installDeps(ctx context.Context, opt WithDockerOpt) 
 			strings.Join(params, " "),
 			dockerAutoInstallScriptPath),
 	}
+	vm := w.c.vertexMeta(ctx, w.c.newCmdID(), false, false, false, opt.Secrets)
+	err := w.c.newLogbusCommand(ctx, vm)
+	if err != nil {
+		return err
+	}
 	runOpts := []llb.RunOption{
 		llb.AddMount(
 			dockerAutoInstallScriptPath, llb.Scratch(), llb.HostBind(), llb.SourcePath(dockerAutoInstallScriptPath)),
 		llb.Args(args),
-		llb.WithCustomNamef("%sWITH DOCKER (install deps)", w.c.vertexPrefix(ctx, w.c.newCmdID(), false, false, false, opt.Secrets)),
+		llb.WithCustomNamef("%sWITH DOCKER (install deps)", vm.ToVertexPrefix()),
 	}
 	w.c.mts.Final.MainState = w.c.mts.Final.MainState.Run(runOpts...).Root()
 	return nil
@@ -151,11 +156,16 @@ func (w *withDockerRunBase) getComposeConfig(ctx context.Context, opt WithDocker
 			strings.Join(params, " "),
 			dockerdWrapperPath),
 	}
+	vm := w.c.vertexMeta(ctx, w.c.newCmdID(), false, false, false, opt.Secrets)
+	err := w.c.newLogbusCommand(ctx, vm)
+	if err != nil {
+		return nil, err
+	}
 	runOpts := []llb.RunOption{
 		llb.AddMount(
 			dockerdWrapperPath, llb.Scratch(), llb.HostBind(), llb.SourcePath(dockerdWrapperPath)),
 		llb.Args(args),
-		llb.WithCustomNamef("%sWITH DOCKER (docker-compose config)", w.c.vertexPrefix(ctx, w.c.newCmdID(), false, false, false, opt.Secrets)),
+		llb.WithCustomNamef("%sWITH DOCKER (docker-compose config)", vm.ToVertexPrefix()),
 	}
 	state := w.c.mts.Final.MainState.Run(runOpts...).Root()
 	ref, err := llbutil.StateToRef(

--- a/earthfile2llb/with_docker_run_base.go
+++ b/earthfile2llb/with_docker_run_base.go
@@ -70,8 +70,7 @@ func (w *withDockerRunBase) installDeps(ctx context.Context, opt WithDockerOpt) 
 			strings.Join(params, " "),
 			dockerAutoInstallScriptPath),
 	}
-	vm := w.c.vertexMeta(ctx, w.c.newCmdID(), false, false, false, opt.Secrets)
-	err := w.c.newLogbusCommandFromVertex(ctx, vm)
+	prefix, _, err := w.c.newVertexMeta(ctx, false, false, false, opt.Secrets)
 	if err != nil {
 		return err
 	}
@@ -79,7 +78,7 @@ func (w *withDockerRunBase) installDeps(ctx context.Context, opt WithDockerOpt) 
 		llb.AddMount(
 			dockerAutoInstallScriptPath, llb.Scratch(), llb.HostBind(), llb.SourcePath(dockerAutoInstallScriptPath)),
 		llb.Args(args),
-		llb.WithCustomNamef("%sWITH DOCKER (install deps)", vm.ToVertexPrefix()),
+		llb.WithCustomNamef("%sWITH DOCKER (install deps)", prefix),
 	}
 	w.c.mts.Final.MainState = w.c.mts.Final.MainState.Run(runOpts...).Root()
 	return nil
@@ -156,8 +155,7 @@ func (w *withDockerRunBase) getComposeConfig(ctx context.Context, opt WithDocker
 			strings.Join(params, " "),
 			dockerdWrapperPath),
 	}
-	vm := w.c.vertexMeta(ctx, w.c.newCmdID(), false, false, false, opt.Secrets)
-	err := w.c.newLogbusCommandFromVertex(ctx, vm)
+	prefix, _, err := w.c.newVertexMeta(ctx, false, false, false, opt.Secrets)
 	if err != nil {
 		return nil, err
 	}
@@ -165,7 +163,7 @@ func (w *withDockerRunBase) getComposeConfig(ctx context.Context, opt WithDocker
 		llb.AddMount(
 			dockerdWrapperPath, llb.Scratch(), llb.HostBind(), llb.SourcePath(dockerdWrapperPath)),
 		llb.Args(args),
-		llb.WithCustomNamef("%sWITH DOCKER (docker-compose config)", vm.ToVertexPrefix()),
+		llb.WithCustomNamef("%sWITH DOCKER (docker-compose config)", prefix),
 	}
 	state := w.c.mts.Final.MainState.Run(runOpts...).Root()
 	ref, err := llbutil.StateToRef(

--- a/earthfile2llb/with_docker_run_local_reg.go
+++ b/earthfile2llb/with_docker_run_local_reg.go
@@ -153,7 +153,7 @@ func (w *withDockerRunLocalReg) load(ctx context.Context, opt DockerLoadOpt) (ch
 			return nil, err
 		}
 	} else {
-		mts, err := w.c.buildTarget(ctx, depTarget.String(), opt.Platform, opt.AllowPrivileged, opt.PassArgs, opt.BuildArgs, false, loadCmd)
+		mts, err := w.c.buildTarget(ctx, depTarget.String(), opt.Platform, opt.AllowPrivileged, opt.PassArgs, opt.BuildArgs, false, loadCmd, "")
 		if err != nil {
 			return nil, err
 		}

--- a/earthfile2llb/with_docker_run_local_reg.go
+++ b/earthfile2llb/with_docker_run_local_reg.go
@@ -3,9 +3,7 @@ package earthfile2llb
 import (
 	"context"
 	"fmt"
-	"time"
 
-	"github.com/earthly/cloud-api/logstream"
 	"github.com/earthly/earthly/domain"
 	"github.com/earthly/earthly/states"
 	"github.com/earthly/earthly/util/containerutil"
@@ -44,11 +42,7 @@ func (w *withDockerRunLocalReg) Run(ctx context.Context, args []string, opt With
 	}
 
 	defer func() {
-		if retErr != nil {
-			cmd.SetEnd(time.Now(), logstream.RunStatus_RUN_STATUS_FAILURE, retErr.Error())
-			return
-		}
-		cmd.SetEnd(time.Now(), logstream.RunStatus_RUN_STATUS_SUCCESS, "")
+		cmd.SetEndError(retErr)
 	}()
 
 	var imagesToBuild []*states.ImageDef

--- a/earthfile2llb/with_docker_run_local_tar.go
+++ b/earthfile2llb/with_docker_run_local_tar.go
@@ -136,7 +136,7 @@ func (wdrl *withDockerRunLocalTar) load(ctx context.Context, opt DockerLoadOpt) 
 			return nil, err
 		}
 	} else {
-		mts, err := wdrl.c.buildTarget(ctx, depTarget.String(), opt.Platform, opt.AllowPrivileged, opt.PassArgs, opt.BuildArgs, false, loadCmd)
+		mts, err := wdrl.c.buildTarget(ctx, depTarget.String(), opt.Platform, opt.AllowPrivileged, opt.PassArgs, opt.BuildArgs, false, loadCmd, "")
 		if err != nil {
 			return nil, err
 		}

--- a/earthfile2llb/with_docker_run_local_tar.go
+++ b/earthfile2llb/with_docker_run_local_tar.go
@@ -6,9 +6,7 @@ import (
 	"path"
 	"sort"
 	"sync"
-	"time"
 
-	"github.com/earthly/cloud-api/logstream"
 	"github.com/earthly/earthly/domain"
 	"github.com/earthly/earthly/states"
 	"github.com/earthly/earthly/util/syncutil/semutil"
@@ -57,11 +55,7 @@ func (w *withDockerRunLocalTar) Run(ctx context.Context, args []string, opt With
 	}
 
 	defer func() {
-		if retErr != nil {
-			cmd.SetEnd(time.Now(), logstream.RunStatus_RUN_STATUS_FAILURE, retErr.Error())
-			return
-		}
-		cmd.SetEnd(time.Now(), logstream.RunStatus_RUN_STATUS_SUCCESS, "")
+		cmd.SetEndError(retErr)
 	}()
 
 	// Build and solve images to be loaded.

--- a/earthfile2llb/with_docker_run_local_tar.go
+++ b/earthfile2llb/with_docker_run_local_tar.go
@@ -6,7 +6,9 @@ import (
 	"path"
 	"sort"
 	"sync"
+	"time"
 
+	"github.com/earthly/cloud-api/logstream"
 	"github.com/earthly/earthly/domain"
 	"github.com/earthly/earthly/states"
 	"github.com/earthly/earthly/util/syncutil/semutil"
@@ -42,17 +44,30 @@ type tarLoadLocal struct {
 	imgFile string
 }
 
-func (wdrl *withDockerRunLocalTar) Run(ctx context.Context, args []string, opt WithDockerOpt) error {
-	err := wdrl.c.checkAllowed(runCmd)
+func (w *withDockerRunLocalTar) Run(ctx context.Context, args []string, opt WithDockerOpt) (retErr error) {
+	err := w.c.checkAllowed(runCmd)
 	if err != nil {
 		return err
 	}
-	wdrl.c.nonSaveCommand()
+	w.c.nonSaveCommand()
+
+	cmdID, cmd, err := w.c.newLogbusCommand(ctx, "WITH DOCKER RUN")
+	if err != nil {
+		return errors.Wrap(err, "failed to create command")
+	}
+
+	defer func() {
+		if retErr != nil {
+			cmd.SetEnd(time.Now(), logstream.RunStatus_RUN_STATUS_FAILURE, retErr.Error())
+			return
+		}
+		cmd.SetEnd(time.Now(), logstream.RunStatus_RUN_STATUS_SUCCESS, "")
+	}()
 
 	// Build and solve images to be loaded.
 	loadPromises := make([]chan DockerLoadOpt, 0, len(opt.Loads))
 	for _, loadOpt := range opt.Loads {
-		lp, err := wdrl.load(ctx, loadOpt)
+		lp, err := w.load(ctx, cmdID, loadOpt)
 		if err != nil {
 			return errors.Wrap(err, "load")
 		}
@@ -66,16 +81,16 @@ func (wdrl *withDockerRunLocalTar) Run(ctx context.Context, args []string, opt W
 		}
 	}
 	// Sort the tar list, to make the operation consistent.
-	sort.Slice(wdrl.tarLoads, func(i, j int) bool {
-		return wdrl.tarLoads[i].imgName < wdrl.tarLoads[j].imgName
+	sort.Slice(w.tarLoads, func(i, j int) bool {
+		return w.tarLoads[i].imgName < w.tarLoads[j].imgName
 	})
 	// Issue docker load.
-	for _, tl := range wdrl.tarLoads {
+	for _, tl := range w.tarLoads {
 		runOpts := []llb.RunOption{
 			llb.IgnoreCache,
-			llb.Args([]string{localhost.RunOnLocalHostMagicStr, "/bin/sh", "-c", wdrl.c.containerFrontend.ImageLoadFromFileCommand(tl.imgFile)}),
+			llb.Args([]string{localhost.RunOnLocalHostMagicStr, "/bin/sh", "-c", w.c.containerFrontend.ImageLoadFromFileCommand(tl.imgFile)}),
 		}
-		wdrl.c.mts.Final.MainState = wdrl.c.mts.Final.MainState.Run(runOpts...).Root()
+		w.c.mts.Final.MainState = w.c.mts.Final.MainState.Run(runOpts...).Root()
 	}
 
 	crOpts := ConvertRunOpts{
@@ -93,14 +108,14 @@ func (wdrl *withDockerRunLocalTar) Run(ctx context.Context, args []string, opt W
 	}
 
 	// then finally run the command
-	_, err = wdrl.c.internalRun(ctx, crOpts)
+	_, err = w.c.internalRun(ctx, crOpts)
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func (wdrl *withDockerRunLocalTar) load(ctx context.Context, opt DockerLoadOpt) (chan DockerLoadOpt, error) {
+func (w *withDockerRunLocalTar) load(ctx context.Context, cmdID string, opt DockerLoadOpt) (chan DockerLoadOpt, error) {
 	optPromise := make(chan DockerLoadOpt, 1)
 	depTarget, err := domain.ParseTarget(opt.Target)
 	if err != nil {
@@ -120,23 +135,23 @@ func (wdrl *withDockerRunLocalTar) load(ctx context.Context, opt DockerLoadOpt) 
 			}
 			opt.ImageName = mts.Final.SaveImages[0].DockerTag
 		}
-		err := wdrl.solveImage(
+		err := w.solveImage(
 			ctx, mts, depTarget.String(), opt.ImageName,
 			llb.WithCustomNamef(
-				"%sDOCKER LOAD %s %s", wdrl.c.imageVertexPrefix(opt.ImageName, opt.Platform), depTarget.String(), opt.ImageName))
+				"%sDOCKER LOAD %s %s", w.c.imageVertexPrefix(opt.ImageName, opt.Platform), depTarget.String(), opt.ImageName))
 		if err != nil {
 			return err
 		}
 		optPromise <- opt
 		return nil
 	}
-	if wdrl.enableParallel {
-		err = wdrl.c.BuildAsync(ctx, depTarget.String(), opt.Platform, opt.AllowPrivileged, opt.PassArgs, opt.BuildArgs, loadCmd, afterFun, wdrl.sem)
+	if w.enableParallel {
+		err = w.c.BuildAsync(ctx, depTarget.String(), opt.Platform, opt.AllowPrivileged, opt.PassArgs, opt.BuildArgs, loadCmd, afterFun, w.sem)
 		if err != nil {
 			return nil, err
 		}
 	} else {
-		mts, err := wdrl.c.buildTarget(ctx, depTarget.String(), opt.Platform, opt.AllowPrivileged, opt.PassArgs, opt.BuildArgs, false, loadCmd, "")
+		mts, err := w.c.buildTarget(ctx, depTarget.String(), opt.Platform, opt.AllowPrivileged, opt.PassArgs, opt.BuildArgs, false, loadCmd, cmdID)
 		if err != nil {
 			return nil, err
 		}
@@ -148,22 +163,22 @@ func (wdrl *withDockerRunLocalTar) load(ctx context.Context, opt DockerLoadOpt) 
 	return optPromise, nil
 }
 
-func (wdrl *withDockerRunLocalTar) solveImage(ctx context.Context, mts *states.MultiTarget, opName string, dockerTag string, opts ...llb.RunOption) error {
+func (w *withDockerRunLocalTar) solveImage(ctx context.Context, mts *states.MultiTarget, opName string, dockerTag string, opts ...llb.RunOption) error {
 	outDir, err := os.MkdirTemp(os.TempDir(), "earthly-docker-load")
 	if err != nil {
 		return errors.Wrap(err, "mk temp dir for docker load")
 	}
-	wdrl.c.opt.CleanCollection.Add(func() error {
+	w.c.opt.CleanCollection.Add(func() error {
 		return os.RemoveAll(outDir)
 	})
 	outFile := path.Join(outDir, "image.tar")
-	err = wdrl.c.opt.DockerImageSolverTar.SolveImage(ctx, mts, dockerTag, outFile, !wdrl.c.ftrs.NoTarBuildOutput)
+	err = w.c.opt.DockerImageSolverTar.SolveImage(ctx, mts, dockerTag, outFile, !w.c.ftrs.NoTarBuildOutput)
 	if err != nil {
 		return errors.Wrapf(err, "build target %s for docker load", opName)
 	}
-	wdrl.mu.Lock()
-	defer wdrl.mu.Unlock()
-	wdrl.tarLoads = append(wdrl.tarLoads, tarLoadLocal{
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.tarLoads = append(w.tarLoads, tarLoadLocal{
 		imgName: dockerTag,
 		imgFile: outFile,
 	})

--- a/earthfile2llb/with_docker_run_reg.go
+++ b/earthfile2llb/with_docker_run_reg.go
@@ -5,9 +5,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
-	"time"
 
-	"github.com/earthly/cloud-api/logstream"
 	"github.com/earthly/earthly/domain"
 	"github.com/earthly/earthly/states"
 	"github.com/earthly/earthly/util/llbutil/pllb"
@@ -128,11 +126,7 @@ func (w *withDockerRunRegistry) Run(ctx context.Context, args []string, opt With
 	}
 
 	defer func() {
-		if retErr != nil {
-			cmd.SetEnd(time.Now(), logstream.RunStatus_RUN_STATUS_FAILURE, retErr.Error())
-			return
-		}
-		cmd.SetEnd(time.Now(), logstream.RunStatus_RUN_STATUS_SUCCESS, "")
+		cmd.SetEndError(retErr)
 	}()
 
 	err = w.installDeps(ctx, opt)

--- a/earthfile2llb/with_docker_run_reg.go
+++ b/earthfile2llb/with_docker_run_reg.go
@@ -309,7 +309,7 @@ func (w *withDockerRunRegistry) load(ctx context.Context, opt DockerLoadOpt) (ch
 			return nil, err
 		}
 	} else {
-		mts, err := w.c.buildTarget(ctx, depTarget.String(), opt.Platform, opt.AllowPrivileged, opt.PassArgs, opt.BuildArgs, false, loadCmd)
+		mts, err := w.c.buildTarget(ctx, depTarget.String(), opt.Platform, opt.AllowPrivileged, opt.PassArgs, opt.BuildArgs, false, loadCmd, "")
 		if err != nil {
 			return nil, err
 		}

--- a/earthfile2llb/with_docker_run_reg.go
+++ b/earthfile2llb/with_docker_run_reg.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
+	"github.com/earthly/cloud-api/logstream"
 	"github.com/earthly/earthly/domain"
 	"github.com/earthly/earthly/states"
 	"github.com/earthly/earthly/util/llbutil/pllb"
@@ -38,7 +40,7 @@ func newWithDockerRunRegistry(c *Converter, enableParallel bool) *withDockerRunR
 	}
 }
 
-func (w *withDockerRunRegistry) prepareImages(ctx context.Context, opt *WithDockerOpt) ([]*states.ImageDef, error) {
+func (w *withDockerRunRegistry) prepareImages(ctx context.Context, cmdID string, opt *WithDockerOpt) ([]*states.ImageDef, error) {
 	// Grab relevant images from compose file(s).
 	composePulls, err := w.getComposePulls(ctx, *opt)
 	if err != nil {
@@ -65,7 +67,7 @@ func (w *withDockerRunRegistry) prepareImages(ctx context.Context, opt *WithDock
 	imageDefChans := make([]chan *states.ImageDef, 0, len(opt.Loads))
 	for _, loadOpt := range opt.Loads {
 		loadOpt.Platform = w.c.platr.SubPlatform(loadOpt.Platform)
-		imageDefChan, err := w.load(ctx, loadOpt)
+		imageDefChan, err := w.load(ctx, cmdID, loadOpt)
 		if err != nil {
 			return nil, errors.Wrap(err, "load")
 		}
@@ -112,7 +114,7 @@ func (w *withDockerRunRegistry) prepareImages(ctx context.Context, opt *WithDock
 	return imagesToBuild, nil
 }
 
-func (w *withDockerRunRegistry) Run(ctx context.Context, args []string, opt WithDockerOpt) error {
+func (w *withDockerRunRegistry) Run(ctx context.Context, args []string, opt WithDockerOpt) (retErr error) {
 	err := w.c.checkAllowed(runCmd)
 	if err != nil {
 		return err
@@ -120,12 +122,25 @@ func (w *withDockerRunRegistry) Run(ctx context.Context, args []string, opt With
 
 	w.c.nonSaveCommand()
 
+	cmdID, cmd, err := w.c.newLogbusCommand(ctx, "WITH DOCKER RUN")
+	if err != nil {
+		return errors.Wrap(err, "failed to create command")
+	}
+
+	defer func() {
+		if retErr != nil {
+			cmd.SetEnd(time.Now(), logstream.RunStatus_RUN_STATUS_FAILURE, retErr.Error())
+			return
+		}
+		cmd.SetEnd(time.Now(), logstream.RunStatus_RUN_STATUS_SUCCESS, "")
+	}()
+
 	err = w.installDeps(ctx, opt)
 	if err != nil {
 		return err
 	}
 
-	imagesToBuild, err := w.prepareImages(ctx, &opt)
+	imagesToBuild, err := w.prepareImages(ctx, cmdID, &opt)
 	if err != nil {
 		return err
 	}
@@ -273,7 +288,7 @@ func (w *withDockerRunRegistry) pull(ctx context.Context, opt DockerPullOpt) (*s
 
 var errNoImageTag = errors.New("no docker image tag specified in load and it cannot be inferred from the SAVE IMAGE statement")
 
-func (w *withDockerRunRegistry) load(ctx context.Context, opt DockerLoadOpt) (chan *states.ImageDef, error) {
+func (w *withDockerRunRegistry) load(ctx context.Context, cmdID string, opt DockerLoadOpt) (chan *states.ImageDef, error) {
 	imageDefChan := make(chan *states.ImageDef, 1)
 
 	depTarget, err := domain.ParseTarget(opt.Target)
@@ -309,7 +324,7 @@ func (w *withDockerRunRegistry) load(ctx context.Context, opt DockerLoadOpt) (ch
 			return nil, err
 		}
 	} else {
-		mts, err := w.c.buildTarget(ctx, depTarget.String(), opt.Platform, opt.AllowPrivileged, opt.PassArgs, opt.BuildArgs, false, loadCmd, "")
+		mts, err := w.c.buildTarget(ctx, depTarget.String(), opt.Platform, opt.AllowPrivileged, opt.PassArgs, opt.BuildArgs, false, loadCmd, cmdID)
 		if err != nil {
 			return nil, err
 		}

--- a/earthfile2llb/with_docker_run_tar.go
+++ b/earthfile2llb/with_docker_run_tar.go
@@ -340,7 +340,7 @@ func (w *withDockerRunTar) solveImage(ctx context.Context, mts *states.MultiTarg
 		sha256SessionIDKey := sha256.Sum256([]byte(sessionIDKey))
 		sessionID := hex.EncodeToString(sha256SessionIDKey[:])
 
-		prefix, _, err := w.c.newVertexMeta(ctx, false, false, true, nil)
+		prefix, _, err := w.c.newVertexMeta(ctx, false, false, true, nil, true)
 		if err != nil {
 			return pllb.State{}, err
 		}

--- a/earthfile2llb/with_docker_run_tar.go
+++ b/earthfile2llb/with_docker_run_tar.go
@@ -340,7 +340,7 @@ func (w *withDockerRunTar) solveImage(ctx context.Context, mts *states.MultiTarg
 		sha256SessionIDKey := sha256.Sum256([]byte(sessionIDKey))
 		sessionID := hex.EncodeToString(sha256SessionIDKey[:])
 
-		vm := w.c.vertexMeta(ctx, w.c.newCmdID(), false, false, true, nil)
+		prefix, _, err := w.c.newVertexMeta(ctx, false, false, true, nil)
 		if err != nil {
 			return pllb.State{}, err
 		}
@@ -348,7 +348,7 @@ func (w *withDockerRunTar) solveImage(ctx context.Context, mts *states.MultiTarg
 			string(solveID),
 			llb.SessionID(sessionID),
 			llb.Platform(w.c.platr.LLBNative()),
-			llb.WithCustomNamef("%sdocker tar context %s %s", vm.ToVertexPrefix(), opName, sessionID),
+			llb.WithCustomNamef("%sdocker tar context %s %s", prefix, opName, sessionID),
 		)
 		// Add directly to build context so that if a later statement forces execution, the images are available.
 		w.c.opt.BuildContextProvider.AddDir(string(solveID), outDir)

--- a/earthfile2llb/with_docker_run_tar.go
+++ b/earthfile2llb/with_docker_run_tar.go
@@ -340,7 +340,7 @@ func (w *withDockerRunTar) solveImage(ctx context.Context, mts *states.MultiTarg
 		sha256SessionIDKey := sha256.Sum256([]byte(sessionIDKey))
 		sessionID := hex.EncodeToString(sha256SessionIDKey[:])
 
-		prefix, _, err := w.c.newVertexMeta(ctx, false, false, true, nil, true)
+		prefix, _, err := w.c.newVertexMeta(ctx, false, false, true, nil)
 		if err != nil {
 			return pllb.State{}, err
 		}

--- a/earthfile2llb/with_docker_run_tar.go
+++ b/earthfile2llb/with_docker_run_tar.go
@@ -294,7 +294,7 @@ func (w *withDockerRunTar) load(ctx context.Context, opt DockerLoadOpt) (chan Do
 			return nil, err
 		}
 	} else {
-		mts, err := w.c.buildTarget(ctx, depTarget.String(), opt.Platform, opt.AllowPrivileged, opt.PassArgs, opt.BuildArgs, false, loadCmd)
+		mts, err := w.c.buildTarget(ctx, depTarget.String(), opt.Platform, opt.AllowPrivileged, opt.PassArgs, opt.BuildArgs, false, loadCmd, "")
 		if err != nil {
 			return nil, err
 		}
@@ -340,11 +340,15 @@ func (w *withDockerRunTar) solveImage(ctx context.Context, mts *states.MultiTarg
 		sha256SessionIDKey := sha256.Sum256([]byte(sessionIDKey))
 		sessionID := hex.EncodeToString(sha256SessionIDKey[:])
 
+		vm := w.c.vertexMeta(ctx, w.c.newCmdID(), false, false, true, nil)
+		if err != nil {
+			return pllb.State{}, err
+		}
 		tarContext := pllb.Local(
 			string(solveID),
 			llb.SessionID(sessionID),
 			llb.Platform(w.c.platr.LLBNative()),
-			llb.WithCustomNamef("%sdocker tar context %s %s", w.c.vertexPrefix(ctx, w.c.newCmdID(), false, false, true, nil), opName, sessionID),
+			llb.WithCustomNamef("%sdocker tar context %s %s", vm.ToVertexPrefix(), opName, sessionID),
 		)
 		// Add directly to build context so that if a later statement forces execution, the images are available.
 		w.c.opt.BuildContextProvider.AddDir(string(solveID), outDir)

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-units v0.5.0
 	github.com/dustin/go-humanize v1.0.1
-	github.com/earthly/cloud-api v1.0.1-0.20240202022707-2e046f82d1df
+	github.com/earthly/cloud-api v1.0.1-0.20240216175649-9c937bc41efb
 	github.com/earthly/earthly/ast v0.0.0-00010101000000-000000000000
 	github.com/earthly/earthly/util/deltautil v0.0.0-20231221211955-0fd4ae2cc257
 	github.com/elastic/go-sysinfo v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -195,6 +195,10 @@ github.com/earthly/buildkit v0.0.0-20240208233503-fbd249f838cc h1:+m89xt7JlBQvwb
 github.com/earthly/buildkit v0.0.0-20240208233503-fbd249f838cc/go.mod h1:1/yAC8A0Tu94Bdmv07gaG1pFBp+CetVwO7oB3qvZXUc=
 github.com/earthly/cloud-api v1.0.1-0.20240202022707-2e046f82d1df h1:b7iT0tlIjgnvUY8FmFCX0kCy/IFgRHp4mqKTF2WJikw=
 github.com/earthly/cloud-api v1.0.1-0.20240202022707-2e046f82d1df/go.mod h1:rU/tYJ7GFBjdKAITV2heDbez++glpGSbtJaZcp73rNI=
+github.com/earthly/cloud-api v1.0.1-0.20240216174543-e3ae007ca640 h1:hGp8wuv5YfpCTmEtivg7VskftoO0c6WyyemJ2D0IHkM=
+github.com/earthly/cloud-api v1.0.1-0.20240216174543-e3ae007ca640/go.mod h1:rU/tYJ7GFBjdKAITV2heDbez++glpGSbtJaZcp73rNI=
+github.com/earthly/cloud-api v1.0.1-0.20240216175649-9c937bc41efb h1:lYdDcDqqEQ7QNNU3BPr8Pfs8M8caOfa8ctZvByNTc1Y=
+github.com/earthly/cloud-api v1.0.1-0.20240216175649-9c937bc41efb/go.mod h1:rU/tYJ7GFBjdKAITV2heDbez++glpGSbtJaZcp73rNI=
 github.com/earthly/fsutil v0.0.0-20231030221755-644b08355b65 h1:6oyWHoxHXwcTt4EqmMw6361scIV87uEAB1N42+VpIwk=
 github.com/earthly/fsutil v0.0.0-20231030221755-644b08355b65/go.mod h1:9kMVqMyQ/Sx2df5LtnGG+nbrmiZzCS7V6gjW3oGHsvI=
 github.com/elastic/go-sysinfo v1.9.0 h1:usICqY/Nw4Mpn9f4LdtpFrKxXroJDe81GaxxUlCckIo=

--- a/logbus/command.go
+++ b/logbus/command.go
@@ -113,6 +113,13 @@ func (c *Command) SetEnd(end time.Time, status logstream.RunStatus, errorStr str
 	})
 }
 
+// SetName sets the name of the command.
+func (c *Command) SetName(name string) {
+	c.commandDelta(&logstream.DeltaCommandManifest{
+		Name: name,
+	})
+}
+
 func (c *Command) commandDelta(dcm *logstream.DeltaCommandManifest) {
 	c.b.WriteDeltaManifest(&logstream.DeltaManifest{
 		DeltaManifestOneof: &logstream.DeltaManifest_Fields{

--- a/logbus/command.go
+++ b/logbus/command.go
@@ -137,6 +137,27 @@ func (c *Command) SetEnd(end time.Time, status logstream.RunStatus, errorStr str
 	})
 }
 
+// SetEndError is a helper that allows for setting expected end metadata on
+// a command based on whether there was an error. Note, this method assumes the
+// status values.
+func (c *Command) SetEndError(err error) {
+	now := time.Now()
+
+	if err != nil {
+		c.commandDelta(&logstream.DeltaCommandManifest{
+			Status:           logstream.RunStatus_RUN_STATUS_FAILURE,
+			ErrorMessage:     err.Error(),
+			EndedAtUnixNanos: c.b.TsUnixNanos(now),
+		})
+		return
+	}
+
+	c.commandDelta(&logstream.DeltaCommandManifest{
+		Status:           logstream.RunStatus_RUN_STATUS_SUCCESS,
+		EndedAtUnixNanos: c.b.TsUnixNanos(now),
+	})
+}
+
 // SetName sets the name of the command.
 func (c *Command) SetName(name string) {
 	c.commandDelta(&logstream.DeltaCommandManifest{

--- a/logbus/command.go
+++ b/logbus/command.go
@@ -91,7 +91,7 @@ func (t *Command) AddDependsOn(targetID, refName string) {
 	// Only add the dependency link once to avoid sending duplicates to Logstream.
 	t.mu.Lock()
 	if _, ok := t.dependsOn[targetID]; ok {
-		defer t.mu.Unlock()
+		t.mu.Unlock()
 		return
 	}
 	t.dependsOn[targetID] = struct{}{}

--- a/logbus/run.go
+++ b/logbus/run.go
@@ -87,7 +87,7 @@ func (run *Run) Target(targetID string) (*Target, bool) {
 }
 
 // NewCommand creates a new command printer.
-func (run *Run) NewCommand(commandID string, command string, targetID string, category string, platform string, cached, local, interactive bool, sourceLocation *spec.SourceLocation, repoURL, repoHash, fileRelToRepo string) (*Command, error) {
+func (run *Run) NewCommand(commandID, command string, targetID, category, platform string, cached, local, interactive bool, sourceLocation *spec.SourceLocation, repoURL, repoHash, fileRelToRepo string) (*Command, error) {
 	run.mu.Lock()
 	defer run.mu.Unlock()
 	_, ok := run.commands[commandID]

--- a/logbus/solvermon/solvermon.go
+++ b/logbus/solvermon/solvermon.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/earthly/cloud-api/logstream"
 	"github.com/earthly/earthly/logbus"
 	"github.com/earthly/earthly/util/statsstreamparser"
@@ -73,12 +74,17 @@ func (sm *SolverMonitor) handleBuildkitStatus(ctx context.Context, status *clien
 	bp := sm.b.Run()
 	for _, vertex := range status.Vertexes {
 		meta, operation := vertexmeta.ParseFromVertexPrefix(vertex.Name)
+
+		spew.Dump(operation, meta)
+
 		var cmdID string
 		createCmd := true
 		switch {
 		case meta.TargetName == "context":
 			cmdID = operation
 		case meta.CommandID != "":
+			// If the command ID is set, the Logbus command is guaranteed to
+			// have been created by Earthly in the converter ahead of time.
 			cmdID = meta.CommandID
 			createCmd = false
 		default:

--- a/logbus/solvermon/solvermon.go
+++ b/logbus/solvermon/solvermon.go
@@ -109,7 +109,11 @@ func (sm *SolverMonitor) handleBuildkitStatus(ctx context.Context, status *clien
 				var ok bool
 				cp, ok = bp.Command(cmdID)
 				if !ok {
-					return errors.Errorf("expected command not found: %s", cmdID)
+					// Note: if we receive a vertex with a full command ID that
+					// does not exist in this process, it may have originated
+					// from another Earthly process. It should be safe to
+					// ignore, in this case.
+					continue
 				}
 				cp.SetName(operation) // Command created prior may not have a full name.
 			}

--- a/logbus/solvermon/solvermon.go
+++ b/logbus/solvermon/solvermon.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/earthly/cloud-api/logstream"
 	"github.com/earthly/earthly/logbus"
 	"github.com/earthly/earthly/util/statsstreamparser"
@@ -74,9 +73,6 @@ func (sm *SolverMonitor) handleBuildkitStatus(ctx context.Context, status *clien
 	bp := sm.b.Run()
 	for _, vertex := range status.Vertexes {
 		meta, operation := vertexmeta.ParseFromVertexPrefix(vertex.Name)
-
-		spew.Dump(operation, meta)
-
 		var cmdID string
 		createCmd := true
 		switch {

--- a/logbus/target.go
+++ b/logbus/target.go
@@ -46,7 +46,7 @@ func (t *Target) AddDependsOn(targetID string) {
 	// Only add the dependency link once to avoid sending duplicates to Logstream.
 	t.mu.Lock()
 	if _, ok := t.dependsOn[targetID]; ok {
-		defer t.mu.Unlock()
+		t.mu.Unlock()
 		return
 	}
 	t.dependsOn[targetID] = struct{}{}

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -163,6 +163,7 @@ ga-no-qemu-group3:
     BUILD +remote-test
     BUILD +save-artifact-dont-overwrite
     BUILD --pass-args ./with-docker-expose+all
+    BUILD --pass-args ./logbus+test-all
 
 ga-no-qemu-group4:
     BUILD +cache-mount-arg

--- a/tests/logbus/Earthfile
+++ b/tests/logbus/Earthfile
@@ -10,9 +10,9 @@ test-all:
 
 test-manifest:
     DO tests+RUN_EARTHLY --earthfile=manifest.earth --extra_args="--no-output --logstream-debug-manifest-file man.json"
-    RUN cat man.json | jq '.commands | length' | acbgrep 15
+    RUN cat man.json | jq '.commands | length' | acbgrep 16
     RUN cat man.json | jq '.commands[]' | jq 'select(.name | contains("COPY"))' | jq '.dependsOn[0].referencedName' | acbgrep 'src'
-    RUN cat man.json | jq '.commands[]' | jq 'select(.name | contains("COPY"))' | jq '.dependsOn | length'
+    RUN cat man.json | jq '.commands[]' | jq 'select(.name | contains("COPY"))' | jq '.dependsOn | length' | acbgrep 1
     RUN cat man.json | jq '.commands[]' | jq 'select(.name | contains("BUILD +foo"))' | jq '.dependsOn[0].referencedName' | acbgrep 'foo'
     RUN cat man.json | jq '.commands[]' | jq 'select(.name | contains("BUILD +foo"))' | jq '.' | acbgrep RUN_STATUS_SUCCESS
     RUN cat man.json | jq '.commands[]' | jq 'select(.name | contains("SAVE IMAGE foo"))' | jq '.' | acbgrep RUN_STATUS_SUCCESS

--- a/tests/logbus/Earthfile
+++ b/tests/logbus/Earthfile
@@ -15,3 +15,4 @@ test-manifest:
     RUN cat man.json | jq '.commands[]' | jq 'select(.name | contains("COPY"))' | jq '.dependsOn | length'
     RUN cat man.json | jq '.commands[]' | jq 'select(.name | contains("BUILD +foo"))' | jq '.dependsOn[0].referencedName' | acbgrep 'foo'
     RUN cat man.json | jq '.commands[]' | jq 'select(.name | contains("BUILD +foo"))' | jq '.' | acbgrep RUN_STATUS_SUCCESS
+    #RUN cat man.json | jq '.commands[]' | jq 'select(.name | contains("SAVE IMAGE foo"))' | jq '.' | acbgrep RUN_STATUS_SUCCESS

--- a/tests/logbus/Earthfile
+++ b/tests/logbus/Earthfile
@@ -9,8 +9,8 @@ test-all:
     BUILD +test-manifest
 
 test-manifest:
-    DO tests+RUN_EARTHLY --earthfile=manifest.earth --extra_args="-P --logstream-debug-manifest-file man.json"
-    RUN cat man.json | jq '.commands | length' | acbgrep 14
+    DO tests+RUN_EARTHLY --earthfile=manifest.earth --extra_args="--no-output --logstream-debug-manifest-file man.json"
+    RUN cat man.json | jq '.commands | length' | acbgrep 15
     RUN cat man.json | jq '.commands[]' | jq 'select(.name | contains("COPY"))' | jq '.dependsOn[0].referencedName' | acbgrep 'src'
     RUN cat man.json | jq '.commands[]' | jq 'select(.name | contains("COPY"))' | jq '.dependsOn | length'
     RUN cat man.json | jq '.commands[]' | jq 'select(.name | contains("BUILD +foo"))' | jq '.dependsOn[0].referencedName' | acbgrep 'foo'

--- a/tests/logbus/Earthfile
+++ b/tests/logbus/Earthfile
@@ -14,3 +14,4 @@ test-manifest:
     RUN cat man.json | jq '.commands[]' | jq 'select(.name | contains("COPY"))' | jq '.dependsOn[0].referencedName' | acbgrep 'src'
     RUN cat man.json | jq '.commands[]' | jq 'select(.name | contains("COPY"))' | jq '.dependsOn | length'
     RUN cat man.json | jq '.commands[]' | jq 'select(.name | contains("BUILD +foo"))' | jq '.dependsOn[0].referencedName' | acbgrep 'foo'
+    RUN cat man.json | jq '.commands[]' | jq 'select(.name | contains("BUILD +foo"))' | jq '.' | acbgrep RUN_STATUS_SUCCESS

--- a/tests/logbus/Earthfile
+++ b/tests/logbus/Earthfile
@@ -15,4 +15,4 @@ test-manifest:
     RUN cat man.json | jq '.commands[]' | jq 'select(.name | contains("COPY"))' | jq '.dependsOn | length'
     RUN cat man.json | jq '.commands[]' | jq 'select(.name | contains("BUILD +foo"))' | jq '.dependsOn[0].referencedName' | acbgrep 'foo'
     RUN cat man.json | jq '.commands[]' | jq 'select(.name | contains("BUILD +foo"))' | jq '.' | acbgrep RUN_STATUS_SUCCESS
-    #RUN cat man.json | jq '.commands[]' | jq 'select(.name | contains("SAVE IMAGE foo"))' | jq '.' | acbgrep RUN_STATUS_SUCCESS
+    RUN cat man.json | jq '.commands[]' | jq 'select(.name | contains("SAVE IMAGE foo"))' | jq '.' | acbgrep RUN_STATUS_SUCCESS

--- a/tests/logbus/Earthfile
+++ b/tests/logbus/Earthfile
@@ -1,0 +1,16 @@
+VERSION 0.8
+FROM --pass-args ..+base
+
+IMPORT .. AS tests
+
+WORKDIR /test
+
+test-all:
+    BUILD +test-manifest
+
+test-manifest:
+    DO tests+RUN_EARTHLY --earthfile=manifest.earth --extra_args="-P --logstream-debug-manifest-file man.json"
+    RUN cat man.json | jq '.commands | length' | acbgrep 14
+    RUN cat man.json | jq '.commands[]' | jq 'select(.name | contains("COPY"))' | jq '.dependsOn[0].referencedName' | acbgrep 'src'
+    RUN cat man.json | jq '.commands[]' | jq 'select(.name | contains("COPY"))' | jq '.dependsOn | length'
+    RUN cat man.json | jq '.commands[]' | jq 'select(.name | contains("BUILD +foo"))' | jq '.dependsOn[0].referencedName' | acbgrep 'foo'

--- a/tests/logbus/manifest.earth
+++ b/tests/logbus/manifest.earth
@@ -1,0 +1,15 @@
+VERSION 0.8
+
+FROM alpine
+
+all:
+    BUILD +foo
+    COPY +src/x .
+    RUN cat x
+
+src:
+    RUN echo foo > x
+    SAVE ARTIFACT x
+
+foo:
+    RUN echo foo > x

--- a/tests/logbus/manifest.earth
+++ b/tests/logbus/manifest.earth
@@ -3,9 +3,9 @@ VERSION 0.8
 FROM alpine
 
 all:
-    BUILD +foo
     COPY +src/x .
     RUN cat x
+    BUILD +foo
 
 src:
     RUN echo foo > x
@@ -13,3 +13,4 @@ src:
 
 foo:
     RUN echo foo > x
+    SAVE IMAGE foo

--- a/util/deltautil/apply.go
+++ b/util/deltautil/apply.go
@@ -183,6 +183,9 @@ func setManifestFields(dm *pb.DeltaManifest, ret *pb.RunManifest) {
 		if c2.GetHasSourceLocation() {
 			c.SourceLocation = c2.GetSourceLocation()
 		}
+		if len(c2.GetDependsOn()) > 0 {
+			c.DependsOn = append(c.DependsOn, c2.GetDependsOn()...)
+		}
 	}
 }
 

--- a/util/deltautil/go.mod
+++ b/util/deltautil/go.mod
@@ -3,7 +3,7 @@ module github.com/earthly/earthly/util/deltautil
 go 1.21
 
 require (
-	github.com/earthly/cloud-api v1.0.1-0.20240202022707-2e046f82d1df
+	github.com/earthly/cloud-api v1.0.1-0.20240216175649-9c937bc41efb
 	google.golang.org/protobuf v1.30.0
 )
 

--- a/util/deltautil/go.sum
+++ b/util/deltautil/go.sum
@@ -8,6 +8,8 @@ github.com/earthly/cloud-api v1.0.1-0.20240202015256-8e04f321c470 h1:meTGm4XI4Xt
 github.com/earthly/cloud-api v1.0.1-0.20240202015256-8e04f321c470/go.mod h1:rU/tYJ7GFBjdKAITV2heDbez++glpGSbtJaZcp73rNI=
 github.com/earthly/cloud-api v1.0.1-0.20240202022707-2e046f82d1df h1:b7iT0tlIjgnvUY8FmFCX0kCy/IFgRHp4mqKTF2WJikw=
 github.com/earthly/cloud-api v1.0.1-0.20240202022707-2e046f82d1df/go.mod h1:rU/tYJ7GFBjdKAITV2heDbez++glpGSbtJaZcp73rNI=
+github.com/earthly/cloud-api v1.0.1-0.20240216175649-9c937bc41efb h1:lYdDcDqqEQ7QNNU3BPr8Pfs8M8caOfa8ctZvByNTc1Y=
+github.com/earthly/cloud-api v1.0.1-0.20240216175649-9c937bc41efb/go.mod h1:rU/tYJ7GFBjdKAITV2heDbez++glpGSbtJaZcp73rNI=
 github.com/golang/glog v1.1.0 h1:/d3pCKDPWNnvIWe0vVUpNP32qc8U3PDVxySP/y360qE=
 github.com/golang/glog v1.1.0/go.mod h1:pfYeQZ3JWZoXTV5sFc986z3HTpwQs9At6P4ImfuP3NQ=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=


### PR DESCRIPTION
Addresses: https://github.com/earthly/earthly/issues/3807

This PR adds new Logbus commands for pseudo-commands like `BUILD` & `FROM` that don't necessarily lead to a command being run in BuildKit. It also links commands to any referenced targets. For example: `COPY +foo/file .` will ensure the Logstream data reflects the fact that the `COPY` command refers to the `+foo` target. This will allow for some more interesting UI features.

The main changes are:
* Some Logbus commands are created ahead of time rather than while listening for solve updates
* Some commands are created and updated in place for pseudo-commands
* If set, the command ID will be used in Earthfile2LLB to link a command to a target

Please have a look at the implementation. I'll take a look at adding tests where possible if this approach makes sense. 
