### PR TITLE
Restore missed commits 

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -50,6 +50,7 @@
         '(:|\\s+)earthly/earthly:(?<currentValue>.+?)[\\s\\n/]+',
         'the `latest` tag is `(?<currentValue>.+?)`',
         'earthly/compare/(?<currentValue>.+?)\\.\\.\\.main',
+        'earthly/satellite:(?<currentValue>.+?)\\n',
       ],
       depNameTemplate: 'earthly/earthly',
       datasourceTemplate: 'github-releases',

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -84,4 +84,5 @@
 * [Earthly Satellites](cloud/satellites.md)
     * [Managing Satellites](cloud/satellites/managing.md)
     * [Using Satellites](cloud/satellites/using.md)
+    * [Self-Hosted Satellites](cloud/satellites/self-hosted.md)
     * [Best Practices](cloud/satellites/best-practices.md)

--- a/docs/ci-integration/guides/kubernetes.md
+++ b/docs/ci-integration/guides/kubernetes.md
@@ -1,5 +1,11 @@
 # Kubernetes
 
+{% hint style='info' %}
+##### Note
+This guide is related to self-hosting a remote Buildkit, however, Self-Hosted Satellites **beta** are now available. Self-Hosted Satellites provide more features, have better security, and are easier to deploy than remote Buildkit. Check out the [Self-Hosted Satellites Guide](../../cloud/satellites/self-hosted.md) for more details and instructions to deploy in Kubernetes or AWS EC2.
+{% endhint %}
+
+
 ## Overview
 
 Kubernetes isn't a CI per-se, but it _can_ serve as the underpinning for many modern CI systems. As such, this example serves as a bare-bones example to base your implementations on.

--- a/docs/ci-integration/remote-buildkit.md
+++ b/docs/ci-integration/remote-buildkit.md
@@ -1,5 +1,10 @@
 # Remote BuildKit 
 
+{% hint style='info' %}
+##### Note
+This guide is related to self-hosting a remote Buildkit, however, Self-Hosted Satellites **beta** are now available. Self-Hosted Satellites provide more features, have better security, and are easier to deploy than remote Buildkit. Check out the [Self-Hosted Satellites Guide](../cloud/satellites/self-hosted.md) for more details. If your use case cannot tolerate a cloud-based control plane, however, then self-hosting a remote Buildkit is still supported.
+{% endhint %}
+
 ## Introduction
 
 In some cases, you may want to run a remote instance of [`earthly/buildkitd`](https://hub.docker.com/r/earthly/buildkitd). This guide is intended to help you identify if you might benefit from this configuration, and to help you set it up correctly.

--- a/docs/cloud/satellites.md
+++ b/docs/cloud/satellites.md
@@ -1,10 +1,11 @@
 # Earthly Satellites
 
-Earthly Satellites are [remote runner](../remote-runners.md) instances managed by the Earthly team. They allow you to perform builds in the cloud, while retaining cache between runs.
+Earthly Satellites are [remote runners](../remote-runners.md) that work seamlessly with Earthly, using persistent cache to improve build times.
+Satellites can be either [fully managed](https://earthly.dev/earthly-satellites) by Earthly Cloud or [self-hosted](./satellites/self-hosted.md) in your own environment.
 
-## Get started with Earthly Satellites for free!
+## Get started with Earthly Cloud Satellites for free!
 
-Earthly Satellites is included with [Earthly Cloud](https://docs.earthly.dev/earthly-cloud/overview). Earthly Cloud is a SaaS build automation platform with consistent builds, ridiculous speed, and a next-gen developer experience that works seamlessly with any CI. *Get 6,000 build minutes/month as part of Earthly Cloud's no time limit free tier.* ***[Sign up today](https://cloud.earthly.dev/login).***
+Fully managed Satellites are included with [Earthly Cloud](https://docs.earthly.dev/earthly-cloud/overview). Earthly Cloud is a SaaS build automation platform with consistent builds, ridiculous speed, and a next-gen developer experience that works seamlessly with any CI. *Get 6,000 build minutes/month as part of Earthly Cloud's no time limit free tier.* ***[Sign up today](https://cloud.earthly.dev/login).***
 
 ## Benefits
 
@@ -44,7 +45,11 @@ Earthly Satellites is part of Earthly Cloud. You can use it for free as part of 
 
 ### 2. Launch a new satellite
 
-To launch a new satellite, run:
+Satellites are launched in one of the following two ways, depending on which kind of satellite you intend on creating.
+
+#### Earthly Cloud
+
+To launch a new managed Satellite on Earthly Cloud, run:
 
 ```bash
 earthly sat launch <satellite-name>
@@ -60,6 +65,10 @@ earthly sat launch <satellite-name>
 ```
 
 Once the satellite is created it will be automatically selected for use as part of your builds. The selection takes place by Earthly adding some information in your Earthly config file (usually located under `~/.earthly/config.yml`).
+
+#### Self-Hosted
+
+Self-Hosted Satellites are instead launched by running the satellite container directly. See the [self-hosted guide](./satellites/self-hosted.md) for instructions.
 
 ### 3. Run a build
 
@@ -113,7 +122,7 @@ For more information on managing satellites, see the [Managing Satellites page](
 
 ## Satellite specs
 
-The satellite size and architecture can be specified at launch time using the `--size` and `--platform` flags.
+When using Cloud Satellites, the size and architecture can be specified at launch time using the `--size` and `--platform` flags.
 For the full list of supported options, please see the [Pricing Page](https://earthly.dev/pricing).
 
 ## Using Satellites in CI
@@ -123,7 +132,7 @@ A key benefit of using satellites in a CI environment is that the cache is share
 {% hint style='danger' %}
 ##### Note
 
-If a satellite is shared between multiple CI pipelines, it is possible that it becomes overloaded by too many parallel builds. For best performance, you can create a dedicated satellite for each CI pipeline.
+If a satellite is shared between multiple CI pipelines, it is possible that it becomes overloaded by too many parallel builds. For best performance, you can create a dedicated satellite for each CI pipeline. See the [best practices guide](./satellites/best-practices.md) for more details.
 {% endhint %}
 
 To get started with using Earthly Satellites in CI, you can create a login token for access.
@@ -146,6 +155,8 @@ Then as part of your CI script, simply select your satellite using one of these 
 
 before running your Earthly targets.
 
+Note that when using [Self-Hosted Satelites](./satellites/self-hosted.md), your CI runner must be able to access the satellite on the network where it is hosted.
+
 {% hint style='danger' %}
 ##### Registry Login
 
@@ -157,7 +168,6 @@ See our [Docker authentication](../guides/auth.md) guide for more details.
 
 ## Known limitations
 
-* The output phase (the phase in which a satellite outputs build results back to the local machine) is slower than it could be. To work around this issue, you can make use of the `--no-output` flag (assuming that local outputs are not needed). You can even use `--no-output` in conjunction with `--push`. We are working on ways in which local outputs can be synchronized more intelligently such that only a diff is transferred over the network.
 * Pull-through cache is currently not supported
 
 If you run into any issues please let us know either via [Slack](https://earthly.dev/slack), [GitHub issues](https://github.com/earthly/cloud-issues/issues) or by [emailing support](mailto:support+satellite@earthly.dev).

--- a/docs/cloud/satellites/best-practices.md
+++ b/docs/cloud/satellites/best-practices.md
@@ -92,3 +92,9 @@ On top of the metrics mentioned above, these other symptoms may indicate an over
 * Unexpected build failures or crashes during a build
 
 If you are unsure that your satellite is overloaded, please reach out via [email](mailto:support@earthly.dev) or our [Community Slack channel](https://earthly.dev/slack). An Earthly team member will be happy to investigate your instance and provide advice.
+
+## Limiting Unnecessary Outputs
+
+By default, Earthly outputs artifacts or images locally at the end of the build. When running in CI, however, these artifacts may not actually be needed locally. For example, when your earthly build pushes an image to an external registry, but you do not actually need a copy of that image to be downloaded back to your CI runner.
+
+Using the [`--ci` flag](../../../guides/best-practices.md#use-ci-when-running-in-ci) can result in better performance, especially when using satellites, since the output will run over the network.

--- a/docs/cloud/satellites/managing.md
+++ b/docs/cloud/satellites/managing.md
@@ -2,7 +2,11 @@
 
 This page describes how to manage [Earthly Satellites](../satellites.md).
 
-## Launching and removing satellites
+## Launching a new satellite
+
+Satellites are launched in one of the following two ways, depending on which kind of satellite you intend on creating.
+
+### Earthly Cloud
 
 To launch a new satellite on Earthly Cloud, run:
 
@@ -20,13 +24,29 @@ earthly sat launch <satellite-name>
 
 Once the satellite is created it will be automatically selected for use as part of your builds. The selection takes place by Earthly adding some information in your Earthly config file (usually located under `~/.earthly/config.yml`).
 
-To remove a satellite, you can run:
+### Self-Hosted
+
+Self-Hosted Satellites are created by running the satellite container directly. See the [self-hosted guide](self-hosted.md) for instructions.
+
+## Removing a satellite
+
+Satellites are removed in one of the following two ways, depending on where they are deployed.
+
+### Earthly Cloud
+
+To remove a satellite from Earthly Cloud, you can run:
 
 ```bash
 earthly sat rm <satellite-name>
 ```
 
-Note that [Self-Hosted Satellites](self-hosted.md) are created by running the satellite process directly, instead of using the `launch` command.
+Note that it is best to remove a satellite while it is asleep, to prevent accidentally cancelling an ongoing build.
+
+### Self-Hosted
+
+Self-Hosted Satellites are typically removed by gracefully terminating the satellite container directly. Once the satellite has terminated, it will continue listing in an `offline` state in the output of `satellite ls`. This record is for historical or debugging purposes, however, it can be permanently removed by running `satellite rm <name>`.
+
+See the [self-hosted guide](self-hosted.md) for more details.
 
 ## Listing satellites
 

--- a/docs/cloud/satellites/managing.md
+++ b/docs/cloud/satellites/managing.md
@@ -4,7 +4,7 @@ This page describes how to manage [Earthly Satellites](../satellites.md).
 
 ## Launching and removing satellites
 
-To launch a new satellite, run:
+To launch a new satellite on Earthly Cloud, run:
 
 ```bash
 earthly sat launch <satellite-name>
@@ -25,6 +25,8 @@ To remove a satellite, you can run:
 ```bash
 earthly sat rm <satellite-name>
 ```
+
+Note that [Self-Hosted Satellites](self-hosted.md) are created by running the satellite process directly, instead of using the `launch` command.
 
 ## Listing satellites
 
@@ -78,7 +80,7 @@ Currently selected: No
 
 ## Clearing cache
 
-There are two ways to clear the cache on satellite.
+There are two ways to clear the cache on a satellite. One may be faster than the other, depending on the size of the cache.
 
 ### Recreating the Underlying Satellite Instance (often faster)
 
@@ -88,7 +90,10 @@ Note that this operation can take a while, and the satellite may also receive an
 ```bash
 earthly satellite update --drop-cache my-satellite
 ```
-### Using the prune command (slower)
+
+Note: the `update` comamnd only works with Earthly Cloud satellites.
+
+### Using the prune command
 
 The `earthly prune` command also works on satellites.
 It usually takes longer than running `satellite update`; however, it does not trigger a relaunch.
@@ -100,7 +105,9 @@ earthly prune -a
 
 ## Updating a satellite
 
-Satellites receive version updates by default, unless they are pinned to a specific version (by using the `--version` launch flag).
+The steps below apply only to Earthly Cloud satellites. For [Self-Hosted Satellites](self-hosted.md), you must upgrade the version being used in your deployment manually.
+
+Earthly Cloud Satellites receive automatic version updates by default, unless they are pinned to a specific version (by using the `--version` launch flag).
 Pinned versions will still receive minor patches, such as security updates.
 
 ### Auto-Update Maintenance Windows
@@ -205,7 +212,7 @@ You can view your current satellite version and revision number using the `earth
 
 ## Managing instance state
 
-To save costs, satellites automatically enter a **sleep** state after 30 min of inactivity. While a satellite is asleep, you are not billed for any compute minutes.
+To save costs, Earthly Cloud satellites automatically enter a **sleep** state after 30 min of inactivity. While a satellite is asleep, you are not billed for any compute minutes.
 
 The satellite will automatically **wake up** when a new build is started while it's in a sleep state. This is visible during the `Init` phase of the Earthly log.
 
@@ -235,4 +242,4 @@ Once a user has been invited, you can forward them a link to the page [Using Sat
 
 ## Satellite IP address
 
-The source IP address of the satellite for all internet traffic is `35.160.176.56`. This can be used for granting access to private resources or to production environments.
+The source IP address of an Earthly Cloud satellite for all internet traffic is `35.160.176.56`. This can be used for granting access to private resources or to production environments.

--- a/docs/cloud/satellites/self-hosted.md
+++ b/docs/cloud/satellites/self-hosted.md
@@ -20,7 +20,7 @@ Here is a minimal command to start a self-managed satellite using Docker:
 
 ```
 docker run --privileged \
-    -v earthly-cache:/tmp/earthly:rw \
+    -v satellite-cache:/tmp/earthly:rw \
     -p 8372:8372 \
     -e EARTHLY_TOKEN=GuFna*****nve7e \ 
     -e EARTHLY_ORG=my-org \

--- a/docs/cloud/satellites/self-hosted.md
+++ b/docs/cloud/satellites/self-hosted.md
@@ -1,0 +1,227 @@
+# Self-Hosted Satellites
+
+Self-hosted satellites **Beta** are a good alternative to Earthly Cloud’s [managed satellites](../satellites.md) when CI/CD is required to run in your own environment. Self-hosted satellites provide most of the benefits of Earthly Cloud while ensuring that your code and build-related data never leave your network.
+
+Self-Hosted Satellites have the following features:
+* Automatic and instantly available build cache that makes builds faster
+* Cloud-enabled control plane
+* Encrypted connections by default using mTLS
+* Ready to run builds with just a single command
+
+On the other hand, they may have the following drawbacks when compared to Cloud Satellites offered in Earthly Cloud:
+* No automatic updates
+* Does not automatically sleep to save costs while idle
+* Requires more knowledge and tuning to achieve good performance
+
+## Getting Started
+Launching a self-hosted satellite is as easy as running the public Docker image. A few environment variables are needed to link the satellite with your Earthly account. The satellite will use these values to automatically register with Earthly Cloud servers once it starts. Note that Earthly Cloud will never connect to your satellite directly. The host and port of your satellite can thus be private to your internal corporate network or VPC, if you wish.
+
+Here is a minimal command to start a self-managed satellite using Docker:
+
+```
+docker run --privileged \
+    -v earthly-cache:/tmp/earthly:rw \
+    -p 8372:8372 \
+    -e EARTHLY_TOKEN=GuFna*****nve7e \ 
+    -e EARTHLY_ORG=my-org \
+    -e SATELLITE_NAME=my-satellite \
+    -e SATELLITE_HOST=153.65.8.0 \
+  earthly/satellite:v0.8.3
+```
+
+The following environment variables are required:
+* `EARTHLY_TOKEN` - a persistent auth token obtained by running `earthly account create-token <token-name>`
+* `EARTHLY_ORG` - the name of your Earthly Organization created on [https://cloud.earthly.dev](https://cloud.earthly.dev)
+* `SATELLITE_NAME` - a name chosen by the user to identify the satellite instance
+* `SATELLITE_HOST` - Hostname or IP address for the Earthly CLI to connect. Note that users will select the satellite by name when running builds.
+
+Using a volume for cache storage is recommended for preserving cache after the container is destroyed. See [Advanced Configuration](#advanced-configuration) below for more details and a list of optional environment variables that can be used to finetune your deployment. See also [Platform Specific Guides](#platform-specific-guides) for examples of deploying to platforms like Kubernetes or EC2.
+
+The self-hosted satellite will not accept localhost as an address. For instructions on testing locally, please refer to [Running on Localhost](#running-on-localhost) below.
+
+
+{% hint style='info' %}
+##### Security Advisory
+The `--privileged` flag is currently required. Privileged mode is used by some features of Earthly, including the `WITH DOCKER` command in Earthfiles. If using privileged mode is a concern, running satellites in a dedicated VM or separate Kubernetes cluster can provide better isolation compared to running the container directly in your production environment. A rootless version will be available in the future.
+{% endhint %}
+
+### Auto-discovery of Host _\*experimental\*_
+
+When `SATELLITE_HOST` is left unset, the satellite will attempt to auto-discover its host address. Auto-discovery may not always work, and currently only supports environments using cloud-init (such as EC2).
+
+## Connecting to a Self-Hosted Satellite
+
+Once the satellite has finished registering, it can be selected and managed using typical earthly satellite commands from the CLI. 
+For example, to select the satellite for use in subsequent builds:
+
+```
+earthly sat select my-satellite
+```
+
+Or, to invoke a build once on the satellite, without having it persistently selecting:
+
+```
+earthly --sat my-satellite +my-target
+```
+
+Note that `earthly` `v0.8.0` or later is required to connect to a self-hosted satellite.
+
+## Managing Self-Hosted Satellites
+
+A list of satellites in your org can be viewed via the satellite ls command. For example:
+
+```
+> earthly sat ls
+NAME          PLATFORM     SIZE         VERSION  STATE
+my-satellite  linux/amd64  self-hosted  v0.8.3   operational
+...
+```
+
+The size field of a self-hosted satellite will be listed as `self-hosted`, as opposed to one of the sizes of Earthly Cloud’s managed satellites.
+
+The state field will be either `operational` or `offline`. A self-hosted satellite automatically transitions to an `offline` state when it is gracefully terminated, or if no heartbeat has been received by Earthly’s servers for a while.
+
+You can run `satellite rm` on a self-hosted satellite when it is in an offline state to remove it from your account permenantly.
+
+## Platform-Specific Guides
+
+### AWS EC2 (Recommended)
+
+Deploying Satellites in a dedicated VM is the most secure method, since it isolates the satellite process from the rest of your infrastructure.
+
+When launching on EC2, we recommend using the latest version of Amazon Linux 2023. The following cloud-init script can be configured when launching a new EC2 instance so that it automatically starts the satellite on boot.
+
+```yaml
+#cloud-config
+runcmd:
+  - sudo dnf update
+  - sudo dnf install -y docker
+  - sudo systemctl start docker.service
+  - sudo systemctl enable docker.service
+  - |-
+      sudo docker run -d --privileged \
+        --restart always \
+        --name satellite \
+        -p 8372:8372 \
+        -v /earthly-cache:/tmp/earthly:rw \
+        -e EARTHLY_TOKEN=GuFna*****nve7e \
+        -e EARTHLY_ORG=my-org \
+        -e SATELLITE_NAME=my-satellite \
+        earthly/satellite:v0.8.3
+```
+
+Note that the `SATELLITE_HOST` variable is unset in this example so that the host is auto-discovered by the satellite when it starts. This should result in the instance’s private DNS being used as the host.
+
+If the Earthly CLI is unable to connect to the satellite via the EC2’s private DNS, then `SATELLITE_HOST` should be provided in the `docker run` command with an alternate value.
+
+
+### Kubernetes
+
+Below is a basic example of how to start a self-hosted satellite as a Kubernetes Pod:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: my-satellite
+  namespace: earthly-satellites
+spec:
+  volumes:
+  - name: earthly-cache
+    emptyDir: {} # or other volume type
+  containers:
+   - name:
+   valueFrom:
+     fieldRef:
+       fieldPath: metadata.name
+      image: earthly/satellite:v0.8.3
+      securityContext:
+        privileged: true
+      ports:
+      - containerPort: 8372
+      volumeMounts:
+      - mountPath: /tmp/earthly
+        name: earthly-cache
+       env:
+       - name: EARTHLY_ORG
+         value: my-org
+       - name: EARTHLY_TOKEN
+         value: u4a*************l92
+       - name: SATELLITE_NAME
+         valueFrom:
+           fieldRef:
+             fieldPath: metadata.name
+       - name: SATELLITE_HOST
+         valueFrom:
+           fieldRef:
+             fieldPath: status.podIP
+```
+
+This example uses the pod’s IP address (via [Downward API](https://kubernetes.io/docs/concepts/workloads/pods/downward-api/)) as the `SATELLITE_HOST` value. The Earthly CLI must be able to reach the IP on its network.
+
+If the Earthly CLI should connect via a different address, such as DNS, then this value should be provided as the `SATELLITE_HOST` instead.
+
+Note: for best security, deploy satellites in a Kubernetes cluster that is separate from production.
+
+## Advanced Configuration
+
+### Cache Disk
+
+Many deployments can benefit from using a dedicated volume as the satellite’s cache directory. Using a separate volume allows for persistent cache, even after the container is destroyed, such as when upgrading to a newer version. The satellite’s cache directory is located at `/tmp/Earthly` within the Docker container.
+
+Here’s an example of how to attach the volume using the Docker command line:
+
+```
+docker run -v earthly-cache:/tmp/earthly:rw \
+  ...
+  earthly/satellite:v0.8.3
+```
+
+## Additional Environment Variables
+
+The following environment variables can also be set to tweak the performance of a self-hosted satellite.
+
+* `SATELLITE_PORT` - Sets an alternate port for Earthly CLI clients to connect to. Must be changed if exposing the satellite on a port other than 8372.
+* `CACHE_SIZE_PCT` - The amount of disk to use for long-term cache storage. An integer from 1-100. Note that in-progress builds may consume additional disk space, so this value can result in "no space left on device" errors if set too high.
+* `BUILDKIT_MAX_PARALLELISM` - The number of concurrent processes the satellite can run at once. Consider the number of cores available to the satellite when configuring this.
+* `BUILDKIT_SESSION_TIMEOUT` - The max duration a single build can run for before timing out. Set to 24h by default.
+* `CACHE_KEEP_DURATION` - How long idle cache will be retained on disk before being pruned.
+* `RUNNER_DISABLE_TLS` - Disable TLS on the satellite. Requires Earthly CLI to also disable TLS. Not recommended in most cases.
+* `LOG_LEVEL` - The log level of the internal "runner" process within the satellite. Set to INFO by default.
+* `BUILDKIT_DEBUG` - Enable buildkit debug-level logs. False by default.
+* `EARTHLY_ADDITIONAL_BUILDKIT_CONFIG` - allows additional buildkit configs to be injected in TOML format.
+
+## Running on Localhost
+
+For testing purposes, you may want to try your self-hosted satellite on localhost. Satellites currently do not support using `localhost` or `127.0.0.1` as an address when supplied to `SATELLITE_HOST`, in part because Earthly CLI has reserved this address for use as its own local Buildkit container.
+
+It’s still possible to test self-hosted satellites locally, however, by using an alternate entry in your `/etc/hosts` file that maps to `localhost`. For example, you can try adding this entry:
+
+```
+# Local test for Earthly
+127.0.0.1	earthly.local
+```
+
+Starting your satellite with `SATELLITE_HOST` set to `earthly.local` should allow for a localhost connection using your Earthly CLI.
+
+## Debugging
+
+If you are having problems using or deploying your self-hosted satellite, please refer to the following tips or reach out to us through our community [Slack channel](https://earthly.dev/slack).
+
+### Problem: Satellite is not listed in the output of `earthly satellite ls`
+
+**Resolution:** Check the logs from the satellite’s Docker container. There may be a message containing the phrase `SATELLITE IS NOT REGISTERED`. This usually means there was a problem with the values supplied to the satellite’s run command. Check the error for additional context. Ensure the values provided for account token, earthly org, etc are correct.
+
+
+### Problem: Satellite is not starting
+
+**Resolution:** There may be some required environment variables missing or they may contain invalid values. Ensure all values are entered correctly. Check the container logs for more information.
+
+### Problem: Earthly client is unable to connect to the satellite
+
+**Resolution:** Check the address of the satellite. This is printed at the start of the build during the "Init" phase, or can be found via the satellite inspect command. Ensure the value here is as expected, and that the earthly client can reach the address on its network. If the port has been remapped from 8372, you may also need to change this via the `SATELLITE_PORT` environment variable.
+
+
+### Problem: The satellite log says that it is running on port 9372
+
+**Resolution:** The log message `"running server on [::]:9372"` can be misleading, however, the exposed port on the container is still 8372. Multiple processes are running inside the satellite container, including an earthly/buildkit process. This log message comes from the buildkit process, however, a separate process on port 8372 handles the incoming gRPC requests to the container.

--- a/docs/cloud/satellites/self-hosted.md
+++ b/docs/cloud/satellites/self-hosted.md
@@ -185,7 +185,7 @@ The following environment variables can also be set to tweak the performance of 
 * `CACHE_SIZE_PCT` - The amount of disk to use for long-term cache storage. An integer from 1-100. Note that in-progress builds may consume additional disk space, so this value can result in "no space left on device" errors if set too high.
 * `BUILDKIT_MAX_PARALLELISM` - The number of concurrent processes the satellite can run at once. Consider the number of cores available to the satellite when configuring this.
 * `BUILDKIT_SESSION_TIMEOUT` - The max duration a single build can run for before timing out. Set to 24h by default.
-* `CACHE_KEEP_DURATION` - How long idle cache will be retained on disk before being pruned.
+* `CACHE_KEEP_DURATION` - How long idle cache will be retained on disk before being pruned (in seconds).
 * `RUNNER_DISABLE_TLS` - Disable TLS on the satellite. Requires Earthly CLI to also disable TLS. Not recommended in most cases.
 * `LOG_LEVEL` - The log level of the internal "runner" process within the satellite. Set to INFO by default.
 * `BUILDKIT_DEBUG` - Enable buildkit debug-level logs. False by default.
@@ -221,7 +221,10 @@ If you are having problems using or deploying your self-hosted satellite, please
 
 **Resolution:** Check the address of the satellite. This is printed at the start of the build during the "Init" phase, or can be found via the satellite inspect command. Ensure the value here is as expected, and that the earthly client can reach the address on its network. If the port has been remapped from 8372, you may also need to change this via the `SATELLITE_PORT` environment variable.
 
-
 ### Problem: The satellite log says that it is running on port 9372
 
 **Resolution:** The log message `"running server on [::]:9372"` can be misleading, however, the exposed port on the container is still 8372. Multiple processes are running inside the satellite container, including an earthly/buildkit process. This log message comes from the buildkit process, however, a separate process on port 8372 handles the incoming gRPC requests to the container.
+
+### Problem: Satellite shows an `operational` state even though it is no longer running
+
+**Resolution:** It is possible that the satellite did not terminate gracefully, and hence did not automatically deregister as it shutdown. You can run `earthly sat rm --force` to force-remove the satellite from the list, or wait some time for the satellite to automatically be removed. Earthly Cloud will automatically drop the satellite from the list if it detects no heartbeat messages for a while.

--- a/docs/earthfile/earthfile.md
+++ b/docs/earthfile/earthfile.md
@@ -602,6 +602,13 @@ A global `ARG` is an arg that is made available to all targets in the Earthfile.
 
 Global args may only be declared in base targets.
 
+{% hint style='danger' %}
+##### Important
+Avoid using `ARG --global` for args that change frequently (e.g. git sha, branch name, PR number, etc). Any change to the value of this arg would typically cause all targets in the Earthfile to re-execute with no cache.
+
+It's always best to declare args as deep and late as possible within the specific target where they are needed, to get the most performance, even if this may require more verbose passing of args from one target to another. See also [`BUILD --pass-args`](#build).
+{% endhint %}
+
 ## SAVE ARTIFACT
 
 #### Synopsis

--- a/docs/remote-runners.md
+++ b/docs/remote-runners.md
@@ -26,6 +26,19 @@ When using remote runners, even though the build executes remotely, the followin
 
 To get started with free remote runners managed by Earthly, check out [Earthly Satellites](cloud/satellites.md).
 
-To get started with self-managed remote runners, see
-* The [remote buildkit page](ci-integration/remote-buildkit.md)
-* The [Kubernetes setup page](ci-integration/guides/kubernetes.md)
+To get started with self-hosted runners, see the [Self-Hosted Satellites Guide](cloud/satellites/self-hosted.md).
+
+If your use case cannot tolerate a cloud-based control plane, then self-hosting a remote Buildkit is the best approach. Remote Buildkit has less features, is less secure, and is more difficult to deploy than Self-Hosted Satellites (see diagram below for comparison). To get started self-hosting Buildkit, see the [remote buildkit page](ci-integration/remote-buildkit.md).
+
+### Types of Remote Runners
+
+Below is a comparison of the different features available with each kind of remote runner.
+
+| Feature | Cloud Satellites | Self-Hosted Satellites | Remote Buildkit |
+| --- | --- | --- | --- |
+| Managed By | Earthly | You | You |
+| Cache Persistence | ✅ Yes | 🟡 Needs configuration | 🟡 Needs configuration |
+| Cloud Control-Plane | ✅ Yes | ✅ Yes | ❌ No |
+| Managed TLS Certificates |  ✅ Yes | ✅ Yes | ❌ No |
+| Auto-Sleep | ✅ Yes | ❌ No | ❌ No | 
+| Auto-Updates | ✅ Yes | ❌ No | ❌ No |


### PR DESCRIPTION
Restores commits from `77eba05`, which was the tip of `docs-0.8` before the updates yesterday. 