### PR TITLE
Bring back support for org env/flag for log streaming

### DIFF
--- a/cmd/earthly/subcmd/build_cmd.go
+++ b/cmd/earthly/subcmd/build_cmd.go
@@ -625,8 +625,8 @@ func (a *Build) ActionBuildImp(cliCtx *cli.Context, flagArgs, nonFlagArgs []stri
 		// Use the flag/env values for org & project if specified, but fallback to
 		// the PROJECT command if provided.
 		orgName := d.EarthlyOrgName
-		if a.cli.Flags().OrgName != "" {
-			orgName = a.cli.Flags().OrgName
+		if a.cli.OrgName() != "" {
+			orgName = a.cli.OrgName()
 		}
 		projectName := d.EarthlyProjectName
 		if a.cli.Flags().ProjectName != "" {


### PR DESCRIPTION
We need to support `EARTHLY_ORG` & `--org` to get org ID data to Logstream in all cases. It looks like we inadvertently lost support for these settings with this change: https://github.com/earthly/earthly/commit/cbcad005b087f2177fabbbb8dee908de371eb69d#diff-1ca730ef8be44ea6574fb0c5e06a96627cea73b86f46ba51ba09c5807418527aL158

I'll look into adding a test or two if this looks good. 