### PR TITLE
Fix bug with wildcard BUILD & flags

### DIFF
--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -1749,7 +1749,7 @@ func (c *Converter) ExpandWildcard(ctx context.Context, fullTargetName string, c
 		}
 
 		cloned := cmd.Clone()
-		cloned.Args[0] = childTargetName
+		cloned.Args[len(cloned.Args)-1] = childTargetName
 		children = append(children, cloned)
 	}
 

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -78,6 +78,7 @@ ga-no-qemu-group1:
     BUILD +wildcard-build
     BUILD +wildcard-build-remote
     BUILD +wildcard-build-pwd
+    BUILD +wildcard-build-auto-skip
 
 ga-no-qemu-group2:
     BUILD +target-first-line
@@ -609,6 +610,10 @@ wildcard-build-pwd:
     RUN cat earthly.output | acbgrep 'hello world 2'
     RUN cat earthly.output | acbgrep 'hello world 3'
     RUN cat earthly.output | acbgrep -v 'not-test run'
+
+wildcard-build-auto-skip:
+    COPY wildcard-build .
+    DO +RUN_EARTHLY --earthfile=wildcard-build.earth --target=+wildcard-build-auto-skip
 
 wildcard-build-pwd-rel:
     COPY wildcard-build subdir

--- a/tests/wildcard-build.earth
+++ b/tests/wildcard-build.earth
@@ -1,15 +1,14 @@
 VERSION --wildcard-builds 0.8
 
+FROM alpine
+
 wildcard-build:
-    FROM alpine
     BUILD ./wildcard-build/*+test
 
 wildcard-globstar:
-    FROM alpine
     BUILD ./wildcard-build/**/*+test
 
 wildcard-glob:
-    FROM alpine
     BUILD ./wildcard-build/b*[rz]+test
 
 wildcard-remote:
@@ -19,9 +18,10 @@ wildcard-remote-glob:
     BUILD github.com/earthly/test-remote/wildcard-build:fb0ebe1c6181bdfc5a7d92165f3317e85e199794+wildcard-glob
 
 wildcard-build-pwd:
-    FROM alpine
     BUILD ./*+test
 
 wildcard-build-rel-dir:
-    FROM alpine
     BUILD ../../tmp/other-dir/*+test
+
+wildcard-build-auto-skip:
+    BUILD --auto-skip ./*+test


### PR DESCRIPTION
Addresses: https://github.com/earthly/earthly/issues/3862

The code should replace the wildcard target with the expanded one while accounting for flags & args.