### PR TITLE
BUILD --auto-skip was silently ignored when not feature flagged

### DIFF
--- a/earthfile2llb/interpreter.go
+++ b/earthfile2llb/interpreter.go
@@ -1235,6 +1235,10 @@ func (i *Interpreter) handleBuild(ctx context.Context, cmd spec.Command, async b
 		return i.errorf(cmd.SourceLocation, "the BUILD --pass-args flag must be enabled with the VERSION --pass-args feature flag.")
 	}
 
+	if !i.converter.ftrs.BuildAutoSkip && opts.AutoSkip {
+		return i.errorf(cmd.SourceLocation, "the BUILD --auto-skip flag must be enabled with the VERSION --build-auto-skip feature flag.")
+	}
+
 	for _, buildArgs := range crossProductBuildArgs {
 		saveHashFn := func() {}
 		if opts.AutoSkip {

--- a/tests/wildcard-build.earth
+++ b/tests/wildcard-build.earth
@@ -1,4 +1,4 @@
-VERSION --wildcard-builds 0.8
+VERSION --wildcard-builds --build-auto-skip 0.8
 
 FROM alpine
 


### PR DESCRIPTION
`BUILD --auto-skip ...` is only valid when `VERSION --build-auto-skip ...` is enabled. When it isn't, an error should be returned