### PR TITLE
Fix COPY --if-exists with wildcard

### DIFF
--- a/ast/tests/copy.ast.json
+++ b/ast/tests/copy.ast.json
@@ -1212,6 +1212,87 @@
           }
         }
       ]
+    },
+    {
+      "name": "copy-if-exists-wildcard",
+      "recipe": [
+        {
+          "command": {
+            "args": [
+              "--if-exists",
+              "non_existing_folder/*",
+              "/"
+            ],
+            "name": "COPY"
+          }
+        }
+      ]
+    },
+    {
+      "name": "copy-if-exists-wildcard-exists-empty",
+      "recipe": [
+        {
+          "command": {
+            "args": [
+              "--if-exists",
+              "existing_folder/*",
+              "."
+            ],
+            "name": "COPY"
+          }
+        },
+        {
+          "command": {
+            "args": [
+              "!",
+              "test",
+              "-f",
+              "foo"
+            ],
+            "name": "RUN"
+          }
+        }
+      ]
+    },
+    {
+      "name": "copy-if-exists-wildcard-exists",
+      "recipe": [
+        {
+          "command": {
+            "args": [
+              "--if-exists",
+              "existing_folder/*",
+              "."
+            ],
+            "name": "COPY"
+          }
+        },
+        {
+          "command": {
+            "args": [
+              "test",
+              "-f",
+              "foo"
+            ],
+            "name": "RUN"
+          }
+        }
+      ]
+    },
+    {
+      "name": "copy-wildcard",
+      "recipe": [
+        {
+          "command": {
+            "args": [
+              "--if-exists",
+              "prefix-*",
+              "/"
+            ],
+            "name": "COPY"
+          }
+        }
+      ]
     }
   ],
   "version": {

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -261,7 +261,7 @@ copy-test-wildcard:
     DO +RUN_EARTHLY --earthfile=copy.earth --target=+copy-wildcard
 
 copy-test-if-exists-wildcard:
-    #DO +RUN_EARTHLY --earthfile=copy.earth --target=+copy-if-exists-wildcard
+    DO +RUN_EARTHLY --earthfile=copy.earth --target=+copy-if-exists-wildcard
 
     RUN mkdir existing_folder
     DO +RUN_EARTHLY --earthfile=copy.earth --target="+copy-if-exists-wildcard-exists-empty"

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -33,6 +33,7 @@ ga-no-qemu-group1:
     BUILD +copy-keep-own-test
     BUILD +copy-test-empty-src
     BUILD +copy-test-if-exists-wildcard
+    BUILD +copy-test-wildcard
     BUILD +git-clone-test
     BUILD +builtin-args-invalid-default-test
     BUILD +builtin-args-invalid-pass-test
@@ -253,7 +254,6 @@ copy-test:
     DO +RUN_EARTHLY --earthfile=copy.earth --output_does_not_contain="which does not expand to a home directory"
 
 copy-test-empty-src:
-    # Regression tests for 'COPY --if-exists "" <dst>' (empty string)
     DO +RUN_EARTHLY --earthfile=copy.earth --target=+copy-empty-src
     DO +RUN_EARTHLY --earthfile=copy.earth --target=+copy-empty-src-if-exists
 
@@ -261,14 +261,13 @@ copy-test-wildcard:
     DO +RUN_EARTHLY --earthfile=copy.earth --target=+copy-wildcard
 
 copy-test-if-exists-wildcard:
-    # Regression test for 'COPY --if-exists non_existent_folder/* /'
-    DO +RUN_EARTHLY --earthfile=copy.earth --target=+copy-if-exists-wildcard
+    #DO +RUN_EARTHLY --earthfile=copy.earth --target=+copy-if-exists-wildcard
 
-    RUN mkdir non_existent_folder
-    DO +RUN_EARTHLY --earthfile=copy.earth --target=+copy-if-exists-wildcard
+    RUN mkdir existing_folder
+    DO +RUN_EARTHLY --earthfile=copy.earth --target="+copy-if-exists-wildcard-exists-empty"
 
-    RUN touch non_existent_folder/foo
-    DO +RUN_EARTHLY --earthfile=copy.earth --target=+copy-if-exists-wildcard
+    RUN touch existing_folder/foo
+    DO +RUN_EARTHLY --earthfile=copy.earth --target="+copy-if-exists-wildcard-exists"
 
 copy-test-verbose-output:
     RUN mkdir -p subdir/a.txt && \

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -32,6 +32,7 @@ ga-no-qemu-group1:
     BUILD +copy-tilde-test
     BUILD +copy-keep-own-test
     BUILD +copy-test-empty-src
+    BUILD +copy-test-if-exists-wildcard
     BUILD +git-clone-test
     BUILD +builtin-args-invalid-default-test
     BUILD +builtin-args-invalid-pass-test
@@ -255,6 +256,19 @@ copy-test-empty-src:
     # Regression tests for 'COPY --if-exists "" <dst>' (empty string)
     DO +RUN_EARTHLY --earthfile=copy.earth --target=+copy-empty-src
     DO +RUN_EARTHLY --earthfile=copy.earth --target=+copy-empty-src-if-exists
+
+copy-test-wildcard:
+    DO +RUN_EARTHLY --earthfile=copy.earth --target=+copy-wildcard
+
+copy-test-if-exists-wildcard:
+    # Regression test for 'COPY --if-exists non_existent_folder/* /'
+    DO +RUN_EARTHLY --earthfile=copy.earth --target=+copy-if-exists-wildcard
+
+    RUN mkdir non_existent_folder
+    DO +RUN_EARTHLY --earthfile=copy.earth --target=+copy-if-exists-wildcard
+
+    RUN touch non_existent_folder/foo
+    DO +RUN_EARTHLY --earthfile=copy.earth --target=+copy-if-exists-wildcard
 
 copy-test-verbose-output:
     RUN mkdir -p subdir/a.txt && \

--- a/tests/copy.earth
+++ b/tests/copy.earth
@@ -222,3 +222,9 @@ copy-empty-src:
 copy-empty-src-if-exists:
     ARG SRC=""
     COPY --if-exists $SRC $SRC
+
+copy-if-exists-wildcard:
+    COPY --if-exists non_existing_folder/* /
+
+copy-wildcard:
+    COPY --if-exists prefix-* /

--- a/tests/copy.earth
+++ b/tests/copy.earth
@@ -226,5 +226,13 @@ copy-empty-src-if-exists:
 copy-if-exists-wildcard:
     COPY --if-exists non_existing_folder/* /
 
+copy-if-exists-wildcard-exists-empty:
+    COPY --if-exists existing_folder/* .
+    RUN ! test -f foo
+
+copy-if-exists-wildcard-exists:
+    COPY --if-exists existing_folder/* .
+    RUN test -f foo
+
 copy-wildcard:
     COPY --if-exists prefix-* /

--- a/util/llbutil/copyop.go
+++ b/util/llbutil/copyop.go
@@ -30,13 +30,13 @@ func CopyOp(ctx context.Context, srcState pllb.State, srcs []string, destState p
 		baseCopyOpts = append(baseCopyOpts, llb.WithCreatedTime(*defaultTs()))
 	}
 	for _, src := range srcs {
-		// HACK: For COPY --if-exists, we can use a glob expression (e.g., '[f]oo') to
-		// prevent errors caused by non-existing files. This approach also works
-		// with additional wildcards (e.g., '[f]oo/*').
 		if ifExists && len(src) != 0 {
 			// Strip ./ and / prefixes as to make paths relative to top-level.
 			src = strings.TrimPrefix(src, "./")
 			src = strings.TrimPrefix(src, "/")
+			// HACK: For COPY --if-exists, we can use a glob expression (e.g., '[f]oo') to
+			// prevent errors caused by non-existing files. This approach also works
+			// with additional wildcards (e.g., '[f]oo/*').
 			src = fmt.Sprintf("[%s]%s", string(src[0]), string(src[1:]))
 		}
 		copyOpts := append([]llb.CopyOption{


### PR DESCRIPTION
Fixes: https://github.com/earthly/earthly/issues/3875

This PR fixes the issue, but I'm curious why the `!strings.Contains(src, "*")` was added in the first place. It seems like all of the relevant tests pass without this extra condition.