### PR TITLE
Add Renovate rules to update alpine-dind image dependencies

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -19,6 +19,7 @@
     'buildcontext/**',
     'tests/**',
     'ast/tests/**',
+    'Earthfile',
   ],
   ignorePaths: [
     "**/node_modules/**",
@@ -76,6 +77,23 @@
       matchStrings: [
         'datasource=(?<datasource>.*?) depName=(?<depName>.*?)[\\s\\n]+ARG .*?_version=(?<currentValue>.*)[\\n\\s]+',
       ]
+    },
+    {
+      customType: 'regex',
+      fileMatch: ['^Earthfile$'],
+      matchStrings: [
+        '\\s*#\\s*renovate:\\s*datasource=(?<datasource>.*?)\\s+depName=(?<depName>.*?)[\\s\\n]+(versioning=(?<versioning>.*?)\\s+)?ARG\\s+.*?(_VERSION|_VER)=(?<currentValue>.*)($|\\s|\\n)',
+      ],
+    },
+    {
+      customType: 'regex',
+      fileMatch: ['^Earthfile$'],
+      matchStrings: ["# renovate: datasource=repology depName=alpine_(?<currentValue>\\d+_\\d+)"],
+      currentValueTemplate: "{{{ replace '_' '.' currentValue }}}",
+      datasourceTemplate: "docker",
+      depNameTemplate: "alpine",
+      versioningTemplate: "regex:^(?<major>\\d+)[._](?<minor>\\d+)$",
+      autoReplaceStringTemplate: "# renovate: datasource=repology depName=alpine_{{{newMajor}}}_{{{newMinor}}}"
     }
   ],
   labels: [
@@ -132,6 +150,20 @@
       ],
       excludePackagePatterns: ['alpine/git'],
       enabled: false,
+    },
+    // set the group name for alpine dind dependencies in the root Earthfile
+    {
+      groupName: '{{{depName}}}-for-alpine-dind-image',
+      matchPackagePatterns: [
+        'alpine', 'alpine.*?/docker'
+      ],
+      matchManagers: [
+        'regex',
+      ],
+      matchDatasources: [
+        'docker', 'repology'
+      ],
+      matchFileNames: ["Earthfile"],
     }
   ],
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -19,7 +19,6 @@
     'buildcontext/**',
     'tests/**',
     'ast/tests/**',
-    'Earthfile',
   ],
   ignorePaths: [
     "**/node_modules/**",
@@ -71,18 +70,9 @@
     },
     {
       customType: 'regex',
-      fileMatch: [
-        'Earthfile',
-      ],
-      matchStrings: [
-        'datasource=(?<datasource>.*?) depName=(?<depName>.*?)[\\s\\n]+ARG .*?_version=(?<currentValue>.*)[\\n\\s]+',
-      ]
-    },
-    {
-      customType: 'regex',
       fileMatch: ['^Earthfile$'],
       matchStrings: [
-        '\\s*#\\s*renovate:\\s*datasource=(?<datasource>.*?)\\s+depName=(?<depName>.*?)[\\s\\n]+(versioning=(?<versioning>.*?)\\s+)?ARG\\s+.*?(_VERSION|_VER)=(?<currentValue>.*)($|\\s|\\n)',
+        '\\s*#\\s*renovate:\\s*datasource=(?<datasource>.*?)\\s+depName=(?<depName>.*?)[\\s\\n]+(versioning=(?<versioning>.*?)\\s+)?ARG\\s+.*?(_VERSION|_VER|version)=(?<currentValue>.*?)($|\\s|\\n)',
       ],
     },
     {

--- a/Earthfile
+++ b/Earthfile
@@ -651,9 +651,9 @@ all-buildkitd:
 
 dind-alpine:
     # renovate: datasource=repology depName=alpine_3_18/docker versioning=loose
-    ARG DOCKER_VERSION=23.0.6-r5
+    ARG DOCKER_VERSION=25.0.3-r1
     # renovate: datasource=docker depName=alpine
-    ARG OS_VERSION=3.18
+    ARG OS_VERSION=3.19
     BUILD +dind --OS_IMAGE=alpine --OS_VERSION=$OS_VERSION --DOCKER_VERSION=$DOCKER_VERSION
 
 dind-ubuntu-20.04:

--- a/Earthfile
+++ b/Earthfile
@@ -650,7 +650,7 @@ all-buildkitd:
         ./buildkitd+buildkitd --BUILDKIT_PROJECT="$BUILDKIT_PROJECT"
 
 dind-alpine:
-    # renovate: datasource=repology depName=alpine_3_18/docker versioning=loose
+    # renovate: datasource=repology depName=alpine_3_19/docker versioning=loose
     ARG DOCKER_VERSION=25.0.3-r1
     # renovate: datasource=docker depName=alpine
     ARG OS_VERSION=3.19

--- a/Earthfile
+++ b/Earthfile
@@ -650,7 +650,11 @@ all-buildkitd:
         ./buildkitd+buildkitd --BUILDKIT_PROJECT="$BUILDKIT_PROJECT"
 
 dind-alpine:
-    DO --pass-args +BUILD_AND_FROM --TARGET=dind --OS_IMAGE=alpine --OS_VERSION=3.19 --DOCKER_VERSION=25.0.3-r1
+    # renovate: datasource=repology depName=alpine_3_18/docker versioning=loose
+    ARG DOCKER_VERSION=23.0.6-r5
+    # renovate: datasource=docker depName=alpine
+    ARG OS_VERSION=3.18
+    BUILD +dind --OS_IMAGE=alpine --OS_VERSION=$OS_VERSION --DOCKER_VERSION=$DOCKER_VERSION
 
 dind-ubuntu-20.04:
     DO --pass-args +BUILD_AND_FROM --TARGET=dind --OS_IMAGE=ubuntu --OS_VERSION=20.04 --DOCKER_VERSION=5:24.0.5-1~ubuntu.20.04~focal


### PR DESCRIPTION
This will open separate PRs when a new alpine docker image or docker apk package becomes available.

This will be followed by another PR to add a github action to release a new image upon merging the Renovate PR.

Once the above is done similar PRs will be opened to address the ubuntu images.