### PR TITLE
Fix worklow that merges main to docs-0.8

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -897,9 +897,10 @@ merge-main-to-docs:
         # 3. create a new PR and wait till checks complete (if checks fail, close the PR)
         gh pr create --title "Temp PR to merge $from_branch to $to_branch" --draft -B $to_branch \
         --body "Opened by +merge-main-to-docs" --repo $git_repo && \
-        sleep 5 && \
+        sleep 15 && \
         ( \
-            timeout --signal=SIGINT 300 gh pr checks $temp_pr_branch --watch --fail-fast || \
+            timeout --signal=SIGINT 300 \
+            gh run watch $(gh run list --commit $(git rev-parse HEAD) -w "Check Docs for Broken Links" --json "databaseId" --jq '.[]|.databaseId') --exit-status || \
             (gh pr close $temp_pr_branch --delete-branch && exit 1) \
         ) && \
         # 4. try to push the branch now that the PR checks have passed


### PR DESCRIPTION
Before this change, the target `+merge-main-to-docs`  would open a new temp PR and wait for all its GH checks to complete (or for first failure). Unfortunately, One of those checks that it was waiting for is the job that invoked the target, so the target would get stuck waiting on itself until timing out.

This change limits the target to only watch for the "check broken links" job to complete before trying to merge the PR/branch.