### PR TITLE
Auto-skip: ensure we account for +base

### DIFF
--- a/ast/Earthfile
+++ b/ast/Earthfile
@@ -1,7 +1,6 @@
 VERSION 0.8
 
-# Note: the tag below is needed for auto-skip.
-FROM github.com/earthly/earthly:tags/v0.8.5+base
+FROM ../+base
 
 # deps downloads and caches all dependencies for the ast package. When called
 # directly, go.mod and go.sum will be updated locally.

--- a/ast/Earthfile
+++ b/ast/Earthfile
@@ -1,6 +1,7 @@
 VERSION 0.8
 
-FROM github.com/earthly/earthly+base
+# Note: the tag below is needed for auto-skip.
+FROM github.com/earthly/earthly:tags/v0.8.5+base
 
 # deps downloads and caches all dependencies for the ast package. When called
 # directly, go.mod and go.sum will be updated locally.

--- a/tests/autoskip/Earthfile
+++ b/tests/autoskip/Earthfile
@@ -33,6 +33,7 @@ test-all:
     BUILD +test-build-flag
     BUILD +test-flag-conflict
     BUILD +test-init-failure
+    BUILD +test-arg-change
 
 test-files:
     RUN echo hello > my-file
@@ -276,6 +277,14 @@ test-init-failure:
     DO --pass-args tests+RUN_EARTHLY --extra_args="--auto-skip-db-path=/tmp --auto-skip" \
                                      --earthfile=build-flag.earth --target=+basic \
                                      --output_contains="Failed to initialize auto-skip database"
+
+test-arg-change:
+    COPY arg-change.earth Earthfile
+    RUN cat Earthfile
+    DO --pass-args tests+RUN_EARTHLY --extra_args="--auto-skip-db-path=test.db" --target=+expand-args-from --output_contains="VERSION_ID=3.18.6"
+    RUN sed -i "s/3.18.6/3.19.1/g" Earthfile
+    RUN cat Earthfile
+    DO --pass-args tests+RUN_EARTHLY --extra_args="--auto-skip-db-path=test.db" --target=+expand-args-from --output_contains="VERSION_ID=3.19.1"
 
 RUN_EARTHLY_ARGS:
     FUNCTION

--- a/tests/autoskip/Earthfile
+++ b/tests/autoskip/Earthfile
@@ -279,10 +279,15 @@ test-init-failure:
                                      --output_contains="Failed to initialize auto-skip database"
 
 test-arg-change:
+    # Please don't update. These versions are pinned to ensure a version
+    # argument change triggers auto-skip cache-busting.
+    ARG V1="3.18.6"
+    ARG V2="3.19.1"
     COPY arg-change.earth Earthfile
-    DO --pass-args tests+RUN_EARTHLY --extra_args="--auto-skip-db-path=test.db" --target=+expand-args-from --output_contains="VERSION_ID=3.18.6"
-    RUN sed -i "s/3.18.6/3.19.1/g" Earthfile
-    DO --pass-args tests+RUN_EARTHLY --extra_args="--auto-skip-db-path=test.db" --target=+expand-args-from --output_contains="VERSION_ID=3.19.1"
+    RUN sed -i "s/<VERSION>/$V1/g" Earthfile
+    DO --pass-args tests+RUN_EARTHLY --extra_args="--auto-skip-db-path=test.db" --target=+expand-args-from --output_contains="VERSION_ID=$V1"
+    RUN sed -i "s/$V1/$V2/g" Earthfile
+    DO --pass-args tests+RUN_EARTHLY --extra_args="--auto-skip-db-path=test.db" --target=+expand-args-from --output_contains="VERSION_ID=$V2"
 
 RUN_EARTHLY_ARGS:
     FUNCTION

--- a/tests/autoskip/Earthfile
+++ b/tests/autoskip/Earthfile
@@ -280,10 +280,8 @@ test-init-failure:
 
 test-arg-change:
     COPY arg-change.earth Earthfile
-    RUN cat Earthfile
     DO --pass-args tests+RUN_EARTHLY --extra_args="--auto-skip-db-path=test.db" --target=+expand-args-from --output_contains="VERSION_ID=3.18.6"
     RUN sed -i "s/3.18.6/3.19.1/g" Earthfile
-    RUN cat Earthfile
     DO --pass-args tests+RUN_EARTHLY --extra_args="--auto-skip-db-path=test.db" --target=+expand-args-from --output_contains="VERSION_ID=3.19.1"
 
 RUN_EARTHLY_ARGS:

--- a/tests/autoskip/Earthfile
+++ b/tests/autoskip/Earthfile
@@ -279,10 +279,11 @@ test-init-failure:
                                      --output_contains="Failed to initialize auto-skip database"
 
 test-arg-change:
-    # Please don't update. These versions are pinned to ensure a version
-    # argument change triggers auto-skip cache-busting.
+    # These 2 distinct versions are pinned to ensure a version argument change
+    # triggers auto-skip cache-busting.
     ARG V1="3.18.6"
     ARG V2="3.19.1"
+    RUN acbtest "$V1" != "$V2" # Ensure that the values are kept distinct.
     COPY arg-change.earth Earthfile
     RUN sed -i "s/<VERSION>/$V1/g" Earthfile
     DO --pass-args tests+RUN_EARTHLY --extra_args="--auto-skip-db-path=test.db" --target=+expand-args-from --output_contains="VERSION_ID=$V1"

--- a/tests/autoskip/arg-change.earth
+++ b/tests/autoskip/arg-change.earth
@@ -3,8 +3,6 @@ VERSION --build-auto-skip 0.8
 ARG VERSION=3.18.6
 FROM alpine:$VERSION
 
-PROJECT earthly-technologies/cloud
-
 parent:
     RUN cat /etc/os-release
 

--- a/tests/autoskip/arg-change.earth
+++ b/tests/autoskip/arg-change.earth
@@ -1,6 +1,7 @@
 VERSION --build-auto-skip 0.8
 
-ARG VERSION=3.18.6
+# Note: '<VERSION>' is replaced in tests/autoskip/Earthfile.
+ARG VERSION=<VERSION>
 FROM alpine:$VERSION
 
 parent:

--- a/tests/autoskip/arg-change.earth
+++ b/tests/autoskip/arg-change.earth
@@ -1,0 +1,7 @@
+VERSION 0.8
+
+ARG VERSION=3.18.6
+
+expand-args-from:
+    FROM alpine:$VERSION
+    RUN cat /etc/os-release

--- a/tests/autoskip/arg-change.earth
+++ b/tests/autoskip/arg-change.earth
@@ -1,7 +1,12 @@
-VERSION 0.8
+VERSION --build-auto-skip 0.8
 
 ARG VERSION=3.18.6
+FROM alpine:$VERSION
+
+PROJECT earthly-technologies/cloud
+
+parent:
+    RUN cat /etc/os-release
 
 expand-args-from:
-    FROM alpine:$VERSION
-    RUN cat /etc/os-release
+    BUILD --auto-skip +parent

--- a/util/deltautil/Earthfile
+++ b/util/deltautil/Earthfile
@@ -1,6 +1,7 @@
 VERSION 0.8
 
-FROM github.com/earthly/earthly+base
+# Note: the tag below is needed for auto-skip.
+FROM github.com/earthly/earthly:tags/v0.8.5+base
 
 # deps downloads and caches all dependencies for the deltautil package. When
 # called directly, go.mod and go.sum will be updated locally.

--- a/util/deltautil/Earthfile
+++ b/util/deltautil/Earthfile
@@ -1,7 +1,6 @@
 VERSION 0.8
 
-# Note: the tag below is needed for auto-skip.
-FROM github.com/earthly/earthly:tags/v0.8.5+base
+FROM ../../+base
 
 # deps downloads and caches all dependencies for the deltautil package. When
 # called directly, go.mod and go.sum will be updated locally.


### PR DESCRIPTION
The auto-skip code did not account for the "base" target. Hence, the change to root-level `ARG`s were not breaking the cache. 

https://github.com/earthly/earthly/issues/3895