### PR TITLE
Logstream: add command ID to formatted logs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-units v0.5.0
 	github.com/dustin/go-humanize v1.0.1
-	github.com/earthly/cloud-api v1.0.1-0.20240216175649-9c937bc41efb
+	github.com/earthly/cloud-api v1.0.1-0.20240325213041-e8ba54479b17
 	github.com/earthly/earthly/ast v0.0.0-00010101000000-000000000000
 	github.com/earthly/earthly/util/deltautil v0.0.0-20231221211955-0fd4ae2cc257
 	github.com/elastic/go-sysinfo v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -195,6 +195,10 @@ github.com/earthly/buildkit v0.0.0-20240311170941-20d4e2ffaa09 h1:3x2kOOXGBbrQsA
 github.com/earthly/buildkit v0.0.0-20240311170941-20d4e2ffaa09/go.mod h1:1/yAC8A0Tu94Bdmv07gaG1pFBp+CetVwO7oB3qvZXUc=
 github.com/earthly/cloud-api v1.0.1-0.20240216175649-9c937bc41efb h1:lYdDcDqqEQ7QNNU3BPr8Pfs8M8caOfa8ctZvByNTc1Y=
 github.com/earthly/cloud-api v1.0.1-0.20240216175649-9c937bc41efb/go.mod h1:rU/tYJ7GFBjdKAITV2heDbez++glpGSbtJaZcp73rNI=
+github.com/earthly/cloud-api v1.0.1-0.20240325194450-8c2f04afae52 h1:0P3c+znC6o5rCn0f2Yey6CPms8+DZ+BNKGw02XEwMFI=
+github.com/earthly/cloud-api v1.0.1-0.20240325194450-8c2f04afae52/go.mod h1:rU/tYJ7GFBjdKAITV2heDbez++glpGSbtJaZcp73rNI=
+github.com/earthly/cloud-api v1.0.1-0.20240325213041-e8ba54479b17 h1:qreZf5PtVqL9sSdr27R/YY+UVqgroaO3tRJokBSBw+0=
+github.com/earthly/cloud-api v1.0.1-0.20240325213041-e8ba54479b17/go.mod h1:rU/tYJ7GFBjdKAITV2heDbez++glpGSbtJaZcp73rNI=
 github.com/earthly/fsutil v0.0.0-20231030221755-644b08355b65 h1:6oyWHoxHXwcTt4EqmMw6361scIV87uEAB1N42+VpIwk=
 github.com/earthly/fsutil v0.0.0-20231030221755-644b08355b65/go.mod h1:9kMVqMyQ/Sx2df5LtnGG+nbrmiZzCS7V6gjW3oGHsvI=
 github.com/elastic/go-sysinfo v1.9.0 h1:usICqY/Nw4Mpn9f4LdtpFrKxXroJDe81GaxxUlCckIo=

--- a/logbus/bus.go
+++ b/logbus/bus.go
@@ -171,6 +171,6 @@ func (b *Bus) WriteFormattedLog(dfl *logstream.DeltaFormattedLog) {
 }
 
 // FormattedWriter returns a writer that writes formatted deltas to the bus.
-func (b *Bus) FormattedWriter(targetID string) *FormattedWriter {
-	return NewFormattedWriter(b, targetID)
+func (b *Bus) FormattedWriter(targetID, commandID string) *FormattedWriter {
+	return NewFormattedWriter(b, targetID, commandID)
 }

--- a/logbus/formattedwriter.go
+++ b/logbus/formattedwriter.go
@@ -6,30 +6,34 @@ import (
 
 // FormattedWriter is a writer that produces DeltaFormattedLog messages.
 type FormattedWriter struct {
-	bus      *Bus
-	targetID string
+	bus       *Bus
+	targetID  string
+	commandID string
 }
 
 // NewFormattedWriter creates a new FormattedWriter.
-func NewFormattedWriter(bus *Bus, targetID string) *FormattedWriter {
+func NewFormattedWriter(bus *Bus, targetID, commandID string) *FormattedWriter {
 	return &FormattedWriter{
-		bus:      bus,
-		targetID: targetID,
+		bus:       bus,
+		targetID:  targetID,
+		commandID: commandID,
 	}
 }
 
 // Write writes the given bytes to the writer.
-func (fw *FormattedWriter) Write(dt []byte) (int, error) {
+func (w *FormattedWriter) Write(dt []byte) (int, error) {
 	// TODO (vladaionescu): Can the timestamp be passed along straight
 	// 						from buildkit?
-	now := fw.bus.NowUnixNanos()
-	fw.bus.WriteFormattedLog(&logstream.DeltaFormattedLog{
-		TargetId:           fw.targetID,
+	now := w.bus.NowUnixNanos()
+	w.bus.WriteFormattedLog(&logstream.DeltaFormattedLog{
+		TargetId:           w.targetID,
+		CommandId:          w.commandID,
 		TimestampUnixNanos: now,
 		Data:               dt,
 	})
-	fw.bus.WriteFormattedLog(&logstream.DeltaFormattedLog{
+	w.bus.WriteFormattedLog(&logstream.DeltaFormattedLog{
 		TargetId:           "_full",
+		CommandId:          w.commandID,
 		TimestampUnixNanos: now,
 		Data:               dt,
 	})

--- a/logbus/formatter/formatter.go
+++ b/logbus/formatter/formatter.go
@@ -323,7 +323,7 @@ func (f *Formatter) handleDeltaLog(dl *logstream.DeltaLog) error {
 }
 
 func (f *Formatter) processOngoingTick(ctx context.Context) error {
-	c := f.console.WithWriter(f.bus.FormattedWriter("ongoing")).WithPrefix("ongoing")
+	c := f.console.WithWriter(f.bus.FormattedWriter("ongoing", "")).WithPrefix("ongoing")
 	c.VerbosePrintf("ongoing TODO\n")
 	// TODO(vladaionescu): Go through all the commands and find which one is ongoing.
 	// Print their targets on the console.
@@ -498,6 +498,6 @@ func (f *Formatter) targetConsole(targetID string, commandID string) (consloggin
 		writerTargetID = "_unknown"
 	}
 	return f.console.
-		WithWriter(f.bus.FormattedWriter(writerTargetID)).
+		WithWriter(f.bus.FormattedWriter(writerTargetID, commandID)).
 		WithPrefixAndSalt(targetName, writerTargetID), verboseOnly
 }


### PR DESCRIPTION
Used to filter log entries by command ID in the UI. 