### PR TITLE
warn if arch mismatch between host and local buildkit

### DIFF
--- a/util/containerutil/shell_shared.go
+++ b/util/containerutil/shell_shared.go
@@ -276,8 +276,10 @@ func (sf *shellFrontend) ImageInfo(ctx context.Context, refs ...string) (map[str
 
 	// Anonymous struct to just pick out what we need
 	images := []struct {
-		ID   string   `json:"Id"`
-		Tags []string `json:"RepoTags"`
+		ID           string   `json:"Id"`
+		Architecture string   `json:"Architecture"`
+		OS           string   `json:"Os"`
+		Tags         []string `json:"RepoTags"`
 	}{}
 	err := json.Unmarshal([]byte(output.stdout.String()), &images)
 	if err != nil {
@@ -286,8 +288,10 @@ func (sf *shellFrontend) ImageInfo(ctx context.Context, refs ...string) (map[str
 
 	for i, image := range images {
 		infos[refs[i]] = &ImageInfo{
-			ID:   image.ID,
-			Tags: image.Tags,
+			ID:           image.ID,
+			Architecture: image.Architecture,
+			OS:           image.OS,
+			Tags:         image.Tags,
 		}
 	}
 

--- a/util/containerutil/types.go
+++ b/util/containerutil/types.go
@@ -9,15 +9,16 @@ import (
 
 // ContainerInfo contains things we may care about from inspect output for a given container.
 type ContainerInfo struct {
-	ID      string
-	Name    string
-	Created time.Time
-	Status  string
-	IPs     map[string]string
-	Ports   []string
-	Image   string
-	ImageID string
-	Labels  map[string]string
+	ID       string
+	Name     string
+	Platform string
+	Created  time.Time
+	Status   string
+	IPs      map[string]string
+	Ports    []string
+	Image    string
+	ImageID  string
+	Labels   map[string]string
 }
 
 const (
@@ -66,8 +67,10 @@ type FrontendInfo struct {
 
 // ImageInfo contains information about a given image ref, including all relevant tags.
 type ImageInfo struct {
-	ID   string
-	Tags []string
+	ID           string
+	OS           string
+	Architecture string
+	Tags         []string
 }
 
 // VolumeInfo contains information about a given volume, including its name, where its mounted from, and the size of the volume.


### PR DESCRIPTION
Examples of the new warning:

When starting a new container:
```
           buildkitd | Starting buildkit daemon as a docker container (earthly-dev-buildkitd)...
           buildkitd | Warning: earthly-dev-buildkitd was started using architecture amd64, but host architecture is arm64; is DOCKER_DEFAULT_PLATFORM accidentally set?
```

When checking an existing container:
```
           buildkitd | Found buildkit daemon as docker container (earthly-dev-buildkitd)
           buildkitd | Warning: currently running earthly-dev-buildkitd under architecture amd64, but host architecture is arm64; is DOCKER_DEFAULT_PLATFORM accidentally set?
```

fixes #3937