### PR TITLE
exec-stats-summary: output summary of stats at end

### DIFF
--- a/cmd/earthly/app/before.go
+++ b/cmd/earthly/app/before.go
@@ -15,6 +15,7 @@ import (
 	"github.com/earthly/earthly/util/cliutil"
 	"github.com/earthly/earthly/util/containerutil"
 	"github.com/earthly/earthly/util/envutil"
+	"github.com/earthly/earthly/util/execstatssummary"
 	"github.com/earthly/earthly/util/fileutil"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
@@ -50,13 +51,17 @@ func (app *EarthlyApp) before(cliCtx *cli.Context) error {
 		if app.BaseCLI.Flags().BuildID == "" {
 			app.BaseCLI.Flags().BuildID = uuid.NewString()
 		}
+		var execStatsTracker *execstatssummary.Tracker
+		if app.BaseCLI.Flags().ExecStatsSummary != "" {
+			execStatsTracker = execstatssummary.NewTracker(app.BaseCLI.Flags().ExecStatsSummary)
+		}
 		disableOngoingUpdates := !app.BaseCLI.Flags().Logstream || app.BaseCLI.Flags().InteractiveDebugging
 		forceColor := envutil.IsTrue("FORCE_COLOR")
 		noColor := envutil.IsTrue("NO_COLOR")
 		var err error
 		newSetup, err := logbussetup.New(
 			cliCtx.Context, app.BaseCLI.Logbus(), app.BaseCLI.Flags().Debug, app.BaseCLI.Flags().Verbose, app.BaseCLI.Flags().DisplayExecStats, forceColor, noColor,
-			disableOngoingUpdates, app.BaseCLI.Flags().LogstreamDebugFile, app.BaseCLI.Flags().BuildID)
+			disableOngoingUpdates, app.BaseCLI.Flags().LogstreamDebugFile, app.BaseCLI.Flags().BuildID, execStatsTracker)
 		app.BaseCLI.SetLogbusSetup(newSetup)
 		if err != nil {
 			return errors.Wrap(err, "logbus setup")

--- a/cmd/earthly/app/run.go
+++ b/cmd/earthly/app/run.go
@@ -134,7 +134,7 @@ func unhideFlagsCommands(ctx context.Context, cmds []*cli.Command) {
 func (app *EarthlyApp) run(ctx context.Context, args []string, lastSignal *syncutil.Signal) int {
 	defer func() {
 		if app.BaseCLI.LogbusSetup() != nil {
-			err := app.BaseCLI.LogbusSetup().Close()
+			err := app.BaseCLI.LogbusSetup().Close(ctx)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error(s) in logbus: %v", err)
 			}

--- a/cmd/earthly/flag/global.go
+++ b/cmd/earthly/flag/global.go
@@ -41,6 +41,7 @@ type Global struct {
 	GitUsernameOverride        string
 	GitPasswordOverride        string
 	GitBranchOverride          string
+	ExecStatsSummary           string
 	SSHAuthSock                string
 	Verbose                    bool
 	Debug                      bool
@@ -182,6 +183,13 @@ func (global *Global) RootFlags(installName string, bkImage string) []cli.Flag {
 			EnvVars:     []string{"EARTHLY_EXEC_STATS"},
 			Usage:       "Display container stats (e.g. cpu and memory usage)",
 			Destination: &global.DisplayExecStats,
+			Hidden:      true, // Experimental
+		},
+		&cli.StringFlag{
+			Name:        "exec-stats-summary",
+			EnvVars:     []string{"EARTHLY_EXEC_STATS_SUMMARY"},
+			Usage:       "Output summarized container stats (e.g. cpu and memory usage) to the specified file",
+			Destination: &global.ExecStatsSummary,
 			Hidden:      true, // Experimental
 		},
 		&cli.BoolFlag{

--- a/cmd/earthly/subcmd/build_cmd.go
+++ b/cmd/earthly/subcmd/build_cmd.go
@@ -540,8 +540,8 @@ func (a *Build) ActionBuildImp(cliCtx *cli.Context, flagArgs, nonFlagArgs []stri
 	var logbusSM *solvermon.SolverMonitor
 	if a.cli.Flags().Logstream {
 		logbusSM = a.cli.LogbusSetup().SolverMonitor
-	} else if a.cli.Flags().DisplayExecStats {
-		return fmt.Errorf("the --exec-stats feature is only available when --logstream is enabled")
+	} else if a.cli.Flags().DisplayExecStats || a.cli.Flags().ExecStatsSummary != "" {
+		return fmt.Errorf("the --exec-stats and --exec-stats-summary features are only available when --logstream is enabled")
 	}
 
 	builderOpts := builder.Opt{

--- a/util/execstatssummary/tracker.go
+++ b/util/execstatssummary/tracker.go
@@ -1,0 +1,91 @@
+package execstatssummary
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"sync"
+	"text/tabwriter"
+	"time"
+
+	"github.com/dustin/go-humanize"
+)
+
+// Tracker is used for tracking exec stats summary for each RUN command
+type Tracker struct {
+	mu    sync.Mutex
+	stats map[string]*stats
+	path  string
+}
+
+// NewTracker creates a new exec stats summary tracker
+func NewTracker(path string) *Tracker {
+	return &Tracker{
+		stats: map[string]*stats{},
+		path:  path,
+	}
+}
+
+// Observe records an exec stats payload for a particular (target, command) pair
+func (t *Tracker) Observe(target, command string, memory uint64, cpu time.Duration) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	k := target + "|" + command
+	stat, ok := t.stats[k]
+	if !ok {
+		stat = &stats{
+			target:  target,
+			command: command,
+		}
+		t.stats[k] = stat
+	}
+	if memory > stat.memory {
+		stat.memory = memory
+	}
+	if cpu > stat.cpu {
+		stat.cpu = cpu
+	}
+}
+
+// String returns a summarized table
+func (t *Tracker) String() string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	keys := make([]string, 0, len(t.stats))
+	for k := range t.stats {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		return t.stats[keys[i]].memory < t.stats[keys[j]].memory
+	})
+
+	var buf bytes.Buffer
+	w := tabwriter.NewWriter(&buf, 0, 0, 2, ' ', 0)
+	fmt.Fprintf(w, "target\tcommand\tmemory\tcpu\n")
+	for _, k := range keys {
+		v := t.stats[k]
+		fmt.Fprintf(w, "%s\t%s\t%v\t%v\n", v.target, v.command, humanize.Bytes(v.memory), v.cpu)
+	}
+	w.Flush()
+	return buf.String()
+}
+
+// Close closes the tracker, and writes the summary to disk (or stdout)
+func (t *Tracker) Close(ctx context.Context) error {
+	summary := t.String()
+	if t.path == "-" {
+		fmt.Print(summary)
+		return nil
+	}
+	return os.WriteFile(t.path, []byte(summary), 0644)
+}
+
+type stats struct {
+	memory  uint64
+	cpu     time.Duration
+	target  string
+	command string
+}


### PR DESCRIPTION
Outputs a list of targets which include the max memory and cpu time that was consumed from a single RUN command.