### PR TITLE
Logstream: prevent context cancels from disrupting conn

### DIFF
--- a/cloud/client.go
+++ b/cloud/client.go
@@ -202,7 +202,8 @@ func newLogstreamClient(ctx context.Context, addr string, transportCreds credent
 		grpc.WithTransportCredentials(transportCreds),
 	}
 
-	conn, err := grpc.DialContext(ctx, addr, dialOpts...)
+	// Client context cancellation is managed by another process.
+	conn, err := grpc.DialContext(context.WithoutCancel(ctx), addr, dialOpts...)
 	if err != nil {
 		return nil, errors.Wrap(err, "cloud: failed dialing logstream grpc")
 	}


### PR DESCRIPTION
Fixes a problem with log deltas being disrupted before being fully sent.