### PR TITLE
Logstream: improve message draining

### DIFF
--- a/cmd/earthly/subcmd/build_cmd.go
+++ b/cmd/earthly/subcmd/build_cmd.go
@@ -651,7 +651,7 @@ func (a *Build) ActionBuildImp(cliCtx *cli.Context, flagArgs, nonFlagArgs []stri
 		_, isCI := analytics.DetectCI(a.cli.Flags().EarthlyCIRunner)
 		setup.SetCI(isCI)
 		if doLogstreamUpload {
-			setup.StartLogStreamer(cliCtx.Context, cloudClient)
+			setup.StartLogStreamer(cloudClient)
 		}
 		return nil
 	}

--- a/logbus/ship/ship.go
+++ b/logbus/ship/ship.go
@@ -50,9 +50,10 @@ func (l *LogShipper) Write(delta *pb.Delta) {
 }
 
 // Start the log streaming process and begin writing logs to the server.
-func (l *LogShipper) Start(ctx context.Context) {
+func (l *LogShipper) Start() {
 	go func() {
-		ctx, l.cancel = context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(context.Background())
+		l.cancel = cancel
 		defer l.cancel()
 		out := bufferedDeltaChan(ctx, l.ch)
 		errCh := l.cl.StreamLogs(ctx, l.man, out)

--- a/logbus/ship/ship_test.go
+++ b/logbus/ship/ship_test.go
@@ -48,9 +48,7 @@ func TestLogShipper(t *testing.T) {
 		done: make(chan struct{}),
 	}
 
-	ctx := context.Background()
-
-	s.Start(ctx)
+	s.Start()
 
 	n := 50
 	for i := 0; i < n; i++ {


### PR DESCRIPTION
The previous PR https://github.com/earthly/earthly/pull/3953 surfaced that not all messages were being written after a user-initiated cancelation. This PR adds a short sleep to allow the messages to be written to the send channel. I tried another approach using channels but gave up after several hours because target & command writers are not reliably closed on cancellation. I don't like adding `time.Sleep` but the alternative will require a lot of effort. 