### PR TITLE
rename tests-quick to test-misc

### DIFF
--- a/.github/workflows/ci-docker-satellites.yml
+++ b/.github/workflows/ci-docker-satellites.yml
@@ -46,7 +46,7 @@ jobs:
       EARTHLY_ORG: "earthly-technologies"
     secrets: inherit
 
-  docker-tests-quick:
+  docker-test-misc:
     needs: build-earthly
     uses: ./.github/workflows/reusable-test.yml
     with:

--- a/.github/workflows/ci-docker-ubuntu.yml
+++ b/.github/workflows/ci-docker-ubuntu.yml
@@ -53,7 +53,7 @@ jobs:
       SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
 
-  docker-tests-quick:
+  docker-test-misc:
     needs: build-earthly
     if: ${{ !failure() }}
     uses: ./.github/workflows/reusable-test.yml
@@ -602,7 +602,7 @@ jobs:
       SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
 
-  race-tests-quick:
+  race-test-misc:
     needs: build-earthly
     if: ${{ !failure() }}
     uses: ./.github/workflows/reusable-race-test.yml


### PR DESCRIPTION
c502950b56e9247c659a593567e2a3ff30f08054 renamed test-quick to test-misc; however tests-quick was missed. This renames it to singular test-quick (to make searching easier in the future).