### PR TITLE
renovate- fix rules

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -95,7 +95,6 @@
         '("|\\`|\\s+)earthly/dind:(?<currentValue>.+?)("|\\`|\\s+\\|)',
         'FROM(\\s+|\\s+.*?\\s+)earthly/dind:(?<currentValue>.*?)($|\\s|\\n|\\`)',
         'docker.io/earthly/dind:(?<currentValue>.*?)@',
-
       ],
       depNameTemplate: 'earthly/dind',
       datasourceTemplate: 'docker',
@@ -145,7 +144,7 @@
         'docs-0.8',
       ],
       matchFileNames: [
-        '^Earthfile$',
+        'Earthfile',
         'earthfile2llb/**',
         'tests/**',
         'scripts/tests/interactive-debugger/**',


### PR DESCRIPTION
1. `matchFileNames` takes exact file name or a globbing expression but not regex (this rule excludes updates of earthly/dind  in docs-0.8 when found in the root Earthfile
2. remove new line