### PR TITLE
Allow for local --BUILDKIT_PROJECT when running RUN_EARTHLY tests

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -475,7 +475,8 @@ earthly-docker:
 # if no dockerhub mirror is not set it will attempt to login to dockerhub using the provided docker hub username and token.
 # Otherwise, it will attempt to login to the docker hub mirror using the provided username and password
 earthly-integration-test-base:
-    FROM +earthly-docker
+    ARG BUILDKIT_PROJECT
+    FROM --pass-args +earthly-docker
     RUN apk update && apk add pcre-tools curl python3 bash perl findutils expect yq && apk add --upgrade sed
     COPY scripts/acbtest/acbtest scripts/acbtest/acbgrep /bin/
     ENV NO_DOCKER=1

--- a/Earthfile
+++ b/Earthfile
@@ -475,7 +475,6 @@ earthly-docker:
 # if no dockerhub mirror is not set it will attempt to login to dockerhub using the provided docker hub username and token.
 # Otherwise, it will attempt to login to the docker hub mirror using the provided username and password
 earthly-integration-test-base:
-    ARG BUILDKIT_PROJECT
     FROM --pass-args +earthly-docker
     RUN apk update && apk add pcre-tools curl python3 bash perl findutils expect yq && apk add --upgrade sed
     COPY scripts/acbtest/acbtest scripts/acbtest/acbgrep /bin/

--- a/tests/integration-base/Earthfile
+++ b/tests/integration-base/Earthfile
@@ -8,6 +8,7 @@ test-base:
   ARG DOCKERHUB_MIRROR_AUTH=false
   ARG DOCKERHUB_MIRROR_AUTH_FROM_CLOUD_SECRETS=false
   ARG DOCKERHUB_AUTH=false
+  ARG BUILDKIT_PROJECT
 
   FROM ../..+earthly-integration-test-base \
     --DOCKERHUB_MIRROR=$DOCKERHUB_MIRROR \
@@ -15,7 +16,8 @@ test-base:
     --DOCKERHUB_MIRROR_HTTP=$DOCKERHUB_MIRROR_HTTP \
     --DOCKERHUB_MIRROR_AUTH=$DOCKERHUB_MIRROR_AUTH \
     --DOCKERHUB_MIRROR_AUTH_FROM_CLOUD_SECRETS=$DOCKERHUB_MIRROR_AUTH_FROM_CLOUD_SECRETS \
-    --DOCKERHUB_AUTH=$DOCKERHUB_AUTH
+    --DOCKERHUB_AUTH=$DOCKERHUB_AUTH \
+    --BUILDKIT_PROJECT=$BUILDKIT_PROJECT
 
   # uncomment this to debug dockerhub rate-limiting issues
   #RUN if !grep "registry-1.docker.io.mirror.corp.earthly.dev" /root/.docker/config.json >/dev/null; then echo "The earthly mirror was not setup correctly" && exit 1; fi


### PR DESCRIPTION
The BuildKit specified when running `+for-linux` and friends is not also being used by `RUN_EARTHLY` tests which use the `earthly-integration-test-base` image. This PR adds a similar argument for tests based on the latter image. 

```
earthly -P +test-no-qemu-group8 --BUILDKIT_PROJECT="../buildkit"
```