### PR TITLE
feat: add GHA token setting

### DIFF
--- a/cloud/github.go
+++ b/cloud/github.go
@@ -1,0 +1,25 @@
+package cloud
+
+import (
+	"context"
+	"fmt"
+
+	pb "github.com/earthly/cloud-api/compute"
+)
+
+func (c *Client) SetGithubToken(ctx context.Context, orgName string, ghOrg string, ghRepo string, token string) error {
+	orgID, err := c.GetOrgID(ctx, orgName)
+	if err != nil {
+		return fmt.Errorf("failed getting org ID: %w", err)
+	}
+	_, err = c.compute.SetGithubToken(c.withAuth(ctx), &pb.SetGithubTokenRequest{
+		OrgId:          orgID,
+		GithubOrgName:  ghOrg,
+		GithubRepoName: ghRepo,
+		GithubToken:    token,
+	})
+	if err != nil {
+		return fmt.Errorf("failed setting Github token: %w", err)
+	}
+	return nil
+}

--- a/cmd/earthly/subcmd/account_cmds.go
+++ b/cmd/earthly/subcmd/account_cmds.go
@@ -358,6 +358,7 @@ func promptHiddenText(hiddenTextPrompt string) (string, error) {
 	fmt.Println("")
 	return string(password), nil
 }
+
 func promptPassword() (string, error) {
 	return promptHiddenText("password")
 }

--- a/cmd/earthly/subcmd/github_cmds.go
+++ b/cmd/earthly/subcmd/github_cmds.go
@@ -1,0 +1,77 @@
+package subcmd
+
+import (
+	"fmt"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/earthly/earthly/cmd/earthly/helper"
+)
+
+type Github struct {
+	cli CLI
+
+	Token  string
+	GHOrg  string
+	GHRepo string
+}
+
+func NewGithub(cli CLI) *Github {
+	return &Github{
+		cli: cli,
+	}
+}
+
+func (a *Github) Cmds() []*cli.Command {
+	return []*cli.Command{
+		{
+			Name:        "github",
+			Usage:       "*experimental* Manage GitHub integration",
+			Description: "*experimental* Manage GitHub integration.",
+			Hidden:      true,
+			Subcommands: []*cli.Command{
+				{
+					Name:  "add",
+					Usage: "Add GHA integration",
+					Description: `This command sets the configuration to create a new Github-Earthly integration to trigger satellite builds from GHA (GitHub Actions).
+Integration can be done at two levels: org-wide and per repository. 
+The provided token must have enough permissions to register webhook and to create Github self hosted runners in those two different scenarios.`,
+					UsageText: "earthly github add --org <org> [--repo <repo>] --token <token>",
+					Action:    a.actionAdd,
+					Flags: []cli.Flag{
+						&cli.StringFlag{
+							Name:        "org",
+							Usage:       "GitHub organization.",
+							Required:    true,
+							Destination: &a.GHOrg,
+						},
+						&cli.StringFlag{
+							Name:        "repo",
+							Usage:       "GitHub repo.",
+							Destination: &a.GHRepo,
+						},
+						&cli.StringFlag{
+							Name:        "token",
+							Usage:       "GitHub token.",
+							Destination: &a.Token,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (a *Github) actionAdd(cliCtx *cli.Context) error {
+	a.cli.SetCommandName("githubAdd")
+	cloudClient, err := helper.NewCloudClient(a.cli)
+	if err != nil {
+		return err
+	}
+	err = cloudClient.SetGithubToken(cliCtx.Context, a.cli.OrgName(), a.GHOrg, a.GHRepo, a.Token)
+	if err != nil {
+		return fmt.Errorf("error found running github add: %w", err)
+	}
+	fmt.Println("GitHub integration successfully created")
+	return nil
+}

--- a/cmd/earthly/subcmd/github_cmds.go
+++ b/cmd/earthly/subcmd/github_cmds.go
@@ -41,7 +41,7 @@ The provided token must have enough permissions to register webhook and to creat
 					Flags: []cli.Flag{
 						&cli.StringFlag{
 							Name:        "org",
-							Usage:       "GitHub organization.",
+							Usage:       "The name of the GitHub organization to set an integration with",
 							Required:    true,
 							Destination: &a.GHOrg,
 						},

--- a/cmd/earthly/subcmd/github_cmds.go
+++ b/cmd/earthly/subcmd/github_cmds.go
@@ -52,7 +52,7 @@ The provided token must have enough permissions to register webhook and to creat
 						},
 						&cli.StringFlag{
 							Name:        "token",
-							Usage:       "GitHub token.",
+							Usage:       "The GitHub token used for the integration",
 							Destination: &a.Token,
 						},
 					},

--- a/cmd/earthly/subcmd/github_cmds.go
+++ b/cmd/earthly/subcmd/github_cmds.go
@@ -2,6 +2,8 @@ package subcmd
 
 import (
 	"fmt"
+	"os/signal"
+	"syscall"
 
 	"github.com/urfave/cli/v2"
 
@@ -11,9 +13,10 @@ import (
 type Github struct {
 	cli CLI
 
-	Token  string
-	GHOrg  string
-	GHRepo string
+	Org     string
+	GHOrg   string
+	GHRepo  string
+	GHToken string
 }
 
 func NewGithub(cli CLI) *Github {
@@ -33,27 +36,32 @@ func (a *Github) Cmds() []*cli.Command {
 				{
 					Name:  "add",
 					Usage: "Add GHA integration",
-					Description: `This command sets the configuration to create a new Github-Earthly integration to trigger satellite builds from GHA (GitHub Actions).
-Integration can be done at two levels: org-wide and per repository. 
-The provided token must have enough permissions to register webhook and to create Github self hosted runners in those two different scenarios.`,
+					Description: `This command sets the configuration to create a new Github-Earthly integration, to trigger satellite builds from GHA (GitHub Actions).
+From the Github side, integration can be done at two levels: organization-wide and per repository. 
+The provided token must have enough permissions to register webhooks and to create Github self hosted runners in those two scenarios.`,
 					UsageText: "earthly github add --org <org> [--repo <repo>] --token <token>",
 					Action:    a.actionAdd,
 					Flags: []cli.Flag{
 						&cli.StringFlag{
 							Name:        "org",
+							Usage:       "The name of the Earthly organization to set an integration with. Defaults to selected organization",
+							Destination: &a.Org,
+						},
+						&cli.StringFlag{
+							Name:        "gh-org",
 							Usage:       "The name of the GitHub organization to set an integration with",
 							Required:    true,
 							Destination: &a.GHOrg,
 						},
 						&cli.StringFlag{
-							Name:        "repo",
+							Name:        "gh-repo",
 							Usage:       "The name of the GitHub repository to set an integration with",
 							Destination: &a.GHRepo,
 						},
 						&cli.StringFlag{
-							Name:        "token",
+							Name:        "gh-token",
 							Usage:       "The GitHub token used for the integration",
-							Destination: &a.Token,
+							Destination: &a.GHToken,
 						},
 					},
 				},
@@ -64,14 +72,34 @@ The provided token must have enough permissions to register webhook and to creat
 
 func (a *Github) actionAdd(cliCtx *cli.Context) error {
 	a.cli.SetCommandName("githubAdd")
+	if a.Org == "" {
+		if a.cli.OrgName() == "" {
+			return fmt.Errorf("coudn't determine Earthly organization")
+		}
+		a.Org = a.cli.OrgName()
+	}
+	if a.GHToken == "" {
+		// Our signal handling under main() doesn't cause reading from stdin to cancel
+		// as there's no way to pass app.ctx to stdin read calls.
+		signal.Reset(syscall.SIGINT, syscall.SIGTERM)
+		token, err := promptToken()
+		if err != nil {
+			return err
+		}
+		a.GHToken = token
+	}
 	cloudClient, err := helper.NewCloudClient(a.cli)
 	if err != nil {
 		return err
 	}
-	err = cloudClient.SetGithubToken(cliCtx.Context, a.cli.OrgName(), a.GHOrg, a.GHRepo, a.Token)
+	err = cloudClient.SetGithubToken(cliCtx.Context, a.cli.OrgName(), a.GHOrg, a.GHRepo, a.GHToken)
 	if err != nil {
 		return fmt.Errorf("error found running github add: %w", err)
 	}
 	a.cli.Console().Printf("GitHub integration successfully created")
 	return nil
+}
+
+func promptToken() (string, error) {
+	return promptHiddenText("Enter GH token")
 }

--- a/cmd/earthly/subcmd/github_cmds.go
+++ b/cmd/earthly/subcmd/github_cmds.go
@@ -72,6 +72,6 @@ func (a *Github) actionAdd(cliCtx *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("error found running github add: %w", err)
 	}
-	fmt.Println("GitHub integration successfully created")
+	a.cli.Console().Printf("GitHub integration successfully created")
 	return nil
 }

--- a/cmd/earthly/subcmd/github_cmds.go
+++ b/cmd/earthly/subcmd/github_cmds.go
@@ -47,7 +47,7 @@ The provided token must have enough permissions to register webhook and to creat
 						},
 						&cli.StringFlag{
 							Name:        "repo",
-							Usage:       "GitHub repo.",
+							Usage:       "The name of the GitHub repository to set an integration with",
 							Destination: &a.GHRepo,
 						},
 						&cli.StringFlag{

--- a/cmd/earthly/subcmd/root_cmds.go
+++ b/cmd/earthly/subcmd/root_cmds.go
@@ -37,6 +37,7 @@ func (a *Root) Cmds() []*cli.Command {
 		NewSecret(a.cli).Cmds(),
 		NewWeb(a.cli).Cmds(),
 		NewBilling(a.cli).Cmds(),
+		NewGithub(a.cli).Cmds(),
 	})
 
 	return cmds

--- a/tests/autocompletion/Earthfile
+++ b/tests/autocompletion/Earthfile
@@ -24,6 +24,7 @@ web " > expected
 
 test-hidden-root-commands:
     ENV EARTHLY_SHOW_HIDDEN=1
+    RUN echo "no-cache"
     RUN echo "account 
 billing 
 bootstrap 
@@ -45,7 +46,6 @@ satellite
 secret 
 web " > expected
     DO +COMPLETION_TEST --COMP_LINE="earthly "
-
 
 test-build-flags:
     RUN COMP_LINE="earthly --" COMP_POINT=10 earthly | grep -- "--allow-privileged"

--- a/tests/autocompletion/Earthfile
+++ b/tests/autocompletion/Earthfile
@@ -32,7 +32,8 @@ config
 debug 
 doc 
 docker-build 
-docker2earthly 
+docker2earthly
+github
 init 
 ls 
 org 

--- a/tests/autocompletion/Earthfile
+++ b/tests/autocompletion/Earthfile
@@ -46,6 +46,7 @@ secret
 web " > expected
     DO +COMPLETION_TEST --COMP_LINE="earthly "
 
+
 test-build-flags:
     RUN COMP_LINE="earthly --" COMP_POINT=10 earthly | grep -- "--allow-privileged"
 

--- a/tests/autocompletion/Earthfile
+++ b/tests/autocompletion/Earthfile
@@ -33,8 +33,8 @@ config
 debug 
 doc 
 docker-build 
-docker2earthly
-github
+docker2earthly 
+github 
 init 
 ls 
 org 

--- a/tests/shared-cache/lib2/Earthfile
+++ b/tests/shared-cache/lib2/Earthfile
@@ -1,0 +1,8 @@
+VERSION --global-cache 0.7
+FROM alpine:3.18
+
+test:
+    WAIT
+      RUN --secret content --mount=type=cache,target=/cache-test,id=cacheid echo "$content">/cache-test/test.txt
+    END
+    BUILD ../lib1+check

--- a/tests/shared-cache/lib2/Earthfile
+++ b/tests/shared-cache/lib2/Earthfile
@@ -1,8 +1,0 @@
-VERSION --global-cache 0.7
-FROM alpine:3.18
-
-test:
-    WAIT
-      RUN --secret content --mount=type=cache,target=/cache-test,id=cacheid echo "$content">/cache-test/test.txt
-    END
-    BUILD ../lib1+check


### PR DESCRIPTION
Adds a new hidden command `earthly github add` that lets the user create a new [GHA-Satellites integration](https://docs.google.com/document/d/1Hl42AT8OjRTw2f9Yv0J757_GewLrOk8RVZsBsoxYjbY/edit#heading=h.5imekt3ni58h) (experimental)