### PR TITLE
display unit-test test durations

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -215,10 +215,17 @@ mocks:
         SAVE ARTIFACT $mockfile AS LOCAL $mockfile
     END
 
+unit-test-parser:
+    FROM +deps
+    COPY scripts/unit-test-parser/main.go .
+    RUN go build -o testparser main.go
+    SAVE ARTIFACT testparser
+
 # unit-test runs unit tests (and some integration tests).
 unit-test:
     FROM +code
     RUN apk add --no-cache --update podman fuse-overlayfs
+    COPY +unit-test-parser/testparser .
     COPY not-a-unit-test.sh .
 
     ARG testname # when specified, only run specific unit-test, otherwise run all.

--- a/not-a-unit-test.sh
+++ b/not-a-unit-test.sh
@@ -75,4 +75,4 @@ if [ -n "$testname" ]
 then
     testarg="-run $testname"
 fi
-go test -timeout 20m $testarg $pkgname
+go test -timeout 20m -json $testarg $pkgname | ./testparser

--- a/scripts/unit-test-parser/main.go
+++ b/scripts/unit-test-parser/main.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"sort"
+	"text/tabwriter"
+	"time"
+)
+
+type TestEvent struct {
+	Time    time.Time // encodes as an RFC3339-format string
+	Action  string
+	Package string
+	Test    string
+	Elapsed float64 // seconds
+	Output  string
+}
+
+func main() {
+	eventsWithElapsedTimes := []TestEvent{}
+	scanner := bufio.NewScanner(os.Stdin)
+	passed := true
+	for scanner.Scan() {
+		var event TestEvent
+		l := scanner.Text()
+		if err := json.Unmarshal([]byte(l), &event); err != nil {
+			log.Println(err)
+			os.Exit(1)
+		}
+		fmt.Printf("%s", event.Output)
+		if event.Elapsed > 0 {
+			eventsWithElapsedTimes = append(eventsWithElapsedTimes, event)
+		}
+		if event.Action == "fail" {
+			passed = false
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		log.Println(err)
+		os.Exit(1)
+	}
+
+	sort.Slice(eventsWithElapsedTimes, func(i, j int) bool {
+		return eventsWithElapsedTimes[i].Elapsed < eventsWithElapsedTimes[j].Elapsed
+	})
+
+	fmt.Printf("\n--- Test Duration Summary ---\n")
+
+	var buf bytes.Buffer
+	w := tabwriter.NewWriter(&buf, 0, 0, 2, ' ', 0)
+	fmt.Fprintf(w, "Package\tTest\tAction\tElapsed (seconds)\n")
+	for _, event := range eventsWithElapsedTimes {
+		if event.Test != "" {
+			fmt.Fprintf(w, "%s\t%s\t%s\t%v\n", event.Package, event.Test, event.Action, event.Elapsed)
+		}
+	}
+	w.Flush()
+	fmt.Printf("%s", buf.String())
+
+	if !passed {
+		fmt.Printf("test(s) failed\n")
+		os.Exit(1)
+	}
+	fmt.Printf("test(s) passed\n")
+}


### PR DESCRIPTION
example output:

```
          +unit-test | --- Test Duration Summary ---
          +unit-test | Package                                               Test                                                                                        Action  Elapsed (seconds)
          +unit-test | github.com/earthly/earthly/debugger/server            TestServer                                                                                  pass    0.01
          +unit-test | github.com/earthly/earthly/inputgraph                 TestHashTargetCache                                                                         pass    0.01
          +unit-test | github.com/earthly/earthly/inputgraph                 TestHashTargetNoCache                                                                       pass    0.01
          +unit-test | github.com/earthly/earthly/inputgraph                 TestHashTargetWithDockerRemote                                                              pass    0.01
          +unit-test | github.com/earthly/earthly/autocomplete               TestCachedCloudClient/caches_satellites                                                     pass    0.01
          +unit-test | github.com/earthly/earthly/autocomplete               TestCachedCloudClient/caches_projects                                                       pass    0.01
          +unit-test | github.com/earthly/earthly/inputgraph                 TestHashTargetWithDocker                                                                    pass    0.02
          +unit-test | github.com/earthly/earthly/util/llbutil/authprovider  TestMultiAuth/it_does_not_continue_to_contact_servers_with_no_credentials_for_a_given_host  pass    0.02
          +unit-test | github.com/earthly/earthly/cloud                      TestStreamLogsResume                                                                        pass    0.06
          +unit-test | github.com/earthly/earthly/util/containerutil         TestFrontendScheme/podman                                                                   pass    0.07
          +unit-test | github.com/earthly/earthly/util/containerutil         TestFrontendScheme/docker                                                                   pass    0.07
          +unit-test | github.com/earthly/earthly/util/containerutil         TestFrontendIsAvailable/docker                                                              pass    0.07
          +unit-test | github.com/earthly/earthly/util/containerutil         TestFrontendNew/podman                                                                      pass    0.07
          +unit-test | github.com/earthly/earthly/util/containerutil         TestFrontendInformation/docker                                                              pass    0.08
          +unit-test | github.com/earthly/earthly/util/containerutil         TestFrontendIsAvailable/podman                                                              pass    0.08
          +unit-test | github.com/earthly/earthly/util/containerutil         TestFrontendNew/docker                                                                      pass    0.1
          +unit-test | github.com/earthly/earthly/util/containerutil         TestFrontendVolumeInfo/docker                                                               pass    0.12
          +unit-test | github.com/earthly/earthly/util/containerutil         TestFrontendInformation/podman                                                              pass    0.13
          +unit-test | github.com/earthly/earthly/util/containerutil         TestFrontendScheme                                                                          pass    0.14
          +unit-test | github.com/earthly/earthly/util/containerutil         TestFrontendIsAvailable                                                                     pass    0.16
          +unit-test | github.com/earthly/earthly/util/containerutil         TestFrontendNew                                                                             pass    0.17
          +unit-test | github.com/earthly/earthly/util/containerutil         TestFrontendVolumeInfo/podman                                                               pass    0.18
          +unit-test | github.com/earthly/earthly/util/containerutil         TestFrontendInformation                                                                     pass    0.21
          +unit-test | github.com/earthly/earthly/util/containerutil         TestFrontendImageLoadHybrid/docker                                                          pass    0.23
          +unit-test | github.com/earthly/earthly/util/containerutil         TestFrontendVolumeInfo                                                                      pass    0.31
          +unit-test | github.com/earthly/earthly/util/containerutil         TestFrontendImageLoadHybrid/podman                                                          pass    0.31
          +unit-test | github.com/earthly/earthly/util/containerutil         TestFrontendImageLoadHybrid                                                                 pass    0.54
          +unit-test | github.com/earthly/earthly/util/containerutil         TestFrontendContainerStop/podman                                                            pass    0.57
          +unit-test | github.com/earthly/earthly/util/containerutil         TestFrontendContainerRemove/docker                                                          pass    0.98
          +unit-test | github.com/earthly/earthly/util/containerutil         TestFrontendContainerStop/docker                                                            pass    1.03
          +unit-test | github.com/earthly/earthly/util/containerutil         TestFrontendImageTag/docker                                                                 pass    1.06
          +unit-test | github.com/earthly/earthly/util/containerutil         TestFrontendContainerLogs/docker                                                            pass    1.12
          +unit-test | github.com/earthly/earthly/util/containerutil         TestFrontendImageTag/podman                                                                 pass    1.44
          +unit-test | github.com/earthly/earthly/util/containerutil         TestFrontendContainerStop                                                                   pass    1.6
          +unit-test | github.com/earthly/earthly/util/containerutil         TestFrontendContainerRun/docker                                                             pass    1.72
          +unit-test | github.com/earthly/earthly/util/containerutil         TestFrontendImageRemove/docker                                                              pass    2.12
          +unit-test | github.com/earthly/earthly/util/containerutil         TestFrontendImageLoad/docker                                                                pass    2.19
          +unit-test | github.com/earthly/earthly/util/containerutil         TestFrontendImageLoad/podman                                                                pass    2.28
          +unit-test | github.com/earthly/earthly/util/containerutil         TestFrontendImageTag                                                                        pass    2.5
          +unit-test | github.com/earthly/earthly/util/containerutil         TestFrontendImageInfo/podman                                                                pass    2.6
          +unit-test | github.com/earthly/earthly/util/containerutil         TestFrontendImagePull/podman                                                                pass    2.66
          +unit-test | github.com/earthly/earthly/util/containerutil         TestFrontendImageRemove/podman                                                              pass    2.79
          +unit-test | github.com/earthly/earthly/util/containerutil         TestFrontendImagePull/docker                                                                pass    3.59
          +unit-test | github.com/earthly/earthly/util/containerutil         TestFrontendImageLoad                                                                       pass    4.46
          +unit-test | github.com/earthly/earthly/util/containerutil         TestFrontendImageRemove                                                                     pass    4.91
          +unit-test | github.com/earthly/earthly/util/containerutil         TestFrontendImagePull                                                                       pass    6.25
          +unit-test | github.com/earthly/earthly/util/containerutil         TestFrontendImageInfo/docker                                                                pass    9.86
          +unit-test | github.com/earthly/earthly/util/containerutil         TestFrontendContainerInfo/docker                                                            pass    10.28
          +unit-test | github.com/earthly/earthly/util/containerutil         TestFrontendContainerLogs/podman                                                            pass    10.56
          +unit-test | github.com/earthly/earthly/util/containerutil         TestFrontendContainerRemove/podman                                                          pass    10.6
          +unit-test | github.com/earthly/earthly/util/containerutil         TestFrontendContainerInfo/podman                                                            pass    10.65
          +unit-test | github.com/earthly/earthly/util/containerutil         TestFrontendContainerRun/podman                                                             pass    10.84
          +unit-test | github.com/earthly/earthly/util/containerutil         TestFrontendContainerRemove                                                                 pass    11.58
          +unit-test | github.com/earthly/earthly/util/containerutil         TestFrontendContainerLogs                                                                   pass    11.68
          +unit-test | github.com/earthly/earthly/util/containerutil         TestFrontendImageInfo                                                                       pass    12.46
          +unit-test | github.com/earthly/earthly/util/containerutil         TestFrontendContainerRun                                                                    pass    12.56
          +unit-test | github.com/earthly/earthly/util/containerutil         TestFrontendContainerInfo                                                                   pass    20.93
```