### PR TITLE
fix builtin arg for author; add two new args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 ### Added
 
 - New experimental wildcard-based copy, e.g. `COPY ./services/*+artifact/* .` which would invoke `COPY` for `./services/foo+artifact`, and `./services/bar+artifact` (assuming two services foo and bar, both having a `artifact` target in their respective Earthfile). Enable with the `VERSION --wildcard-copy` feature flag. [#3966](https://github.com/earthly/earthly/issues/3966).
+- New built-in `ARG`s - `EARTHLY_GIT_AUTHOR_EMAIL` and `EARTHLY_GIT_AUTHOR_NAME` to will contain the author email and author name respectively. Enable with the `VERSION --git-author-email-name-args` feature flag.
 
 ### Fixed
 
 - Make `LET`/`SET` commands block parallel commands such as `BUILD` until the former are processed, similar to the behavior of `ARG`. [#3997](https://github.com/earthly/earthly/issues/3997)
 - `LET`/`SET` commands were not properly handled with the use of Auto-skip. [#3996](https://github.com/earthly/earthly/issues/3996)
+- `EARTHLY_GIT_AUTHOR` built-in `ARG` contains only the git author email address without the name. Enable with the `VERSION --git-author-email-name-args` feature flag (This fix is behind a feature flag to avoid a breaking change). [#3822](https://github.com/earthly/earthly/issues/3822)
 
 ## v0.8.7 - 2024-04-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,14 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 - New experimental wildcard-based copy, e.g. `COPY ./services/*+artifact/* .` which would invoke `COPY` for `./services/foo+artifact`, and `./services/bar+artifact` (assuming two services foo and bar, both having a `artifact` target in their respective Earthfile). Enable with the `VERSION --wildcard-copy` feature flag. [#3966](https://github.com/earthly/earthly/issues/3966).
 - New built-in `ARG`s - `EARTHLY_GIT_AUTHOR_EMAIL` and `EARTHLY_GIT_AUTHOR_NAME` will contain the author email and author name respectively. Enable with the `VERSION --git-author-email-name-args` feature flag.
 
+### Changed
+
+- `EARTHLY_GIT_AUTHOR` built-in `ARG` will now contain both name and email, when enabled with the `VERSION --git-author-email-name-args` feature flag. Previously it only contained the email. [#3822](https://github.com/earthly/earthly/issues/3822)
+
 ### Fixed
 
 - Make `LET`/`SET` commands block parallel commands such as `BUILD` until the former are processed, similar to the behavior of `ARG`. [#3997](https://github.com/earthly/earthly/issues/3997)
 - `LET`/`SET` commands were not properly handled with the use of Auto-skip. [#3996](https://github.com/earthly/earthly/issues/3996)
-- `EARTHLY_GIT_AUTHOR` built-in `ARG` contains only the git author email address without the name. Enable with the `VERSION --git-author-email-name-args` feature flag (This fix is behind a feature flag to avoid a breaking change). [#3822](https://github.com/earthly/earthly/issues/3822)
 
 ## v0.8.7 - 2024-04-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to [Earthly](https://github.com/earthly/earthly) will be doc
 ### Added
 
 - New experimental wildcard-based copy, e.g. `COPY ./services/*+artifact/* .` which would invoke `COPY` for `./services/foo+artifact`, and `./services/bar+artifact` (assuming two services foo and bar, both having a `artifact` target in their respective Earthfile). Enable with the `VERSION --wildcard-copy` feature flag. [#3966](https://github.com/earthly/earthly/issues/3966).
-- New built-in `ARG`s - `EARTHLY_GIT_AUTHOR_EMAIL` and `EARTHLY_GIT_AUTHOR_NAME` to will contain the author email and author name respectively. Enable with the `VERSION --git-author-email-name-args` feature flag.
+- New built-in `ARG`s - `EARTHLY_GIT_AUTHOR_EMAIL` and `EARTHLY_GIT_AUTHOR_NAME` will contain the author email and author name respectively. Enable with the `VERSION --git-author-email-name-args` feature flag.
 
 ### Fixed
 

--- a/buildcontext/git.go
+++ b/buildcontext/git.go
@@ -57,9 +57,10 @@ type resolvedGitProject struct {
 	// committerTs is the git committer timestamp.
 	committerTs string
 	// authorTs is the git author timestamp.
-	authorTs  string
-	author    string
-	coAuthors []string
+	authorTs    string
+	authorEmail string
+	authorName  string
+	coAuthors   []string
 	// refs is the git refs
 	refs []string
 	// state is the state holding the git files.
@@ -202,7 +203,8 @@ func (gr *gitResolver) resolveEarthProject(ctx context.Context, gwClient gwclien
 			Tags:                 rgp.tags,
 			CommitterTimestamp:   rgp.committerTs,
 			AuthorTimestamp:      rgp.authorTs,
-			Author:               rgp.author,
+			AuthorEmail:          rgp.authorEmail,
+			AuthorName:           rgp.authorName,
 			CoAuthors:            rgp.coAuthors,
 			Refs:                 rgp.refs,
 		},
@@ -269,7 +271,8 @@ func (gr *gitResolver) resolveGitProject(ctx context.Context, gwClient gwclient.
 					"git describe --exact-match --tags >/dest/git-tags || touch /dest/git-tags ; " +
 					"git log -1 --format=%ct >/dest/git-committer-ts || touch /dest/git-committer-ts ; " +
 					"git log -1 --format=%at >/dest/git-author-ts || touch /dest/git-author-ts ; " +
-					"git log -1 --format=%ae >/dest/git-author || touch /dest/git-author ; " +
+					"git log -1 --format=%ae >/dest/git-author-email || touch /dest/git-author-email ; " +
+					"git log -1 --format=%an >/dest/git-author-name || touch /dest/git-author-name ; " +
 					"git log -1 --format=%b >/dest/git-body || touch /dest/git-body ; " +
 					"git for-each-ref --points-at HEAD --format '%(refname:lstrip=-1)' >/dest/git-refs || touch /dest/git-refs ; " +
 					"find -type f -name Earthfile > /dest/Earthfile-paths || touch /dest/Earthfile-paths ; " +
@@ -347,11 +350,17 @@ func (gr *gitResolver) resolveGitProject(ctx context.Context, gwClient gwclient.
 		if err != nil {
 			return nil, errors.Wrap(err, "read git-author-ts")
 		}
-		gitAuthorBytes, err := gitMetaRef.ReadFile(ctx, gwclient.ReadRequest{
-			Filename: "git-author",
+		gitAuthorEmailBytes, err := gitMetaRef.ReadFile(ctx, gwclient.ReadRequest{
+			Filename: "git-author-email",
 		})
 		if err != nil {
-			return nil, errors.Wrap(err, "read git-author")
+			return nil, errors.Wrap(err, "read git-author-email")
+		}
+		gitAuthorNameBytes, err := gitMetaRef.ReadFile(ctx, gwclient.ReadRequest{
+			Filename: "git-author-name",
+		})
+		if err != nil {
+			return nil, errors.Wrap(err, "read git-author-name")
 		}
 		gitBodyBytes, err := gitMetaRef.ReadFile(ctx, gwclient.ReadRequest{
 			Filename: "git-body",
@@ -375,7 +384,8 @@ func (gr *gitResolver) resolveGitProject(ctx context.Context, gwClient gwclient.
 		gitHash := strings.SplitN(string(gitHashBytes), "\n", 2)[0]
 		gitShortHash := strings.SplitN(string(gitShortHashBytes), "\n", 2)[0]
 		gitBranches := strings.SplitN(gitBranch, "\n", 2)
-		gitAuthor := strings.SplitN(string(gitAuthorBytes), "\n", 2)[0]
+		gitAuthorEmail := strings.SplitN(string(gitAuthorEmailBytes), "\n", 2)[0]
+		gitAuthorName := strings.SplitN(string(gitAuthorNameBytes), "\n", 2)[0]
 		gitCoAuthors := gitutil.ParseCoAuthorsFromBody(string(gitBodyBytes))
 		var gitBranches2 []string
 		for _, gitBranch := range gitBranches {
@@ -431,7 +441,8 @@ func (gr *gitResolver) resolveGitProject(ctx context.Context, gwClient gwclient.
 			tags:           gitTags2,
 			committerTs:    gitCommiterTs,
 			authorTs:       gitAuthorTs,
-			author:         gitAuthor,
+			authorEmail:    gitAuthorEmail,
+			authorName:     gitAuthorName,
 			coAuthors:      gitCoAuthors,
 			refs:           gitRefs2,
 			earthfilePaths: strings.Split(strings.TrimSpace(string(earthfilePathsRaw)), "\n"),

--- a/cmd/earthly/subcmd/build_cmd.go
+++ b/cmd/earthly/subcmd/build_cmd.go
@@ -253,14 +253,14 @@ func (a *Build) ActionBuildImp(cliCtx *cli.Context, flagArgs, nonFlagArgs []stri
 	a.cli.SetAnaMetaTarget(target)
 
 	var (
-		gitCommitAuthor string
-		gitConfigEmail  string
+		gitCommitAuthorEmail string
+		gitConfigEmail       string
 	)
 	if !target.IsRemote() {
 		meta, _ := gitutil.Metadata(cliCtx.Context, target.GetLocalPath(), a.cli.Flags().GitBranchOverride)
 		if meta != nil {
 			// Git commit detection here is best effort
-			gitCommitAuthor = meta.Author
+			gitCommitAuthorEmail = meta.AuthorEmail
 		}
 		if email, err := gitutil.ConfigEmail(cliCtx.Context); err == nil {
 			gitConfigEmail = email
@@ -354,7 +354,7 @@ func (a *Build) ActionBuildImp(cliCtx *cli.Context, flagArgs, nonFlagArgs []stri
 		return errors.Wrapf(err, "could not init frontend")
 	}
 
-	cleanupTLS, err := a.cli.ConfigureSatellite(cliCtx, cloudClient, gitCommitAuthor, gitConfigEmail)
+	cleanupTLS, err := a.cli.ConfigureSatellite(cliCtx, cloudClient, gitCommitAuthorEmail, gitConfigEmail)
 	if err != nil {
 		return errors.Wrapf(err, "could not configure satellite")
 	}
@@ -647,7 +647,7 @@ func (a *Build) ActionBuildImp(cliCtx *cli.Context, flagArgs, nonFlagArgs []stri
 		}
 		setup := a.cli.LogbusSetup()
 		setup.SetOrgAndProject(orgName, projectName)
-		setup.SetGitAuthor(gitCommitAuthor, gitConfigEmail)
+		setup.SetGitAuthor(gitCommitAuthorEmail, gitConfigEmail)
 		_, isCI := analytics.DetectCI(a.cli.Flags().EarthlyCIRunner)
 		setup.SetCI(isCI)
 		if doLogstreamUpload {

--- a/docs/earthfile/builtin-args.md
+++ b/docs/earthfile/builtin-args.md
@@ -43,19 +43,21 @@ RUN echo "The current target is $EARTHLY_TARGET"
 
 ### Git-related args
 
-| Name | Description | Example value |
-| --- | --- | --- |
-| `EARTHLY_GIT_AUTHOR` | The git author detected within the build context directory. If no git directory is detected, then the value is an empty string. | `John Doe <john@example.com>` |
-| `EARTHLY_GIT_CO_AUTHORS` | The git co-authors detected within the build context directory, separated by space. If no git directory is detected, then the value is an empty string. | `Jane Doe <jane@example.com Jack Smith <jack@example.com>` |
-| `EARTHLY_GIT_COMMIT_AUTHOR_TIMESTAMP` | The author timestamp, as unix seconds, of the git commit detected within the build context directory. If no git directory is detected, then the value is an empty string. | `1626881847` |
-| `EARTHLY_GIT_BRANCH` | The git branch of the git commit detected within the build context directory. If no git directory is detected, then the value is an empty string. | `main` |
-| `EARTHLY_GIT_COMMIT_TIMESTAMP` | The committer timestamp, as unix seconds, of the git commit detected within the build context directory. If no git directory is detected, then the value is an empty string. | `1626881847` |
-| `EARTHLY_GIT_HASH` | The git hash detected within the build context directory. If no git directory is detected, then the value is an empty string. Take care when using this arg, as the frequently changing git hash may be cause for not using the cache. | `41cb5666ade67b29e42bef121144456d3977a67a` |
-| `EARTHLY_GIT_ORIGIN_URL` | The git URL detected within the build context directory. If no git directory is detected, then the value is an empty string. Please note that this may be inconsistent, depending on whether an HTTPS or SSH URL was used. | `git@github.com:bar/buz.git` or `https://github.com/bar/buz.git` |
-| `EARTHLY_GIT_PROJECT_NAME` | The git project name from within the git URL detected within the build context directory. If no git directory is detected, then the value is an empty string. | `bar/buz` |
-| `EARTHLY_GIT_REFS` | The git references of the git commit detected within the build context directory, separated by space. If no git directory is detected, then the value is an empty string. | `issue-2735-git-ref main` |
-| `EARTHLY_GIT_SHORT_HASH` | The first 8 characters of the git hash detected within the build context directory. If no git directory is detected, then the value is an empty string. Take care when using this arg, as the frequently changing git hash may be cause for not using the cache. | `41cb5666` |
-| `EARTHLY_SOURCE_DATE_EPOCH` | The timestamp, as unix seconds, of the git commit detected within the build context directory. If no git directory is detected, then the value is `0` (the unix epoch) | `1626881847`, `0` |
+| Name | Description | Example value | Feature Flag                           |
+| --- | --- | --- |----------------------------------------|
+| `EARTHLY_GIT_AUTHOR` | The git author detected within the build context directory. If no git directory is detected, then the value is an empty string. This is currently the author's email address but the feature flag adds the name as well | `john@example.com` (or `John Doe <john@example.com>` with flag turned on) | `--earthly-git-author-individual-args` |
+| `EARTHLY_GIT_AUTHOR_EMAIL` | The git author email detected within the build context directory. If no git directory is detected, then the value is an empty string. | `john@example.com` | `--earthly-git-author-individual-args` |
+| `EARTHLY_GIT_AUTHOR_NAME` | The git author name detected within the build context directory. If no git directory is detected, then the value is an empty string. | `John Doe` | `--earthly-git-author-individual-args` |
+| `EARTHLY_GIT_CO_AUTHORS` | The git co-authors detected within the build context directory, separated by space. If no git directory is detected, then the value is an empty string. | `Jane Doe <jane@example.com Jack Smith <jack@example.com>` |                                        |
+| `EARTHLY_GIT_COMMIT_AUTHOR_TIMESTAMP` | The author timestamp, as unix seconds, of the git commit detected within the build context directory. If no git directory is detected, then the value is an empty string. | `1626881847` |                                        |
+| `EARTHLY_GIT_BRANCH` | The git branch of the git commit detected within the build context directory. If no git directory is detected, then the value is an empty string. | `main` |                                        |
+| `EARTHLY_GIT_COMMIT_TIMESTAMP` | The committer timestamp, as unix seconds, of the git commit detected within the build context directory. If no git directory is detected, then the value is an empty string. | `1626881847` |                                        |
+| `EARTHLY_GIT_HASH` | The git hash detected within the build context directory. If no git directory is detected, then the value is an empty string. Take care when using this arg, as the frequently changing git hash may be cause for not using the cache. | `41cb5666ade67b29e42bef121144456d3977a67a` |                                        |
+| `EARTHLY_GIT_ORIGIN_URL` | The git URL detected within the build context directory. If no git directory is detected, then the value is an empty string. Please note that this may be inconsistent, depending on whether an HTTPS or SSH URL was used. | `git@github.com:bar/buz.git` or `https://github.com/bar/buz.git` |                                        |
+| `EARTHLY_GIT_PROJECT_NAME` | The git project name from within the git URL detected within the build context directory. If no git directory is detected, then the value is an empty string. | `bar/buz` |                                        |
+| `EARTHLY_GIT_REFS` | The git references of the git commit detected within the build context directory, separated by space. If no git directory is detected, then the value is an empty string. | `issue-2735-git-ref main` |                                        |
+| `EARTHLY_GIT_SHORT_HASH` | The first 8 characters of the git hash detected within the build context directory. If no git directory is detected, then the value is an empty string. Take care when using this arg, as the frequently changing git hash may be cause for not using the cache. | `41cb5666` |                                        |
+| `EARTHLY_SOURCE_DATE_EPOCH` | The timestamp, as unix seconds, of the git commit detected within the build context directory. If no git directory is detected, then the value is `0` (the unix epoch) | `1626881847`, `0` |                                        |
 
 ### Platform-related args
 

--- a/features/features.go
+++ b/features/features.go
@@ -72,6 +72,7 @@ type Features struct {
 	AllowPrivilegedFromDockerfile bool `long:"allow-privileged-from-dockerfile" description:"Allow the use of the --allow-privileged flag in the FROM DOCKERFILE command"`
 	RunWithAWS                    bool `long:"run-with-aws" description:"make AWS credentials in the environment or ~/.aws available to RUN commands"`
 	WildcardCopy                  bool `long:"wildcard-copy" description:"allow for the expansion of wildcard (glob) paths for COPY commands"`
+	GitAuthorEmailNameArgs        bool `long:"git-author-email-name-args" description:"includes EARTHLY_GIT_AUTHOR_EMAIL and EARTHLY_GIT_AUTHOR_NAME builtin ARGs"`
 
 	Major int
 	Minor int

--- a/tests/git-metadata/Earthfile
+++ b/tests/git-metadata/Earthfile
@@ -35,8 +35,12 @@ test -n \"\$(git config --global user.email)\"
 
 # clone the repo and add a test Earthfile to it
 git clone git@git.example.com:testuser/repo.git
-mv Earthfile repo/
-git -C repo add Earthfile
+mkdir -p repo/flag_on repo/flag_off
+cp Earthfile repo/flag_on
+mv Earthfile repo/flag_off
+sed -i '1s/VERSION --git-author-email-name-args \(.*\)/VERSION \1/' ./repo/flag_off/Earthfile
+
+git -C repo add flag_on flag_off
 git -C repo commit -m \"test
 
 Co-authored-by: Testy McTest <testy@earthly.dev>
@@ -58,13 +62,14 @@ export expected_refs=\"\$(git -C repo for-each-ref --points-at HEAD --format '%(
 test -n \"\$expected_refs\"
 
 # finally perform earthly tests
+# flag --git-author-email-name-args on
 earthly --config \$earthly_config --verbose -D \
   --build-arg expected_sha \
   --build-arg expected_committer_timestamp \
   --build-arg expected_author_timestamp \
   --build-arg expected_branch \
   --build-arg expected_refs \
-  ./repo+test-git-metadata
+  ./repo/flag_on+test-git-metadata
 
 EARTHLY_GIT_BRANCH_OVERRIDE=branch-override earthly --config \$earthly_config --verbose -D \
   --build-arg expected_sha \
@@ -72,18 +77,38 @@ EARTHLY_GIT_BRANCH_OVERRIDE=branch-override earthly --config \$earthly_config --
   --build-arg expected_author_timestamp \
   --build-arg expected_branch=branch-override \
   --build-arg expected_refs \
-  ./repo+test-git-metadata
+  ./repo/flag_on+test-git-metadata
+
+# flag --git-author-email-name-args off
+earthly --config \$earthly_config --verbose -D \
+  --build-arg expected_sha \
+  --build-arg expected_committer_timestamp \
+  --build-arg expected_author_timestamp \
+  --build-arg expected_branch \
+  --build-arg expected_refs \
+  --build-arg flag_on=false \
+  ./repo/flag_off+test-git-metadata
+
+EARTHLY_GIT_BRANCH_OVERRIDE=branch-override earthly --config \$earthly_config --verbose -D \
+  --build-arg expected_sha \
+  --build-arg expected_committer_timestamp \
+  --build-arg expected_author_timestamp \
+  --build-arg expected_branch=branch-override \
+  --build-arg expected_refs \
+  --build-arg flag_on=false \
+  ./repo/flag_off+test-git-metadata
 
 rm -rf repo
 export expected_refs=\"main\"
 
+# flag on
 earthly --config \$earthly_config --verbose -D \
   --build-arg expected_sha \
   --build-arg expected_committer_timestamp \
   --build-arg expected_author_timestamp \
   --build-arg expected_branch \
   --build-arg expected_refs \
-  git.example.com/testuser/repo:main+test-git-metadata
+  git.example.com/testuser/repo/flag_on:main+test-git-metadata
 
 EARTHLY_GIT_BRANCH_OVERRIDE=branch-override earthly --config \$earthly_config --verbose -D \
   --build-arg expected_sha \
@@ -91,7 +116,26 @@ EARTHLY_GIT_BRANCH_OVERRIDE=branch-override earthly --config \$earthly_config --
   --build-arg expected_author_timestamp \
   --build-arg expected_branch=branch-override \
   --build-arg expected_refs \
-  git.example.com/testuser/repo:main+test-git-metadata
+  git.example.com/testuser/repo/flag_on:main+test-git-metadata
+
+# flag off
+earthly --config \$earthly_config --verbose -D \
+  --build-arg expected_sha \
+  --build-arg expected_committer_timestamp \
+  --build-arg expected_author_timestamp \
+  --build-arg expected_branch \
+  --build-arg expected_refs \
+  --build-arg flag_on=false \
+  git.example.com/testuser/repo/flag_off:main+test-git-metadata
+
+EARTHLY_GIT_BRANCH_OVERRIDE=branch-override earthly --config \$earthly_config --verbose -D \
+  --build-arg expected_sha \
+  --build-arg expected_committer_timestamp \
+  --build-arg expected_author_timestamp \
+  --build-arg expected_branch=branch-override \
+  --build-arg expected_refs \
+  --build-arg flag_on=false \
+  git.example.com/testuser/repo/flag_off:main+test-git-metadata
 " >/tmp/test-earthly-script && chmod +x /tmp/test-earthly-script
     DO --pass-args +RUN_EARTHLY_ARGS --pre_command=start-sshd --exec_cmd=/tmp/test-earthly-script
 

--- a/tests/git-metadata/test.earth
+++ b/tests/git-metadata/test.earth
@@ -1,4 +1,4 @@
-VERSION 0.8
+VERSION --git-author-email-name-args 0.8
 
 # Note: this is tests both locally and remotely
 # the population of git metadata occurs in two **different** functions respectively:
@@ -12,9 +12,21 @@ test-git-metadata:
     ARG --required expected_author_timestamp
     ARG --required expected_branch
     ARG --required expected_refs
+    ARG flag_on=true
+    LET expected_author="onlyspammersemailthis@earthly.dev"
+    LET expected_author_email=""
+    LET expected_author_name=""
+    IF [ "$flag_on" = "true" ]
+        SET expected_author="test name <onlyspammersemailthis@earthly.dev>"
+        SET expected_author_email="onlyspammersemailthis@earthly.dev"
+        SET expected_author_name="test name"
+    END
+
     ARG EARTHLY_GIT_SHORT_HASH
     ARG EARTHLY_GIT_HASH
     ARG EARTHLY_GIT_AUTHOR
+    ARG EARTHLY_GIT_AUTHOR_EMAIL
+    ARG EARTHLY_GIT_AUTHOR_NAME
     ARG EARTHLY_GIT_CO_AUTHORS
     ARG EARTHLY_GIT_COMMIT_TIMESTAMP
     ARG EARTHLY_GIT_COMMIT_AUTHOR_TIMESTAMP
@@ -27,5 +39,7 @@ test-git-metadata:
     RUN test "$EARTHLY_GIT_REFS" = "$expected_refs"
     RUN test -n "$EARTHLY_GIT_SHORT_HASH"
     RUN echo "$EARTHLY_GIT_HASH" | grep "$EARTHLY_GIT_SHORT_HASH"
-    RUN test "$EARTHLY_GIT_AUTHOR" = "onlyspammersemailthis@earthly.dev"
+    RUN test "$EARTHLY_GIT_AUTHOR" = "$expected_author"
+    RUN test "$EARTHLY_GIT_AUTHOR_EMAIL" = "$expected_author_email"
+    RUN test "$EARTHLY_GIT_AUTHOR_NAME" = "$expected_author_name"
     RUN test "$EARTHLY_GIT_CO_AUTHORS" = "testy@earthly.dev cover@earthly.dev"

--- a/variables/builtin.go
+++ b/variables/builtin.go
@@ -87,9 +87,17 @@ func BuiltinArgs(target domain.Target, platr *platutil.Resolver, gitMeta *gituti
 			ret.Add(arg.EarthlySourceDateEpoch, gitMeta.CommitterTimestamp)
 		}
 		if ftrs.EarthlyGitAuthorArgs {
-			ret.Add(arg.EarthlyGitAuthor, gitMeta.Author)
+			ret.Add(arg.EarthlyGitAuthor, gitMeta.AuthorEmail)
 			ret.Add(arg.EarthlyGitCoAuthors, strings.Join(gitMeta.CoAuthors, " "))
 		}
+		if ftrs.GitAuthorEmailNameArgs {
+			if gitMeta.AuthorName != "" && gitMeta.AuthorEmail != "" {
+				ret.Add(arg.EarthlyGitAuthor, fmt.Sprintf("%s <%s>", gitMeta.AuthorName, gitMeta.AuthorEmail))
+			}
+			ret.Add(arg.EarthlyGitAuthorEmail, gitMeta.AuthorEmail)
+			ret.Add(arg.EarthlyGitAuthorName, gitMeta.AuthorName)
+		}
+
 		if ftrs.GitRefs {
 			ret.Add(arg.EarthlyGitRefs, strings.Join(gitMeta.Refs, " "))
 		}

--- a/variables/reserved/names.go
+++ b/variables/reserved/names.go
@@ -10,6 +10,8 @@ const (
 	EarthlyGitOriginURLScrubbed     = "EARTHLY_GIT_ORIGIN_URL_SCRUBBED"
 	EarthlyGitProjectName           = "EARTHLY_GIT_PROJECT_NAME"
 	EarthlyGitAuthor                = "EARTHLY_GIT_AUTHOR"
+	EarthlyGitAuthorEmail           = "EARTHLY_GIT_AUTHOR_EMAIL"
+	EarthlyGitAuthorName            = "EARTHLY_GIT_AUTHOR_NAME"
 	EarthlyGitCoAuthors             = "EARTHLY_GIT_CO_AUTHORS"
 	EarthlyGitShortHash             = "EARTHLY_GIT_SHORT_HASH"
 	EarthlyGitTag                   = "EARTHLY_GIT_TAG"

--- a/variables/reserved/names.go
+++ b/variables/reserved/names.go
@@ -51,6 +51,8 @@ func init() {
 		EarthlyGitCommitTimestamp:       {},
 		EarthlyGitCommitAuthorTimestamp: {},
 		EarthlyGitAuthor:                {},
+		EarthlyGitAuthorEmail:           {},
+		EarthlyGitAuthorName:            {},
 		EarthlyGitCoAuthors:             {},
 		EarthlyGitHash:                  {},
 		EarthlyGitOriginURL:             {},


### PR DESCRIPTION
1. Add EARTHLY_GIT_AUTHOR_EMAIL and `EARTHLY_GIT_AUTHOR_NAME` built-in args.
2. Address #3822 