### PR TITLE
buildkite: display buildkit logs on failure

### DIFF
--- a/.buildkite/tests.sh
+++ b/.buildkite/tests.sh
@@ -14,7 +14,7 @@ function cleanup() {
       echo "buildkite-test passed"
     else
       echo "=== buildkit logs ==="
-      docker logs earthly-dev-buildkit || true
+      docker logs earthly-dev-buildkitd || true
       echo "=== end of buildkit logs ==="
       echo "buildkite-test failed with $status"
     fi


### PR DESCRIPTION
fixes container name typo in 577d8e1e21ab495eb552135bbb74c67cad58174f