### PR TITLE
buildkite: handle interrupts and remove all earthly-* containers

### DIFF
--- a/.buildkite/tests.sh
+++ b/.buildkite/tests.sh
@@ -126,8 +126,10 @@ for target in \
         +test-qemu \
         ; do
     for attempt in $(seq 1 "$max_attempts"); do
-        # kill buildkitd to release memory (the macstadium machines have limited memory)
-        docker rm -f earthly-dev-buildkitd 2> /dev/null || true
+        # kill earthly-* containers to release memory (the macstadium machines have limited memory)
+        set +e
+        docker ps -a | grep earthly- | awk '{print $1}' | xargs -n 1 docker rm -f
+        set -e
 
         echo "=== running $target (attempt $attempt/$max_attempts ==="
         set +e

--- a/.buildkite/tests.sh
+++ b/.buildkite/tests.sh
@@ -43,7 +43,11 @@ else
     exit 1
 fi
 
+echo "Running under pid=$$"
 echo "The detected architecture of the runner is $(uname -m)"
+for k in BUILDKITE_AGENT_ID BUILDKITE_BUILD_ID BUILDKITE_CLUSTER_ID BUILDKITE_GROUP_ID BUILDKITE_JOB_ID BUILDKITE_REBUILT_FROM_BUILD_ID BUILDKITE_REBUILT_FROM_BUILD_NUMBER BUILDKITE_TRIGGERED_FROM_BUILD_ID; do
+    echo "$k=${!k}"
+done
 
 if ! git symbolic-ref -q HEAD >/dev/null; then
     echo "Add branch info back to git (Earthly uses it for tagging)"


### PR DESCRIPTION
- handle interrupts (in order to print a clearer error message indicating buildkite cancelled the test).
- expand the container cleanup phase of the buildkite test to remove all earthly-* containers.
- display buildkite build, job, and agent IDs (to make it possible to match up test failures with agent logs)