### PR TITLE
split up autoskip tests

### DIFF
--- a/.buildkite/tests.sh
+++ b/.buildkite/tests.sh
@@ -136,6 +136,8 @@ for target in \
         +test-no-qemu-group6 \
         +test-no-qemu-group7 \
         +test-no-qemu-group8 \
+        +test-no-qemu-group9 \
+        +test-no-qemu-group10 \
         +test-no-qemu-slow \
         +test-qemu \
         ; do

--- a/.github/workflows/ci-docker-ubuntu.yml
+++ b/.github/workflows/ci-docker-ubuntu.yml
@@ -291,6 +291,34 @@ jobs:
       SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
 
+  docker-tests-no-qemu-group9:
+    needs: build-earthly
+    if: ${{ !failure() }}
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      TEST_TARGET: "+test-no-qemu-group9"
+      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
+      RUNS_ON: "ubuntu-latest"
+      BINARY: "docker"
+      SUDO: ""
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
+      EXTRA_ARGS: "--auto-skip"
+    secrets: inherit
+
+  docker-tests-no-qemu-group10:
+    needs: build-earthly
+    if: ${{ !failure() }}
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      TEST_TARGET: "+test-no-qemu-group10"
+      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
+      RUNS_ON: "ubuntu-latest"
+      BINARY: "docker"
+      SUDO: ""
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
+      EXTRA_ARGS: "--auto-skip"
+    secrets: inherit
+
   docker-tests-no-qemu-slow:
     needs: build-earthly
     if: ${{ !failure() }}

--- a/.github/workflows/ci-podman-ubuntu.yml
+++ b/.github/workflows/ci-podman-ubuntu.yml
@@ -170,6 +170,32 @@ jobs:
       SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
 
+  podman-tests-no-qemu-group9:
+    needs: build-earthly
+    if: ${{ !failure() }}
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      TEST_TARGET: "+test-no-qemu-group9"
+      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
+      RUNS_ON: "ubuntu-latest"
+      BINARY: "podman"
+      SUDO: "sudo -E"
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
+    secrets: inherit
+
+  podman-tests-no-qemu-group10:
+    needs: build-earthly
+    if: ${{ !failure() }}
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      TEST_TARGET: "+test-no-qemu-group10"
+      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
+      RUNS_ON: "ubuntu-latest"
+      BINARY: "podman"
+      SUDO: "sudo -E"
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
+    secrets: inherit
+
   podman-tests-no-qemu-slow:
     needs: build-earthly
     if: ${{ !failure() }}

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -180,7 +180,6 @@ ga-no-qemu-group7:
     BUILD +cache-mount-arg
     BUILD +infinite-recursion
     BUILD +save-artifact-selective
-    BUILD --pass-args ./autoskip+test-all
     BUILD +if-exists
     BUILD +let-set
     BUILD +let-scope
@@ -202,6 +201,13 @@ ga-no-qemu-group8:
     BUILD --pass-args ./pass-args-default-via-function+test
     BUILD --pass-args ./pass-args-global-via-function+test
     BUILD --pass-args ./pass-args-via-function-with-override+test
+
+ga-no-qemu-group9:
+    BUILD --pass-args ./autoskip+test-group1
+
+ga-no-qemu-group10:
+    BUILD --pass-args ./autoskip+test-group2
+
 
 ga-no-qemu-slow:
     BUILD +server

--- a/tests/autoskip/Earthfile
+++ b/tests/autoskip/Earthfile
@@ -9,6 +9,10 @@ PROJECT earthly-technologies/core
 WORKDIR /test
 
 test-all:
+    BUILD +test-group1
+    BUILD +test-group2
+
+test-group1:
     BUILD +test-files
     BUILD +test-with-subdir
     BUILD +test-requires-project
@@ -23,6 +27,8 @@ test-all:
     BUILD +test-arg-matrix
     BUILD +test-try-catch
     BUILD +test-push
+
+test-group2:
     BUILD +test-no-cache
     BUILD +test-shell-out
     BUILD +test-copy-if-exists


### PR DESCRIPTION
the autoskip+test-all target requires more than 16GB of memory, which is causing the M1 test instance to run out of memory and fail.