### PR TITLE
buildkite: split up autoskip tests

### DIFF
--- a/.buildkite/tests.sh
+++ b/.buildkite/tests.sh
@@ -138,6 +138,7 @@ for target in \
         +test-no-qemu-group8 \
         +test-no-qemu-group9 \
         +test-no-qemu-group10 \
+        +test-no-qemu-group11 \
         +test-no-qemu-slow \
         +test-qemu \
         ; do

--- a/.github/workflows/ci-docker-ubuntu.yml
+++ b/.github/workflows/ci-docker-ubuntu.yml
@@ -319,6 +319,20 @@ jobs:
       EXTRA_ARGS: "--auto-skip"
     secrets: inherit
 
+  docker-tests-no-qemu-group11:
+    needs: build-earthly
+    if: ${{ !failure() }}
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      TEST_TARGET: "+test-no-qemu-group11"
+      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
+      RUNS_ON: "ubuntu-latest"
+      BINARY: "docker"
+      SUDO: ""
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
+      EXTRA_ARGS: "--auto-skip"
+    secrets: inherit
+
   docker-tests-no-qemu-slow:
     needs: build-earthly
     if: ${{ !failure() }}

--- a/.github/workflows/ci-podman-ubuntu.yml
+++ b/.github/workflows/ci-podman-ubuntu.yml
@@ -196,6 +196,19 @@ jobs:
       SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
     secrets: inherit
 
+  podman-tests-no-qemu-group11:
+    needs: build-earthly
+    if: ${{ !failure() }}
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      TEST_TARGET: "+test-no-qemu-group11"
+      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
+      RUNS_ON: "ubuntu-latest"
+      BINARY: "podman"
+      SUDO: "sudo -E"
+      SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
+    secrets: inherit
+
   podman-tests-no-qemu-slow:
     needs: build-earthly
     if: ${{ !failure() }}

--- a/Earthfile
+++ b/Earthfile
@@ -660,6 +660,7 @@ test-no-qemu:
     BUILD --pass-args +test-no-qemu-group8
     BUILD --pass-args +test-no-qemu-group9
     BUILD --pass-args +test-no-qemu-group10
+    BUILD --pass-args +test-no-qemu-group11
     BUILD --pass-args +test-no-qemu-slow
 
 # test-misc runs misc (non earthly-in-earthly) tests

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -209,6 +209,9 @@ ga-no-qemu-group9:
 ga-no-qemu-group10:
     BUILD --pass-args ./autoskip+test-group2
 
+ga-no-qemu-group11:
+    BUILD --pass-args ./autoskip+test-group3
+
 
 ga-no-qemu-slow:
     BUILD +server

--- a/tests/autoskip/Earthfile
+++ b/tests/autoskip/Earthfile
@@ -11,6 +11,7 @@ WORKDIR /test
 test-all:
     BUILD +test-group1
     BUILD +test-group2
+    BUILD +test-group3
 
 test-group1:
     BUILD +test-files
@@ -23,18 +24,20 @@ test-group1:
     BUILD +test-expand-args
     BUILD +test-build-args
     BUILD +test-pass-args
+
+test-group2:
     BUILD +test-copy-target-args
     BUILD +test-arg-matrix
     BUILD +test-try-catch
     BUILD +test-push
-
-test-group2:
     BUILD +test-no-cache
     BUILD +test-shell-out
     BUILD +test-copy-if-exists
     BUILD +test-remote-targets
     BUILD +test-from-dockerfile
     BUILD +test-import
+
+test-group3:
     BUILD +test-copy-target-args-quoted
     BUILD +test-build-flag
     BUILD +test-flag-conflict


### PR DESCRIPTION
The autoskip tests are still periodically OOMing; this splits them up further.