### PR TITLE
Requires FROM error message improvement

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -76,7 +76,7 @@ func ParseOpts(ctx context.Context, from FromOpt, opts ...Opt) (spec.Earthfile, 
 	}
 	if errorStrategy.Err != nil {
 		err := errors.Wrapf(
-			errorStrategy.Err, "%s line %d:%d '%s'",
+			errorStrategy.Err, "%s:%d:%d '%s'",
 			prefs.reader.Name(),
 			errorStrategy.RE.GetOffendingToken().GetLine(),
 			errorStrategy.RE.GetOffendingToken().GetColumn(),

--- a/cmd/earthly/app/run.go
+++ b/cmd/earthly/app/run.go
@@ -386,7 +386,7 @@ func (app *EarthlyApp) run(ctx context.Context, args []string, lastSignal *syncu
 					time.Now(),
 					logstream.FailureType_FAILURE_TYPE_OTHER,
 					"",
-					grpcErr.Message(),
+					messageWithSourceLink(grpcErr.Message()),
 				)
 				return 1
 			}
@@ -502,6 +502,12 @@ func (app *EarthlyApp) printCrashLogs(ctx context.Context) {
 
 func errorWithPrefix(err string) string {
 	return fmt.Sprintf("Error: %s", err)
+}
+
+func messageWithSourceLink(message string) string {
+	re := regexp.MustCompile(`(\S+) line (\d+):(\d+)`)
+	updatedMessage := re.ReplaceAllString(message, "$1:$2:$3")
+	return updatedMessage
 }
 
 func getHintErr(err error, grpcError *status.Status) (*hint.Error, bool) {

--- a/cmd/earthly/app/run.go
+++ b/cmd/earthly/app/run.go
@@ -386,7 +386,7 @@ func (app *EarthlyApp) run(ctx context.Context, args []string, lastSignal *syncu
 					time.Now(),
 					logstream.FailureType_FAILURE_TYPE_OTHER,
 					"",
-					messageWithSourceLink(grpcErr.Message()),
+					grpcErr.Message(),
 				)
 				return 1
 			}
@@ -502,12 +502,6 @@ func (app *EarthlyApp) printCrashLogs(ctx context.Context) {
 
 func errorWithPrefix(err string) string {
 	return fmt.Sprintf("Error: %s", err)
-}
-
-func messageWithSourceLink(message string) string {
-	re := regexp.MustCompile(`(\S+) line (\d+):(\d+)`)
-	updatedMessage := re.ReplaceAllString(message, "$1:$2:$3")
-	return updatedMessage
 }
 
 func getHintErr(err error, grpcError *status.Status) (*hint.Error, bool) {

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -24,6 +24,7 @@ import (
 	"github.com/earthly/cloud-api/logstream"
 	"github.com/earthly/earthly/analytics"
 	"github.com/earthly/earthly/ast/commandflag"
+	"github.com/earthly/earthly/ast/hint"
 	"github.com/earthly/earthly/ast/spec"
 	"github.com/earthly/earthly/buildcontext"
 	debuggercommon "github.com/earthly/earthly/debugger/common"
@@ -2835,7 +2836,7 @@ func (c *Converter) checkAllowed(command cmdType) error {
 		case fromCmd, fromDockerfileCmd, locallyCmd, buildCmd, argCmd, letCmd, setCmd, importCmd, projectCmd, pipelineCmd:
 			return nil
 		default:
-			return errors.New("the first command has to be FROM, FROM DOCKERFILE, LOCALLY, ARG, BUILD or IMPORT")
+			return hint.Wrap(errors.New("requires a FROM, FROM DOCKERFILE, or LOCALLY"), "This command needs to run in a shell. You should be able to solve this by adding 'FROM someImage' on the line before this one.")
 		}
 	}
 

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -2836,7 +2836,7 @@ func (c *Converter) checkAllowed(command cmdType) error {
 		case fromCmd, fromDockerfileCmd, locallyCmd, buildCmd, argCmd, letCmd, setCmd, importCmd, projectCmd, pipelineCmd:
 			return nil
 		default:
-			return hint.Wrap(errors.New("requires a FROM, FROM DOCKERFILE, or LOCALLY"), "This command needs to run in a shell. You should be able to solve this by adding 'FROM someImage' on the line before this one.")
+			return hint.Wrap(errors.New("requires a FROM, FROM DOCKERFILE, or LOCALLY"), "This command needs to run in a shell. You should be able to solve this by adding 'FROM <image>' on the line before this one.")
 		}
 	}
 

--- a/earthfile2llb/interpreter.go
+++ b/earthfile2llb/interpreter.go
@@ -2112,7 +2112,7 @@ To start using the FUNCTION keyword now (experimental) please use VERSION --use-
 		return i.errorf(uc.Recipe[0].SourceLocation, "%s takes no arguments", cmdName)
 	}
 	scopeName := fmt.Sprintf(
-		"%s (%s line %d:%d)",
+		"%s (%s:%d:%d)",
 		command.StringCanonical(), do.SourceLocation.File, do.SourceLocation.StartLine, do.SourceLocation.StartColumn)
 	err := i.converter.EnterScopeDo(ctx, command, baseTarget(relCommand), allowPrivileged, passArgs, scopeName, buildArgs)
 	if err != nil {

--- a/earthfile2llb/interpretererror.go
+++ b/earthfile2llb/interpretererror.go
@@ -13,7 +13,7 @@ import (
 var _ error = &InterpreterError{}
 
 // note this regex should be updated in case the error format changes in Errorf
-var regex = regexp.MustCompile(`(?P<file_path>.*?) line (?P<line>\d+):(?P<column>\d+) (?P<error>.+?)($|\nin\t\t(?P<stack>.+?)$)`)
+var regex = regexp.MustCompile(`(?P<file_path>.*?):(?P<line>\d+):(?P<column>\d+) (?P<error>.+?)($|\nin\t\t(?P<stack>.+?)$)`)
 
 // InterpreterError is an error of the interpreter, which contains optional references to the original
 // source code location.

--- a/earthfile2llb/interpretererror.go
+++ b/earthfile2llb/interpretererror.go
@@ -56,7 +56,7 @@ func (ie InterpreterError) Error() string {
 		return err.Error()
 	}
 	ret := fmt.Sprintf(
-		"%s line %d:%d %s",
+		"%s:%d:%d %s",
 		ie.SourceLocation.File, ie.SourceLocation.StartLine, ie.SourceLocation.StartColumn,
 		err.Error())
 	if ie.stack != "" {

--- a/inputgraph/error.go
+++ b/inputgraph/error.go
@@ -33,7 +33,7 @@ func (e *Error) Error() string {
 func FormatError(err error) string {
 	e := &Error{}
 	if errors.As(err, &e) {
-		return fmt.Sprintf("%s line %d:%d: %s", e.srcLoc.File, e.srcLoc.StartLine, e.srcLoc.StartColumn, err)
+		return fmt.Sprintf("%s:%d:%d %s", e.srcLoc.File, e.srcLoc.StartLine, e.srcLoc.StartColumn, err)
 	}
 	return e.Error()
 }

--- a/logbus/solvermon/vertexmon.go
+++ b/logbus/solvermon/vertexmon.go
@@ -135,7 +135,7 @@ func (vm *vertexMonitor) parseError() {
 	slString := ""
 	if vm.meta.SourceLocation != nil {
 		slString = fmt.Sprintf(
-			"%s:%d:%d",
+			" %s:%d:%d",
 			vm.meta.SourceLocation.File, vm.meta.SourceLocation.StartLine,
 			vm.meta.SourceLocation.StartColumn)
 	}

--- a/logbus/solvermon/vertexmon.go
+++ b/logbus/solvermon/vertexmon.go
@@ -135,7 +135,7 @@ func (vm *vertexMonitor) parseError() {
 	slString := ""
 	if vm.meta.SourceLocation != nil {
 		slString = fmt.Sprintf(
-			" %s line %d:%d",
+			"%s:%d:%d",
 			vm.meta.SourceLocation.File, vm.meta.SourceLocation.StartLine,
 			vm.meta.SourceLocation.StartColumn)
 	}

--- a/outmon/vertexmon.go
+++ b/outmon/vertexmon.go
@@ -235,7 +235,7 @@ func (vm *vertexMonitor) printError() bool {
 	slString := ""
 	if vm.meta.SourceLocation != nil {
 		slString = fmt.Sprintf(
-			" %s line %d:%d",
+			"%s:%d:%d",
 			vm.meta.SourceLocation.File, vm.meta.SourceLocation.StartLine,
 			vm.meta.SourceLocation.StartColumn)
 	}

--- a/outmon/vertexmon.go
+++ b/outmon/vertexmon.go
@@ -235,7 +235,7 @@ func (vm *vertexMonitor) printError() bool {
 	slString := ""
 	if vm.meta.SourceLocation != nil {
 		slString = fmt.Sprintf(
-			"%s:%d:%d",
+			" %s:%d:%d",
 			vm.meta.SourceLocation.File, vm.meta.SourceLocation.StartLine,
 			vm.meta.SourceLocation.StartColumn)
 	}

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -566,13 +566,13 @@ fail-test:
     # The output of the failed command should have been printed twice.
     RUN cat output.txt | grep 'ZmFpbCA3YjcyZTAyNC01ZTIxLTRlMWItOTZlNC02NTVjMzk4NzYxMDcK' | test "$(wc -l)" -eq 2
     RUN cat output.txt | grep 'Repeating the failure error...'
-    RUN cat output.txt | grep 'ERROR Earthfile line 10:4'
+    RUN cat output.txt | grep 'ERROR Earthfile:10:4'
     RUN cat output.txt | grep 'RUN echo "fail 7b72e024-5e21-4e1b-96e4-655c39876107" | base64; false'
     RUN cat output.txt | grep 'did not complete successfully. Exit code 1'
     DO +RUN_EARTHLY --earthfile=fail.earth --should_fail=true --verbose=0 --target=+test-copy --post_command="2>output.txt"
     RUN cat output.txt
     RUN cat output.txt | grep 'Repeating the failure error...'
-    RUN cat output.txt | grep 'ERROR Earthfile line 14:4'
+    RUN cat output.txt | grep 'ERROR Earthfile:14:4'
     RUN cat output.txt | grep 'COPY ./does-not-exist ./'
     RUN cat output.txt | grep 'failed: "/does-not-exist": not found'
     RUN cat output.txt | grep 'Should not be reached'; test "$?" -eq 1


### PR DESCRIPTION
Old Error:
```
Error: tests/raw-output2/Earthfile Line:7:4 the first command has to be FROM, FROM DOCKERFILE, LOCALLY, ARG, BUILD or IMPORT
```
New Error:
```
Error: tests/raw-output2/Earthfile:7:4 apply FOR ... IN: requires a FROM, FROM DOCKERFILE, or LOCALLY

  Hint: This command needs to run in a shell. You should be able to solve this by adding 'FROM someImage' on the line before this one.

in              github.com/earthly/earthly/tests/raw-output2:agbell/error_message+for
```

### Error to Source link format

The `path:line:col` is source link format that is clickable in VS Code, intellij and other IDEs. Changing errors to use it instead of `Error: file Line:line:col`