### PR TITLE
feat: --ticktock flag

### DIFF
--- a/cmd/earthly/flag/global.go
+++ b/cmd/earthly/flag/global.go
@@ -87,6 +87,7 @@ type Global struct {
 	Pull                       bool
 	Push                       bool
 	CI                         bool
+	UseTickTockBuildkitImage   bool
 	Output                     bool
 	NoOutput                   bool
 	NoCache                    bool
@@ -367,6 +368,13 @@ func (global *Global) RootFlags(installName string, bkImage string) []cli.Flag {
 			EnvVars:     []string{"EARTHLY_CI"},
 			Usage:       common.Wrap("Execute in CI mode. ", "Implies --no-output --strict"),
 			Destination: &global.CI,
+		},
+		&cli.BoolFlag{
+			Name:        "ticktock",
+			EnvVars:     []string{"EARTHLY_TICKTOCK"},
+			Usage:       "Use earthly's experimental buildkit ticktock codebase",
+			Destination: &global.UseTickTockBuildkitImage,
+			Hidden:      true, // Experimental
 		},
 		&cli.BoolFlag{
 			Name:        "output",

--- a/cmd/earthly/subcmd/build_cmd.go
+++ b/cmd/earthly/subcmd/build_cmd.go
@@ -371,10 +371,18 @@ func (a *Build) ActionBuildImp(cliCtx *cli.Context, flagArgs, nonFlagArgs []stri
 		return errors.New("could not determine buildkit address - is Docker or Podman running?")
 	}
 
+	buildkitdImage := a.cli.Flags().BuildkitdImage
+	if a.cli.Flags().UseTickTockBuildkitImage {
+		if cliCtx.IsSet("buildkit-image") {
+			return fmt.Errorf("the --buildkit-image and --ticktock flags are mutually exclusive")
+		}
+		buildkitdImage += "-ticktock"
+	}
+
 	bkClient, err := buildkitd.NewClient(
 		cliCtx.Context,
 		a.cli.Console(),
-		a.cli.Flags().BuildkitdImage,
+		buildkitdImage,
 		a.cli.Flags().ContainerName,
 		a.cli.Flags().InstallationName,
 		a.cli.Flags().ContainerFrontend,


### PR DESCRIPTION
Adds a new hidden --ticktock flag, which can be used to enable to new experimental fork of buildkit which features a different scheduler.