### PR TITLE
Backwards compatability test for WITH DOCKER

### DIFF
--- a/.github/workflows/ci-docker-ubuntu.yml
+++ b/.github/workflows/ci-docker-ubuntu.yml
@@ -874,6 +874,41 @@ jobs:
       EXTRA_ARGS: "--auto-skip"
     secrets: inherit
 
+  backwards-compatability-test:
+    needs: build-earthly
+    name: Backwards Compatability
+    runs-on: ubuntu-latest
+    env:
+      FORCE_COLOR: 1
+      EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"
+      EARTHLY_INSTALL_ID: "earthly-githubactions"
+      # Used in our github action as the token - TODO: look to change it into an input
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Docker mirror login (Earthly Only)
+        run: docker login registry-1.docker.io.mirror.corp.earthly.dev --username "${{ secrets.DOCKERHUB_MIRROR_USERNAME }}" --password "${{ secrets.DOCKERHUB_MIRROR_PASSWORD }}"
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+      - name: Retrieve earthly from build-earthly job
+        run: |-
+          BUILDKITD_IMAGE=docker.io/earthly/buildkitd-staging TAG=${GITHUB_SHA}-ubuntu-latest-docker ./earthly upgrade
+          mkdir -p $(dirname "./build/earthly")
+          mv ${HOME}/.earthly/earthly-${GITHUB_SHA}-ubuntu-latest-docker ./build/earthly
+      - name: Configure Earthly to use mirror (Earthly Only)
+        run: |-
+          ./build/earthly config global.buildkit_additional_config "'[registry.\"docker.io\"]
+          mirrors = [\"registry-1.docker.io.mirror.corp.earthly.dev\"]'"
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+      - name: Download older version of earthly (v0.8.0)
+        run: |-
+          sudo wget https://github.com/earthly/earthly/releases/download/v0.8.0/earthly-linux-amd64 -O /usr/bin/earthly-v0.8.0
+          sudo chmod +x /usr/bin/earthly-v0.8.0
+          earthly-v0.8.0 --version
+      - name: execute backwards compatability script
+        run: earthly=./build/earthly scripts/tests/backwards-compatability.sh
+
   tutorial:
     needs: build-earthly
     name: Tutorial

--- a/scripts/tests/backwards-compatability.sh
+++ b/scripts/tests/backwards-compatability.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -xeu
+
+# used to start earthly-integration-buildkitd
+earthly="${earthly:=earthly}"
+if [ -f "$earthly" ]; then
+  earthly=$(realpath "$earthly")
+fi
+
+# used for testing backwards compatability issues
+crustly="${crustly:=earthly-v0.8.0}"
+if [ -f "$crustly" ]; then
+  crustly=$(realpath "$crustly")
+fi
+
+# change directory to script location
+cd -- "$( dirname -- "${BASH_SOURCE[0]}" )"
+
+current_git_sha="$(git rev-parse HEAD)"
+
+if "$("$crustly" --version)" | grep "$current_git_sha" >/dev/null; then
+  echo "ERROR: $crustly was built using the current git sha $current_git_sha"
+  exit 1
+fi
+
+echo "running tests with earthly=$earthly for bootstrapping and crustly=$crustly for cli"
+echo "earthly=$("$earthly" --version)"
+echo "crustly=$("$crustly" --version)"
+frontend="${frontend:-$(which docker || which podman)}"
+test -n "$frontend" || (>&2 echo "Error: frontend is empty" && exit 1)
+echo "using frontend=$frontend"
+
+PATH="$(realpath ../acbtest):$PATH"
+
+# prevent the self-update of earthly from running (this ensures no bogus data is printed to stdout,
+# which would mess with the secrets data being fetched)
+date +%s > /tmp/last-earthly-prerelease-check
+
+set +x # dont remove or the token will be leaked
+if [ -z "${EARTHLY_TOKEN:-}" ]; then
+  echo "using EARTHLY_TOKEN from earthly secrets"
+  EARTHLY_TOKEN="$(earthly secrets --org earthly-technologies --project core get earthly-token-for-satellite-tests)"
+  export EARTHLY_TOKEN
+fi
+test -n "$EARTHLY_TOKEN" || (echo "error: EARTHLY_TOKEN is not set" && exit 1)
+set -x
+
+EARTHLY_INSTALLATION_NAME="earthly-integration"
+export EARTHLY_INSTALLATION_NAME
+rm -rf "$HOME/.earthly.integration/"
+
+echo "$earthly"
+# ensure earthly login works (and print out who gets logged in)
+"$earthly" account login
+
+# start buildkitd container
+"$earthly" bootstrap
+
+# start a build using an older version of the earthly cli
+"$crustly" --no-buildkit-update -P ../../tests/with-docker+all
+
+# validate buildkitd container was compiled using the current branch
+buildkitd_earthly_version="$(docker logs earthly-integration-buildkitd |& grep -o 'EARTHLY_GIT_HASH=[a-z0-9]*')"
+acbtest "$buildkitd_earthly_version" = "EARTHLY_GIT_HASH=$current_git_sha"
+
+echo "=== All tests have passed ==="


### PR DESCRIPTION
Introduces a new test for validating earthly v0.8.0 can work with the current version of earthly-buildkitd.

Fixes https://github.com/earthly/earthly/issues/4128