### PR TITLE
Fix errant paren in file info message

### DIFF
--- a/util/fsutilprogress/progress.go
+++ b/util/fsutilprogress/progress.go
@@ -89,7 +89,7 @@ func (s *progressCallback) Verbose(relPath string, status fsutil.VerboseProgress
 			}
 			s.console.Printf("sent %s (%s)%s\n", humanize.Bytes(uint64(s.bytesSent)), puralize(s.numSent, "file"), transferRate)
 		} else {
-			s.console.Printf("sent %s)\n", puralize(s.numStats, "file stat"))
+			s.console.Printf("sent %s\n", puralize(s.numStats, "file stat"))
 		}
 		if s.numReceived > 0 {
 			var transferRate string


### PR DESCRIPTION
I noticed this apparent typo while debugging source op caching in BuildKit. 

Before: 
![image](https://github.com/earthly/earthly/assets/332408/e19e6213-d18b-48a7-a932-267846baf925)
After: 
![image](https://github.com/earthly/earthly/assets/332408/456edce9-629d-451b-8e86-5f9ec522b72c)
