### PR TITLE
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        fix: don't warn when -ticktock image is used

### DIFF
--- a/buildkitd/buildkitd.go
+++ b/buildkitd/buildkitd.go
@@ -918,7 +918,7 @@ func printBuildkitInfo(bkCons conslogging.ConsoleLogger, info *client.Info, work
 		if info.BuildkitVersion.Package != "github.com/earthly/buildkit" {
 			bkCons.Warnf("Using a non-Earthly version of Buildkit. This is not supported.")
 		} else {
-			if info.BuildkitVersion.Version != earthlyVersion {
+			if strings.TrimSuffix(info.BuildkitVersion.Version, "-ticktock") != earthlyVersion {
 				if isLocal {
 					// For local buildkits we expect perfect version match.
 					bkCons.Warnf(


### PR DESCRIPTION
Silence invalid warnings related to the -ticktock image being used. e.g.

    Warning: Buildkit version (v0.8.12-ticktock) is different from Earthly version (v0.8.12)

will no longer appear.