### PR TITLE
fix: the --ticktock flag should also be used for bootstrap

### DIFF
--- a/cmd/earthly/base/init_frontend.go
+++ b/cmd/earthly/base/init_frontend.go
@@ -1,6 +1,7 @@
 package base
 
 import (
+	"fmt"
 	"net/url"
 	"path/filepath"
 	"time"
@@ -15,6 +16,16 @@ func (cli *CLI) InitFrontend(cliCtx *cli.Context) error {
 	// command line option overrides the config which overrides the default value
 	if !cliCtx.IsSet("buildkit-image") && cli.Cfg().Global.BuildkitImage != "" {
 		cli.Flags().BuildkitdImage = cli.Cfg().Global.BuildkitImage
+	}
+
+	if cli.Flags().UseTickTockBuildkitImage {
+		if cliCtx.IsSet("buildkit-image") {
+			return fmt.Errorf("the --buildkit-image and --ticktock flags are mutually exclusive")
+		}
+		if cli.Cfg().Global.BuildkitImage != "" {
+			return fmt.Errorf("the --ticktock flags can not be used in combination with the buildkit_image config option")
+		}
+		cli.Flags().BuildkitdImage += "-ticktock"
 	}
 
 	bkURL, err := url.Parse(cli.Flags().BuildkitHost) // Not validated because we already did that when we calculated it.

--- a/cmd/earthly/subcmd/build_cmd.go
+++ b/cmd/earthly/subcmd/build_cmd.go
@@ -371,18 +371,10 @@ func (a *Build) ActionBuildImp(cliCtx *cli.Context, flagArgs, nonFlagArgs []stri
 		return errors.New("could not determine buildkit address - is Docker or Podman running?")
 	}
 
-	buildkitdImage := a.cli.Flags().BuildkitdImage
-	if a.cli.Flags().UseTickTockBuildkitImage {
-		if cliCtx.IsSet("buildkit-image") {
-			return fmt.Errorf("the --buildkit-image and --ticktock flags are mutually exclusive")
-		}
-		buildkitdImage += "-ticktock"
-	}
-
 	bkClient, err := buildkitd.NewClient(
 		cliCtx.Context,
 		a.cli.Console(),
-		buildkitdImage,
+		a.cli.Flags().BuildkitdImage,
 		a.cli.Flags().ContainerName,
 		a.cli.Flags().InstallationName,
 		a.cli.Flags().ContainerFrontend,


### PR DESCRIPTION
This fixes the issue where the bootstrap command was ignoring the --ticktock option.