### PR TITLE
Better error message for WITH DOCKER (unlazy force execution)

### DIFF
--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -2514,8 +2514,6 @@ func (c *Converter) parseSecretFlag(secretKeyValue string) (secretID string, env
 	return "", "", errors.Errorf("secret definition %s not supported. Format must be either <env-var>=+secrets/<secret-id> or <secret-id>", secretKeyValue)
 }
 
-var ErrUnlazyForceExecution = errors.New("unlazy force execution")
-
 func (c *Converter) forceExecution(ctx context.Context, state pllb.State, platr *platutil.Resolver) error {
 	if state.Output() == nil {
 		// Scratch - no need to execute.
@@ -2534,7 +2532,7 @@ func (c *Converter) forceExecution(ctx context.Context, state pllb.State, platr 
 	// want to un-lazy the ref so that the commands have executed.
 	_, err = ref.ReadDir(ctx, gwclient.ReadDirRequest{Path: "/"})
 	if err != nil {
-		return fmt.Errorf("%w: %v", ErrUnlazyForceExecution, err)
+		return errors.Wrap(err, "unlazy force execution")
 	}
 	return nil
 }

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -2514,6 +2514,8 @@ func (c *Converter) parseSecretFlag(secretKeyValue string) (secretID string, env
 	return "", "", errors.Errorf("secret definition %s not supported. Format must be either <env-var>=+secrets/<secret-id> or <secret-id>", secretKeyValue)
 }
 
+var ErrUnlazyForceExecution = errors.New("unlazy force execution")
+
 func (c *Converter) forceExecution(ctx context.Context, state pllb.State, platr *platutil.Resolver) error {
 	if state.Output() == nil {
 		// Scratch - no need to execute.
@@ -2532,7 +2534,7 @@ func (c *Converter) forceExecution(ctx context.Context, state pllb.State, platr 
 	// want to un-lazy the ref so that the commands have executed.
 	_, err = ref.ReadDir(ctx, gwclient.ReadDirRequest{Path: "/"})
 	if err != nil {
-		return errors.Wrap(err, "unlazy force execution")
+		return fmt.Errorf("%w: %v", ErrUnlazyForceExecution, err)
 	}
 	return nil
 }

--- a/earthfile2llb/with_docker_run_local_reg.go
+++ b/earthfile2llb/with_docker_run_local_reg.go
@@ -124,7 +124,10 @@ func (w *withDockerRunLocalReg) Run(ctx context.Context, args []string, opt With
 
 	// Force synchronous command execution if we're using the local registry for
 	// loads and pulls.
-	return w.c.forceExecution(ctx, w.c.mts.Final.MainState, w.c.platr)
+	// The forced error will be returned elsewhere via magic I don't understand
+	// So swallowing the error here keeps error messages consistent.
+	_ = w.c.forceExecution(ctx, w.c.mts.Final.MainState, w.c.platr)
+	return nil
 }
 
 func (w *withDockerRunLocalReg) load(ctx context.Context, cmdID string, opt DockerLoadOpt) (chan *states.ImageDef, error) {

--- a/earthfile2llb/with_docker_run_local_reg.go
+++ b/earthfile2llb/with_docker_run_local_reg.go
@@ -45,8 +45,10 @@ func (w *withDockerRunLocalReg) Run(ctx context.Context, args []string, opt With
 	}
 
 	defer func() {
-		message := solvermon.FormatError("WITH DOCKER RUN", retErr.Error())
-		cmd.SetEnd(time.Now(), logstream.RunStatus_RUN_STATUS_FAILURE, message)
+		if retErr != nil {
+			message := solvermon.FormatError("WITH DOCKER RUN", retErr.Error())
+			cmd.SetEnd(time.Now(), logstream.RunStatus_RUN_STATUS_FAILURE, message)
+		}
 	}()
 
 	var imagesToBuild []*states.ImageDef

--- a/earthfile2llb/with_docker_run_local_reg.go
+++ b/earthfile2llb/with_docker_run_local_reg.go
@@ -124,10 +124,13 @@ func (w *withDockerRunLocalReg) Run(ctx context.Context, args []string, opt With
 
 	// Force synchronous command execution if we're using the local registry for
 	// loads and pulls.
-	// The forced error will be returned elsewhere via magic I don't understand
-	// So swallowing the error here keeps error messages consistent.
-	_ = w.c.forceExecution(ctx, w.c.mts.Final.MainState, w.c.platr)
-	return nil
+	err = w.c.forceExecution(ctx, w.c.mts.Final.MainState, w.c.platr)
+	if err != nil && errors.Is(err, ErrUnlazyForceExecution) {
+		// The forced error will be returned elsewhere via magic I don't understand
+		// So swallowing the error here keeps error messages consistent.
+		return nil
+	}
+	return err
 }
 
 func (w *withDockerRunLocalReg) load(ctx context.Context, cmdID string, opt DockerLoadOpt) (chan *states.ImageDef, error) {

--- a/earthfile2llb/with_docker_run_local_reg.go
+++ b/earthfile2llb/with_docker_run_local_reg.go
@@ -130,7 +130,7 @@ func (w *withDockerRunLocalReg) Run(ctx context.Context, args []string, opt With
 	err = w.c.forceExecution(ctx, w.c.mts.Final.MainState, w.c.platr)
 	if err != nil && errors.Is(err, ErrUnlazyForceExecution) {
 		// If error is ErrUnlazyForceExecution, Error is logged via SetEnd in
-		// solvermon.handleBuildkitStatus. So we don't setend we don't SetEndError here
+		// solvermon.handleBuildkitStatus. So we don't SetEndError here
 		endErrorExecution = false
 	}
 	return err

--- a/earthfile2llb/with_docker_run_reg.go
+++ b/earthfile2llb/with_docker_run_reg.go
@@ -252,7 +252,10 @@ func (w *withDockerRunRegistry) Run(ctx context.Context, args []string, opt With
 
 	// Force synchronous command execution if we're using the local registry for
 	// loads and pulls.
-	return w.c.forceExecution(ctx, w.c.mts.Final.MainState, w.c.platr)
+	// The forced error will be returned elsewhere via magic I don't understand
+	// So swallowing the error here keeps error messages consistent.
+	_ = w.c.forceExecution(ctx, w.c.mts.Final.MainState, w.c.platr)
+	return nil
 }
 
 func (w *withDockerRunRegistry) pull(ctx context.Context, opt DockerPullOpt) (*states.ImageDef, error) {

--- a/earthfile2llb/with_docker_run_reg.go
+++ b/earthfile2llb/with_docker_run_reg.go
@@ -125,8 +125,11 @@ func (w *withDockerRunRegistry) Run(ctx context.Context, args []string, opt With
 		return errors.Wrap(err, "failed to create command")
 	}
 
+	endErrorExecution := true
 	defer func() {
-		cmd.SetEndError(retErr)
+		if endErrorExecution {
+			cmd.SetEndError(retErr)
+		}
 	}()
 
 	err = w.installDeps(ctx, opt)
@@ -254,9 +257,9 @@ func (w *withDockerRunRegistry) Run(ctx context.Context, args []string, opt With
 	// loads and pulls.
 	err = w.c.forceExecution(ctx, w.c.mts.Final.MainState, w.c.platr)
 	if err != nil && errors.Is(err, ErrUnlazyForceExecution) {
-		// The forced error will be returned elsewhere via magic I don't understand
-		// So swallowing the error here keeps error messages consistent.
-		return nil
+		// If error is ErrUnlazyForceExecution, Error is logged via SetEnd in
+		// solvermon.handleBuildkitStatus. So we don't setend we don't SetEndError here
+		endErrorExecution = false
 	}
 	return err
 }

--- a/earthfile2llb/with_docker_run_reg.go
+++ b/earthfile2llb/with_docker_run_reg.go
@@ -254,6 +254,8 @@ func (w *withDockerRunRegistry) Run(ctx context.Context, args []string, opt With
 		return err
 	}
 
+	// Force synchronous command execution if we're using the local registry for
+	// loads and pulls.
 	return w.c.forceExecution(ctx, w.c.mts.Final.MainState, w.c.platr)
 }
 

--- a/earthfile2llb/with_docker_run_reg.go
+++ b/earthfile2llb/with_docker_run_reg.go
@@ -258,7 +258,7 @@ func (w *withDockerRunRegistry) Run(ctx context.Context, args []string, opt With
 	err = w.c.forceExecution(ctx, w.c.mts.Final.MainState, w.c.platr)
 	if err != nil && errors.Is(err, ErrUnlazyForceExecution) {
 		// If error is ErrUnlazyForceExecution, Error is logged via SetEnd in
-		// solvermon.handleBuildkitStatus. So we don't setend we don't SetEndError here
+		// solvermon.handleBuildkitStatus. So we don't SetEndError here
 		endErrorExecution = false
 	}
 	return err

--- a/earthfile2llb/with_docker_run_reg.go
+++ b/earthfile2llb/with_docker_run_reg.go
@@ -252,10 +252,13 @@ func (w *withDockerRunRegistry) Run(ctx context.Context, args []string, opt With
 
 	// Force synchronous command execution if we're using the local registry for
 	// loads and pulls.
-	// The forced error will be returned elsewhere via magic I don't understand
-	// So swallowing the error here keeps error messages consistent.
-	_ = w.c.forceExecution(ctx, w.c.mts.Final.MainState, w.c.platr)
-	return nil
+	err = w.c.forceExecution(ctx, w.c.mts.Final.MainState, w.c.platr)
+	if err != nil && errors.Is(err, ErrUnlazyForceExecution) {
+		// The forced error will be returned elsewhere via magic I don't understand
+		// So swallowing the error here keeps error messages consistent.
+		return nil
+	}
+	return err
 }
 
 func (w *withDockerRunRegistry) pull(ctx context.Context, opt DockerPullOpt) (*states.ImageDef, error) {

--- a/earthfile2llb/with_docker_run_reg.go
+++ b/earthfile2llb/with_docker_run_reg.go
@@ -129,8 +129,10 @@ func (w *withDockerRunRegistry) Run(ctx context.Context, args []string, opt With
 	}
 
 	defer func() {
-		message := solvermon.FormatError("WITH DOCKER RUN", retErr.Error())
-		cmd.SetEnd(time.Now(), logstream.RunStatus_RUN_STATUS_FAILURE, message)
+		if retErr != nil {
+			message := solvermon.FormatError("WITH DOCKER RUN", retErr.Error())
+			cmd.SetEnd(time.Now(), logstream.RunStatus_RUN_STATUS_FAILURE, message)
+		}
 	}()
 
 	err = w.installDeps(ctx, opt)

--- a/logbus/solvermon/vertexmon.go
+++ b/logbus/solvermon/vertexmon.go
@@ -59,7 +59,7 @@ var reHint = regexp.MustCompile(`^(?P<msg>.+?):Hint: .+`)
 
 func determineFatalErrorType(errString string, exitCode uint64) (logstream.FailureType, bool) {
 	if strings.Contains(errString, "context canceled") || errString == "no active sessions" {
-		return 0, false
+		return logstream.FailureType_FAILURE_TYPE_UNKNOWN, false
 	}
 	if reErrExitCode.MatchString(errString) {
 		switch exitCode {
@@ -75,7 +75,7 @@ func determineFatalErrorType(errString string, exitCode uint64) (logstream.Failu
 	if strings.Contains(errString, errutil.EarthlyGitStdErrMagicString) {
 		return logstream.FailureType_FAILURE_TYPE_GIT, true
 	}
-	return logstream.FailureType(0), false
+	return logstream.FailureType_FAILURE_TYPE_UNKNOWN, false
 }
 
 func formatErrorTemplate(errString string, fatalErrorType logstream.FailureType) string {
@@ -150,7 +150,6 @@ func FormatError(operation string, errString string) string {
 func (vm *vertexMonitor) parseError() {
 	errString := vm.vertex.Error
 
-	// Add operation context to the error string
 	indentOp := strings.Join(strings.Split(vm.operation, "\n"), "\n          ")
 	internalStr := ""
 	if vm.meta.Internal {
@@ -184,7 +183,7 @@ func (vm *vertexMonitor) parseError() {
 
 	formattedError := buf.String()
 
-	// Add source location if available
+	// Add Error location
 	slString := ""
 	if vm.meta.SourceLocation != nil {
 		slString = fmt.Sprintf(

--- a/logbus/solvermon/vertexmon.go
+++ b/logbus/solvermon/vertexmon.go
@@ -38,8 +38,121 @@ type vertexMonitor struct {
 }
 
 var reErrExitCode = regexp.MustCompile(`^(?:process ".*" did not complete successfully|error calling LocalhostExec): exit code: (?P<exit_code>[0-9]+)$`)
+
+func getExitCode(errString string) (uint64, bool) {
+	if reErrExitCode.MatchString(errString) {
+		matches, _ := stringutil.NamedGroupMatches(errString, reErrExitCode)
+		exitCodeMatch := matches["exit_code"][0]
+		exitCode, err := strconv.ParseUint(exitCodeMatch, 10, 32)
+		if err != nil {
+			return 0, false
+		}
+		return exitCode, true
+	}
+	return 0, false
+}
+
 var reErrNotFound = regexp.MustCompile(`^failed to calculate checksum of ref ([^ ]*): (.*)$`)
 var reHint = regexp.MustCompile(`^(?P<msg>.+?):Hint: .+`)
+
+func determineFatalErrorType(errString string, exitCode uint64) (logstream.FailureType, bool) {
+	if strings.Contains(errString, "context canceled") || errString == "no active sessions" {
+		return 0, false
+	}
+	if reErrExitCode.MatchString(errString) {
+		switch exitCode {
+		case math.MaxUint32:
+			return logstream.FailureType_FAILURE_TYPE_OOM_KILLED, true
+		default:
+			return logstream.FailureType_FAILURE_TYPE_NONZERO_EXIT, true
+		}
+	}
+	if reErrNotFound.MatchString(errString) {
+		return logstream.FailureType_FAILURE_TYPE_FILE_NOT_FOUND, true
+	}
+	if strings.Contains(errString, errutil.EarthlyGitStdErrMagicString) {
+		return logstream.FailureType_FAILURE_TYPE_GIT, true
+	}
+	return logstream.FailureType(0), false
+}
+
+func formatError(errString string, fatalErrorType logstream.FailureType, exitCode uint64, indentOp string, internalStr string) string {
+	if matches, _ := stringutil.NamedGroupMatches(errString, reHint); len(matches["msg"]) == 1 {
+		errString = matches["msg"][0]
+	}
+	formattedError := ""
+	switch fatalErrorType {
+	case logstream.FailureType_FAILURE_TYPE_OOM_KILLED:
+		formattedError = fmt.Sprintf(""+
+			"      The%s command\n"+
+			"          %s\n"+
+			"      was terminated because the build system ran out of memory. If you are using a satellite or other remote buildkit, it is the remote system that ran out of memory.",
+			internalStr, indentOp)
+	case logstream.FailureType_FAILURE_TYPE_NONZERO_EXIT:
+		formattedError = fmt.Sprintf(""+
+			"      The%s command\n"+
+			"          %s\n"+
+			"      did not complete successfully. Exit code %d",
+			internalStr, indentOp, exitCode)
+	case logstream.FailureType_FAILURE_TYPE_FILE_NOT_FOUND:
+		m := reErrNotFound.FindStringSubmatch(errString)
+		formattedError = fmt.Sprintf(""+
+			"      The%s command\n"+
+			"          %s\n"+
+			"      failed: %s",
+			internalStr, indentOp, m[2])
+	case logstream.FailureType_FAILURE_TYPE_GIT:
+		gitStdErr, shorterErr, ok := errutil.ExtractEarthlyGitStdErr(errString)
+		if ok {
+			formattedError = fmt.Sprintf("The%s command\n          %s\nfailed: %s\n\n%s", internalStr, indentOp, shorterErr, gitStdErr)
+		} else {
+			formattedError = fmt.Sprintf("The%s command\n          %s\nfailed: %s", internalStr, indentOp, errString)
+		}
+	default:
+		formattedError = fmt.Sprintf("The%s command\n          %s\nfailed: %s", internalStr, indentOp, errString)
+	}
+	return formattedError
+}
+
+func FormatError(errString string) string {
+	exitCode, _ := getExitCode(errString)
+	fatalErrorType, _ := determineFatalErrorType(errString, exitCode)
+	return formatError(errString, fatalErrorType, exitCode, "", "")
+}
+
+func (vm *vertexMonitor) parseError() {
+	errString := vm.vertex.Error
+
+	// Add operation context to the error string
+	indentOp := strings.Join(strings.Split(vm.operation, "\n"), "\n          ")
+	internalStr := ""
+	if vm.meta.Internal {
+		internalStr = " internal"
+	}
+	errString = fmt.Sprintf("%s%s", internalStr, errString)
+
+	exitCode, _ := getExitCode(errString)
+	fatalErrorType, isFatalError := determineFatalErrorType(errString, exitCode)
+	formattedError := formatError(errString, fatalErrorType, exitCode, indentOp, internalStr)
+
+	// Add source location if available
+	slString := ""
+	if vm.meta.SourceLocation != nil {
+		slString = fmt.Sprintf(
+			" %s:%d:%d",
+			vm.meta.SourceLocation.File, vm.meta.SourceLocation.StartLine,
+			vm.meta.SourceLocation.StartColumn)
+	}
+
+	// Set the error string and flags on the vertexMonitor
+	if isFatalError {
+		vm.errorStr = fmt.Sprintf("ERROR%s\n%s", slString, formattedError)
+	} else {
+		vm.errorStr = fmt.Sprintf("WARN%s: %s", slString, formattedError)
+	}
+	vm.isFatalError = isFatalError
+	vm.fatalErrorType = fatalErrorType
+}
 
 func (vm *vertexMonitor) Write(dt []byte, ts time.Time, stream int) (int, error) {
 	if stream == BuildkitStatsStream {
@@ -64,84 +177,4 @@ func (vm *vertexMonitor) Write(dt []byte, ts time.Time, stream int) (int, error)
 		return 0, errors.Wrap(err, "write log line")
 	}
 	return len(dt), nil
-}
-
-func (vm *vertexMonitor) parseError() {
-	errString := vm.vertex.Error
-	indentOp := strings.Join(strings.Split(vm.operation, "\n"), "\n          ")
-	internalStr := ""
-	if vm.meta.Internal {
-		internalStr = " internal"
-	}
-	if matches, _ := stringutil.NamedGroupMatches(errString, reHint); len(matches["msg"]) == 1 {
-		errString = matches["msg"][0]
-	}
-	switch {
-	case strings.Contains(errString, "context canceled"):
-		vm.isCanceled = true
-		vm.errorStr = "WARN: Canceled"
-		return
-	case reErrExitCode.MatchString(errString):
-		matches, _ := stringutil.NamedGroupMatches(errString, reErrExitCode)
-		exitCodeMatch := matches["exit_code"][0]
-
-		// Ignore the parse error as default case will print it as a string using
-		// the source, so we won't miss any data.
-		exitCode, _ := strconv.ParseUint(exitCodeMatch, 10, 32)
-		switch exitCode {
-		case math.MaxUint32:
-			errString = fmt.Sprintf(""+
-				"      The%s command\n"+
-				"          %s\n"+
-				"      was terminated because the build system ran out of memory.\n"+
-				"      If you are using a satellite or other remote buildkit, it is the remote system that ran out of memory.",
-				internalStr, indentOp)
-			vm.fatalErrorType = logstream.FailureType_FAILURE_TYPE_OOM_KILLED
-		default:
-			errString = fmt.Sprintf(""+
-				"      The%s command\n"+
-				"          %s\n"+
-				"      did not complete successfully. Exit code %s",
-				internalStr, indentOp, exitCodeMatch)
-			vm.fatalErrorType = logstream.FailureType_FAILURE_TYPE_NONZERO_EXIT
-		}
-		vm.isFatalError = true
-	case reErrNotFound.MatchString(errString):
-		m := reErrNotFound.FindStringSubmatch(errString)
-		errString = fmt.Sprintf(""+
-			"      The%s command\n"+
-			"          %s\n"+
-			"      failed: %s",
-			internalStr, indentOp, m[2])
-		vm.isFatalError = true
-		vm.fatalErrorType = logstream.FailureType_FAILURE_TYPE_FILE_NOT_FOUND
-	case errString == "no active sessions":
-		vm.isCanceled = true
-		errString = "WARN: Canceled"
-	case strings.Contains(errString, errutil.EarthlyGitStdErrMagicString):
-		gitStdErr, shorterErr, ok := errutil.ExtractEarthlyGitStdErr(errString)
-		if ok {
-			errString = fmt.Sprintf(
-				"The%s command '%s' failed: %s\n\n%s", internalStr, vm.operation, shorterErr, gitStdErr)
-		} else {
-			errString = fmt.Sprintf(
-				"The%s command '%s' failed: %s", internalStr, vm.operation, errString)
-		}
-		vm.isFatalError = true
-	default:
-		errString = fmt.Sprintf(
-			"The%s command '%s' failed: %s", internalStr, vm.operation, errString)
-	}
-	slString := ""
-	if vm.meta.SourceLocation != nil {
-		slString = fmt.Sprintf(
-			" %s:%d:%d",
-			vm.meta.SourceLocation.File, vm.meta.SourceLocation.StartLine,
-			vm.meta.SourceLocation.StartColumn)
-	}
-	if vm.isFatalError {
-		vm.errorStr = fmt.Sprintf("ERROR%s\n%s", slString, errString)
-	} else {
-		vm.errorStr = fmt.Sprintf("WARN%s: %s", slString, errString)
-	}
 }

--- a/logbus/solvermon/vertexmon.go
+++ b/logbus/solvermon/vertexmon.go
@@ -49,14 +49,13 @@ func getExitCode(errString string) (int, bool) {
 			return 0, false
 		}
 		// Check if the exit code can fit into an int
-		if exitCode > int64(^int(0)) {
+		if exitCode > int64(^uint(0)>>1) {
 			return 0, false // Value is too large to fit into an int
 		}
 		return int(exitCode), true
 	}
 	return 0, false
 }
-
 
 var reErrNotFound = regexp.MustCompile(`^failed to calculate checksum of ref ([^ ]*): (.*)$`)
 var reHint = regexp.MustCompile(`^(?P<msg>.+?):Hint: .+`)

--- a/logbus/solvermon/vertexmon.go
+++ b/logbus/solvermon/vertexmon.go
@@ -39,14 +39,14 @@ type vertexMonitor struct {
 
 var reErrExitCode = regexp.MustCompile(`(?:process ".*" did not complete successfully|error calling LocalhostExec): exit code: (?P<exit_code>[0-9]+)$`)
 
-func getExitCode(errString string) (uint32, bool) {
+func getExitCode(errString string) (int, bool) {
 	if matches, _ := stringutil.NamedGroupMatches(errString, reErrExitCode); len(matches["exit_code"]) == 1 {
 		exitCodeMatch := matches["exit_code"][0]
 		exitCode, err := strconv.ParseUint(exitCodeMatch, 10, 32)
 		if err != nil {
 			return 0, false
 		}
-		return uint32(exitCode), true
+		return int(exitCode), true
 	}
 	return 0, false
 }
@@ -56,7 +56,7 @@ var reHint = regexp.MustCompile(`^(?P<msg>.+?):Hint: .+`)
 
 // determineFatalErrorType returns logstream.FailureType
 // and whether or not its a Fatal Error
-func determineFatalErrorType(errString string, exitCode uint32) (logstream.FailureType, bool) {
+func determineFatalErrorType(errString string, exitCode int) (logstream.FailureType, bool) {
 	if strings.Contains(errString, "context canceled") || errString == "no active sessions" {
 		return logstream.FailureType_FAILURE_TYPE_UNKNOWN, false
 	}
@@ -77,7 +77,7 @@ func determineFatalErrorType(errString string, exitCode uint32) (logstream.Failu
 	return logstream.FailureType_FAILURE_TYPE_UNKNOWN, false
 }
 
-func formatErrorMessage(errString, operation string, internal bool, fatalErrorType logstream.FailureType, exitCode uint32) string {
+func formatErrorMessage(errString, operation string, internal bool, fatalErrorType logstream.FailureType, exitCode int) string {
 	if matches, _ := stringutil.NamedGroupMatches(errString, reHint); len(matches["msg"]) == 1 {
 		errString = matches["msg"][0]
 	}

--- a/logbus/solvermon/vertexmon.go
+++ b/logbus/solvermon/vertexmon.go
@@ -1,12 +1,14 @@
 package solvermon
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"math"
 	"regexp"
 	"strconv"
 	"strings"
+	"text/template"
 	"time"
 
 	"github.com/earthly/cloud-api/logstream"
@@ -37,19 +39,19 @@ type vertexMonitor struct {
 	isCanceled     bool
 }
 
-var reErrExitCode = regexp.MustCompile(`^(?:process ".*" did not complete successfully|error calling LocalhostExec): exit code: (?P<exit_code>[0-9]+)$`)
+var reErrExitCode = regexp.MustCompile(`(?:process ".*" did not complete successfully|error calling LocalhostExec): exit code: (?P<exit_code>[0-9]+)$`)
 
-func getExitCode(errString string) (uint64, bool) {
+func getExitCode(errString string) uint64 {
 	if reErrExitCode.MatchString(errString) {
 		matches, _ := stringutil.NamedGroupMatches(errString, reErrExitCode)
 		exitCodeMatch := matches["exit_code"][0]
 		exitCode, err := strconv.ParseUint(exitCodeMatch, 10, 32)
 		if err != nil {
-			return 0, false
+			return 0
 		}
-		return exitCode, true
+		return exitCode
 	}
-	return 0, false
+	return 0
 }
 
 var reErrNotFound = regexp.MustCompile(`^failed to calculate checksum of ref ([^ ]*): (.*)$`)
@@ -76,48 +78,73 @@ func determineFatalErrorType(errString string, exitCode uint64) (logstream.Failu
 	return logstream.FailureType(0), false
 }
 
-func formatError(errString string, fatalErrorType logstream.FailureType, exitCode uint64, indentOp string, internalStr string) string {
+func formatErrorTemplate(errString string, fatalErrorType logstream.FailureType) string {
 	if matches, _ := stringutil.NamedGroupMatches(errString, reHint); len(matches["msg"]) == 1 {
 		errString = matches["msg"][0]
 	}
-	formattedError := ""
+	var formattedError string
 	switch fatalErrorType {
 	case logstream.FailureType_FAILURE_TYPE_OOM_KILLED:
-		formattedError = fmt.Sprintf(""+
-			"      The%s command\n"+
-			"          %s\n"+
-			"      was terminated because the build system ran out of memory. If you are using a satellite or other remote buildkit, it is the remote system that ran out of memory.",
-			internalStr, indentOp)
+		formattedError = "" +
+			"      The{{.Internal}} command\n" +
+			"          {{.Operation}}\n" +
+			"      was terminated because the build system ran out of memory. If you are using a satellite or other remote buildkit, it is the remote system that ran out of memory."
 	case logstream.FailureType_FAILURE_TYPE_NONZERO_EXIT:
-		formattedError = fmt.Sprintf(""+
-			"      The%s command\n"+
-			"          %s\n"+
-			"      did not complete successfully. Exit code %d",
-			internalStr, indentOp, exitCode)
+		formattedError = "" +
+			"      The{{.Internal}} command\n" +
+			"          {{.Operation}}\n" +
+			"      did not complete successfully. Exit code {{.ExitCode}}"
 	case logstream.FailureType_FAILURE_TYPE_FILE_NOT_FOUND:
 		m := reErrNotFound.FindStringSubmatch(errString)
 		formattedError = fmt.Sprintf(""+
-			"      The%s command\n"+
-			"          %s\n"+
-			"      failed: %s",
-			internalStr, indentOp, m[2])
+			"      The{{.Internal}} command\n"+
+			"          {{.Operation}}\n"+
+			"      failed: %s", m[2])
 	case logstream.FailureType_FAILURE_TYPE_GIT:
 		gitStdErr, shorterErr, ok := errutil.ExtractEarthlyGitStdErr(errString)
 		if ok {
-			formattedError = fmt.Sprintf("The%s command\n          %s\nfailed: %s\n\n%s", internalStr, indentOp, shorterErr, gitStdErr)
+			formattedError = fmt.Sprintf(""+
+				"The{{.Internal}} command\n"+
+				"          {{.Operation}}\n"+
+				"failed: %s\n\n%s", shorterErr, gitStdErr)
 		} else {
-			formattedError = fmt.Sprintf("The%s command\n          %s\nfailed: %s", internalStr, indentOp, errString)
+			formattedError = "" +
+				"The{{.Internal}} command\n" +
+				"          {{.Operation}}\n" +
+				"failed: {{.Error}}"
 		}
 	default:
-		formattedError = fmt.Sprintf("The%s command\n          %s\nfailed: %s", internalStr, indentOp, errString)
+		formattedError = "" +
+			"The{{.Internal}} command\n" +
+			"          {{.Operation}}\n" +
+			"failed: {{.Error}}"
 	}
 	return formattedError
 }
 
-func FormatError(errString string) string {
-	exitCode, _ := getExitCode(errString)
+func FormatError(operation string, errString string) string {
+	exitCode := getExitCode(errString)
 	fatalErrorType, _ := determineFatalErrorType(errString, exitCode)
-	return formatError(errString, fatalErrorType, exitCode, "", "")
+	templateStr := formatErrorTemplate(errString, fatalErrorType)
+
+	tmpl, err := template.New("error").Parse(templateStr)
+	if err != nil {
+		return fmt.Sprintf("Failed to parse template: %v", err)
+	}
+
+	data := map[string]interface{}{
+		"Internal":  "",
+		"Operation": operation,
+		"ExitCode":  exitCode,
+		"Error":     errString,
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return fmt.Sprintf("Failed to build error template: %v", err)
+	}
+
+	return buf.String()
 }
 
 func (vm *vertexMonitor) parseError() {
@@ -131,9 +158,31 @@ func (vm *vertexMonitor) parseError() {
 	}
 	errString = fmt.Sprintf("%s%s", internalStr, errString)
 
-	exitCode, _ := getExitCode(errString)
+	exitCode := getExitCode(errString)
 	fatalErrorType, isFatalError := determineFatalErrorType(errString, exitCode)
-	formattedError := formatError(errString, fatalErrorType, exitCode, indentOp, internalStr)
+	templateStr := formatErrorTemplate(errString, fatalErrorType)
+
+	tmpl, err := template.New("error").Parse(templateStr)
+	if err != nil {
+		vm.errorStr = fmt.Sprintf("Failed to parse template: %v", err)
+		return
+	}
+
+	// Parameters to fill in the template
+	data := map[string]interface{}{
+		"Internal":  internalStr,
+		"Operation": indentOp,
+		"ExitCode":  exitCode,
+		"Error":     errString,
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		vm.errorStr = fmt.Sprintf("Failed to execute template: %v", err)
+		return
+	}
+
+	formattedError := buf.String()
 
 	// Add source location if available
 	slString := ""

--- a/logbus/solvermon/vertexmon_test.go
+++ b/logbus/solvermon/vertexmon_test.go
@@ -11,7 +11,7 @@ func TestGetExitCode(t *testing.T) {
 	tests := []struct {
 		name         string
 		errString    string
-		expectedCode uint32
+		expectedCode int
 	}{
 		{
 			name:         "no match",
@@ -49,7 +49,7 @@ func TestDetermineFatalErrorType(t *testing.T) {
 	tests := []struct {
 		name          string
 		errString     string
-		exitCode      uint32
+		exitCode      int
 		expectedType  logstream.FailureType
 		expectedFatal bool
 	}{

--- a/logbus/solvermon/vertexmon_test.go
+++ b/logbus/solvermon/vertexmon_test.go
@@ -1,7 +1,7 @@
 package solvermon
 
 import (
-	"math"
+	"fmt"
 	"testing"
 
 	"github.com/earthly/cloud-api/logstream"
@@ -9,37 +9,45 @@ import (
 
 func TestGetExitCode(t *testing.T) {
 	tests := []struct {
-		name         string
-		errString    string
-		expectedCode int
+		name          string
+		errString     string
+		expectedCode  int
+		expectedError error
 	}{
 		{
-			name:         "no match",
-			errString:    "random error message",
-			expectedCode: 0,
+			name:          "no match",
+			errString:     "random error message",
+			expectedCode:  0,
+			expectedError: nil,
 		},
 		{
-			name:         "match with exit code",
-			errString:    "process \"foo\" did not complete successfully: exit code: 123",
-			expectedCode: 123,
+			name:          "match with exit code",
+			errString:     "process \"foo\" did not complete successfully: exit code: 123",
+			expectedCode:  123,
+			expectedError: nil,
 		},
 		{
-			name:         "match with max uint32",
-			errString:    "process \"foo\" did not complete successfully: exit code: 4294967295",
-			expectedCode: math.MaxUint32,
+			name:          "match with max uint32",
+			errString:     "process \"foo\" did not complete successfully: exit code: 4294967295",
+			expectedCode:  0,
+			expectedError: errNoExitCodeOMM,
 		},
 		{
-			name:         "match with max uint32",
-			errString:    "some wrap message: process \"foo\" did not complete successfully: exit code: 8",
-			expectedCode: 8,
+			name:          "match with max uint32",
+			errString:     "some wrap message: process \"foo\" did not complete successfully: exit code: 8",
+			expectedCode:  8,
+			expectedError: nil,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			code, _ := getExitCode(tt.errString)
+			code, _, err := getExitCode(tt.errString)
 			if code != tt.expectedCode {
 				t.Errorf("getExitCode(%q) = %d, want %d", tt.errString, code, tt.expectedCode)
+			}
+			if err != tt.expectedError {
+				t.Errorf("getExitCode(%q) = %d, want %d", tt.errString, err, tt.expectedError)
 			}
 		})
 	}
@@ -50,6 +58,7 @@ func TestDetermineFatalErrorType(t *testing.T) {
 		name          string
 		errString     string
 		exitCode      int
+		parseErr      error
 		expectedType  logstream.FailureType
 		expectedFatal bool
 	}{
@@ -57,6 +66,7 @@ func TestDetermineFatalErrorType(t *testing.T) {
 			name:          "context canceled",
 			errString:     "context canceled",
 			exitCode:      0,
+			parseErr:      nil,
 			expectedType:  logstream.FailureType_FAILURE_TYPE_UNKNOWN,
 			expectedFatal: false,
 		},
@@ -64,13 +74,15 @@ func TestDetermineFatalErrorType(t *testing.T) {
 			name:          "exit code 123",
 			errString:     "process \"foo\" did not complete successfully: exit code: 123",
 			exitCode:      123,
+			parseErr:      nil,
 			expectedType:  logstream.FailureType_FAILURE_TYPE_NONZERO_EXIT,
 			expectedFatal: true,
 		},
 		{
 			name:          "exit code max uint32",
 			errString:     "process \"foo\" did not complete successfully: exit code: 4294967295",
-			exitCode:      math.MaxUint32,
+			exitCode:      0,
+			parseErr:      errNoExitCodeOMM,
 			expectedType:  logstream.FailureType_FAILURE_TYPE_OOM_KILLED,
 			expectedFatal: true,
 		},
@@ -78,28 +90,36 @@ func TestDetermineFatalErrorType(t *testing.T) {
 			name:          "file not found",
 			errString:     "failed to calculate checksum of ref foo: bar",
 			exitCode:      0,
+			parseErr:      nil,
 			expectedType:  logstream.FailureType_FAILURE_TYPE_FILE_NOT_FOUND,
 			expectedFatal: true,
 		},
 		{
 			name:          "git error",
 			errString:     "EARTHLY_GIT_STDERR: Z2l0IC1jI...",
-			exitCode:      0,
+			parseErr:      nil,
 			expectedType:  logstream.FailureType_FAILURE_TYPE_GIT,
 			expectedFatal: true,
 		},
 		{
 			name:          "unknown error",
 			errString:     "unknown error",
-			exitCode:      0,
+			parseErr:      nil,
 			expectedType:  logstream.FailureType_FAILURE_TYPE_UNKNOWN,
 			expectedFatal: false,
+		},
+		{
+			name:          "invalid exit code",
+			errString:     "exit code: 9999",
+			parseErr:      fmt.Errorf("exit code 9999 out of expected range (0-255)"),
+			expectedType:  logstream.FailureType_FAILURE_TYPE_UNKNOWN,
+			expectedFatal: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fatalType, fatal := determineFatalErrorType(tt.errString, tt.exitCode)
+			fatalType, fatal := determineFatalErrorType(tt.errString, tt.exitCode, tt.parseErr)
 			if fatalType != tt.expectedType {
 				t.Errorf("determineFatalErrorType(%q, %d) = %v, want %v", tt.errString, tt.exitCode, fatalType, tt.expectedType)
 			}

--- a/logbus/solvermon/vertexmon_test.go
+++ b/logbus/solvermon/vertexmon_test.go
@@ -1,0 +1,111 @@
+package solvermon
+
+import (
+	"math"
+	"testing"
+
+	"github.com/earthly/cloud-api/logstream"
+)
+
+func TestGetExitCode(t *testing.T) {
+	tests := []struct {
+		name         string
+		errString    string
+		expectedCode uint64
+	}{
+		{
+			name:         "no match",
+			errString:    "random error message",
+			expectedCode: 0,
+		},
+		{
+			name:         "match with exit code",
+			errString:    "process \"foo\" did not complete successfully: exit code: 123",
+			expectedCode: 123,
+		},
+		{
+			name:         "match with max uint32",
+			errString:    "process \"foo\" did not complete successfully: exit code: 4294967295",
+			expectedCode: math.MaxUint32,
+		},
+		{
+			name:         "match with max uint32",
+			errString:    "some wrap message: process \"foo\" did not complete successfully: exit code: 8",
+			expectedCode: 8,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			code := getExitCode(tt.errString)
+			if code != tt.expectedCode {
+				t.Errorf("getExitCode(%q) = %d, want %d", tt.errString, code, tt.expectedCode)
+			}
+		})
+	}
+}
+
+func TestDetermineFatalErrorType(t *testing.T) {
+	tests := []struct {
+		name          string
+		errString     string
+		exitCode      uint64
+		expectedType  logstream.FailureType
+		expectedFatal bool
+	}{
+		{
+			name:          "context canceled",
+			errString:     "context canceled",
+			exitCode:      0,
+			expectedType:  0,
+			expectedFatal: false,
+		},
+		{
+			name:          "exit code 123",
+			errString:     "process \"foo\" did not complete successfully: exit code: 123",
+			exitCode:      123,
+			expectedType:  logstream.FailureType_FAILURE_TYPE_NONZERO_EXIT,
+			expectedFatal: true,
+		},
+		{
+			name:          "exit code max uint32",
+			errString:     "process \"foo\" did not complete successfully: exit code: 4294967295",
+			exitCode:      math.MaxUint32,
+			expectedType:  logstream.FailureType_FAILURE_TYPE_OOM_KILLED,
+			expectedFatal: true,
+		},
+		{
+			name:          "file not found",
+			errString:     "failed to calculate checksum of ref foo: bar",
+			exitCode:      0,
+			expectedType:  logstream.FailureType_FAILURE_TYPE_FILE_NOT_FOUND,
+			expectedFatal: true,
+		},
+		{
+			name:          "git error",
+			errString:     "EARTHLY_GIT_STDERR: Z2l0IC1jI...",
+			exitCode:      0,
+			expectedType:  logstream.FailureType_FAILURE_TYPE_GIT,
+			expectedFatal: true,
+		},
+		{
+			name:          "unknown error",
+			errString:     "unknown error",
+			exitCode:      0,
+			expectedType:  logstream.FailureType_FAILURE_TYPE_UNKNOWN,
+			expectedFatal: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fatalType, fatal := determineFatalErrorType(tt.errString, tt.exitCode)
+			if fatalType != tt.expectedType {
+				t.Errorf("determineFatalErrorType(%q, %d) = %v, want %v", tt.errString, tt.exitCode, fatalType, tt.expectedType)
+			}
+			if fatal != tt.expectedFatal {
+				t.Errorf("determineFatalErrorType(%q, %d) = %v, want %v", tt.errString, tt.exitCode, fatal, tt.expectedFatal)
+			}
+		})
+	}
+}

--- a/logbus/solvermon/vertexmon_test.go
+++ b/logbus/solvermon/vertexmon_test.go
@@ -18,7 +18,7 @@ func TestGetExitCode(t *testing.T) {
 			name:          "no match",
 			errString:     "random error message",
 			expectedCode:  0,
-			expectedError: nil,
+			expectedError: errNoExitCode,
 		},
 		{
 			name:          "match with exit code",
@@ -42,7 +42,7 @@ func TestGetExitCode(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			code, _, err := getExitCode(tt.errString)
+			code, err := getExitCode(tt.errString)
 			if code != tt.expectedCode {
 				t.Errorf("getExitCode(%q) = %d, want %d", tt.errString, code, tt.expectedCode)
 			}

--- a/logbus/solvermon/vertexmon_test.go
+++ b/logbus/solvermon/vertexmon_test.go
@@ -57,7 +57,7 @@ func TestDetermineFatalErrorType(t *testing.T) {
 			name:          "context canceled",
 			errString:     "context canceled",
 			exitCode:      0,
-			expectedType:  0,
+			expectedType:  logstream.FailureType_FAILURE_TYPE_UNKNOWN,
 			expectedFatal: false,
 		},
 		{

--- a/logbus/solvermon/vertexmon_test.go
+++ b/logbus/solvermon/vertexmon_test.go
@@ -11,7 +11,7 @@ func TestGetExitCode(t *testing.T) {
 	tests := []struct {
 		name         string
 		errString    string
-		expectedCode uint64
+		expectedCode uint32
 	}{
 		{
 			name:         "no match",
@@ -37,7 +37,7 @@ func TestGetExitCode(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			code := getExitCode(tt.errString)
+			code, _ := getExitCode(tt.errString)
 			if code != tt.expectedCode {
 				t.Errorf("getExitCode(%q) = %d, want %d", tt.errString, code, tt.expectedCode)
 			}
@@ -49,7 +49,7 @@ func TestDetermineFatalErrorType(t *testing.T) {
 	tests := []struct {
 		name          string
 		errString     string
-		exitCode      uint64
+		exitCode      uint32
 		expectedType  logstream.FailureType
 		expectedFatal bool
 	}{


### PR DESCRIPTION
If a run fails in WITH DOCKER you get an error message like this:
```
================================== ❌ FAILURE ===================================

./t/with-docker+fail-test1 *failed* | Repeating the failure error...
./t/with-docker+fail-test1 *failed* | --> WITH DOCKER RUN --privileged echo "dummy" && false
./t/with-docker+fail-test1 *failed* | Starting dockerd with data root /var/earthly/dind/7b5da64c458d405fff1f21d3a985f6812f9eaad6af9c6eb0d2b8c1ca7422a2e2/tmp.lbamkM
./t/with-docker+fail-test1 *failed* | dummy
./t/with-docker+fail-test1 *failed* | ERROR tests/with-docker/Earthfile:186:8
./t/with-docker+fail-test1 *failed* |       The command
./t/with-docker+fail-test1 *failed* |           WITH DOCKER RUN --privileged echo "dummy" && false
./t/with-docker+fail-test1 *failed* |       did not complete successfully. Exit code 1
./t/with-docker+fail-test1 | unlazy force execution: process "/bin/sh -c 
EARTHLY_DOCKERD_DATA_ROOT=\"/var/earthly/dind/7b5da64c458d405fff1f21d3a985f6812f9eaad6af9c6eb0d2b8c1
ca7422a2e2\" EARTHLY_DOCKERD_CACHE_DATA=\"false\" EARTHLY_DOCKER_LOAD_FILES=\"\" 
EARTHLY_IMAGES_WITH_DIGESTS=\"\" EARTHLY_START_COMPOSE=\"false\" EARTHLY_COMPOSE_FILES=\"\" 
EARTHLY_COMPOSE_SERVICES=\"\" DIND_IMAGE=earthly/dind:alpine-3.19-docker-25.0.5-r0 
OTEL_TRACES_EXPORTER=none PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin /var/earthly/dockerd-
wrapper.sh execute /usr/bin/earth_debugger /bin/sh -c 'echo \"dummy\" && false'" did not complete successfully: exit 
code: 1
```

The last part is confusing:
```
unlazy force execution: process "/bin/sh -c 
EARTHLY_DOCKERD_DATA_ROOT=\"/var/earthly/dind/7b5da64c458d405fff1f21d3a985f6812f9eaad6af9c6eb0d2b8c1
ca7422a2e2\" EARTHLY_DOCKERD_CACHE_DATA=\"false\" EARTHLY_DOCKER_LOAD_FILES=\"\" 
EARTHLY_IMAGES_WITH_DIGESTS=\"\" EARTHLY_START_COMPOSE=\"false\" EARTHLY_COMPOSE_FILES=\"\" 
EARTHLY_COMPOSE_SERVICES=\"\" DIND_IMAGE=earthly/dind:alpine-3.19-docker-25.0.5-r0 
OTEL_TRACES_EXPORTER=none PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin /var/earthly/dockerd-
wrapper.sh execute /usr/bin/earth_debugger /bin/sh -c 'echo \"dummy\" && false'" did not complete successfully: exit 
code: 1
```
In some conditions, only `unlazy force execution` generates an error, so we need it there, even if duplicated in this case. 

With this change the last error is properly formatted:
```
/U/a/s/gha_earthly_test+fail1 |       The command
/U/a/s/gha_earthly_test+fail1 |           WITH DOCKER RUN
/U/a/s/gha_earthly_test+fail1 |       did not complete successfully. Exit code 1
```

I also changed vertormon.parseError to use templates and added some tests around the error type and exit code parsing. 