### PR TITLE
remove invalid test

### DIFF
--- a/tests/locally-in-command/Earthfile
+++ b/tests/locally-in-command/Earthfile
@@ -18,7 +18,6 @@ test-command-in-sub-dir:
     RUN touch /this-file-exists-locally
     DO --pass-args +RUN_EARTHLY_ARGS --target=/the-test+test
     RUN test "$(cat /the-test/data)" = "I am running in /the-test"
-    DO --pass-args +RUN_EARTHLY_ARGS --target=/the-test+test --should-fail=true
 
     # cleanup
     RUN rm /the-test/data

--- a/tests/locally-in-command/target-that-calls-command.earth
+++ b/tests/locally-in-command/target-that-calls-command.earth
@@ -5,6 +5,7 @@ test:
     FROM alpine
     RUN ! test -f /this-file-exists-locally
     DO imported-name+UDC_THAT_SAVES_FILE_LOCALLY
+    # at this point the command will have switched this to LOCALLY rather than the alpine-container
     RUN test "$(cat data)" = "I am running in /the-test"
     RUN test -f /this-file-exists-locally
 
@@ -14,7 +15,3 @@ test-other:
 test-both:
     BUILD +test
     BUILD ./other/path+test
-
-test-fails:
-    FROM alpine
-    DO imported-name+UDC_THAT_SAVES_FILE_LOCALLY


### PR DESCRIPTION
This test was passing `should-fail=true` rather than `should_fail=true`; however it's not clear what this test was doing as earthly was passing so changing the argument to `should_fail=true` then causes this test to fail (since earthly was not failing).

There was also a `test-fails` target, which was never used anywhere. Ironically this target was also passing, so it wasn't a matter of simply changing

    DO --pass-args +RUN_EARTHLY_ARGS --target=/the-test+test --should-fail=true

to

    DO --pass-args +RUN_EARTHLY_ARGS --target=/the-test+test-fails --should_fail=true