### PR TITLE
Lexer - Unknown Token Hint

### DIFF
--- a/ast/parse_errors_test.go
+++ b/ast/parse_errors_test.go
@@ -44,6 +44,18 @@ test:
   Hint: I got lost looking for '=' - did you define a key/value pair without a value?
 `,
 		},
+		{
+			name: "unrecognized keyword",
+			earthfile: `
+VERSION 0.7
+
+test:
+	RIN apk --update add build-base cmake bash
+`,
+			expectedHint: `
+Hint: 'RIN ' is not a recognized keyword.
+`,
+		},
 	}
 
 	for _, test := range tests {
@@ -54,7 +66,7 @@ test:
 			_, err := ast.ParseOpts(context.Background(), ast.FromReader(&namedReader))
 			r := require.New(t)
 			r.Error(err)
-			r.ErrorContains(err, test.expectedHint)
+			r.ErrorContains(err, strings.TrimSpace(test.expectedHint))
 		})
 	}
 }


### PR DESCRIPTION
See #4196

Given this:

```
RIN apk --update add build-base cmake bash
```

Error produced was:

```
Error: resolve build context for target +all: lexer error:  
syntax error: line 5:4: token recognition error at: 'RIN '
syntax error: line 5:8: token recognition error at: 'apk '
syntax error: line 5:12: token recognition error at: '-'
syntax error: line 5:13: token recognition error at: '-'
syntax error: line 5:14: token recognition error at: 'update '
syntax error: line 5:21: token recognition error at: 'add '
syntax error: line 5:25: token recognition error at: 'build-base '
syntax error: line 5:36: token recognition error at: 'cmake '
syntax error: line 5:42: token recognition error at: 'bash
```

Now:

```
Error: resolve build context for target /Users/adam/sandbox/gha_earthly_test+rin: 
syntax error: line 45:4: token recognition error at: 'RIN '

  Hint: 'RIN ' is not a recognized keyword.
```
That is we only return the first `token recognition error` and add a hint.
