### PR TITLE
Disable cloud upsell at the end of build

### DIFF
--- a/cmd/earthly/flag/global.go
+++ b/cmd/earthly/flag/global.go
@@ -50,6 +50,7 @@ type Global struct {
 	AuthToken                  string
 	AuthJWT                    string
 	DisableAnalytics           bool
+	DisableUpsell              bool
 	FeatureFlagOverrides       string
 	EnvFile                    string
 	ArgFile                    string
@@ -253,6 +254,13 @@ func (global *Global) RootFlags(installName string, bkImage string) []cli.Flag {
 			EnvVars:     []string{"EARTHLY_DISABLE_ANALYTICS", "DO_NOT_TRACK"},
 			Usage:       "Disable collection of analytics",
 			Destination: &global.DisableAnalytics,
+		},
+		&cli.BoolFlag{
+			Name:        "disable-upsell",
+			Hidden:      true,
+			EnvVars:     []string{"EARTHLY_DISABLE_UPSELL"},
+			Usage:       "Disable printing marketing/upselling messages",
+			Destination: &global.DisableUpsell,
 		},
 		&cli.StringFlag{
 			Name:        "version-flag-overrides",

--- a/cmd/earthly/subcmd/build_cmd.go
+++ b/cmd/earthly/subcmd/build_cmd.go
@@ -942,10 +942,12 @@ func (a *Build) logShareLink(ctx context.Context, cloudClient *cloud.Client, tar
 
 	if !cloudClient.IsLoggedIn(ctx) {
 		printLinkFn := func() {
-			a.cli.Console().Printf(
-				"🛰️ Reuse cache between CI runs with Earthly Satellites! " +
-					"2-20X faster than without cache. Generous free tier " +
-					"https://cloud.earthly.dev\n")
+			if !a.cli.Cfg().Global.DisableUpsell {
+				a.cli.Console().Printf(
+					"🛰️ Reuse cache between CI runs with Earthly Satellites! " +
+						"2-20X faster than without cache. Generous free tier " +
+						"https://cloud.earthly.dev\n")
+			}
 		}
 		return "", false, printLinkFn
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -68,6 +68,7 @@ var (
 // GlobalConfig contains global config values
 type GlobalConfig struct {
 	DisableAnalytics           bool          `yaml:"disable_analytics"              help:"Controls Earthly telemetry."`
+	DisableUpsell              bool          `yaml:"disable_upsell"                 help:"Controls Earthly marketing/upsell message printing."`
 	BuildkitCacheSizeMb        int           `yaml:"cache_size_mb"                  help:"Size of the buildkit cache in Megabytes."`
 	BuildkitCacheSizePct       int           `yaml:"cache_size_pct"                 help:"Size of the buildkit cache, as percentage (0-100)."`
 	BuildkitCacheKeepDurationS int           `yaml:"buildkit_cache_keep_duration_s" help:"Max age of cache, in seconds. 0 disables age-based cache expiry."`


### PR DESCRIPTION
This is implemented as a separte flag instead of piggy-backing on EARTHLY_DISABLE_ANALYTICS as suggested in #3601 because the purpose of these two things seem separate.

urfave/cli doesn't support env-only flags. The EARTHLY_DISABLE_ANALYTICS flag was simply defined with no name, which makes it show up in --help but seemingly without a --option. However, defining two flags that way doesn't work, as now we have 2 flags named empty string and the flagset will panic.

So instead I've opted for a hidden flag. Unfortunately this causes no documentation related to this environment variable to be present in --help.

Fixes: #3601