### PR TITLE
fix: Match internalfailed errors in formatErrorMessage() (fixes #4221)

### DIFF
--- a/logbus/solvermon/vertexmon.go
+++ b/logbus/solvermon/vertexmon.go
@@ -63,7 +63,7 @@ func getExitCode(errString string) (int, error) {
 	return 0, errNoExitCode
 }
 
-var reErrNotFound = regexp.MustCompile(`^failed to calculate checksum of ref ([^ ]*): (.*)$`)
+var reErrNotFound = regexp.MustCompile(`^\s*(internal)?failed to calculate checksum of ref ([^ ]::[^ ]*|[^ ]*): (.*)\s*$`)
 var reHint = regexp.MustCompile(`^(?P<msg>.+?):Hint: .+`)
 
 // determineFatalErrorType returns logstream.FailureType
@@ -114,10 +114,14 @@ func formatErrorMessage(errString, operation string, internal bool, fatalErrorTy
 				"      did not complete successfully. Exit code %d", internalStr, operation, exitCode)
 	case logstream.FailureType_FAILURE_TYPE_FILE_NOT_FOUND:
 		m := reErrNotFound.FindStringSubmatch(errString)
+		reason := fmt.Sprintf("unable to parse file_not_found error:%s", errString)
+		if len(m) > 2 {
+			reason = m[3]
+		}
 		return fmt.Sprintf(
 			"      The%s command\n"+
 				"          %s\n"+
-				"      failed: %s", internalStr, operation, m[2])
+				"      failed: %s", internalStr, operation, reason)
 	case logstream.FailureType_FAILURE_TYPE_GIT:
 		gitStdErr, shorterErr, ok := errutil.ExtractEarthlyGitStdErr(errString)
 		if ok {


### PR DESCRIPTION
See #4221 for details and how to repro.

Added tests to validate that the regex matches as expected.

Didn't have time to add tests for formatErrorMessage(), but I confirmed that it correctly formats the error now:
![CleanShot 2024-06-24 at 08 54 16@2x](https://github.com/earthly/earthly/assets/10719325/f6ed2fdd-776c-4045-a959-a28f15ea4962)

Also verified that it doesn't panic when the regex fails to match:
![CleanShot 2024-06-24 at 08 54 00@2x](https://github.com/earthly/earthly/assets/10719325/5a232481-2674-4501-bb84-02e94f0eaf43)
