### PR TITLE
Fix device name parsing for MTU discovery when using link scoped devices

### DIFF
--- a/buildkitd/entrypoint.sh
+++ b/buildkitd/entrypoint.sh
@@ -138,7 +138,7 @@ echo "$EARTHLY_GIT_CONFIG" | base64 -d >/root/.gitconfig
 
 #Set up CNI
 if [ -z "$CNI_MTU" ]; then
-  device=$(ip route show | grep default | cut -d' ' -f5 | head -n 1)
+  device=$(ip route show | grep ^default | head -n 1 | sed 's|.* dev \(\w*\)\s.*|\1|')
   CNI_MTU=$(cat /sys/class/net/"$device"/mtu)
   export CNI_MTU
 fi
@@ -324,7 +324,7 @@ do
             if [ "$OOM_SCORE_ADJ" -ne "0" ]; then
                 ! "$BUILDKIT_DEBUG" || echo "$(date) | $PID($(cat /proc/"$PID"/cmdline)) killed with OOM_SCORE_ADJ=$OOM_SCORE_ADJ" >> /var/log/oom_adj
                 kill -9 "$PID"
-            else 
+            else
                 ! "$BUILDKIT_DEBUG" || echo "$(date) | $PID($(cat /proc/"$PID"/cmdline)) was not killed because OOM_SCORE_ADJ was default or not set" >> /var/log/oom_adj
             fi
         fi


### PR DESCRIPTION
This fix is relevant for tun devices, which are common in VPN implementations. For example, while a "normal" default route may look like:

	default via 192.168.1.1 dev enp1s0 proto dhcp src 192.168.1.123 metric 100

A tun device for a VPN may instead look like:

	default dev tun0 scope link

In the current entrypoint, the device name would be incorrectly parsed as "link" instead of "tun0". By using sed to find the word after "dev", the result is more likely to be correct. Sed is used elsewhere in the entrypoint, so it is already an expected utility.

When the device name is incorrectly parsed, the earthly-buildkitd container fails with the error:

	cat: can't open '/sys/class/net/link/mtu': No such file or directory