### PR TITLE
Propagate aws and oidc related options for WITH DOCKER command

### DIFF
--- a/earthfile2llb/interpreter.go
+++ b/earthfile2llb/interpreter.go
@@ -775,6 +775,8 @@ func (i *Interpreter) handleRun(ctx context.Context, cmd spec.Command) error {
 		i.withDocker.NoCache = opts.NoCache
 		i.withDocker.Interactive = opts.Interactive
 		i.withDocker.interactiveKeep = opts.InteractiveKeep
+		i.withDocker.WithAWSCredentials = opts.WithAWS
+		i.withDocker.OIDCInfo = awsOIDCInfo
 
 		// TODO: Could this be allowed in the future, if dynamic build args
 		//       are expanded ahead of time?

--- a/earthfile2llb/with_docker_run_base.go
+++ b/earthfile2llb/with_docker_run_base.go
@@ -9,6 +9,7 @@ import (
 	"github.com/containerd/containerd/platforms"
 	debuggercommon "github.com/earthly/earthly/debugger/common"
 	"github.com/earthly/earthly/util/llbutil"
+	"github.com/earthly/earthly/util/oidcutil"
 	"github.com/earthly/earthly/util/platutil"
 	"github.com/moby/buildkit/client/llb"
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
@@ -49,6 +50,8 @@ type WithDockerOpt struct {
 	NoCache               bool
 	Interactive           bool
 	interactiveKeep       bool
+	WithAWSCredentials    bool
+	OIDCInfo              *oidcutil.AWSOIDCInfo
 	Pulls                 []DockerPullOpt
 	Loads                 []DockerLoadOpt
 	ComposeFiles          []string

--- a/earthfile2llb/with_docker_run_local_reg.go
+++ b/earthfile2llb/with_docker_run_local_reg.go
@@ -121,6 +121,8 @@ func (w *withDockerRunLocalReg) Run(ctx context.Context, args []string, opt With
 		Interactive:          opt.Interactive,
 		InteractiveKeep:      opt.interactiveKeep,
 		InteractiveSaveFiles: opt.TryCatchSaveArtifacts,
+		WithAWSCredentials:   opt.WithAWSCredentials,
+		OIDCInfo:             opt.OIDCInfo,
 	}
 
 	_, err = w.c.internalRun(ctx, crOpts)

--- a/earthfile2llb/with_docker_run_local_tar.go
+++ b/earthfile2llb/with_docker_run_local_tar.go
@@ -99,6 +99,8 @@ func (w *withDockerRunLocalTar) Run(ctx context.Context, args []string, opt With
 		Interactive:          opt.Interactive,
 		InteractiveKeep:      opt.interactiveKeep,
 		InteractiveSaveFiles: opt.TryCatchSaveArtifacts,
+		WithAWSCredentials:   opt.WithAWSCredentials,
+		OIDCInfo:             opt.OIDCInfo,
 	}
 
 	// then finally run the command

--- a/earthfile2llb/with_docker_run_reg.go
+++ b/earthfile2llb/with_docker_run_reg.go
@@ -203,6 +203,8 @@ func (w *withDockerRunRegistry) Run(ctx context.Context, args []string, opt With
 		Interactive:          opt.Interactive,
 		InteractiveKeep:      opt.interactiveKeep,
 		InteractiveSaveFiles: opt.TryCatchSaveArtifacts,
+		WithAWSCredentials:   opt.WithAWSCredentials,
+		OIDCInfo:             opt.OIDCInfo,
 	}
 
 	crOpts.extraRunOpts = append(crOpts.extraRunOpts, pllb.AddMount(

--- a/earthfile2llb/with_docker_run_tar.go
+++ b/earthfile2llb/with_docker_run_tar.go
@@ -170,6 +170,8 @@ func (w *withDockerRunTar) Run(ctx context.Context, args []string, opt WithDocke
 		Interactive:          opt.Interactive,
 		InteractiveKeep:      opt.interactiveKeep,
 		InteractiveSaveFiles: opt.TryCatchSaveArtifacts,
+		WithAWSCredentials:   opt.WithAWSCredentials,
+		OIDCInfo:             opt.OIDCInfo,
 	}
 
 	// TODO: /tmp/earthly should not be hard-coded here. It should match whatever

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -1627,15 +1627,15 @@ test-aws-flag-envs:
 # for happy path test go to <repo>/tests/oidc
 test-aws-oidc:
    DO +RUN_EARTHLY --earthfile=aws-flag.earth --target=+oidc --should_fail=true --output_contains="RUN --aws-oidc requires the --run-with-aws-oidc feature flag"
-   DO +RUN_EARTHLY --earthfile=aws-flag.earth --target=+oidc-with-docker --should_fail=true --output_contains="RUN --aws-oidc requires the --run-with-aws-oidc feature flag"
+   DO +RUN_EARTHLY --earthfile=aws-flag.earth --extra_args="--allow-privileged" --target=+oidc-with-docker --should_fail=true --output_contains="RUN --aws-oidc requires the --run-with-aws-oidc feature flag"
    # enable flag
    RUN sed -i "1s/VERSION \(.*\)/VERSION --run-with-aws-oidc \1/" Earthfile
    # empty oidc flag
    DO +RUN_EARTHLY --target=+oidc --should_fail=true --output_contains="role-arn must be specified"
-   DO +RUN_EARTHLY --target=+oidc-with-docker --should_fail=true --output_contains="role-arn must be specified"
+   DO +RUN_EARTHLY --extra_args="--allow-privileged" --target=+oidc-with-docker --should_fail=true --output_contains="role-arn must be specified"
    # invalid oidc flag
    DO +RUN_EARTHLY --target=+oidc --extra_args="--build-arg OIDC=\"foo=bar\"" --should_fail=true --output_contains="invalid value for oidc flag: 1 error(s) decoding"
-   DO +RUN_EARTHLY --target=+oidc-with-docker --extra_args="--build-arg OIDC=\"foo=bar\"" --should_fail=true --output_contains="invalid value for oidc flag: 1 error(s) decoding"
+   DO +RUN_EARTHLY --extra_args="--allow-privileged" --target=+oidc-with-docker --extra_args="--build-arg OIDC=\"foo=bar\"" --should_fail=true --output_contains="invalid value for oidc flag: 1 error(s) decoding"
 
 test-aws-flag-configs:
    RUN mkdir -p /root/.aws

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -1627,12 +1627,15 @@ test-aws-flag-envs:
 # for happy path test go to <repo>/tests/oidc
 test-aws-oidc:
    DO +RUN_EARTHLY --earthfile=aws-flag.earth --target=+oidc --should_fail=true --output_contains="RUN --aws-oidc requires the --run-with-aws-oidc feature flag"
+   DO +RUN_EARTHLY --earthfile=aws-flag.earth --target=+oidc-with-docker --should_fail=true --output_contains="RUN --aws-oidc requires the --run-with-aws-oidc feature flag"
    # enable flag
    RUN sed -i "1s/VERSION \(.*\)/VERSION --run-with-aws-oidc \1/" Earthfile
    # empty oidc flag
    DO +RUN_EARTHLY --target=+oidc --should_fail=true --output_contains="role-arn must be specified"
+   DO +RUN_EARTHLY --target=+oidc-with-docker --should_fail=true --output_contains="role-arn must be specified"
    # invalid oidc flag
    DO +RUN_EARTHLY --target=+oidc --extra_args="--build-arg OIDC=\"foo=bar\"" --should_fail=true --output_contains="invalid value for oidc flag: 1 error(s) decoding"
+   DO +RUN_EARTHLY --target=+oidc-with-docker --extra_args="--build-arg OIDC=\"foo=bar\"" --should_fail=true --output_contains="invalid value for oidc flag: 1 error(s) decoding"
 
 test-aws-flag-configs:
    RUN mkdir -p /root/.aws

--- a/tests/aws-flag.earth
+++ b/tests/aws-flag.earth
@@ -10,3 +10,12 @@ basic:
 oidc:
     ARG OIDC=""
     RUN --aws --oidc=$OIDC echo this should not succeed
+
+oidc-with-docker:
+    FROM earthly/dind:alpine-3.20-docker-26.1.3-r1
+
+    ARG OIDC=""
+
+    WITH DOCKER
+        RUN --aws --oidc=$OIDC echo this should not succeed
+    END

--- a/tests/oidc/aws.earth
+++ b/tests/oidc/aws.earth
@@ -13,3 +13,20 @@ oidc:
     LET OIDC="role-arn=$ROLE_ARN,session-name=earthly-ci-test-session,region=us-west-2"
     RUN --aws --oidc=$OIDC export result=$(env |grep AWS_ |wc -l); \
     test $result -eq $expected || (echo "expected $expected env vars for AWS but got $result" && exit 1)
+
+oidc-with-docker:
+    FROM earthly/dind:alpine-3.20-docker-26.1.3-r1
+
+    # set baseline - expects no envs with AWS_ prefix
+    LET expected=0
+    RUN export result=$(env |grep AWS_ |wc -l); \
+    test $result -eq $expected || (echo "expected \$expected env vars for AWS but got $result" && exit 1)
+    SET expected=4
+
+    ARG --required ROLE_ARN
+    LET OIDC="role-arn=$ROLE_ARN,session-name=earthly-ci-test-session,region=us-west-2"
+    
+    WITH DOCKER
+        RUN --aws --oidc=$OIDC export result=$(env |grep AWS_ |wc -l); \
+        test $result -eq $expected || (echo "expected $expected env vars for AWS but got $result" && exit 1)
+    END

--- a/tests/oidc/test-aws.sh
+++ b/tests/oidc/test-aws.sh
@@ -13,4 +13,4 @@ echo "== it should access aws via oidc =="
 earthly --config "$earthly_config" +oidc --ROLE_ARN="$ROLE_ARN"
 
 echo "== it should access aws via oidc-with-docker =="
-earthly --config "$earthly_config" +oidc-with-docker --ROLE_ARN="$ROLE_ARN"
+earthly --config "$earthly_config" --allow-privileged +oidc-with-docker --ROLE_ARN="$ROLE_ARN"

--- a/tests/oidc/test-aws.sh
+++ b/tests/oidc/test-aws.sh
@@ -11,3 +11,6 @@ EARTHLY_TOKEN="$OIDC_USER_TOKEN" earthly account login 2>&1 | acbgrep 'Logged in
 
 echo "== it should access aws via oidc =="
 earthly --config "$earthly_config" +oidc --ROLE_ARN="$ROLE_ARN"
+
+echo "== it should access aws via oidc-with-docker =="
+earthly --config "$earthly_config" +oidc-with-docker --ROLE_ARN="$ROLE_ARN"


### PR DESCRIPTION
This PR fixes AWS and OIDC related options not being handled when running `WITH DOCKER ...` command.

Added related tests which are mostly based off the non `WITH DOCKER ...` variant.

Fixes https://github.com/earthly/earthly/issues/4241