### PR TITLE
Add terraform and manual installation support

### DIFF
--- a/cloud/cloud_installation.go
+++ b/cloud/cloud_installation.go
@@ -33,6 +33,7 @@ type CloudConfigurationOpt struct {
 	SecurityGroupId    string
 	Region             string
 	InstanceProfileArn string
+	AddressResolution  string
 }
 
 func (c *Client) ConfigureCloud(ctx context.Context, orgID string, configuration *CloudConfigurationOpt) (*Installation, error) {
@@ -47,6 +48,7 @@ func (c *Client) ConfigureCloud(ctx context.Context, orgID string, configuration
 		SecurityGroupId:    configuration.SecurityGroupId,
 		Region:             configuration.Region,
 		InstanceProfileArn: configuration.InstanceProfileArn,
+		//AddressResolution:  configuration.AddressResolution,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "error from ConfigureCloud API")

--- a/cloud/cloud_installation.go
+++ b/cloud/cloud_installation.go
@@ -14,6 +14,11 @@ const (
 	CloudStatusUnknown = "Unknown"
 )
 
+const (
+	AddressResolutionPrivateIP  = "private_ip"
+	AddressResolutionPrivateDNS = "private_dns"
+)
+
 type Installation struct {
 	Name          string
 	Org           string
@@ -37,6 +42,10 @@ type CloudConfigurationOpt struct {
 }
 
 func (c *Client) ConfigureCloud(ctx context.Context, orgID string, configuration *CloudConfigurationOpt) (*Installation, error) {
+	resolution := pb.AddressResolution_ADDRESS_RESOLUTION_PRIVATE_IP
+	if configuration.AddressResolution == AddressResolutionPrivateDNS {
+		resolution = pb.AddressResolution_ADDRESS_RESOLUTION_PRIVATE_DNS
+	}
 	resp, err := c.compute.ConfigureCloud(c.withAuth(ctx), &pb.ConfigureCloudRequest{
 		OrgId:              orgID,
 		Name:               configuration.Name,
@@ -48,7 +57,7 @@ func (c *Client) ConfigureCloud(ctx context.Context, orgID string, configuration
 		SecurityGroupId:    configuration.SecurityGroupId,
 		Region:             configuration.Region,
 		InstanceProfileArn: configuration.InstanceProfileArn,
-		//AddressResolution:  configuration.AddressResolution,
+		AddressResolution:  resolution,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "error from ConfigureCloud API")

--- a/cmd/earthly/subcmd/cloud_installation_cmds.go
+++ b/cmd/earthly/subcmd/cloud_installation_cmds.go
@@ -106,12 +106,14 @@ func (a *CloudInstallation) Cmds() []*cli.Command {
 							Destination: &a.awsSubnetID,
 						},
 						&cli.StringFlag{
-							Name:  "aws-instance-profile-arn",
-							Usage: "The ARN of the IAM instance profile for the BYOC installation to use for new satellites.",
+							Name:        "aws-instance-profile-arn",
+							Usage:       "The ARN of the IAM instance profile for the BYOC installation to use for new satellites.",
+							Destination: &a.awsInstanceProfileARN,
 						},
 						&cli.StringFlag{
-							Name:  "aws-earthly-access-role-arn",
-							Usage: "The ARN of the IAM role for Earthly to use when orchestrating and managing the new BYOC satellites.",
+							Name:        "aws-earthly-access-role-arn",
+							Usage:       "The ARN of the IAM role for Earthly to use when orchestrating and managing the new BYOC satellites.",
+							Destination: &a.awsEarthlyRoleARN,
 						},
 					},
 				},

--- a/cmd/earthly/subcmd/cloud_installation_cmds.go
+++ b/cmd/earthly/subcmd/cloud_installation_cmds.go
@@ -160,7 +160,11 @@ func (c *CloudInstallation) install(cliCtx *cli.Context) error {
 	}
 
 	if !cliCtx.IsSet("resolution") {
-		c.addressResolution = "private_ip"
+		c.addressResolution = cloud.AddressResolutionPrivateIP
+	}
+	if c.addressResolution != cloud.AddressResolutionPrivateIP &&
+		c.addressResolution != cloud.AddressResolutionPrivateDNS {
+		return errors.Errorf("%q is not a valid value for --resolution", c.addressResolution)
 	}
 
 	cloudClient, err := helper.NewCloudClient(c.cli)

--- a/cmd/earthly/subcmd/cloud_installation_cmds.go
+++ b/cmd/earthly/subcmd/cloud_installation_cmds.go
@@ -96,7 +96,7 @@ func (a *CloudInstallation) Cmds() []*cli.Command {
 							Destination: &a.awsSecurityGroup,
 						},
 						&cli.StringFlag{
-							Name:        "aws-ssh-key-id",
+							Name:        "aws-ssh-key-name",
 							Usage:       "The name of the ssh key for BYOC to include on each newly launched satellite. Useful for debugging.",
 							Destination: &a.awsSSHKeyName,
 						},

--- a/cmd/earthly/subcmd/cloud_installation_cmds.go
+++ b/cmd/earthly/subcmd/cloud_installation_cmds.go
@@ -475,7 +475,7 @@ func (c *CloudInstallation) isManualInstallation(ctx *cli.Context) bool {
 	return ctx.IsSet("aws-account-id") &&
 		ctx.IsSet("aws-region") &&
 		ctx.IsSet("aws-security-group-id") &&
-		ctx.IsSet("aws-ssh-key-id") &&
+		ctx.IsSet("aws-ssh-key-name") &&
 		ctx.IsSet("aws-subnet-id") &&
 		ctx.IsSet("aws-instance-profile-arn") &&
 		ctx.IsSet("aws-earthly-access-role-arn")

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-units v0.5.0
 	github.com/dustin/go-humanize v1.0.1
-	github.com/earthly/cloud-api v1.0.1-0.20240712005719-4c423c0984c8
+	github.com/earthly/cloud-api v1.0.1-0.20240712142419-23b6f0913996
 	github.com/earthly/earthly/ast v0.0.0-00010101000000-000000000000
 	github.com/earthly/earthly/util/deltautil v0.0.0-20240507235053-335389ed3e2a
 	github.com/elastic/go-sysinfo v1.9.0

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-units v0.5.0
 	github.com/dustin/go-humanize v1.0.1
-	github.com/earthly/cloud-api v1.0.1-0.20240530080539-c5171a73ad6f
+	github.com/earthly/cloud-api v1.0.1-0.20240712005719-4c423c0984c8
 	github.com/earthly/earthly/ast v0.0.0-00010101000000-000000000000
 	github.com/earthly/earthly/util/deltautil v0.0.0-20240507235053-335389ed3e2a
 	github.com/elastic/go-sysinfo v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -194,8 +194,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/earthly/buildkit v0.0.0-20240515200521-531b303aa8ec h1:vf6x0fPOWKakjH3n2N1O9Tg5j1HDIJsC3Kkgmuko2U0=
 github.com/earthly/buildkit v0.0.0-20240515200521-531b303aa8ec/go.mod h1:1/yAC8A0Tu94Bdmv07gaG1pFBp+CetVwO7oB3qvZXUc=
-github.com/earthly/cloud-api v1.0.1-0.20240712005719-4c423c0984c8 h1:h/BZzalPJOK/YKL3db5jP4FwsC9d07v79aq2D8NwVUA=
-github.com/earthly/cloud-api v1.0.1-0.20240712005719-4c423c0984c8/go.mod h1:rU/tYJ7GFBjdKAITV2heDbez++glpGSbtJaZcp73rNI=
+github.com/earthly/cloud-api v1.0.1-0.20240712142419-23b6f0913996 h1:UobaUMrXjUcVaHXAev9aOflHHRg9gO+uOwhCvWJ9+cw=
+github.com/earthly/cloud-api v1.0.1-0.20240712142419-23b6f0913996/go.mod h1:rU/tYJ7GFBjdKAITV2heDbez++glpGSbtJaZcp73rNI=
 github.com/earthly/fsutil v0.0.0-20231030221755-644b08355b65 h1:6oyWHoxHXwcTt4EqmMw6361scIV87uEAB1N42+VpIwk=
 github.com/earthly/fsutil v0.0.0-20231030221755-644b08355b65/go.mod h1:9kMVqMyQ/Sx2df5LtnGG+nbrmiZzCS7V6gjW3oGHsvI=
 github.com/elastic/go-sysinfo v1.9.0 h1:usICqY/Nw4Mpn9f4LdtpFrKxXroJDe81GaxxUlCckIo=

--- a/go.sum
+++ b/go.sum
@@ -194,8 +194,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/earthly/buildkit v0.0.0-20240515200521-531b303aa8ec h1:vf6x0fPOWKakjH3n2N1O9Tg5j1HDIJsC3Kkgmuko2U0=
 github.com/earthly/buildkit v0.0.0-20240515200521-531b303aa8ec/go.mod h1:1/yAC8A0Tu94Bdmv07gaG1pFBp+CetVwO7oB3qvZXUc=
-github.com/earthly/cloud-api v1.0.1-0.20240530080539-c5171a73ad6f h1:QjB03JW1E4dS4nvkqE1JKrVxGs95jBBqMYhM6LOEd34=
-github.com/earthly/cloud-api v1.0.1-0.20240530080539-c5171a73ad6f/go.mod h1:rU/tYJ7GFBjdKAITV2heDbez++glpGSbtJaZcp73rNI=
+github.com/earthly/cloud-api v1.0.1-0.20240712005719-4c423c0984c8 h1:h/BZzalPJOK/YKL3db5jP4FwsC9d07v79aq2D8NwVUA=
+github.com/earthly/cloud-api v1.0.1-0.20240712005719-4c423c0984c8/go.mod h1:rU/tYJ7GFBjdKAITV2heDbez++glpGSbtJaZcp73rNI=
 github.com/earthly/fsutil v0.0.0-20231030221755-644b08355b65 h1:6oyWHoxHXwcTt4EqmMw6361scIV87uEAB1N42+VpIwk=
 github.com/earthly/fsutil v0.0.0-20231030221755-644b08355b65/go.mod h1:9kMVqMyQ/Sx2df5LtnGG+nbrmiZzCS7V6gjW3oGHsvI=
 github.com/elastic/go-sysinfo v1.9.0 h1:usICqY/Nw4Mpn9f4LdtpFrKxXroJDe81GaxxUlCckIo=


### PR DESCRIPTION
This tweaks the BYOC cloud installation methods to enable manual installation; and installation via terraform. Example commands:

To install automatically via CloudFormation: `earthly cloud install --via cloudformation --name <stack-name>`

To install automatically via Terraform: `earthly cloud install --via terraform`

To install manually:
```
earthly cloud install \
   --name <name> \
  --aws-account-id <aws-account-id> \
  --aws-region <aws-region> \
  --aws-security-group-id <aws-security-group-id> \
  --aws-ssh-key-id <aws-ssh-key-id> \
  --aws-subnet-id <aws-subnet-id> \
  --aws-instance-profile-arn <aws-instance-profile-arn> \
  --aws-earthly-access-role-arn <aws-earthly-access-role-arn>
```

Docs forthcoming on the new installation options.