### PR TITLE
Docs: Update suggested IAM policy for BYOC manual install

### DIFF
--- a/docs/cloud/satellites/byoc/aws/manual.md
+++ b/docs/cloud/satellites/byoc/aws/manual.md
@@ -121,12 +121,12 @@ Start by creating the policy needed:
             ],
             "Resource": [
                 "arn:aws:ec2:us-west-2::image/*",
-                "arn:aws:ec2:us-west-2:767397660820:volume/*",
-                "arn:aws:ec2:us-west-2:767397660820:security-group/sg-032c157ecdb6b593f",
-                "arn:aws:ec2:us-west-2:767397660820:network-interface/*",
-                "arn:aws:ec2:us-west-2:767397660820:key-pair/test-iam-14-satellite-key",
-                "arn:aws:ec2:us-west-2:767397660820:instance/*",
-                "arn:aws:ec2:us-west-2:767397660820:subnet/subnet-04dd222e0ac875763"
+                "arn:aws:ec2:us-west-2:012345678901:volume/*",
+                "arn:aws:ec2:us-west-2:012345678901:security-group/sg-032c157ecdb6b593f",
+                "arn:aws:ec2:us-west-2:012345678901:network-interface/*",
+                "arn:aws:ec2:us-west-2:012345678901:key-pair/test-iam-14-satellite-key",
+                "arn:aws:ec2:us-west-2:012345678901:instance/*",
+                "arn:aws:ec2:us-west-2:012345678901:subnet/subnet-04dd222e0ac875763"
             ],
             "Effect": "Allow"
         },
@@ -141,9 +141,9 @@ Start by creating the policy needed:
                 "ec2:CreateVolume"
             ],
             "Resource": [
-                "arn:aws:ec2:us-west-2:767397660820:volume/*",
-                "arn:aws:ec2:us-west-2:767397660820:network-interface/*",
-                "arn:aws:ec2:us-west-2:767397660820:instance/*"
+                "arn:aws:ec2:us-west-2:012345678901:volume/*",
+                "arn:aws:ec2:us-west-2:012345678901:network-interface/*",
+                "arn:aws:ec2:us-west-2:012345678901:instance/*"
             ],
             "Effect": "Allow"
         },
@@ -158,7 +158,7 @@ Start by creating the policy needed:
                 "ec2:StopInstances",
                 "ec2:StartInstances"
             ],
-            "Resource": "arn:aws:ec2:us-west-2:767397660820:instance/*",
+            "Resource": "arn:aws:ec2:us-west-2:012345678901:instance/*",
             "Effect": "Allow"
         },
         {
@@ -173,8 +173,8 @@ Start by creating the policy needed:
                 "ec2:AttachVolume"
             ],
             "Resource": [
-                "arn:aws:ec2:us-west-2:767397660820:volume/*",
-                "arn:aws:ec2:us-west-2:767397660820:instance/*"
+                "arn:aws:ec2:us-west-2:012345678901:volume/*",
+                "arn:aws:ec2:us-west-2:012345678901:instance/*"
             ],
             "Effect": "Allow"
         },
@@ -191,9 +191,9 @@ Start by creating the policy needed:
                 "ec2:CreateTags"
             ],
             "Resource": [
-                "arn:aws:ec2:us-west-2:767397660820:volume/*",
-                "arn:aws:ec2:us-west-2:767397660820:instance/*",
-                "arn:aws:ec2:us-west-2:767397660820:network-interface/*"
+                "arn:aws:ec2:us-west-2:012345678901:volume/*",
+                "arn:aws:ec2:us-west-2:012345678901:instance/*",
+                "arn:aws:ec2:us-west-2:012345678901:network-interface/*"
             ],
             "Effect": "Allow"
         }

--- a/docs/cloud/satellites/byoc/aws/manual.md
+++ b/docs/cloud/satellites/byoc/aws/manual.md
@@ -121,34 +121,79 @@ Start by creating the policy needed:
             ],
             "Resource": [
                 "arn:aws:ec2:us-west-2::image/*",
-                "arn:aws:ec2:us-west-2:012345678901:volume/*",
-                "arn:aws:ec2:us-west-2:012345678901:security-group/sg-012345678901",
-                "arn:aws:ec2:us-west-2:012345678901:network-interface/*",
-                "arn:aws:ec2:us-west-2:012345678901:key-pair/name-satellite-key",
-                "arn:aws:ec2:us-west-2:012345678901:instance/*",
-                "arn:aws:ec2:us-west-2:012345678901:subnet/subnet-012345678901"
+                "arn:aws:ec2:us-west-2:767397660820:volume/*",
+                "arn:aws:ec2:us-west-2:767397660820:security-group/sg-032c157ecdb6b593f",
+                "arn:aws:ec2:us-west-2:767397660820:network-interface/*",
+                "arn:aws:ec2:us-west-2:767397660820:key-pair/test-iam-14-satellite-key",
+                "arn:aws:ec2:us-west-2:767397660820:instance/*",
+                "arn:aws:ec2:us-west-2:767397660820:subnet/subnet-04dd222e0ac875763"
             ],
             "Effect": "Allow"
         },
         {
+            "Condition": {
+                "StringEquals": {
+                    "aws:ResourceTag/earthly:application": "satellite"
+                }
+            },
+            "Action": [
+                "ec2:RunInstances",
+                "ec2:CreateVolume"
+            ],
+            "Resource": [
+                "arn:aws:ec2:us-west-2:767397660820:volume/*",
+                "arn:aws:ec2:us-west-2:767397660820:network-interface/*",
+                "arn:aws:ec2:us-west-2:767397660820:instance/*"
+            ],
+            "Effect": "Allow"
+        },
+        {
+            "Condition": {
+                "StringEquals": {
+                    "aws:ResourceTag/earthly:application": "satellite"
+                }
+            },
             "Action": [
                 "ec2:TerminateInstances",
                 "ec2:StopInstances",
                 "ec2:StartInstances"
             ],
-            "Resource": "arn:aws:ec2:us-west-2:012345678901:instance/*",
+            "Resource": "arn:aws:ec2:us-west-2:767397660820:instance/*",
             "Effect": "Allow"
         },
         {
+            "Condition": {
+                "StringEquals": {
+                    "aws:ResourceTag/earthly:application": "satellite"
+                }
+            },
             "Action": [
                 "ec2:DetachVolume",
                 "ec2:DeleteVolume",
-                "ec2:CreateTags",
                 "ec2:AttachVolume"
             ],
             "Resource": [
-                "arn:aws:ec2:us-west-2:012345678901:volume/*",
-                "arn:aws:ec2:us-west-2:012345678901:instance/*"
+                "arn:aws:ec2:us-west-2:767397660820:volume/*",
+                "arn:aws:ec2:us-west-2:767397660820:instance/*"
+            ],
+            "Effect": "Allow"
+        },
+        {
+            "Condition": {
+                "StringEquals": {
+                    "ec2:CreateAction": [
+                        "RunInstances",
+                        "CreateVolume"
+                    ]
+                }
+            },
+            "Action": [
+                "ec2:CreateTags"
+            ],
+            "Resource": [
+                "arn:aws:ec2:us-west-2:767397660820:volume/*",
+                "arn:aws:ec2:us-west-2:767397660820:instance/*",
+                "arn:aws:ec2:us-west-2:767397660820:network-interface/*"
             ],
             "Effect": "Allow"
         }

--- a/docs/cloud/satellites/byoc/aws/manual.md
+++ b/docs/cloud/satellites/byoc/aws/manual.md
@@ -122,11 +122,11 @@ Start by creating the policy needed:
             "Resource": [
                 "arn:aws:ec2:us-west-2::image/*",
                 "arn:aws:ec2:us-west-2:012345678901:volume/*",
-                "arn:aws:ec2:us-west-2:012345678901:security-group/sg-032c157ecdb6b593f",
+                "arn:aws:ec2:us-west-2:012345678901:security-group/sg-012345678901",
                 "arn:aws:ec2:us-west-2:012345678901:network-interface/*",
-                "arn:aws:ec2:us-west-2:012345678901:key-pair/test-iam-14-satellite-key",
+                "arn:aws:ec2:us-west-2:012345678901:key-pair/name-satellite-key",
                 "arn:aws:ec2:us-west-2:012345678901:instance/*",
-                "arn:aws:ec2:us-west-2:012345678901:subnet/subnet-04dd222e0ac875763"
+                "arn:aws:ec2:us-west-2:012345678901:subnet/subnet-012345678901"
             ],
             "Effect": "Allow"
         },

--- a/docs/cloud/satellites/byoc/aws/terraform.md
+++ b/docs/cloud/satellites/byoc/aws/terraform.md
@@ -16,7 +16,7 @@ You can find the module in the [public Terraform Registry](https://registry.terr
 ```hcl
 module "byoc" {
   source  = "earthly/byoc/aws"
-  version = "0.0.8"
+  version = "0.0.9"
 
   cloud_name = "my-cloud"
   subnet = "subnet-0123456789abcde01"

--- a/docs/cloud/satellites/byoc/aws/terraform.md
+++ b/docs/cloud/satellites/byoc/aws/terraform.md
@@ -16,7 +16,7 @@ You can find the module in the [public Terraform Registry](https://registry.terr
 ```hcl
 module "byoc" {
   source  = "earthly/byoc/aws"
-  version = "0.0.9"
+  version = "0.0.10"
 
   cloud_name = "my-cloud"
   subnet = "subnet-0123456789abcde01"


### PR DESCRIPTION
The policy suggested in the docs (the one that allows Earthly's backend access to the 3rd party cloud) now includes tags that limit Earthly's access to resources that contain a certain tag.