### PR TITLE
Dockerd wrapper housekeeping

### DIFF
--- a/buildkitd/dockerd-wrapper.sh
+++ b/buildkitd/dockerd-wrapper.sh
@@ -116,7 +116,7 @@ execute() {
         for img in $(docker images -q); do
             docker tag "$img" "${earthly_cached_docker_image_prefix}${img}"
         done
-        docker images -a --format '{{.Repository}}:{{.Tag}}' | grep -v "^$earthly_cached_docker_image_prefix" | xargs --no-run-if-empty docker rmi
+        docker images -a --format '{{.Repository}}:{{.Tag}}' | grep -v "^$earthly_cached_docker_image_prefix" | xargs --no-run-if-empty docker rmi --force
     fi
 
     load_file_images
@@ -124,8 +124,8 @@ execute() {
 
     # delete cached images (which weren't re-tagged via the pull)
     if [ "$EARTHLY_DOCKERD_CACHE_DATA" = "true" ]; then
-        docker images -f reference=$earthly_cached_docker_image_prefix'*' --format '{{.Repository}}:{{.Tag}}' | xargs --no-run-if-empty docker rmi
-        docker images -f "dangling=true" -q | xargs --no-run-if-empty docker rmi
+        docker images -f reference=$earthly_cached_docker_image_prefix'*' --format '{{.Repository}}:{{.Tag}}' | xargs --no-run-if-empty docker rmi --force
+        docker images -f "dangling=true" -q | xargs --no-run-if-empty docker rmi --force
     fi
 
     if [ "$EARTHLY_START_COMPOSE" = "true" ]; then
@@ -340,7 +340,7 @@ load_registry_images() {
             esac
             echo "Pulling $with_reg and retagging as $user_tag"
             # Download and tag images in parallel
-            (docker pull -q "$with_reg" && docker tag "$with_reg" "$user_tag" && docker rmi "$with_reg") &
+            (docker pull -q "$with_reg" && docker tag "$with_reg" "$user_tag" && docker rmi --force "$with_reg") &
 
             bg_processes="$bg_processes $!"
 


### PR DESCRIPTION
When using a self-hosted satellite with the `--docker-cache` experimental feature enabled, it was found that leftover bad state in the cached data-root could cause builds to start failing. In particular, a leftover, stopped container making use of one of the images that the `dockerd-wrapper.sh` attempts to `rmi` would result in a `unable to remove repository reference` error. Some additional debugging revealed that other types of docker objects are potentially left behind in the data-root. This change modifies the `docker-wrapper.sh` to do some housekeeping of these undesirable objects, and also makes changes to avoid having builds fail due to unanticipated leftover state.