### PR TITLE
chore: Remove deprecation notice from the top of the introduction

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,7 @@
 # Introduction
 
-**Please note that Earthly is no longer actively maintained.** [Read more](https://earthly.dev/blog/shutting-down-earthfiles-cloud).
+> **EarthBuild** is the community-maintained fork of the product formerly known as earthly from earthly
+> technologies. [Read more](https://earthbuild.dev/blog/shutting-down-earthfiles-cloud).
 
 Earthly is a super simple CI/CD framework that gives you repeatable builds that you write once and run anywhere; has a simple, instantly recognizable syntax; and works with every language, framework, and build tool. With Earthly, you can create Docker images and build artifacts (e.g. binaries, packages, and arbitrary files).
 


### PR DESCRIPTION
Self-explanatory: https://docs.earthbuild.dev/#:~:text=Please%20note%20that%20Earthbuild%20is%20no%20longer%20actively%20maintained.