### PR TITLE
feat: read IdentityAgent from ~/.ssh/config for SSH agent socket

### DIFF
--- a/cmd/earthly/flag/global.go
+++ b/cmd/earthly/flag/global.go
@@ -1,7 +1,6 @@
 package flag
 
 import (
-	"os"
 	"time"
 
 	"github.com/urfave/cli/v2"
@@ -9,6 +8,7 @@ import (
 	"github.com/earthly/earthly/buildkitd"
 	"github.com/earthly/earthly/cmd/earthly/common"
 	"github.com/earthly/earthly/util/containerutil"
+	"github.com/earthly/earthly/util/sshutil"
 )
 
 const (
@@ -108,7 +108,7 @@ func (global *Global) RootFlags(installName string, bkImage string) []cli.Flag {
 		},
 		&cli.StringFlag{
 			Name:        "ssh-auth-sock",
-			Value:       os.Getenv("SSH_AUTH_SOCK"),
+			Value:       sshutil.GetSSHAuthSock(),
 			EnvVars:     []string{"EARTHLY_SSH_AUTH_SOCK"},
 			Usage:       "The SSH auth socket to use for ssh-agent forwarding",
 			Destination: &global.SSHAuthSock,

--- a/util/sshutil/identity_agent.go
+++ b/util/sshutil/identity_agent.go
@@ -1,3 +1,6 @@
+// Package sshutil provides helpers for SSH configuration and authentication.
+// Currently it exposes GetSSHAuthSock to resolve the SSH agent socket path
+// from the environment or from ~/.ssh/config (IdentityAgent directive).
 package sshutil
 
 import (

--- a/util/sshutil/identity_agent.go
+++ b/util/sshutil/identity_agent.go
@@ -51,23 +51,17 @@ func identityAgentFromConfig() string {
 			continue
 		}
 
-		lower := strings.ToLower(line)
-		if strings.HasPrefix(lower, "host ") {
+		// Extract keyword and value, handling both "keyword value" and
+		// "keyword=value" forms (both are valid per ssh_config(5)).
+		keyword, value := splitDirective(line)
+		switch strings.ToLower(keyword) {
+		case "host":
 			seenAnyHostBlock = true
-			inWildcardHost = isUniversalWildcard(strings.TrimSpace(line[5:]))
-			continue
-		}
-		if strings.HasPrefix(lower, "match ") {
+			inWildcardHost = isUniversalWildcard(value)
+		case "match":
 			seenAnyHostBlock = true
 			inWildcardHost = false
-			continue
-		}
-
-		if strings.HasPrefix(lower, "identityagent ") {
-			value := strings.TrimSpace(line[len("identityagent "):])
-			// Handle optional = syntax: IdentityAgent = /path
-			value = strings.TrimPrefix(value, "=")
-			value = strings.TrimSpace(value)
+		case "identityagent":
 			// Strip surrounding quotes that SSH config allows for paths with spaces
 			value = stripQuotes(value)
 			if value == "" {
@@ -87,6 +81,22 @@ func identityAgentFromConfig() string {
 	}
 
 	return globalAgent
+}
+
+// splitDirective splits an SSH config line into a keyword and its value.
+// It handles both space/tab-separated ("Host *") and equals-separated
+// ("IdentityAgent=/path") forms, stripping any surrounding whitespace from
+// both parts. Returns empty strings if the line has no separating whitespace
+// or '=' character.
+func splitDirective(line string) (keyword, value string) {
+	// Find the first whitespace or '=' separator
+	idx := strings.IndexAny(line, " \t=")
+	if idx < 0 {
+		return line, ""
+	}
+	keyword = line[:idx]
+	rest := strings.TrimLeft(line[idx:], " \t=")
+	return keyword, strings.TrimSpace(rest)
 }
 
 // isUniversalWildcard reports whether a Host pattern line represents a

--- a/util/sshutil/identity_agent.go
+++ b/util/sshutil/identity_agent.go
@@ -7,9 +7,10 @@ import (
 	"strings"
 )
 
-// GetSSHAuthSock returns the SSH auth socket path by checking:
-// 1. The SSH_AUTH_SOCK environment variable
-// 2. The IdentityAgent directive from ~/.ssh/config (Host *)
+// GetSSHAuthSock returns the SSH auth socket path to use. It checks the
+// SSH_AUTH_SOCK environment variable first. If that is not set, it falls back
+// to reading the IdentityAgent directive from ~/.ssh/config (Host * or global
+// scope). Returns an empty string when no socket can be determined.
 func GetSSHAuthSock() string {
 	if sock := os.Getenv("SSH_AUTH_SOCK"); sock != "" {
 		return sock
@@ -18,8 +19,10 @@ func GetSSHAuthSock() string {
 }
 
 // identityAgentFromConfig reads ~/.ssh/config and returns the IdentityAgent
-// value from the Host * block (or the first IdentityAgent found outside any
-// host block), with ~ and environment variables expanded.
+// value from the first matching wildcard Host block (e.g. "Host *") or the
+// first IdentityAgent directive found outside any Host block. The returned path
+// has ~ and environment variables expanded. Returns empty string when nothing
+// is found or the config file cannot be read.
 func identityAgentFromConfig() string {
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -44,8 +47,7 @@ func identityAgentFromConfig() string {
 
 		lower := strings.ToLower(line)
 		if strings.HasPrefix(lower, "host ") {
-			pattern := strings.TrimSpace(line[5:])
-			inWildcardHost = pattern == "*"
+			inWildcardHost = isWildcardHostPattern(strings.TrimSpace(line[5:]))
 			continue
 		}
 		if strings.HasPrefix(lower, "match ") {
@@ -55,9 +57,11 @@ func identityAgentFromConfig() string {
 
 		if strings.HasPrefix(lower, "identityagent ") {
 			value := strings.TrimSpace(line[len("identityagent "):])
-			// Also handle = syntax: IdentityAgent = /path
+			// Handle optional = syntax: IdentityAgent = /path
 			value = strings.TrimPrefix(value, "=")
 			value = strings.TrimSpace(value)
+			// Strip surrounding quotes that SSH config allows for paths with spaces
+			value = stripQuotes(value)
 			if value == "" {
 				continue
 			}
@@ -75,7 +79,36 @@ func identityAgentFromConfig() string {
 	return globalAgent
 }
 
-// expandPath expands ~ to the home directory and $VAR / ${VAR} environment variables.
+// isWildcardHostPattern reports whether a Host pattern string contains a
+// wildcard entry that would match all hosts. It handles multi-pattern lines
+// like "Host * !excluded.example.com" by checking if any token is or contains
+// "*" (ignoring negation tokens that start with "!").
+func isWildcardHostPattern(pattern string) bool {
+	for _, token := range strings.Fields(pattern) {
+		if strings.HasPrefix(token, "!") {
+			continue
+		}
+		if strings.Contains(token, "*") {
+			return true
+		}
+	}
+	return false
+}
+
+// stripQuotes removes a single pair of matching surrounding quotes (single or
+// double) from s if present. It does not remove mismatched or nested quotes.
+func stripQuotes(s string) string {
+	if len(s) >= 2 {
+		if (s[0] == '"' && s[len(s)-1] == '"') ||
+			(s[0] == '\'' && s[len(s)-1] == '\'') {
+			return s[1 : len(s)-1]
+		}
+	}
+	return s
+}
+
+// expandPath expands a leading ~ to the user home directory and replaces
+// $VAR and ${VAR} references using os.ExpandEnv.
 func expandPath(path string, home string) string {
 	if strings.HasPrefix(path, "~/") {
 		path = filepath.Join(home, path[2:])

--- a/util/sshutil/identity_agent.go
+++ b/util/sshutil/identity_agent.go
@@ -19,10 +19,12 @@ func GetSSHAuthSock() string {
 }
 
 // identityAgentFromConfig reads ~/.ssh/config and returns the IdentityAgent
-// value from the first matching wildcard Host block (e.g. "Host *") or the
-// first IdentityAgent directive found outside any Host block. The returned path
-// has ~ and environment variables expanded. Returns empty string when nothing
-// is found or the config file cannot be read.
+// value from the first matching universal wildcard Host block (i.e. "Host *")
+// or the first IdentityAgent directive that appears before any Host block.
+// IdentityAgent directives inside specific host blocks (e.g. "Host github.com")
+// are intentionally ignored so that host-scoped keys don't pollute the default
+// socket path. The returned path has ~ and environment variables expanded.
+// Returns empty string when nothing is found or the config file cannot be read.
 func identityAgentFromConfig() string {
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -36,6 +38,7 @@ func identityAgentFromConfig() string {
 	defer f.Close()
 
 	var inWildcardHost bool
+	var seenAnyHostBlock bool
 	var globalAgent string
 
 	scanner := bufio.NewScanner(f)
@@ -47,10 +50,12 @@ func identityAgentFromConfig() string {
 
 		lower := strings.ToLower(line)
 		if strings.HasPrefix(lower, "host ") {
-			inWildcardHost = isWildcardHostPattern(strings.TrimSpace(line[5:]))
+			seenAnyHostBlock = true
+			inWildcardHost = isUniversalWildcard(strings.TrimSpace(line[5:]))
 			continue
 		}
 		if strings.HasPrefix(lower, "match ") {
+			seenAnyHostBlock = true
 			inWildcardHost = false
 			continue
 		}
@@ -69,8 +74,10 @@ func identityAgentFromConfig() string {
 			if inWildcardHost {
 				return expanded
 			}
-			// Store first seen global (before any Host block) as fallback
-			if globalAgent == "" {
+			// Only treat as global fallback if we haven't entered any Host block yet.
+			// An IdentityAgent inside a specific host block (e.g. Host github.com)
+			// must not bleed into the default socket path.
+			if !seenAnyHostBlock && globalAgent == "" {
 				globalAgent = expanded
 			}
 		}
@@ -79,16 +86,23 @@ func identityAgentFromConfig() string {
 	return globalAgent
 }
 
-// isWildcardHostPattern reports whether a Host pattern string contains a
-// wildcard entry that would match all hosts. It handles multi-pattern lines
-// like "Host * !excluded.example.com" by checking if any token is or contains
-// "*" (ignoring negation tokens that start with "!").
-func isWildcardHostPattern(pattern string) bool {
+// isUniversalWildcard reports whether a Host pattern line represents a
+// universal match (i.e. matches all hosts). It requires at least one token
+// that is exactly "*". Patterns like "*.example.com" are host-scoped and are
+// not treated as universal. Negation tokens (starting with "!") are skipped.
+//
+// Examples:
+//
+//	"*"                     -> true   (matches all hosts)
+//	"* !excluded.example.com" -> true (universal with exclusion)
+//	"*.example.com"         -> false  (scoped to a domain)
+//	"github.com"            -> false  (specific host)
+func isUniversalWildcard(pattern string) bool {
 	for _, token := range strings.Fields(pattern) {
 		if strings.HasPrefix(token, "!") {
 			continue
 		}
-		if strings.Contains(token, "*") {
+		if token == "*" {
 			return true
 		}
 	}

--- a/util/sshutil/identity_agent.go
+++ b/util/sshutil/identity_agent.go
@@ -1,0 +1,86 @@
+package sshutil
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// GetSSHAuthSock returns the SSH auth socket path by checking:
+// 1. The SSH_AUTH_SOCK environment variable
+// 2. The IdentityAgent directive from ~/.ssh/config (Host *)
+func GetSSHAuthSock() string {
+	if sock := os.Getenv("SSH_AUTH_SOCK"); sock != "" {
+		return sock
+	}
+	return identityAgentFromConfig()
+}
+
+// identityAgentFromConfig reads ~/.ssh/config and returns the IdentityAgent
+// value from the Host * block (or the first IdentityAgent found outside any
+// host block), with ~ and environment variables expanded.
+func identityAgentFromConfig() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	configPath := filepath.Join(home, ".ssh", "config")
+	f, err := os.Open(configPath)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+
+	var inWildcardHost bool
+	var globalAgent string
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		lower := strings.ToLower(line)
+		if strings.HasPrefix(lower, "host ") {
+			pattern := strings.TrimSpace(line[5:])
+			inWildcardHost = pattern == "*"
+			continue
+		}
+		if strings.HasPrefix(lower, "match ") {
+			inWildcardHost = false
+			continue
+		}
+
+		if strings.HasPrefix(lower, "identityagent ") {
+			value := strings.TrimSpace(line[len("identityagent "):])
+			// Also handle = syntax: IdentityAgent = /path
+			value = strings.TrimPrefix(value, "=")
+			value = strings.TrimSpace(value)
+			if value == "" {
+				continue
+			}
+			expanded := expandPath(value, home)
+			if inWildcardHost {
+				return expanded
+			}
+			// Store first seen global (before any Host block) as fallback
+			if globalAgent == "" {
+				globalAgent = expanded
+			}
+		}
+	}
+
+	return globalAgent
+}
+
+// expandPath expands ~ to the home directory and $VAR / ${VAR} environment variables.
+func expandPath(path string, home string) string {
+	if strings.HasPrefix(path, "~/") {
+		path = filepath.Join(home, path[2:])
+	} else if path == "~" {
+		path = home
+	}
+	return os.ExpandEnv(path)
+}

--- a/util/sshutil/identity_agent_test.go
+++ b/util/sshutil/identity_agent_test.go
@@ -6,6 +6,24 @@ import (
 	"testing"
 )
 
+// writeSSHConfig creates a temp HOME directory, writes configContent to
+// ~/.ssh/config, sets HOME and clears SSH_AUTH_SOCK for the test. Returns the
+// tmpDir path so callers can construct expected expanded paths.
+func writeSSHConfig(t *testing.T, configContent string) string {
+	t.Helper()
+	tmpDir := t.TempDir()
+	sshDir := filepath.Join(tmpDir, ".ssh")
+	if err := os.MkdirAll(sshDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sshDir, "config"), []byte(configContent), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("SSH_AUTH_SOCK", "")
+	return tmpDir
+}
+
 func TestExpandPath(t *testing.T) {
 	home := "/home/testuser"
 	tests := []struct {
@@ -35,30 +53,14 @@ func TestExpandPathEnvVar(t *testing.T) {
 }
 
 func TestIdentityAgentFromConfig(t *testing.T) {
-	// Create a temp dir with a fake ssh config
-	tmpDir := t.TempDir()
-	sshDir := filepath.Join(tmpDir, ".ssh")
-	if err := os.MkdirAll(sshDir, 0700); err != nil {
-		t.Fatal(err)
-	}
-
-	configContent := `Host github.com
+	tmpDir := writeSSHConfig(t, `Host github.com
     HostName github.com
     User git
 
 Host *
     IdentityAgent ~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock
     AddKeysToAgent yes
-`
-	if err := os.WriteFile(filepath.Join(sshDir, "config"), []byte(configContent), 0600); err != nil {
-		t.Fatal(err)
-	}
-
-	// Override HOME so identityAgentFromConfig finds our temp config
-	t.Setenv("HOME", tmpDir)
-	// Clear SSH_AUTH_SOCK so GetSSHAuthSock falls through
-	t.Setenv("SSH_AUTH_SOCK", "")
-
+`)
 	sock := GetSSHAuthSock()
 	expected := filepath.Join(tmpDir, "Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock")
 	if sock != expected {
@@ -86,23 +88,9 @@ func TestIdentityAgentNoConfig(t *testing.T) {
 }
 
 func TestIdentityAgentQuotedPath(t *testing.T) {
-	tmpDir := t.TempDir()
-	sshDir := filepath.Join(tmpDir, ".ssh")
-	if err := os.MkdirAll(sshDir, 0700); err != nil {
-		t.Fatal(err)
-	}
-
-	// IdentityAgent with quoted path (common for paths with spaces)
-	configContent := `Host *
+	tmpDir := writeSSHConfig(t, `Host *
     IdentityAgent "~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
-`
-	if err := os.WriteFile(filepath.Join(sshDir, "config"), []byte(configContent), 0600); err != nil {
-		t.Fatal(err)
-	}
-
-	t.Setenv("HOME", tmpDir)
-	t.Setenv("SSH_AUTH_SOCK", "")
-
+`)
 	sock := GetSSHAuthSock()
 	expected := filepath.Join(tmpDir, "Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock")
 	if sock != expected {
@@ -111,23 +99,9 @@ func TestIdentityAgentQuotedPath(t *testing.T) {
 }
 
 func TestIdentityAgentMultiPatternHost(t *testing.T) {
-	tmpDir := t.TempDir()
-	sshDir := filepath.Join(tmpDir, ".ssh")
-	if err := os.MkdirAll(sshDir, 0700); err != nil {
-		t.Fatal(err)
-	}
-
-	// Host * !excluded pattern should still be treated as wildcard
-	configContent := `Host * !excluded.example.com
+	writeSSHConfig(t, `Host * !excluded.example.com
     IdentityAgent /tmp/wildcard-agent.sock
-`
-	if err := os.WriteFile(filepath.Join(sshDir, "config"), []byte(configContent), 0600); err != nil {
-		t.Fatal(err)
-	}
-
-	t.Setenv("HOME", tmpDir)
-	t.Setenv("SSH_AUTH_SOCK", "")
-
+`)
 	sock := GetSSHAuthSock()
 	if sock != "/tmp/wildcard-agent.sock" {
 		t.Errorf("GetSSHAuthSock() with multi-pattern Host = %q, want /tmp/wildcard-agent.sock", sock)
@@ -175,48 +149,29 @@ func TestIsUniversalWildcard(t *testing.T) {
 }
 
 func TestIdentityAgentHostSpecificIsIgnored(t *testing.T) {
-	tmpDir := t.TempDir()
-	sshDir := filepath.Join(tmpDir, ".ssh")
-	if err := os.MkdirAll(sshDir, 0700); err != nil {
-		t.Fatal(err)
-	}
-
-	// IdentityAgent scoped to a specific host should NOT be used as the default
-	configContent := `Host github.com
+	writeSSHConfig(t, `Host github.com
     IdentityAgent /tmp/github-only.sock
-`
-	if err := os.WriteFile(filepath.Join(sshDir, "config"), []byte(configContent), 0600); err != nil {
-		t.Fatal(err)
-	}
-
-	t.Setenv("HOME", tmpDir)
-	t.Setenv("SSH_AUTH_SOCK", "")
-
+`)
 	if got := GetSSHAuthSock(); got != "" {
 		t.Errorf("GetSSHAuthSock() = %q, want empty for host-specific-only config", got)
 	}
 }
 
-func TestIdentityAgentGlobalScope(t *testing.T) {
-	tmpDir := t.TempDir()
-	sshDir := filepath.Join(tmpDir, ".ssh")
-	if err := os.MkdirAll(sshDir, 0700); err != nil {
-		t.Fatal(err)
+func TestIdentityAgentMatchScopeIsIgnored(t *testing.T) {
+	writeSSHConfig(t, `Match host github.com
+    IdentityAgent /tmp/match-only.sock
+`)
+	if got := GetSSHAuthSock(); got != "" {
+		t.Errorf("GetSSHAuthSock() = %q, want empty for match-scoped-only config", got)
 	}
+}
 
-	// IdentityAgent before any Host block
-	configContent := `IdentityAgent /tmp/global-agent.sock
+func TestIdentityAgentGlobalScope(t *testing.T) {
+	writeSSHConfig(t, `IdentityAgent /tmp/global-agent.sock
 
 Host github.com
     HostName github.com
-`
-	if err := os.WriteFile(filepath.Join(sshDir, "config"), []byte(configContent), 0600); err != nil {
-		t.Fatal(err)
-	}
-
-	t.Setenv("HOME", tmpDir)
-	t.Setenv("SSH_AUTH_SOCK", "")
-
+`)
 	sock := GetSSHAuthSock()
 	if sock != "/tmp/global-agent.sock" {
 		t.Errorf("GetSSHAuthSock() = %q, want /tmp/global-agent.sock", sock)

--- a/util/sshutil/identity_agent_test.go
+++ b/util/sshutil/identity_agent_test.go
@@ -157,6 +157,44 @@ func TestIdentityAgentHostSpecificIsIgnored(t *testing.T) {
 	}
 }
 
+func TestIdentityAgentTabSeparated(t *testing.T) {
+	// SSH config allows tabs between keyword and value
+	writeSSHConfig(t, "Host\t*\n\tIdentityAgent\t/tmp/tab-agent.sock\n")
+	if got := GetSSHAuthSock(); got != "/tmp/tab-agent.sock" {
+		t.Errorf("GetSSHAuthSock() with tab-separated config = %q, want /tmp/tab-agent.sock", got)
+	}
+}
+
+func TestIdentityAgentEqualsSyntax(t *testing.T) {
+	// SSH config allows key=value syntax
+	writeSSHConfig(t, "Host=*\nIdentityAgent=/tmp/equals-agent.sock\n")
+	if got := GetSSHAuthSock(); got != "/tmp/equals-agent.sock" {
+		t.Errorf("GetSSHAuthSock() with key=value config = %q, want /tmp/equals-agent.sock", got)
+	}
+}
+
+func TestSplitDirective(t *testing.T) {
+	tests := []struct {
+		line    string
+		keyword string
+		value   string
+	}{
+		{"Host *", "Host", "*"},
+		{"Host\t*", "Host", "*"},
+		{"Host=*", "Host", "*"},
+		{"IdentityAgent /tmp/agent.sock", "IdentityAgent", "/tmp/agent.sock"},
+		{"IdentityAgent=/tmp/agent.sock", "IdentityAgent", "/tmp/agent.sock"},
+		{"IdentityAgent = /tmp/agent.sock", "IdentityAgent", "/tmp/agent.sock"},
+		{"Host", "Host", ""},
+	}
+	for _, tt := range tests {
+		k, v := splitDirective(tt.line)
+		if k != tt.keyword || v != tt.value {
+			t.Errorf("splitDirective(%q) = (%q, %q), want (%q, %q)", tt.line, k, v, tt.keyword, tt.value)
+		}
+	}
+}
+
 func TestIdentityAgentMatchScopeIsIgnored(t *testing.T) {
 	writeSSHConfig(t, `Match host github.com
     IdentityAgent /tmp/match-only.sock

--- a/util/sshutil/identity_agent_test.go
+++ b/util/sshutil/identity_agent_test.go
@@ -1,0 +1,112 @@
+package sshutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestExpandPath(t *testing.T) {
+	home := "/home/testuser"
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"~/some/path", filepath.Join(home, "some/path")},
+		{"~", home},
+		{"/absolute/path", "/absolute/path"},
+		{"relative/path", "relative/path"},
+	}
+	for _, tt := range tests {
+		got := expandPath(tt.input, home)
+		if got != tt.expected {
+			t.Errorf("expandPath(%q, %q) = %q, want %q", tt.input, home, got, tt.expected)
+		}
+	}
+}
+
+func TestExpandPathEnvVar(t *testing.T) {
+	t.Setenv("TEST_SSH_VAR", "myvalue")
+	home := "/home/testuser"
+	got := expandPath("$TEST_SSH_VAR/agent.sock", home)
+	if got != "myvalue/agent.sock" {
+		t.Errorf("expandPath with env var = %q, want %q", got, "myvalue/agent.sock")
+	}
+}
+
+func TestIdentityAgentFromConfig(t *testing.T) {
+	// Create a temp dir with a fake ssh config
+	tmpDir := t.TempDir()
+	sshDir := filepath.Join(tmpDir, ".ssh")
+	if err := os.MkdirAll(sshDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	configContent := `Host github.com
+    HostName github.com
+    User git
+
+Host *
+    IdentityAgent ~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock
+    AddKeysToAgent yes
+`
+	if err := os.WriteFile(filepath.Join(sshDir, "config"), []byte(configContent), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Override HOME so identityAgentFromConfig finds our temp config
+	t.Setenv("HOME", tmpDir)
+	// Clear SSH_AUTH_SOCK so GetSSHAuthSock falls through
+	t.Setenv("SSH_AUTH_SOCK", "")
+
+	sock := GetSSHAuthSock()
+	expected := filepath.Join(tmpDir, "Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock")
+	if sock != expected {
+		t.Errorf("GetSSHAuthSock() = %q, want %q", sock, expected)
+	}
+}
+
+func TestIdentityAgentSSHAuthSockTakesPrecedence(t *testing.T) {
+	t.Setenv("SSH_AUTH_SOCK", "/tmp/existing.sock")
+	sock := GetSSHAuthSock()
+	if sock != "/tmp/existing.sock" {
+		t.Errorf("GetSSHAuthSock() = %q, want SSH_AUTH_SOCK value", sock)
+	}
+}
+
+func TestIdentityAgentNoConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("SSH_AUTH_SOCK", "")
+
+	sock := GetSSHAuthSock()
+	if sock != "" {
+		t.Errorf("GetSSHAuthSock() = %q, want empty", sock)
+	}
+}
+
+func TestIdentityAgentGlobalScope(t *testing.T) {
+	tmpDir := t.TempDir()
+	sshDir := filepath.Join(tmpDir, ".ssh")
+	if err := os.MkdirAll(sshDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	// IdentityAgent before any Host block
+	configContent := `IdentityAgent /tmp/global-agent.sock
+
+Host github.com
+    HostName github.com
+`
+	if err := os.WriteFile(filepath.Join(sshDir, "config"), []byte(configContent), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("SSH_AUTH_SOCK", "")
+
+	sock := GetSSHAuthSock()
+	if sock != "/tmp/global-agent.sock" {
+		t.Errorf("GetSSHAuthSock() = %q, want /tmp/global-agent.sock", sock)
+	}
+}

--- a/util/sshutil/identity_agent_test.go
+++ b/util/sshutil/identity_agent_test.go
@@ -153,23 +153,47 @@ func TestStripQuotes(t *testing.T) {
 	}
 }
 
-func TestIsWildcardHostPattern(t *testing.T) {
+func TestIsUniversalWildcard(t *testing.T) {
 	tests := []struct {
 		pattern  string
 		expected bool
 	}{
 		{"*", true},
 		{"* !excluded.example.com", true},
-		{"*.example.com", true},
+		// *.example.com is a domain-scoped pattern, NOT a universal wildcard
+		{"*.example.com", false},
 		{"github.com", false},
 		{"!excluded.example.com", false},
 		{"github.com bitbucket.org", false},
 	}
 	for _, tt := range tests {
-		got := isWildcardHostPattern(tt.pattern)
+		got := isUniversalWildcard(tt.pattern)
 		if got != tt.expected {
-			t.Errorf("isWildcardHostPattern(%q) = %v, want %v", tt.pattern, got, tt.expected)
+			t.Errorf("isUniversalWildcard(%q) = %v, want %v", tt.pattern, got, tt.expected)
 		}
+	}
+}
+
+func TestIdentityAgentHostSpecificIsIgnored(t *testing.T) {
+	tmpDir := t.TempDir()
+	sshDir := filepath.Join(tmpDir, ".ssh")
+	if err := os.MkdirAll(sshDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	// IdentityAgent scoped to a specific host should NOT be used as the default
+	configContent := `Host github.com
+    IdentityAgent /tmp/github-only.sock
+`
+	if err := os.WriteFile(filepath.Join(sshDir, "config"), []byte(configContent), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("SSH_AUTH_SOCK", "")
+
+	if got := GetSSHAuthSock(); got != "" {
+		t.Errorf("GetSSHAuthSock() = %q, want empty for host-specific-only config", got)
 	}
 }
 

--- a/util/sshutil/identity_agent_test.go
+++ b/util/sshutil/identity_agent_test.go
@@ -85,6 +85,94 @@ func TestIdentityAgentNoConfig(t *testing.T) {
 	}
 }
 
+func TestIdentityAgentQuotedPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	sshDir := filepath.Join(tmpDir, ".ssh")
+	if err := os.MkdirAll(sshDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	// IdentityAgent with quoted path (common for paths with spaces)
+	configContent := `Host *
+    IdentityAgent "~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
+`
+	if err := os.WriteFile(filepath.Join(sshDir, "config"), []byte(configContent), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("SSH_AUTH_SOCK", "")
+
+	sock := GetSSHAuthSock()
+	expected := filepath.Join(tmpDir, "Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock")
+	if sock != expected {
+		t.Errorf("GetSSHAuthSock() with quoted path = %q, want %q", sock, expected)
+	}
+}
+
+func TestIdentityAgentMultiPatternHost(t *testing.T) {
+	tmpDir := t.TempDir()
+	sshDir := filepath.Join(tmpDir, ".ssh")
+	if err := os.MkdirAll(sshDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	// Host * !excluded pattern should still be treated as wildcard
+	configContent := `Host * !excluded.example.com
+    IdentityAgent /tmp/wildcard-agent.sock
+`
+	if err := os.WriteFile(filepath.Join(sshDir, "config"), []byte(configContent), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("SSH_AUTH_SOCK", "")
+
+	sock := GetSSHAuthSock()
+	if sock != "/tmp/wildcard-agent.sock" {
+		t.Errorf("GetSSHAuthSock() with multi-pattern Host = %q, want /tmp/wildcard-agent.sock", sock)
+	}
+}
+
+func TestStripQuotes(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{`"~/path/to/agent.sock"`, "~/path/to/agent.sock"},
+		{`'~/path/to/agent.sock'`, "~/path/to/agent.sock"},
+		{"~/path/to/agent.sock", "~/path/to/agent.sock"},
+		{`"mismatched'`, `"mismatched'`},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		got := stripQuotes(tt.input)
+		if got != tt.expected {
+			t.Errorf("stripQuotes(%q) = %q, want %q", tt.input, got, tt.expected)
+		}
+	}
+}
+
+func TestIsWildcardHostPattern(t *testing.T) {
+	tests := []struct {
+		pattern  string
+		expected bool
+	}{
+		{"*", true},
+		{"* !excluded.example.com", true},
+		{"*.example.com", true},
+		{"github.com", false},
+		{"!excluded.example.com", false},
+		{"github.com bitbucket.org", false},
+	}
+	for _, tt := range tests {
+		got := isWildcardHostPattern(tt.pattern)
+		if got != tt.expected {
+			t.Errorf("isWildcardHostPattern(%q) = %v, want %v", tt.pattern, got, tt.expected)
+		}
+	}
+}
+
 func TestIdentityAgentGlobalScope(t *testing.T) {
 	tmpDir := t.TempDir()
 	sshDir := filepath.Join(tmpDir, ".ssh")


### PR DESCRIPTION
Fixes #3179

## Summary

Earthly was ignoring the `IdentityAgent` directive in `~/.ssh/config`. This means users with custom SSH agents (like 1Password at `~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock`) had to pass `--ssh-auth-sock` manually every single time which is quiet annoying.

This PR adds a fallback: when `SSH_AUTH_SOCK` is not set, Earthly will read `~/.ssh/config` and look for `IdentityAgent` directive (from `Host *` or global scope) and uses that as the SSH auth socket. Tilde and env variables in the path are expanded correctly.

## Changes

- `util/sshutil/identity_agent.go` -- New helper `GetSSHAuthSock()` that checks `SSH_AUTH_SOCK` first then falls back to parsing `~/.ssh/config` for `IdentityAgent`
- `cmd/earthly/flag/global.go` -- Use `sshutil.GetSSHAuthSock()` as default for `--ssh-auth-sock` instead of just reading `SSH_AUTH_SOCK` env directly

## Test plan

- [x] Unit tests for path expansion (tilde, env vars)
- [x] Unit tests for SSH config parsing (wildcard host, global scope, no config, SSH_AUTH_SOCK precedence)
- [x] `go build ./cmd/earthly/` passes
- [x] `go test ./util/sshutil/` -- all 6 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved SSH authentication socket detection: when SSH_AUTH_SOCK is unset, the app now consults SSH config to locate IdentityAgent entries, handles quoted paths, expands ~ and environment variables, and prefers universal wildcard or global directives.

* **Tests**
  * Added extensive tests covering path expansion, config parsing, precedence of env values, wildcard/host matching, quoted paths, and no-config scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->